### PR TITLE
Add RasterData classes for representing constant values.

### DIFF
--- a/src/main/scala/geotrellis/RasterData.scala
+++ b/src/main/scala/geotrellis/RasterData.scala
@@ -1,7 +1,5 @@
 package geotrellis
 
-import sys.error
-
 import geotrellis.raster._
 
 object RasterData {

--- a/src/main/scala/geotrellis/raster/DoubleConstant.scala
+++ b/src/main/scala/geotrellis/raster/DoubleConstant.scala
@@ -1,0 +1,27 @@
+package geotrellis.raster
+
+import geotrellis._
+
+final case class DoubleConstant(n:Double, size:Int) extends StrictRasterData {
+  def getType = TypeDouble
+  def apply(i:Int) = n.asInstanceOf[Int]
+  override def applyDouble(i:Int) = n
+  def length = size
+  def alloc(size:Int) = DoubleArrayRasterData.empty(size)
+  def mutable = Option(DoubleArrayRasterData(Array.fill(size)(n)))
+  def copy = this
+
+  override def combine2(other:RasterData)(f:(Int,Int) => Int) = other.map(z => f(n.toInt, z))
+  override def map(f:Int => Int) = IntConstant(f(n.toInt), size)
+  override def mapIfSet(f:Int => Int) = if (n != NODATA) map(f) else this
+  override def foreach(f: Int => Unit) = foreachDouble(z => f(z.toInt))
+
+  override def combineDouble2(other:RasterData)(f:(Double,Double) => Double) = other.mapDouble(z => f(n, z))
+  override def mapDouble(f:Double => Double) = DoubleConstant(f(n), size)
+  override def mapIfSetDouble(f:Double => Double) = if (n != NODATA) mapDouble(f) else this
+  override def foreachDouble(f: Double => Unit) = {
+    var i = 0
+    val len = length
+    while (i < len) { f(n); i += 1 }
+  }
+}

--- a/src/main/scala/geotrellis/raster/IntConstant.scala
+++ b/src/main/scala/geotrellis/raster/IntConstant.scala
@@ -1,0 +1,27 @@
+package geotrellis.raster
+
+import geotrellis._
+
+final case class IntConstant(n:Int, size:Int) extends StrictRasterData {
+  def getType = TypeInt
+  def apply(i:Int) = n
+  def length = size
+  def alloc(size:Int) = IntArrayRasterData.empty(size)
+  def mutable = Option(IntArrayRasterData(Array.fill(size)(n)))
+  def copy = this
+
+  override def combine2(other:RasterData)(f:(Int,Int) => Int) = other.map(z => f(n, z))
+  override def map(f:Int => Int) = IntConstant(f(n), size)
+  override def mapIfSet(f:Int => Int) = if (n != NODATA) map(f) else this
+
+  override def foreach(f: Int => Unit) {
+    var i = 0
+    val len = length
+    while (i < len) { f(n); i += 1 }
+  }
+
+  override def combineDouble2(other:RasterData)(f:(Double,Double) => Double) = other.mapDouble(z => f(n, z))
+  override def mapDouble(f:Double => Double) = DoubleConstant(f(n), size)
+  override def mapIfSetDouble(f:Double => Double) = if (n != NODATA) mapDouble(f) else this
+  override def foreachDouble(f: Double => Unit) = foreach(z => f(z))
+}

--- a/src/test/scala/geotrellis/raster/DoubleConstantTest.scala
+++ b/src/test/scala/geotrellis/raster/DoubleConstantTest.scala
@@ -1,0 +1,35 @@
+package geotrellis.raster
+
+import geotrellis._
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class DoubleConstantTest extends FunSuite {
+  val size = 4
+
+  test("building") {
+    val d1 = DoubleConstant(99.0, size)
+    val d2 = DoubleArrayRasterData(Array.fill(size)(99.0))
+    assert(d1 === d2)
+  }
+
+  test("basic operations") {
+    val d = DoubleConstant(99.0, size)
+
+    assert(d.length === size)
+    assert(d.getType === TypeDouble)
+    assert(d(0) === 99.0)
+    assert(d.applyDouble(0) === 99.0)
+  }
+
+  test("map") {
+    val d1 = DoubleConstant(99.0, size)
+    val d2 = d1.mapDouble(_ + 1.0)
+
+    assert(d2.isInstanceOf[DoubleConstant])
+    assert(d2(0) === 100.0)
+  }
+}

--- a/src/test/scala/geotrellis/raster/IntConstantTest.scala
+++ b/src/test/scala/geotrellis/raster/IntConstantTest.scala
@@ -1,0 +1,35 @@
+package geotrellis.raster
+
+import geotrellis._
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class IntConstantTest extends FunSuite {
+  val size = 4
+
+  test("building") {
+    val d1 = IntConstant(99, size)
+    val d2 = IntArrayRasterData(Array.fill(size)(99))
+    assert(d1 === d2)
+  }
+
+  test("basic operations") {
+    val d = IntConstant(99, size)
+
+    assert(d.length === size)
+    assert(d.getType === TypeInt)
+    assert(d(0) === 99)
+    assert(d.applyDouble(0) === 99.0)
+  }
+
+  test("map") {
+    val d1 = IntConstant(99, size)
+    val d2 = d1.map(_ + 1)
+
+    assert(d2.isInstanceOf[IntConstant])
+    assert(d2(0) === 100)
+  }
+}


### PR DESCRIPTION
This commit adds IntConstant and DoubleConstant which are intended to be
efficient representations of a raster consisting entirely of one value.
