### PR TITLE
Improve GeoTIFF support, especially ESRI compatibility.

### DIFF
--- a/src/main/scala/geotrellis/data/geotiff.scala
+++ b/src/main/scala/geotrellis/data/geotiff.scala
@@ -118,7 +118,9 @@ object GeoTiffWriter extends Writer {
 
   import geotrellis.data.geotiff._
 
+  val geoTiffSettings = Settings(IntSample, Signed, esriCompat = false)
+
   def write(path:String, raster:IntRaster, name:String) {
-    Encoder.writePath(path, raster, Settings(IntSample, Signed))
+    Encoder.writePath(path, raster, geoTiffSettings)
   }
 }

--- a/src/main/scala/geotrellis/data/geotiff/Settings.scala
+++ b/src/main/scala/geotrellis/data/geotiff/Settings.scala
@@ -3,6 +3,12 @@ package geotrellis.data.geotiff
 /**
  * Used by geotiff.Encoder to control how GeoTiff data is to be written.
  *
- * Currently supports sample size and format.
+ * Currently supports sample size, format and 'esriCompat', an ESRI
+ * compatibility option.
+ *
+ * This compatibility option changes the way that geographic data are written.
+ * The "normal" approach is similar to how GDAL and other strict GeoTIFF
+ * encoders work (we write out the projected CS ID, i.e. 3857). If 'esriCompat'
+ * is set to true, we instead write out a "user-defined" projected CS.
  */
-case class Settings(size:SampleSize, format:SampleFormat)
+case class Settings(size:SampleSize, format:SampleFormat, esriCompat:Boolean)


### PR DESCRIPTION
This commit adds an option to write GeoTIFF files with a bunch of ESRI-specific
metadata. It also adds the capability to write multiple strips of data, which
fixes certain bugs with large data sets.
