### PR TITLE
Support GeoTiff encoding with other sample widths/types.

### DIFF
--- a/src/main/scala/geotrellis/data/geotiff.scala
+++ b/src/main/scala/geotrellis/data/geotiff.scala
@@ -119,9 +119,16 @@ object GeoTiffWriter extends Writer {
 
   import geotrellis.data.geotiff._
 
-  val geoTiffSettings = Settings(IntSample, Signed, esriCompat = false)
+  //val geoTiffSettings = Settings(IntSample, Signed, esriCompat = false)
 
   def write(path:String, raster:Raster, name:String) {
-    Encoder.writePath(path, raster, geoTiffSettings)
+    val settings = raster.data.getType match {
+      case TypeBit | TypeByte => Settings(ByteSample, Signed, false)
+      case TypeShort => Settings(ShortSample, Signed, false)
+      case TypeInt => Settings(IntSample, Signed, false)
+      case TypeFloat => Settings(IntSample, Floating, false)
+      case TypeDouble => Settings(LongSample, Floating, false)
+    }
+    Encoder.writePath(path, raster, settings)
   }
 }

--- a/src/main/scala/geotrellis/data/geotiff/SampleSize.scala
+++ b/src/main/scala/geotrellis/data/geotiff/SampleSize.scala
@@ -1,5 +1,7 @@
 package geotrellis.data.geotiff
 
+//TODO: should probably not be named Int/Long since Float/Double use those too.
+
 /**
  * SampleSize is used by geotiff.Settings to indicate how wide each sample
  * (i.e. each raster cell) will be. Currently we only support 8-, 16-, and
@@ -10,3 +12,4 @@ sealed abstract class SampleSize(val bits:Int)
 case object ByteSample extends SampleSize(8)
 case object ShortSample extends SampleSize(16)
 case object IntSample extends SampleSize(32)
+case object LongSample extends SampleSize(64)

--- a/src/test/scala/geotrellis/data/geotiff.scala
+++ b/src/test/scala/geotrellis/data/geotiff.scala
@@ -91,5 +91,13 @@ class GeoTiffSpec extends Spec with MustMatchers with ShouldMatchers {
       val outpath = "/tmp/written.tif"
       GeoTiffWriter.write(outpath, raster, name)
     }
+
+    it ("should write floating point rasters") {
+      val e = Extent(100.0, 400.0, 120.0, 420.0)
+      val re = RasterExtent(e, 10.0, 10.0, 2, 2)
+      val data = DoubleArrayRasterData(Array(11.0, 22.0, 33.0, 44.0))
+      val r = Raster(data, re)
+      GeoTiffWriter.write("/tmp/float.tif", r, "float")
+    }
   }
 }


### PR DESCRIPTION
Previously, we were hardcoding signed 32-bit integers. Now we can support
signed 8-, 16-, and 32-bit integers as well as 32- and 64-bit floats.
