### PR TITLE
Add support layout.json, a file specifying tiled raster metadata.

### DIFF
--- a/src/main/scala/geotrellis/Operation.scala
+++ b/src/main/scala/geotrellis/Operation.scala
@@ -92,6 +92,8 @@ class Context (server:Server) {
     server.getRaster(path, None, Option(g))
   }
 
+  def loadTileSet(path:String):Raster = Raster.loadTileSet(path, server)
+
   def getRaster(path:String, layer:RasterLayer, re:RasterExtent):Raster = {
     server.getRaster(path, Option(layer), Option(re))
   }

--- a/src/main/scala/geotrellis/io/LoadTileSet.scala
+++ b/src/main/scala/geotrellis/io/LoadTileSet.scala
@@ -1,0 +1,17 @@
+package geotrellis.io
+
+import geotrellis._
+import geotrellis.process._
+
+/**
+ * Load the a set of tiles the specified directory.
+ *
+ * This directory must contain a layout.json file as well as tiles written
+ * in the ARG format.
+ */
+case class LoadTileSet(path:Op[String]) extends Op[Raster] {
+  def _run(context:Context) = runAsync(path :: context :: Nil)
+  val nextSteps:Steps = {
+    case (p:String) :: (c:Context) :: Nil => Result(c.loadTileSet(p))
+  }
+}

--- a/src/main/scala/geotrellis/util.scala
+++ b/src/main/scala/geotrellis/util.scala
@@ -82,6 +82,8 @@ object Filesystem {
     ByteBuffer.wrap(slurp(path, bs), pos, size)
   }
 
+  def join(parts:String*) = parts.mkString(File.separator)
+
   //def findFiles(f:File, r:Regex):Array[File] = {
   //  val these = f.listFiles
   //  val good = these.filter(f => r.findFirstIn(f.getName).isDefined)

--- a/src/test/resources/tiles/layout.json
+++ b/src/test/resources/tiles/layout.json
@@ -1,0 +1,24 @@
+{
+  "layer": "my layer name",
+
+  "type": "tiled",
+  "datatype": "int32",
+
+  "xmin": 0.0,
+  "ymin": 0.0,
+  "xmax": 800.0,
+  "ymax": 800.0,
+
+  "cellheight": 10.0,
+  "cellwidth": 10.0,
+
+  "tile_base": "tile"
+  "layout_cols": 4,
+  "layout_rows": 4,
+  "pixel_cols": 20,
+  "pixel_rows": 20,
+
+  "xskew": 0.0,
+  "yskew": 0.0
+  "epsg": 3785,
+}

--- a/src/test/scala/geotrellis/raster/tiles.scala
+++ b/src/test/scala/geotrellis/raster/tiles.scala
@@ -125,11 +125,11 @@ class TileSpec extends Spec with MustMatchers {
   describe("Tiler") {
     it ("should build a tiled raster from a source raster") {
       val tileRaster2 = Tiler.createTiledRaster(raster, 2, 2)
-      println(raster.asciiDraw)
-      println(tileRaster2.asciiDraw)
+      //println(raster.asciiDraw)
+      //println(tileRaster2.asciiDraw)
 
       for (y <- 0 to 4; x <- 0 to 4) {
-        println("x=%s y=%s" format (x, y))
+        //println("x=%s y=%s" format (x, y))
         tileRaster2.get(x, y) must be === ((y * 5) + x) + 1
       }
 
@@ -146,7 +146,6 @@ class TileSpec extends Spec with MustMatchers {
     it("can be built from in-memory tiles") {
       val s = TestServer()
       val extent = Extent(1, 21, 79, 59)
-      //val loader = Tiler.makeTileLoader("testraster", "/tmp", s)
       val raster4 = Raster(tileData, g)
       for (y <- 2 to 3; x <- 0 to 3) {
         raster4.get(x, y) must be === ((y * 5) + x) + 1
@@ -155,22 +154,34 @@ class TileSpec extends Spec with MustMatchers {
 
     it("can write and read tiles to disk") {
       val trd = Tiler.createTiledRasterData(raster, 2, 2)
-      Tiler.writeTiles(trd, raster.rasterExtent, "testraster", "/tmp")
+      Tiler.writeTiles(trd, raster.rasterExtent, "testraster", "/tmp/foo")
 
       val s = TestServer()
       val extent = Extent(1, 21, 79, 59)
-      val tileSetRD = TileSetRasterData("/tmp", "testraster", TypeInt, layout, s)
+      val tileSetRD = TileSetRasterData("/tmp/foo", "testraster", TypeInt, layout, s)
 
       val raster4 = Raster(tileSetRD, g)
       for (y <- 0 to 3; x <- 0 to 3) {
         val expected = ((y * 5) + x) + 1
         raster4.get(x, y) must be === ((y * 5) + x) + 1
       }
+
+      val raster5 = Raster.loadTileSet("/tmp/foo", server)
+      for (y <- 0 to 3; x <- 0 to 3) {
+        val expected = ((y * 5) + x) + 1
+        raster5.get(x, y) must be === ((y * 5) + x) + 1
+      }
+
+      val raster6 = server.run(io.LoadTileSet("/tmp/foo"))
+      for (y <- 0 to 3; x <- 0 to 3) {
+        val expected = ((y * 5) + x) + 1
+        raster6.get(x, y) must be === ((y * 5) + x) + 1
+      }
     }
 
     it("can delete tiles from the disk") {
       val trd = Tiler.createTiledRasterData(raster, 2, 2)
-      Tiler.deleteTiles(trd, "testraster", "/tmp")
+      Tiler.deleteTiles(trd, "testraster", "/tmp/foo")
     }
   }
   


### PR DESCRIPTION
This includes support for writing this file (via Tiler), for reading it (via
Raster.loadTileSet) and also includes operations for loading rasters with tiled
data (i.e. io.LoadTileSet("/path/to/tiles")).
