### PR TITLE
Improve GeoTiff support

### DIFF
--- a/src/main/scala/geotrellis/data/geotiff.scala
+++ b/src/main/scala/geotrellis/data/geotiff.scala
@@ -106,6 +106,12 @@ object GeoTiffReader extends FileReader {
   }
 }
 
+/**
+ * This GeoTiffWriter is deprecated.
+ *
+ * See geotrellis.data.geotiff.Encoder for the preferred approach to
+ * encoding rasters to geotiff files.
+ */
 object GeoTiffWriter extends Writer {
   def rasterType = "geotiff" 
   def dataType = ""

--- a/src/main/scala/geotrellis/data/geotiff/Const.scala
+++ b/src/main/scala/geotrellis/data/geotiff/Const.scala
@@ -1,0 +1,26 @@
+package geotrellis.data.geotiff
+
+/**
+ * This object is contains useful geotiff-related constants.
+ *
+ * The first group of constants relates to parsing Tiff tags, and the second
+ * group relates to Tiff sample formats.
+ */
+object Const {
+  final def uint8 = 1      // 8-bit unsigned int
+  final def ascii = 2      // 7-bit ascii code (must end in NUL)
+  final def uint16 = 3     // 16-bit unsigned int
+  final def uint32 = 4     // 32-bit unsigned int
+  final def rational = 5   // rational: 2 uint32 values (numerator/denominator)
+  final def sint8 = 6      // 8-bit signed int
+  final def undef8 = 7     // undefined 8-bit
+  final def sint16 = 8     // 16-bit signed int
+  final def sint32 = 9     // 32-bit signed int
+  final def srational = 10 // signed rational: 2 sint32 values (n/d)
+  final def float32 = 11   // 32-bit floating point
+  final def float64 = 12   // 64-bit floating point
+
+  final def unsigned = 1 // unsigned integer samples
+  final def signed = 2   // signed integer samples
+  final def floating = 3 // floating-point samples
+}

--- a/src/main/scala/geotrellis/data/geotiff/SampleFormat.scala
+++ b/src/main/scala/geotrellis/data/geotiff/SampleFormat.scala
@@ -1,0 +1,15 @@
+package geotrellis.data.geotiff
+
+/**
+ * SampleFormat is used by geotiff.Settings to indicate how to interpret each
+ * sample.
+ *
+ * For instance, an 8-bit sample whose value is 0xfe will be interpreted as
+ * -2 with Signed, but at 254 with Unsigned.
+ *
+ * Floating is defined but not yet supported by geotiff.Encoder.
+ */
+sealed abstract class SampleFormat(val kind:Int)
+case object Unsigned extends SampleFormat(Const.unsigned)
+case object Signed extends SampleFormat(Const.signed)
+case object Floating extends SampleFormat(Const.floating)

--- a/src/main/scala/geotrellis/data/geotiff/SampleSize.scala
+++ b/src/main/scala/geotrellis/data/geotiff/SampleSize.scala
@@ -1,0 +1,12 @@
+package geotrellis.data.geotiff
+
+/**
+ * SampleSize is used by geotiff.Settings to indicate how wide each sample
+ * (i.e. each raster cell) will be. Currently we only support 8-, 16-, and
+ * 32-bit samples, although other widths (including 1- and 64-bit samples)
+ * could be supported in the future.
+ */
+sealed abstract class SampleSize(val bits:Int)
+case object ByteSample extends SampleSize(8)
+case object ShortSample extends SampleSize(16)
+case object IntSample extends SampleSize(32)

--- a/src/main/scala/geotrellis/data/geotiff/Settings.scala
+++ b/src/main/scala/geotrellis/data/geotiff/Settings.scala
@@ -1,0 +1,8 @@
+package geotrellis.data.geotiff
+
+/**
+ * Used by geotiff.Encoder to control how GeoTiff data is to be written.
+ *
+ * Currently supports sample size and format.
+ */
+case class Settings(size:SampleSize, format:SampleFormat)


### PR DESCRIPTION
This commit introduces our own GeoTiff encoder. It only supports
the parts of GeoTiff that we are currently using, although it should
be easily extensible. In particular, it writes signed or unsigned
rasters with 8-, 16- or 32-bit values.

It should be possible to write out own GeoTiff decoder as well,
which would remove out geotools dependency.
