### PR TITLE
Move to common ArgReader and ArgWriter classes.

### DIFF
--- a/src/main/scala/geotrellis/RasterType.scala
+++ b/src/main/scala/geotrellis/RasterType.scala
@@ -1,6 +1,6 @@
 package geotrellis
 
-sealed abstract class RasterType(val precedence:Int, val float:Boolean) {
+sealed abstract class RasterType(val precedence:Int, val float:Boolean, val name:String) {
   def bits = if (float) precedence / 10 else precedence
   def union(rhs:RasterType) = if (precedence < rhs.precedence) rhs else this
   def intersect(rhs:RasterType) = if (precedence < rhs.precedence) this else rhs
@@ -8,9 +8,9 @@ sealed abstract class RasterType(val precedence:Int, val float:Boolean) {
   def contains(rhs:RasterType) = precedence >= rhs.precedence
 }
 
-case object TypeBit extends RasterType(1, false)
-case object TypeByte extends RasterType(8, false)
-case object TypeShort extends RasterType(16, false)
-case object TypeInt extends RasterType(32, false)
-case object TypeFloat extends RasterType(320, true)
-case object TypeDouble extends RasterType(640, true)
+case object TypeBit extends RasterType(1, false, "bool")
+case object TypeByte extends RasterType(8, false, "int8")
+case object TypeShort extends RasterType(16, false, "int16")
+case object TypeInt extends RasterType(32, false, "int32")
+case object TypeFloat extends RasterType(320, true, "float32")
+case object TypeDouble extends RasterType(640, true, "float64")

--- a/src/main/scala/geotrellis/data/arg/ArgReader.scala
+++ b/src/main/scala/geotrellis/data/arg/ArgReader.scala
@@ -1,0 +1,26 @@
+package geotrellis.data.arg
+
+import geotrellis._
+import geotrellis.data._
+import geotrellis.process._
+
+object ArgReader extends FileReader {
+  def makeReadState(d:Either[String, Array[Byte]],
+                    rl:RasterLayer,
+                    re:RasterExtent): ReadState = rl.datatyp match {
+    case "int8" => new Int8ReadState(d, rl, re)
+    case "int16" => new Int16ReadState(d, rl, re)
+    case "int32" => new Int32ReadState(d, rl, re)
+    case "float32" => new Float32ReadState(d, rl, re)
+    case "float64" => new Float64ReadState(d, rl, re)
+    case t => sys.error("datatype %s is not supported" format t)
+  }
+
+  def readStateFromCache(b:Array[Byte], rl:RasterLayer, re:RasterExtent) = {
+    makeReadState(Right(b), rl, re)
+  }
+
+  def readStateFromPath(p:String, rl:RasterLayer, re:RasterExtent) = {
+    makeReadState(Left(p), rl, re)
+  }
+}

--- a/src/main/scala/geotrellis/data/arg/ArgWriter.scala
+++ b/src/main/scala/geotrellis/data/arg/ArgWriter.scala
@@ -1,0 +1,38 @@
+package geotrellis.data.arg
+
+import java.io.{BufferedOutputStream, DataOutputStream, FileOutputStream}
+
+import geotrellis._
+import geotrellis.data._
+import geotrellis.util._
+import geotrellis.process._
+
+case class ArgWriter(typ:RasterType) extends Writer {
+  def width = typ.bits / 8
+  def rasterType = typ.name
+  def dataType = "arg"
+
+  def write(path:String, raster:Raster, name:String) {
+    val base = path.substring(0, path.lastIndexOf("."))
+    writeMetadataJSON(base + ".json", name, raster.rasterExtent)
+    writeData(base + ".arg", raster)
+  }
+
+  private def writeBytes(data:RasterData, cols:Int, rows:Int, dos:DataOutputStream) {
+    var row = 0
+    while (row < rows) {
+      var col = 0
+      while (col < cols) {
+        dos.writeByte(data.get(col, row, cols))
+        col += 1
+      }
+      row += 1
+    }
+  }
+
+  private def writeData(path:String, raster:Raster) {
+    val dos = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path)))
+    CellWriter.byType(typ).writeCells(raster, dos)
+    dos.close()
+  }
+}

--- a/src/main/scala/geotrellis/data/arg/CellWriter.scala
+++ b/src/main/scala/geotrellis/data/arg/CellWriter.scala
@@ -1,0 +1,105 @@
+package geotrellis.data.arg
+
+import java.io.DataOutputStream
+
+import geotrellis._
+import geotrellis.data._
+import geotrellis.util._
+import geotrellis.process._
+
+object CellWriter {
+  def byType(typ:RasterType): CellWriter = typ match {
+    case TypeByte => Int8CellWriter
+    case TypeShort => Int16CellWriter
+    case TypeInt => Int32CellWriter
+    case TypeFloat => Float32CellWriter
+    case TypeDouble => Float64CellWriter
+    case t => sys.error("raster type %s is not supported yet" format t)
+  }
+}
+
+trait CellWriter {
+  protected[this] def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream)
+
+  def writeCells(raster:Raster, dos:DataOutputStream) {
+    val data = raster.data
+    val cols = raster.rasterExtent.cols
+    val rows = raster.rasterExtent.rows
+
+    var row = 0
+    while (row < rows) {
+      var col = 0
+      while (col < cols) {
+        writeCell(data, col, row, cols, dos)
+        col += 1
+      }
+      row += 1
+    }
+  }
+}
+
+object BitCellWriter extends CellWriter {
+  override def writeCells(raster:Raster, dos:DataOutputStream) {
+    val data = raster.data
+    val cols = raster.rasterExtent.cols
+    val rows = raster.rasterExtent.rows
+
+    var i = 0
+    var z = 0
+    var row = 0
+    while (row < rows) {
+      var col = 0
+      while (col < cols) {
+        z = (z << 1) | data.get(col, row, cols)
+        i += 1
+        col += 1
+        if (i == 8) {
+          i = 0
+          z = 0
+          dos.writeByte(z)
+        }
+      }
+      row += 1
+    }
+  }
+  def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) = ()
+}
+
+trait IntCellWriter extends CellWriter {
+  def noDataValue:Int
+  def writeValue(z:Int, dos:DataOutputStream): Unit
+  @inline final def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) {
+    val z = data.get(col, row, cols)
+    if (z == NODATA) writeValue(noDataValue, dos) else writeValue(z, dos)
+  }
+}
+
+trait FloatCellWriter extends CellWriter {
+  def writeValue(z:Double, dos:DataOutputStream): Unit
+  @inline final def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) {
+    writeValue(data.getDouble(col, row, cols), dos)
+  }
+}
+
+object Int8CellWriter extends IntCellWriter {
+  @inline final def noDataValue = Byte.MinValue
+  @inline final def writeValue(z:Int, dos:DataOutputStream) { dos.writeByte(z) }
+}
+
+object Int16CellWriter extends IntCellWriter {
+  @inline final def noDataValue = Short.MinValue
+  @inline final def writeValue(z:Int, dos:DataOutputStream) { dos.writeShort(z) }
+}
+
+object Int32CellWriter extends IntCellWriter {
+  @inline final def noDataValue = Int.MinValue
+  @inline final def writeValue(z:Int, dos:DataOutputStream) { dos.writeInt(z) }
+}
+
+object Float32CellWriter extends FloatCellWriter {
+  @inline final def writeValue(z:Double, dos:DataOutputStream) { dos.writeFloat(z.toFloat) }
+}
+
+object Float64CellWriter extends FloatCellWriter {
+  @inline final def writeValue(z:Double, dos:DataOutputStream) { dos.writeDouble(z) }
+}

--- a/src/main/scala/geotrellis/data/arg/FloatNReadState.scala
+++ b/src/main/scala/geotrellis/data/arg/FloatNReadState.scala
@@ -1,0 +1,43 @@
+package geotrellis.data
+
+import java.nio.ByteBuffer
+
+import geotrellis._
+import geotrellis.util._
+import geotrellis.process._
+
+abstract class ArgFloatNReadState(data:Either[String, Array[Byte]],
+                                  val layer:RasterLayer,
+                                  val target:RasterExtent,
+                                  typ:RasterType) extends ReadState {
+  def getType = typ
+
+  final val width:Int = typ.bits / 8
+
+  protected[this] var src:ByteBuffer = null
+
+  def initSource(pos:Int, size:Int) {
+    src = data match {
+      case Left(path) => Filesystem.slurpToBuffer(path, pos * width, size * width)
+      case Right(bytes) => ByteBuffer.wrap(bytes, pos * width, size * width)
+    }
+  }
+}
+
+class Float64ReadState(data:Either[String, Array[Byte]],
+                       layer:RasterLayer,
+                       target:RasterExtent)
+extends ArgFloatNReadState(data, layer, target, TypeDouble) {
+  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+    dest.updateDouble(destIndex, src.getDouble(sourceIndex * width))
+  }
+}
+
+class Float32ReadState(data:Either[String, Array[Byte]],
+                       layer:RasterLayer,
+                       target:RasterExtent)
+extends ArgFloatNReadState(data, layer, target, TypeFloat) {
+  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+    dest.updateDouble(destIndex, src.getFloat(sourceIndex * width))
+  }
+}

--- a/src/main/scala/geotrellis/data/arg/IntNReadState.scala
+++ b/src/main/scala/geotrellis/data/arg/IntNReadState.scala
@@ -1,0 +1,60 @@
+package geotrellis.data.arg
+
+import java.nio.ByteBuffer
+
+import geotrellis._
+import geotrellis.data._
+import geotrellis.util._
+import geotrellis.process._
+
+abstract class IntNReadState(data:Either[String, Array[Byte]],
+                             val layer:RasterLayer,
+                             val target:RasterExtent,
+                             typ:RasterType) extends IntReadState {
+  def getType = typ
+
+  final val width:Int = typ.bits / 8
+
+  protected[this] var src:ByteBuffer = null
+
+  /**
+   * Returns this datatype's no data value. For signed integers, this is the
+   * minimum value storable at this particular bitwidth. For instance, for
+   * 8-bit integers (width 1), the value -128 is the no data value.
+   */
+  def getNoDataValue:Int = -(1 << (width * 8 - 1))
+
+  def initSource(pos:Int, size:Int) {
+    src = data match {
+      case Left(path) => Filesystem.slurpToBuffer(path, pos * width, size * width)
+      case Right(bytes) => ByteBuffer.wrap(bytes, pos * width, size * width)
+    }
+  }
+}
+
+class Int8ReadState(data:Either[String, Array[Byte]],
+                    layer:RasterLayer,
+                    target:RasterExtent)
+extends IntNReadState(data, layer, target, TypeByte) {
+  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+    dest(destIndex) = src.get(sourceIndex)
+  }
+}
+
+class Int16ReadState(data:Either[String, Array[Byte]],
+                     layer:RasterLayer,
+                     target:RasterExtent)
+extends IntNReadState(data, layer, target, TypeShort) {
+  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+    dest(destIndex) = src.getShort(sourceIndex * 2)
+  }
+}
+
+class Int32ReadState(data:Either[String, Array[Byte]],
+                     layer:RasterLayer,
+                     target:RasterExtent)
+extends IntNReadState(data, layer, target, TypeInt) {
+  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+    dest(destIndex) = src.getInt(sourceIndex * 4)
+  }
+}

--- a/src/main/scala/geotrellis/data/arg32.scala
+++ b/src/main/scala/geotrellis/data/arg32.scala
@@ -1,224 +1,224 @@
-package geotrellis.data
-
-import java.io.{BufferedOutputStream, FileOutputStream}
-import java.nio.ByteBuffer
-import java.nio.channels.FileChannel.MapMode._
-
-import geotrellis._
-import geotrellis.util._
-import geotrellis.process._
-
-import scala.math.pow
-import scala.xml._
-
-object ArgFormat {
-  def noData(width:Int):Int = -(1 << (width * 8 - 1))
-}
-
-abstract class ArgNReadState(data:Either[String, Array[Byte]],
-                             val layer:RasterLayer,
-                             val target:RasterExtent) extends ReadState {
-  def width:Int // byte width, e.g. 4 for arg32 with 32bit values
-
-  protected[this] var src:ByteBuffer = null
-
-  // NoData value is the minimum value storable w/ this bitwidth (-1 for sign)
-  def getNoDataValue:Int = ArgFormat.noData(width)
-
-  def initSource(pos:Int, size:Int) {
-    src = data match {
-      case Left(path) => Filesystem.slurpToBuffer(path, pos * width, size * width)
-      case Right(bytes) => ByteBuffer.wrap(bytes, pos * width, size * width)
-    }
-  }
-
-}
-
-
-trait ArgNWriter extends Writer {
-  def width:Int
-  def rasterType:String
-
-  def dataType = "Int" + (width * 8).toString
-
-  def write(path:String, raster:Raster, name:String) {
-    val i = path.lastIndexOf(".")
-    val base = path.substring(0, i)
-    writeMetadataJSON(base + ".json", name, raster.rasterExtent)
-    writeData(base + ".arg", raster)
-  }
-
-  private def writeData(path:String, raster:Raster) {
-    val re = raster.rasterExtent
-    val cols = re.cols
-    val rows = re.rows
-    val buffer = Array.ofDim[Byte](cols * width)
-
-    val bos = new BufferedOutputStream(new FileOutputStream(path))
-
-    var row = 0
-    while (row < rows) {
-      var col = 0
-      while (col < cols) {
-        val i = col * width 
-        var z = raster.get(col, row)
-        var j = 0
-        while (j < width) {
-          val k = width - j - 1
-          buffer(i + j) = (z >> 8 * k).toByte
-
-          //e.g. for width = 4
-          //buffer(i)     = (z >> 24).toByte
-          //buffer(i + 1) = (z >> 16).toByte
-          //buffer(i + 2) = (z >> 8).toByte
-          //buffer(i + 3) = (z >> 0).toByte
-          j += 1
-        }
-        col += 1
-      }
-      bos.write(buffer)
-      row += 1
-    }
-
-    bos.close()
-  }
-}
-
-//REFACTOR: Create a single ArgReader/Writer that passes through bitwidth as an argument.
-//          This would require refactoring the Writer/Reader traits.
-
-// arg int32
-
-class Arg32ReadState(data:Either[String, Array[Byte]],
-                     layer:RasterLayer,
-                     target:RasterExtent)  extends ArgNReadState(data, layer, target) {
-  final val width = 4
-
-  def createRasterData(size:Int) = IntArrayRasterData.empty(size)
-
-  @inline
-  def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
-    dest(destIndex) = src.getInt(sourceIndex * width)
-  }
-}
-
-object Arg32Reader extends FileReader {
-  def readStateFromCache(b:Array[Byte], rl:RasterLayer, re:RasterExtent) = new Arg32ReadState(Right(b), rl, re)
-  def readStateFromPath(p:String, rl:RasterLayer, re:RasterExtent) = new Arg32ReadState(Left(p), rl, re)
-}
-
-object Arg32Writer extends ArgNWriter {
-  final val width = 4
-  final val rasterType = "arg32"
-}
-
-// arg int16
-
-class Arg16ReadState(data:Either[String, Array[Byte]],
-                    layer:RasterLayer,
-                    target:RasterExtent) extends ArgNReadState(data,layer,target) {
-  final val width = 2
-
-  def createRasterData(size:Int) = ShortArrayRasterData.empty(size)
-
-  @inline
-  def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
-    dest(destIndex) = src.get(sourceIndex * width)
-  }
-}
-
-object Arg16Reader extends FileReader {
-  def readStateFromCache(b:Array[Byte], rl:RasterLayer, re:RasterExtent) = new Arg16ReadState(Right(b), rl, re)
-  def readStateFromPath(p:String, rl:RasterLayer, re:RasterExtent) = new Arg16ReadState(Left(p), rl, re)
-}
-
-object Arg16Writer extends ArgNWriter {
-  final val width = 2
-  final val rasterType = "arg16"
-}
-
-// arg int8
-
-class Arg8ReadState(data:Either[String, Array[Byte]],
-                    layer:RasterLayer,
-                    target:RasterExtent) extends ArgNReadState(data,layer,target) {
-  final val width = 1
-
-  def createRasterData(size:Int) = ByteArrayRasterData.empty(size)
-
-  @inline
-  def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
-    dest(destIndex) = src.get(sourceIndex * width)
-  }
-}
-
-
-object Arg8Reader extends FileReader {
-  def readStateFromCache(b:Array[Byte], rl:RasterLayer, re:RasterExtent) = new Arg8ReadState(Right(b), rl, re)
-  def readStateFromPath(p:String, rl:RasterLayer, re:RasterExtent) = new Arg8ReadState(Left(p), rl, re)
-}
-
-object Arg8Writer extends ArgNWriter {
-  final val width = 1
-  final val rasterType = "arg8"
-}
-
-// arg float64
-
-abstract class FloatNReadState(data:Either[String, Array[Byte]],
-                               val layer:RasterLayer,
-                               val target:RasterExtent) extends ReadState {
-
-  def width:Int
-
-  protected[this] var src:ByteBuffer = null
-
-  def getNoDataValue = sys.error("not used") // REFACTOR: ugh
-
-  override def translate(data:StrictRasterData) = data
-
-  def initSource(pos:Int, size:Int) {
-    src = data match {
-      case Left(path) => Filesystem.slurpToBuffer(path, pos * width, size * width)
-      case Right(bytes) => ByteBuffer.wrap(bytes, pos * width, size * width)
-    }
-  }
-}
-
-
-class Float64ReadState(data:Either[String, Array[Byte]],
-                       layer:RasterLayer,
-                       target:RasterExtent)  extends FloatNReadState(data, layer, target) {
-  final val width = 8
-
-  def createRasterData(size:Int) = DoubleArrayRasterData.empty(size)
-
-  @inline
-  def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
-    dest.updateDouble(destIndex, src.getDouble(sourceIndex * width))
-  }
-}
-
-object Float64Reader extends FileReader {
-  def readStateFromCache(b:Array[Byte], rl:RasterLayer, re:RasterExtent) = new Float64ReadState(Right(b), rl, re)
-  def readStateFromPath(p:String, rl:RasterLayer, re:RasterExtent) = new Float64ReadState(Left(p), rl, re)
-}
-
-
-class Float32ReadState(data:Either[String, Array[Byte]],
-                       layer:RasterLayer,
-                       target:RasterExtent)  extends FloatNReadState(data, layer, target) {
-  final val width = 4
-
-  def createRasterData(size:Int) = FloatArrayRasterData.empty(size)
-
-  @inline
-  def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
-    dest.updateDouble(destIndex, src.getFloat(sourceIndex * width))
-  }
-}
-
-object Float32Reader extends FileReader {
-  def readStateFromCache(b:Array[Byte], rl:RasterLayer, re:RasterExtent) = new Float32ReadState(Right(b), rl, re)
-  def readStateFromPath(p:String, rl:RasterLayer, re:RasterExtent) = new Float32ReadState(Left(p), rl, re)
-}
+//package geotrellis.data
+//
+//import java.io.{BufferedOutputStream, DataOutputStream, FileOutputStream}
+//import java.nio.ByteBuffer
+//import java.nio.channels.FileChannel.MapMode._
+//
+//import geotrellis._
+//import geotrellis.util._
+//import geotrellis.process._
+//
+//abstract class ArgIntNReadState(data:Either[String, Array[Byte]],
+//                             val layer:RasterLayer,
+//                             val target:RasterExtent,
+//                             typ:RasterType) extends IntReadState {
+//  def getType = typ
+//
+//  final val width:Int = typ.bits / 8
+//
+//  protected[this] var src:ByteBuffer = null
+//
+//  // NoData value is the minimum value storable w/ this bitwidth (-1 for sign)
+//  def getNoDataValue:Int = -(1 << (width * 8 - 1))
+//
+//  def initSource(pos:Int, size:Int) {
+//    src = data match {
+//      case Left(path) => Filesystem.slurpToBuffer(path, pos * width, size * width)
+//      case Right(bytes) => ByteBuffer.wrap(bytes, pos * width, size * width)
+//    }
+//  }
+//}
+//
+//object ArgReader extends FileReader {
+//  def makeReadState(d:Either[String, Array[Byte]],
+//                    rl:RasterLayer,
+//                    re:RasterExtent): ReadState = rl.datatyp match {
+//    case "int8" => new Int8ReadState(d, rl, re)
+//    case "int16" => new Int16ReadState(d, rl, re)
+//    case "int32" => new Int32ReadState(d, rl, re)
+//    case "float32" => new Float32ReadState(d, rl, re)
+//    case "float64" => new Float64ReadState(d, rl, re)
+//    case t => sys.error("datatype %s is not supported" format t)
+//  }
+//
+//  def readStateFromCache(b:Array[Byte], rl:RasterLayer, re:RasterExtent) = {
+//    makeReadState(Right(b), rl, re)
+//  }
+//
+//  def readStateFromPath(p:String, rl:RasterLayer, re:RasterExtent) = {
+//    makeReadState(Left(p), rl, re)
+//  }
+//}
+//
+//trait CellWriter {
+//  protected[this] def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream)
+//  def writeCells(raster:Raster, dos:DataOutputStream) {
+//    val data = raster.data
+//    val cols = raster.rasterExtent.cols
+//    val rows = raster.rasterExtent.rows
+//
+//    var row = 0
+//    while (row < rows) {
+//      var col = 0
+//      while (col < cols) {
+//        writeCell(data, col, row, cols, dos)
+//        col += 1
+//      }
+//      row += 1
+//    }
+//  }
+//}
+//
+//object BitCellWriter extends CellWriter {
+//  override def writeCells(raster:Raster, dos:DataOutputStream) {
+//    val data = raster.data
+//    val cols = raster.rasterExtent.cols
+//    val rows = raster.rasterExtent.rows
+//
+//    var i = 0
+//    var z = 0
+//    var row = 0
+//    while (row < rows) {
+//      var col = 0
+//      while (col < cols) {
+//        z = (z << 1) | data.get(col, row, cols)
+//        i += 1
+//        col += 1
+//        if (i == 8) {
+//          i = 0
+//          z = 0
+//          dos.writeByte(z)
+//        }
+//      }
+//      row += 1
+//    }
+//  }
+//  def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) = ()
+//}
+//
+//object ByteCellWriter extends CellWriter {
+//  @inline final def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) {
+//    dos.writeByte(data.get(col, row, cols))
+//  }
+//}
+//
+//object ShortCellWriter extends CellWriter {
+//  @inline final def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) {
+//    dos.writeShort(data.get(col, row, cols))
+//  }
+//}
+//
+//object IntCellWriter extends CellWriter {
+//  @inline final def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) {
+//    dos.writeInt(data.get(col, row, cols))
+//  }
+//}
+//
+//object FloatCellWriter extends CellWriter {
+//  @inline final def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) {
+//    dos.writeFloat(data.getDouble(col, row, cols).toFloat)
+//  }
+//}
+//
+//object DoubleCellWriter extends CellWriter {
+//  @inline final def writeCell(data:RasterData, col:Int, row:Int, cols:Int, dos:DataOutputStream) {
+//    dos.writeDouble(data.getDouble(col, row, cols))
+//  }
+//}
+//
+//
+//case class ArgWriter(typ:RasterType) extends Writer {
+//  def width = typ.bits / 8
+//  def rasterType = "arg"
+//  def dataType = typ.name
+//
+//  def write(path:String, raster:Raster, name:String) {
+//    val base = path.substring(0, path.lastIndexOf("."))
+//    writeMetadataJSON(base + ".json", name, raster.rasterExtent)
+//    writeData(base + ".arg", raster)
+//  }
+//
+//  private def writeBytes(data:RasterData, cols:Int, rows:Int, dos:DataOutputStream) {
+//    var row = 0
+//    while (row < rows) {
+//      var col = 0
+//      while (col < cols) {
+//        dos.writeByte(data.get(col, row, cols))
+//        col += 1
+//      }
+//      row += 1
+//    }
+//  }
+//
+//  private def writeData(path:String, raster:Raster) {
+//    val dos = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path)))
+//    val cw = typ match {
+//      case TypeByte => ByteCellWriter
+//      case TypeShort => ShortCellWriter
+//      case TypeInt => IntCellWriter
+//      case TypeFloat => FloatCellWriter
+//      case TypeDouble => DoubleCellWriter
+//      case t => sys.error("raster type %s is not supported yet" format t)
+//    }
+//    cw.writeCells(raster, dos)
+//    dos.close()
+//  }
+//}
+//
+//class Int32ReadState(data:Either[String, Array[Byte]],
+//                     layer:RasterLayer,
+//                     target:RasterExtent)  extends ArgIntNReadState(data, layer, target, TypeInt) {
+//  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+//    dest(destIndex) = src.getInt(sourceIndex * width)
+//  }
+//}
+//
+//class Int16ReadState(data:Either[String, Array[Byte]],
+//                     layer:RasterLayer,
+//                     target:RasterExtent) extends ArgIntNReadState(data, layer, target, TypeShort) {
+//  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+//    dest(destIndex) = src.get(sourceIndex * width)
+//  }
+//}
+//
+//class Int8ReadState(data:Either[String, Array[Byte]],
+//                    layer:RasterLayer,
+//                    target:RasterExtent) extends ArgIntNReadState(data, layer, target, TypeByte) {
+//  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+//    dest(destIndex) = src.get(sourceIndex * width)
+//  }
+//}
+//
+//abstract class ArgFloatNReadState(data:Either[String, Array[Byte]],
+//                               val layer:RasterLayer,
+//                               val target:RasterExtent,
+//                               typ:RasterType) extends ReadState {
+//  def getType = typ
+//
+//  final val width:Int = typ.bits / 8
+//
+//  protected[this] var src:ByteBuffer = null
+//
+//  def initSource(pos:Int, size:Int) {
+//    src = data match {
+//      case Left(path) => Filesystem.slurpToBuffer(path, pos * width, size * width)
+//      case Right(bytes) => ByteBuffer.wrap(bytes, pos * width, size * width)
+//    }
+//  }
+//}
+//
+//class Float64ReadState(data:Either[String, Array[Byte]],
+//                       layer:RasterLayer,
+//                       target:RasterExtent)  extends ArgFloatNReadState(data, layer, target, TypeDouble) {
+//  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+//    dest.updateDouble(destIndex, src.getDouble(sourceIndex * width))
+//  }
+//}
+//
+//class Float32ReadState(data:Either[String, Array[Byte]],
+//                       layer:RasterLayer,
+//                       target:RasterExtent)  extends ArgFloatNReadState(data, layer, target, TypeFloat) {
+//  @inline final def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+//    dest.updateDouble(destIndex, src.getFloat(sourceIndex * width))
+//  }
+//}

--- a/src/main/scala/geotrellis/data/ascii.scala
+++ b/src/main/scala/geotrellis/data/ascii.scala
@@ -11,7 +11,7 @@ import geotrellis.util._
 
 final class AsciiReadState(path:String,
                            val layer:RasterLayer,
-                           val target:RasterExtent) extends ReadState {
+                           val target:RasterExtent) extends IntReadState {
   var ncols:Int = 0
   var nrows:Int = 0
   var xllcorner:Double = 0.0
@@ -21,7 +21,8 @@ final class AsciiReadState(path:String,
 
   var ints:IntArrayRasterData = null
 
-  def createRasterData(size:Int) = IntArrayRasterData.empty(size)
+  def getType = TypeInt
+  //def createRasterData(size:Int) = IntArrayRasterData.empty(size)
 
   def getNoDataValue = nodata_value
 

--- a/src/main/scala/geotrellis/data/geotiff.scala
+++ b/src/main/scala/geotrellis/data/geotiff.scala
@@ -29,11 +29,12 @@ import geotrellis.util._
 
 final class GeoTiffReadState(path:String,
                              val layer:RasterLayer,
-                             val target:RasterExtent) extends ReadState {
+                             val target:RasterExtent) extends IntReadState {
   private var noData:Int = 0
   private var ints:Array[Int] = null
 
-  def createRasterData(size:Int) = IntArrayRasterData.empty(size)
+  def getType = TypeInt
+  //def createRasterData(size:Int) = IntArrayRasterData.empty(size)
 
   private def getReader = {
     val fh    = new File(path)

--- a/src/main/scala/geotrellis/data/intraster.scala
+++ b/src/main/scala/geotrellis/data/intraster.scala
@@ -7,23 +7,28 @@ import geotrellis.util._
 
 final class RasterReadState(raster:Raster,
                             val target:RasterExtent) extends ReadState {
+  val data:ArrayRasterData = raster.data.asInstanceOf[ArrayRasterData] //FIXME
+
   val layer = RasterLayer("raster", "intraster", "", "", raster.rasterExtent, 3857, 0.0, 0.0)
-  var src:IntBuffer = null
+  //var src:IntBuffer = null
 
-  def getNoDataValue = NODATA
+  //def getNoDataValue = NODATA
 
-  def createRasterData(size:Int) = IntArrayRasterData.empty(size)
+  //def createRasterData(size:Int) = IntArrayRasterData.empty(size)
+  def getType = data.getType
 
+  private var pos:Int = 0
+  private var sz:Int = 0
   def initSource(position:Int, size:Int) {
-    src = IntBuffer.wrap(raster.toArray, position, size)
+    pos = position
+    sz = size
+    //src = IntBuffer.wrap(raster.toArray, position, size)
   }
 
-  @inline
-  def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
-    dest(destIndex) = src.get(sourceIndex)
+  @inline def assignFromSource(sourceIndex:Int, dest:StrictRasterData, destIndex:Int) {
+    //dest(destIndex) = src.get(sourceIndex)
+    dest(destIndex) = data.apply(sourceIndex + pos)
   }
-
-  override def translate(data:StrictRasterData) = data.copy()
 }
 
 object RasterReader extends Reader {

--- a/src/main/scala/geotrellis/process/server.scala
+++ b/src/main/scala/geotrellis/process/server.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable
 
 import geotrellis._
 import geotrellis.data._
+import geotrellis.data.arg._
 import geotrellis.data.FileExtensionRegexes._
 import geotrellis.RasterExtent
 import geotrellis.operation._
@@ -141,18 +142,7 @@ akka {
    */
   def getReader(path:String, layerOpt:Option[RasterLayer]): FileReader = {
     path match {
-      case ArgPattern() => {
-        //REVIEW: replace with unified ARG reader
-        layerOpt.getOrElse(RasterLayer.fromPath(metadataPath(path))) match {
-          case RasterLayer(_, "arg", "int32", _, _, _, _, _) => Arg32Reader
-          case RasterLayer(_, "arg", "int16", _, _, _, _, _) => Arg16Reader
-          case RasterLayer(_, "arg", "int8",  _, _, _, _, _) => Arg8Reader
-          case RasterLayer(_, "arg", "float64", _, _, _, _, _) => Float64Reader
-          case RasterLayer(_, "arg", "float32",  _, _, _, _, _) => Float32Reader
-          case RasterLayer(_, typ, datatyp,   _, _, _, _, _) => 
-          throw new Exception("Unsupported raster layer: with type %s, datatype %s".format(typ,datatyp))
-        } 
-      }
+      case ArgPattern() => ArgReader
       case GeoTiffPattern() => GeoTiffReader
       case AsciiPattern() => AsciiReader
       case _ => sys.error("unknown path type %s".format(path))

--- a/src/main/scala/geotrellis/raster/TiledRasterData.scala
+++ b/src/main/scala/geotrellis/raster/TiledRasterData.scala
@@ -1,7 +1,7 @@
 package geotrellis.raster
 
 import geotrellis._
-import geotrellis.data.{Arg32Writer, Arg32Reader}
+import geotrellis.data.arg.ArgWriter
 import geotrellis.process._
 
 case class TileLayout(tileCols:Int, tileRows:Int, pixelCols:Int, pixelRows:Int)
@@ -287,7 +287,8 @@ object Tiler {
 
       val tileExtent = Extent(xmin, ymin, xmax, ymax)
       val rasterExtent = RasterExtent(tileExtent, cw, ch, pixelCols, pixelRows)
-      val data = Array.ofDim[Int](pixelCols * pixelRows)
+      //val data = Array.ofDim[Int](pixelCols * pixelRows)
+      val data = RasterData.allocByType(src.data.getType, pixelCols * pixelRows)
 
       // TODO: if this code ends up being a performance bottleneck, we should
       // refactor away from using raster.get and for-comprehensions.
@@ -311,7 +312,7 @@ object Tiler {
       val r = tiles(i)
       val name2 = tileName(name, col, row)
       val path2 = tilePath(path, name, col, row)
-      Arg32Writer.write(path2, r, name2)
+      ArgWriter(data.getType).write(path2, r, name2)
     }
   }
   

--- a/src/test/scala/geotrellis/data/arg.scala
+++ b/src/test/scala/geotrellis/data/arg.scala
@@ -1,4 +1,4 @@
-package geotrellis.data
+package geotrellis.data.arg
 
 import org.scalatest.Spec
 import org.scalatest.matchers.MustMatchers
@@ -18,7 +18,7 @@ class ArgSpec extends Spec with MustMatchers with ShouldMatchers {
     val path1 = "src/test/resources/fake.img8.arg"
     	 
     it("should build a valid raster") {
-      val raster = Arg8Reader.readPath(path1, None, None)
+      val raster = ArgReader.readPath(path1, None, None)
 
       raster.cols must be === 4
       raster.rows must be === 4
@@ -31,12 +31,12 @@ class ArgSpec extends Spec with MustMatchers with ShouldMatchers {
     }
 
     it("should write out args") {
-      val raster = Arg8Reader.readPath(path1, None, None)
+      val raster = ArgReader.readPath(path1, None, None)
 
       val fh = java.io.File.createTempFile("foog", ".arg")
       val path2 = fh.getPath
 
-      Arg8Writer.write(path2, raster, "name")
+      ArgWriter(TypeByte).write(path2, raster, "name")
 
       val data1 = io.Source.fromFile(path2).mkString
       val data2 = io.Source.fromFile("src/test/resources/fake.img8.arg").mkString
@@ -55,7 +55,7 @@ class ArgSpec extends Spec with MustMatchers with ShouldMatchers {
       val cellheight = abs(ymax - ymin) / cols
       val e = Extent(xmin, ymin, xmax, ymax)
       val re = RasterExtent(e, cellwidth, cellheight, cols, rows)
-      Arg8Reader.readPath("src/test/resources/quad8.arg", None, Some(re))
+      ArgReader.readPath("src/test/resources/quad8.arg", None, Some(re))
     }
 
     // helper function

--- a/src/test/scala/geotrellis/data/arg/ArgTest.scala
+++ b/src/test/scala/geotrellis/data/arg/ArgTest.scala
@@ -1,0 +1,69 @@
+package geotrellis.data.arg
+
+import geotrellis._
+import geotrellis.data._
+import geotrellis.data.arg._
+import geotrellis.operation._
+import geotrellis.process._
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ArgTest extends FunSuite {
+  val server = TestServer()
+
+  val data = IntArrayRasterData(Array(NODATA, -1, 2, -3,
+                                      4, -5, 6, -7,
+                                      8, -9, 10, -11,
+                                      12, -13, 14, -15))
+  val e = Extent(10.0, 11.0, 14.0, 15.0)
+  val re = RasterExtent(e, 1.0, 1.0, 4, 4)
+  val raster = Raster(data, re)
+
+  def loadRaster(path:String) = server.run(LoadFile(path))
+  def loadRasterData(path:String) = loadRaster(path).data.asArray
+
+  test("test float compatibility") {
+    assert(java.lang.Double.isNaN(data.applyDouble(0)))
+    assert(data.apply(0) === NODATA)
+
+    assert(data.applyDouble(1) === -1.0)
+    assert(data.apply(1) === -1)
+  }
+
+  test("write all supported arg datatypes") {
+    ArgWriter(TypeByte).write("/tmp/foo-int8.arg", raster, "foo-int8")
+    ArgWriter(TypeShort).write("/tmp/foo-int16.arg", raster, "foo-int16")
+    ArgWriter(TypeInt).write("/tmp/foo-int32.arg", raster, "foo-int32")
+    ArgWriter(TypeFloat).write("/tmp/foo-float32.arg", raster, "foo-float32")
+    ArgWriter(TypeDouble).write("/tmp/foo-float64.arg", raster, "foo-float64")
+  }
+
+  test("check int8") {
+    assert(loadRasterData("/tmp/foo-int8.arg") === data)
+  }
+
+  test("check int16") {
+    assert(loadRasterData("/tmp/foo-int16.arg") === data)
+  }
+
+  test("check int32") {
+    assert(loadRasterData("/tmp/foo-int32.arg") === data)
+  }
+
+  test("check float32") {
+    val d = loadRasterData("/tmp/foo-float32.arg")
+    assert(java.lang.Double.isNaN(d.applyDouble(0)))
+    assert(d.applyDouble(1) === -1.0)
+    assert(d.applyDouble(2) === 2.0)
+  }
+
+  test("check float64") {
+    val d = loadRasterData("/tmp/foo-float64.arg")
+    assert(java.lang.Double.isNaN(d.applyDouble(0)))
+    assert(d.applyDouble(1) === -1.0)
+    assert(d.applyDouble(2) === 2.0)
+  }
+}

--- a/tasks/src/main/scala/geotrellis/run/GeotiffImporter.scala
+++ b/tasks/src/main/scala/geotrellis/run/GeotiffImporter.scala
@@ -2,10 +2,10 @@ package geotrellis.run
 
 import com.beust.jcommander._
 
-import geotrellis.data.GeoTiffReader
-import geotrellis.data.Arg32Writer
-import geotrellis.process.{Server}
-import geotrellis.operation.LoadFile
+import geotrellis._
+import geotrellis.data._
+import geotrellis.data.arg._
+import geotrellis.operation._
 import geotrellis.process._
 
 
@@ -53,7 +53,7 @@ object GeotiffImporter {
     val version = "1.0"
     
     println("Converting geotiff: " + inpath)
-    val writer = Arg32Writer.write(outpath, raster, name)
+    val writer = ArgWriter(TypeInt).write(outpath, raster, name)
 
     println("ARG file generated: " + outpath )
 

--- a/tasks/src/main/scala/geotrellis/run/RemoteClient.scala
+++ b/tasks/src/main/scala/geotrellis/run/RemoteClient.scala
@@ -80,7 +80,7 @@ object RemoteClient {
 
     for (i <- 0 until cols * rows) data(i) = Random.nextInt() % 1000000
 
-    val r1 = IntRaster(Array.fill(cols * rows)(3), re)
+    val r1 = Raster(Array.fill(cols * rows)(3), re)
     println("CLIENT: Started application.")
     while (true) {
       val remoteOp = AddConstant(r1,3)

--- a/tasks/src/main/scala/geotrellis/run/TileRaster.scala
+++ b/tasks/src/main/scala/geotrellis/run/TileRaster.scala
@@ -2,20 +2,15 @@ package geotrellis.run
 
 import java.util.Calendar
 
-import geotrellis.data.GeoTiffReader
-import geotrellis.data.Arg32Writer
-import geotrellis.process.{Server}
-import geotrellis.operation.LoadFile
-import geotrellis.process._
 import geotrellis._
+import geotrellis.data._
+import geotrellis.process._
 import geotrellis.operation._
 import geotrellis.raster._
 
 object TileRaster {
   def error(msg:String) {
-    if (msg.length > 0) {
-      Console.printf("ERROR: %s\n\n", msg)
-    }
+    if (msg.length > 0) Console.printf("ERROR: %s\n\n", msg)
     Console.printf("usage: geotif-to-arg32.scala INPATH NAME OUTPATH\n")
     sys.exit(1)
   }
@@ -32,19 +27,14 @@ object TileRaster {
 
   def execute(inpath:String, name:String, outpath:String) {
     val server = Server("script", Catalog.empty("script"))
-
     println("Loading file: " + inpath)
     val raster = server.run(LoadFile(inpath))
-    server.shutdown()
-    //val reader = new GeoTiffReader(inpath, server)
-    //val raster = reader.loadRaster
-   
 
-    val trd = Tiler.createTileRasterData(raster, 256)
-    Tiler.writeTiles(trd, name, outpath)
- 
+    val trd = Tiler.createTiledRasterData(raster, 256, 256)
+    Tiler.writeTiles(trd, raster.rasterExtent, name, outpath)
+
     println("Creating tiled raster: " + inpath)
-
+    server.shutdown()
   }
 }
 


### PR DESCRIPTION
This change fixes a number of problems with the existing Reader/Writer traits,
as well as their subclasses. In particular:
1. Unifies the various ARG readers/writers
2. Fixes some bugs with float32/float64 rasters
3. Fixes some other bugs with int16 rasters
4. Adds some ARG tests
5. Allow the "raster reader" to correctly handle types other than int32.
6. Allow tiled rasters to correctly read/write various tile formats

There is still some work to be done on cleaning up the Reader/Writer
interfaces, as well as possibly migrating things like the ascii grid and
geotiff formats away.
