### PR TITLE
Upgrade tests to scalatest 2.0.M4.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,7 +21,7 @@ object MyBuild extends Build {
     javaOptions in run += "-Xmx2G",
 
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "1.6.1" % "test",
+      "org.scalatest" %% "scalatest" % "2.0.M4" % "test",
       "junit" % "junit" % "4.5" % "test",
       "com.vividsolutions" % "jts" % "1.8",
       "java3d" % "j3d-core" % "1.3.1",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,12 @@
+libraryDependencies ++= Seq(
+  "org.jacoco" % "org.jacoco.core" % "0.5.9.201207300726" artifacts(Artifact("org.jacoco.core", "jar", "jar")),
+  "org.jacoco" % "org.jacoco.report" % "0.5.9.201207300726" artifacts(Artifact("org.jacoco.report", "jar", "jar")))
 
+addSbtPlugin("de.johoop" % "jacoco4sbt" % "1.2.4")
 
 resolvers ++= Seq(
   "less is" at "http://repo.lessis.me",
   "coda" at "http://repo.codahale.com")
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.2")
+

--- a/sbt
+++ b/sbt
@@ -4,12 +4,19 @@
 # Author: Paul Phillips <paulp@typesafe.com>
 
 # todo - make this dynamic
-declare -r sbt_release_version=0.11.3
+declare -r sbt_release_version=0.12.0
 declare -r sbt_snapshot_version=0.13.0-SNAPSHOT
 
 unset sbt_jar sbt_dir sbt_create sbt_snapshot sbt_launch_dir
 unset scala_version java_home sbt_explicit_version
 unset verbose debug quiet
+
+for arg in "$@"; do
+  case $arg in
+    -q|-quiet)  quiet=1 ;;
+            *)          ;;
+  esac
+done
 
 build_props_sbt () {
   if [[ -f project/build.properties ]]; then
@@ -50,7 +57,7 @@ sbt_version () {
 }
 
 echoerr () {
-  echo 1>&2 "$@"
+  [[ -z $quiet ]] && echo 1>&2 "$@"
 }
 vlog () {
   [[ $verbose || $debug ]] && echoerr "$@"
@@ -81,7 +88,7 @@ get_mem_opts () {
   (( $perm > 256 )) || perm=256
   (( $perm < 1024 )) || perm=1024
   local codecache=$(( $perm / 2 ))
-  
+
   echo "-Xms${mem}m -Xmx${mem}m -XX:MaxPermSize=${perm}m -XX:ReservedCodeCacheSize=${codecache}m"
 }
 
@@ -94,7 +101,7 @@ make_url () {
   groupid="$1"
   category="$2"
   version="$3"
-  
+
   echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
@@ -105,7 +112,7 @@ declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory
 declare -r sbt_opts_file=".sbtopts"
 declare -r jvm_opts_file=".jvmopts"
 declare -r latest_28="2.8.2"
-declare -r latest_29="2.9.1"
+declare -r latest_29="2.9.2"
 declare -r latest_210="2.10.0-SNAPSHOT"
 
 declare -r script_path=$(get_script_path "$BASH_SOURCE")
@@ -115,7 +122,9 @@ declare -r script_name="$(basename $script_path)"
 # some non-read-onlies set with defaults
 declare java_cmd=java
 declare sbt_launch_dir="$script_dir/.lib"
+declare sbt_universal_launcher="$script_dir/lib/sbt-launch.jar"
 declare sbt_mem=$default_sbt_mem
+declare sbt_jar=$sbt_universal_launcher
 
 # pull -J and -D options to give to java.
 declare -a residual_args
@@ -161,7 +170,7 @@ sbt_artifactory_list () {
   local version=${version0%-SNAPSHOT}
   local url="http://typesafe.artifactoryonline.com/typesafe/ivy-snapshots/$(sbt_groupid)/sbt-launch/"
   dlog "Looking for snapshot list at: $url "
-  
+
   curl -s --list-only "$url" | \
     grep -F $version | \
     perl -e 'print reverse <>' | \
@@ -200,7 +209,7 @@ jar_file () {
 download_url () {
   local url="$1"
   local jar="$2"
-  
+
   echo "Downloading sbt launcher $(sbt_version):"
   echo "  From  $url"
   echo "    To  $jar"
@@ -232,7 +241,7 @@ Usage: $script_name [options]
   -no-colors         disable ANSI color codes
   -sbt-create        start sbt even if current directory contains no sbt project
   -sbt-dir   <path>  path to global settings/plugins directory (default: ~/.sbt/<version>)
-  -sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11 series)
+  -sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11+)
   -ivy       <path>  path to local Ivy repository (default: ~/.ivy2)
   -mem    <integer>  set memory options (default: $sbt_mem, which is
                        $(get_mem_opts $sbt_mem) )
@@ -244,7 +253,7 @@ Usage: $script_name [options]
   # sbt version (default: from project/build.properties if present, else latest release)
   !!! The only way to accomplish this pre-0.12.0 if there is a build.properties file which
   !!! contains an sbt.version property is to update the file on disk.  That's what this does.
-  -sbt-version  <version>   use the specified version of sbt 
+  -sbt-version  <version>   use the specified version of sbt
   -sbt-jar      <path>      use the specified jar as the sbt launcher
   -sbt-snapshot             use a snapshot version of sbt
   -sbt-launch-dir <path>    directory to hold sbt launchers (default: $sbt_launch_dir)
@@ -308,7 +317,7 @@ process_args ()
     local type="$1"
     local opt="$2"
     local arg="$3"
-    
+
     if [[ -z "$arg" ]] || [[ "${arg:0:1}" == "-" ]]; then
       die "$opt requires <$type> argument"
     fi
@@ -350,16 +359,16 @@ process_args ()
               *) addResidual "$1" && shift ;;
     esac
   done
-  
+
   [[ $debug ]] && {
     case $(sbt_version) in
-     0.7.*) addSbt "debug" ;; 
+     0.7.*) addSbt "debug" ;;
          *) addSbt "set logLevel in Global := Level.Debug" ;;
     esac
   }
   [[ $quiet ]] && {
     case $(sbt_version) in
-     0.7.*) ;; 
+     0.7.*) ;;
          *) addSbt "set logLevel in Global := Level.Error" ;;
     esac
   }
@@ -385,7 +394,7 @@ argumentCount=$#
 
 # Update build.properties no disk to set explicit version - sbt gives us no choice
 [[ -n "$sbt_explicit_version" ]] && update_build_props_sbt "$sbt_explicit_version"
-echo "Detected sbt version $(sbt_version)"
+echoerr "Detected sbt version $(sbt_version)"
 
 [[ -n "$scala_version" ]] && echo "Overriding scala version to $scala_version"
 
@@ -416,7 +425,7 @@ EOM
 [[ -n "$sbt_dir" ]] || {
   sbt_dir=~/.sbt/$(sbt_version)
   addJava "-Dsbt.global.base=$sbt_dir"
-  echo "Using $sbt_dir as sbt dir, -sbt-dir to override."
+  echoerr "Using $sbt_dir as sbt dir, -sbt-dir to override."
 }
 
 # since sbt 0.7 doesn't understand iflast

--- a/src/main/scala/geotrellis/rest/op/string/ParseRasterExtent.scala
+++ b/src/main/scala/geotrellis/rest/op/string/ParseRasterExtent.scala
@@ -1,10 +1,10 @@
 package geotrellis.rest.op.string
 
 import geotrellis._
-import geotrellis.raster.op._
+import geotrellis.raster.op.extent.GetRasterExtent
 
 object ParseRasterExtent {
   def apply(bbox:Op[String], colsOp:Op[String], rowsOp:Op[String]) = {
-    extent.GetRasterExtent(ParseExtent(bbox), ParseInt(colsOp), ParseInt(rowsOp))
+    GetRasterExtent(ParseExtent(bbox), ParseInt(colsOp), ParseInt(rowsOp))
   }
 }

--- a/src/test/resources/data/constant.json
+++ b/src/test/resources/data/constant.json
@@ -1,0 +1,17 @@
+{
+  "cellheight": 8.0, 
+  "cellwidth": 8.0, 
+  "cols": 20, 
+  "datatype": "int32", 
+  "epsg": 3785, 
+  "layer": "constant",
+  "rows": 20, 
+  "type": "arg", 
+  "xmax": 150.5, 
+  "xmin": -9.5, 
+  "xskew": 0.0, 
+  "ymax": 163.8, 
+  "ymin": 3.8, 
+  "yskew": 0.0,
+  "constant": 5
+}

--- a/src/test/scala/geotrellis/RasterExtentSpec.scala
+++ b/src/test/scala/geotrellis/RasterExtentSpec.scala
@@ -1,12 +1,12 @@
 package geotrellis
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 //import org.junit.runner.RunWith
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class RasterExtentSpec extends Spec with MustMatchers with ShouldMatchers {
+class RasterExtentSpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("A RasterExtent object") {
     val e1 = Extent(0.0, 0.0, 1.0, 1.0)
     val e2 = Extent(0.0, 0.0, 20.0, 20.0)

--- a/src/test/scala/geotrellis/bugs/example2.scala
+++ b/src/test/scala/geotrellis/bugs/example2.scala
@@ -4,7 +4,7 @@ import geotrellis._
 
 import geotrellis.process._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 case class Timer[T](f:() => T) {
@@ -14,4 +14,4 @@ case class Timer[T](f:() => T) {
   val time = t1 - t0
 }
 
-class ExampleTwoSpec extends Spec with MustMatchers {}
+class ExampleTwoSpec extends FunSpec with MustMatchers {}

--- a/src/test/scala/geotrellis/core/histo.scala
+++ b/src/test/scala/geotrellis/core/histo.scala
@@ -5,13 +5,13 @@ import math.round
 import scala.util.Random
 import Console.printf
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 import geotrellis.statistics._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class HistogramSpec extends Spec with MustMatchers with ShouldMatchers {
+class HistogramSpec extends FunSpec with MustMatchers with ShouldMatchers {
   def stringToInts(s:String) = {
     s.toCharArray.map { _.toByte - 32 }
   }

--- a/src/test/scala/geotrellis/core/tile.scala
+++ b/src/test/scala/geotrellis/core/tile.scala
@@ -1,13 +1,13 @@
 package geotrellis.core
 
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 import geotrellis.raster.TileUtils._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class TileSpec extends Spec with MustMatchers {
+class TileSpec extends FunSpec with MustMatchers {
   describe("Web Mercator Tile Utilities") {
 
     // 340 n 12th St

--- a/src/test/scala/geotrellis/data/ExtentSpec.scala
+++ b/src/test/scala/geotrellis/data/ExtentSpec.scala
@@ -5,12 +5,12 @@ import geotrellis._
 import geotrellis.process._
 import geotrellis.raster.op._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ExtentSpec extends Spec with MustMatchers with ShouldMatchers {
+class ExtentSpec extends FunSpec with MustMatchers with ShouldMatchers {
 
   def re(pt:(Double, Double), cs:(Double, Double), ncols:Int, nrows:Int) = {
     val (x1, y1) = pt

--- a/src/test/scala/geotrellis/data/arg.scala
+++ b/src/test/scala/geotrellis/data/arg.scala
@@ -1,6 +1,6 @@
 package geotrellis.data.arg
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
@@ -12,7 +12,7 @@ import geotrellis.raster._
 import geotrellis.data._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ArgSpec extends Spec with MustMatchers with ShouldMatchers {
+class ArgSpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("An ArgReader") {
     val server = TestServer()
     val path1 = "src/test/resources/fake.img8.arg"

--- a/src/test/scala/geotrellis/data/arg32.scala
+++ b/src/test/scala/geotrellis/data/arg32.scala
@@ -6,14 +6,14 @@ import geotrellis.raster._
 
 import java.io.{DataInputStream, FileInputStream}
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 import scala.math.abs
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class Arg32Spec extends Spec with MustMatchers with ShouldMatchers {
+class Arg32Spec extends FunSpec with MustMatchers with ShouldMatchers {
   val nd = NODATA
 
   describe("An Arg32Reader") {

--- a/src/test/scala/geotrellis/data/ascii.scala
+++ b/src/test/scala/geotrellis/data/ascii.scala
@@ -6,12 +6,12 @@ import geotrellis.raster._
 
 import geotrellis._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class AsciiSpec extends Spec with MustMatchers with ShouldMatchers {
+class AsciiSpec extends FunSpec with MustMatchers with ShouldMatchers {
   val server = TestServer()
 
   val data:Array[Int] = (1 to 100).toArray

--- a/src/test/scala/geotrellis/data/color.scala
+++ b/src/test/scala/geotrellis/data/color.scala
@@ -1,10 +1,10 @@
 package geotrellis.data
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ColorSpec extends Spec with MustMatchers {
+class ColorSpec extends FunSpec with MustMatchers {
   describe("LinearColorRangeChooser(FF0000,0000FF)") {
     val c = new LinearColorRangeChooser(0xFF0000, 0x0000FF)
     val c2 = new MultiColorRangeChooser(Array(0xFF0000, 0x0000FF))

--- a/src/test/scala/geotrellis/data/geotiff.scala
+++ b/src/test/scala/geotrellis/data/geotiff.scala
@@ -6,7 +6,7 @@ import geotrellis.raster._
 import geotrellis.statistics.FastMapHistogram
 import geotrellis.statistics.op._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
@@ -36,7 +36,7 @@ import org.geotools.coverage.grid.{GridCoordinates2D}
 //xyz
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class GeoTiffSpec extends Spec with MustMatchers with ShouldMatchers {
+class GeoTiffSpec extends FunSpec with MustMatchers with ShouldMatchers {
   val server = TestServer()
 
   describe("A GeoTiffReader") {

--- a/src/test/scala/geotrellis/data/intraster.scala
+++ b/src/test/scala/geotrellis/data/intraster.scala
@@ -1,6 +1,6 @@
 package geotrellis.data
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
@@ -9,7 +9,7 @@ import geotrellis.process.TestServer
 import geotrellis.{Extent,RasterExtent}
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class RasterReaderSpec extends Spec with MustMatchers with ShouldMatchers {
+class RasterReaderSpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("An RasterReader") {
     it ("should work") {
       val e = Extent(-9.5, 3.8, 80 + -9.5, 80 + 3.8)

--- a/src/test/scala/geotrellis/data/pg/pg.scala
+++ b/src/test/scala/geotrellis/data/pg/pg.scala
@@ -1,6 +1,6 @@
 package geotrellis.data.pg
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 import scala.collection.mutable.Map
@@ -16,7 +16,7 @@ import geotrellis.data._
 // This test is disabled for now because it won't work for most users.
 
 //@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-//class PgSpec extends Spec with MustMatchers {
+//class PgSpec extends FunSpec with MustMatchers {
 //  Class.forName("org.postgis.DriverWrapper")
 //  describe("postgis connection") {
 //    it ("should connect to a postgis server at 192.168.16.75") {

--- a/src/test/scala/geotrellis/data/png/png.scala
+++ b/src/test/scala/geotrellis/data/png/png.scala
@@ -8,10 +8,10 @@ import java.io.{File,FileInputStream}
 import geotrellis._
 import geotrellis.data.png._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
-class PNGSpec extends Spec with MustMatchers {
+class PNGSpec extends FunSpec with MustMatchers {
 
   def parseHexByte(s:String) = Integer.parseInt(s, 16).toByte
   def parseHexBytes(cs:Array[String]) = cs.map(parseHexByte _)

--- a/src/test/scala/geotrellis/extent/extent.scala
+++ b/src/test/scala/geotrellis/extent/extent.scala
@@ -1,13 +1,13 @@
 package geotrellis.extent
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 import geotrellis.Extent;
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ExtentSpec extends Spec with MustMatchers with ShouldMatchers {
+class ExtentSpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("An Extent object") {
     it("should die when invalid #1") {
       evaluating {

--- a/src/test/scala/geotrellis/feature/feature.scala
+++ b/src/test/scala/geotrellis/feature/feature.scala
@@ -1,18 +1,18 @@
 package geotrellis.feature
 
 import geotrellis._
-import geotrellis.feature.op.geometry._
+import geotrellis.feature.op.geometry.{Buffer,GetCentroid}
 import geotrellis.process._
 import geotrellis.feature._
-
 import math.{max,min,round}
-
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
+import geotrellis.feature.op.geometry.GetEnvelope
+import geotrellis.feature.op.geometry.Intersect
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class FeatureSpec extends Spec with MustMatchers with ShouldMatchers {
+class FeatureSpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("Buffer") {
     it("should buffer") {
       val s = TestServer()

--- a/src/test/scala/geotrellis/geometry/geometry.scala
+++ b/src/test/scala/geotrellis/geometry/geometry.scala
@@ -2,12 +2,12 @@ package geotrellis.geometry
 
 import math.{max,min,round}
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class GeometrySpec extends Spec with MustMatchers with ShouldMatchers {
+class GeometrySpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("A Point") {
     it("should build #1") {
       val p = Point(3.0, 4.0, 0, null)

--- a/src/test/scala/geotrellis/geometry/grid.scala
+++ b/src/test/scala/geotrellis/geometry/grid.scala
@@ -6,11 +6,11 @@ import geotrellis._
 import geotrellis.raster._
 import geotrellis.{Extent,RasterExtent}
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
-class GridPolygonSpec extends Spec with MustMatchers with ShouldMatchers {
+class GridPolygonSpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("A GridPoint") {
     it("should build") {
       val p1 = new GridPoint(0, 0)

--- a/src/test/scala/geotrellis/geometry/rasterizer.scala
+++ b/src/test/scala/geotrellis/geometry/rasterizer.scala
@@ -6,7 +6,7 @@ import geotrellis._
 import geotrellis.geometry.{Polygon}
 import geotrellis.geometry.grid.{GridPoint, GridLine, GridPolygon}
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
@@ -31,7 +31,7 @@ object RasterizerSpec {
   }
 }
 
-class RasterizerSpec extends Spec with MustMatchers with ShouldMatchers {
+class RasterizerSpec extends FunSpec with MustMatchers with ShouldMatchers {
   val mkline = (x1:Int, y1:Int, x2:Int, y2:Int) => {
     new GridLine(new GridPoint(x1, y1), new GridPoint(x2, y2))
   }

--- a/src/test/scala/geotrellis/op/BinaryLocalSpec.scala
+++ b/src/test/scala/geotrellis/op/BinaryLocalSpec.scala
@@ -6,12 +6,12 @@ import geotrellis.raster.op.local.{AddConstant,MultiplyConstant}
 import geotrellis.raster._
 import geotrellis._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class BinaryLocalSpec extends Spec with MustMatchers with ShouldMatchers {
+class BinaryLocalSpec extends FunSpec with MustMatchers with ShouldMatchers {
   def f(op:Op[Raster]) = local.AddConstant(op, 1)
 
   describe("The BinaryLocal operation (Subtract)") {

--- a/src/test/scala/geotrellis/op/DoCell.scala
+++ b/src/test/scala/geotrellis/op/DoCell.scala
@@ -14,12 +14,12 @@ import geotrellis.statistics._
 import geotrellis.raster.op._
 import geotrellis.process._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class DoCellSpec extends Spec with MustMatchers with ShouldMatchers {
+class DoCellSpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("the DoCell operation") {
     val rasterExtent = RasterExtent(Extent(0.0, 0.0, 100.0, 80.0), 20.0, 20.0, 5, 4)
     val server = TestServer()

--- a/src/test/scala/geotrellis/op/Literal.scala
+++ b/src/test/scala/geotrellis/op/Literal.scala
@@ -3,12 +3,12 @@ package geotrellis.op
 import geotrellis.process._
 import geotrellis._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class LiteralSpec extends Spec with MustMatchers with ShouldMatchers {
+class LiteralSpec extends FunSpec with MustMatchers with ShouldMatchers {
   val server = TestServer()
 
   describe("The Literal operation") {

--- a/src/test/scala/geotrellis/op/StandardDeviation.scala
+++ b/src/test/scala/geotrellis/op/StandardDeviation.scala
@@ -5,12 +5,12 @@ import geotrellis._
 import geotrellis.raster.op._
 import geotrellis.statistics.op.stat._
 import geotrellis.io.LoadFile
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class DeviationRasterSpec extends Spec with MustMatchers with ShouldMatchers {
+class DeviationRasterSpec extends FunSpec with MustMatchers with ShouldMatchers {
   val server = TestServer()
 
   describe("The DeviationRaster operation") {

--- a/src/test/scala/geotrellis/op/UnaryLocalSpec.scala
+++ b/src/test/scala/geotrellis/op/UnaryLocalSpec.scala
@@ -7,12 +7,12 @@ import geotrellis.raster.op.local._
 import geotrellis.raster._
 import geotrellis._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class UnaryLocalSpec extends Spec with MustMatchers with ShouldMatchers {
+class UnaryLocalSpec extends FunSpec with MustMatchers with ShouldMatchers {
   def f(op:Op[Raster]) = AddConstant(op, 1)
 
   describe("The UnaryLocal operation (AddConstant)") {

--- a/src/test/scala/geotrellis/op/int.scala
+++ b/src/test/scala/geotrellis/op/int.scala
@@ -19,12 +19,12 @@ import geotrellis.raster.op.transform.{ResampleRaster}
 import geotrellis.raster.op.CreateRaster
 import geotrellis.statistics.op.stat._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class IntSpecX extends Spec with MustMatchers with ShouldMatchers {
+class IntSpecX extends FunSpec with MustMatchers with ShouldMatchers {
   val rasterExtent = RasterExtent(Extent(0.0, 0.0, 100.0, 80.0), 20.0, 20.0, 5, 4)
 
   describe("The operations include") {

--- a/src/test/scala/geotrellis/op/logic/ForEach.scala
+++ b/src/test/scala/geotrellis/op/logic/ForEach.scala
@@ -12,12 +12,12 @@ import geotrellis.statistics._
 import geotrellis.process._
 import geotrellis._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class ForEachSpec extends Spec with MustMatchers with ShouldMatchers {
+class ForEachSpec extends FunSpec with MustMatchers with ShouldMatchers {
   val server = TestServer()
 
   describe("The ForEach operation") {

--- a/src/test/scala/geotrellis/process/cache.scala
+++ b/src/test/scala/geotrellis/process/cache.scala
@@ -1,12 +1,12 @@
 
 package geotrellis.process
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import scala.concurrent.Lock
 import scala.concurrent.ThreadRunner
 
-class LRUCacheSpec extends Spec with MustMatchers {
+class LRUCacheSpec extends FunSpec with MustMatchers {
   
   def f(x: Int):Int = x*100 
 

--- a/src/test/scala/geotrellis/process/catalog.scala
+++ b/src/test/scala/geotrellis/process/catalog.scala
@@ -1,10 +1,10 @@
 package geotrellis.process
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import geotrellis.{Extent,RasterExtent}
 
-class CatalogSpec extends Spec with MustMatchers {
+class CatalogSpec extends FunSpec with MustMatchers {
 
 
 val json0 = """
@@ -56,7 +56,7 @@ val json0 = """
       val catalog = Catalog.fromJSON(json1)
       val store = catalog.stores("stroud:fs")
       val layers = store.getLayers
-      layers.toList.length must be === 3
+      layers.toList.length must be === 4
     } 
   }
 

--- a/src/test/scala/geotrellis/process/error.scala
+++ b/src/test/scala/geotrellis/process/error.scala
@@ -1,6 +1,6 @@
 package geotrellis.process
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 import geotrellis._
@@ -34,7 +34,7 @@ case class LargeWindow(a:Op[Unit], b:Op[Unit]) extends Op2(a,b) ({
   }
 })
 
-class FailingOpSpec extends Spec with MustMatchers {
+class FailingOpSpec extends FunSpec with MustMatchers {
 
 describe("A failing operation") {
     it("should return a StepError") {

--- a/src/test/scala/geotrellis/process/server.scala
+++ b/src/test/scala/geotrellis/process/server.scala
@@ -1,11 +1,11 @@
 package geotrellis.process
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 import geotrellis.{Extent,RasterExtent}
 
-class ServerSpec extends Spec with MustMatchers {
+class ServerSpec extends FunSpec with MustMatchers {
 
 describe("A Server") {
 

--- a/src/test/scala/geotrellis/raster/raster.scala
+++ b/src/test/scala/geotrellis/raster/raster.scala
@@ -2,11 +2,11 @@ package geotrellis.raster
 
 import geotrellis._
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class RasterSpec extends Spec with MustMatchers {
+class RasterSpec extends FunSpec with MustMatchers {
   val e = Extent(0.0, 0.0, 10.0, 10.0)
   val g = RasterExtent(e, 1.0, 1.0, 10, 10)
   describe("A Raster") {

--- a/src/test/scala/geotrellis/raster/tiles.scala
+++ b/src/test/scala/geotrellis/raster/tiles.scala
@@ -1,6 +1,6 @@
 package geotrellis.raster
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 import geotrellis._
@@ -10,7 +10,7 @@ import geotrellis.raster.op.tiles._
 import geotrellis.Implicits._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class TileSpec extends Spec with MustMatchers {
+class TileSpec extends FunSpec with MustMatchers {
   val e = Extent(0.0, 0.0, 100.0, 100.0)
   val g = RasterExtent(e, 20.0, 20.0, 5, 5)
   

--- a/src/test/scala/geotrellis/util/util.scala
+++ b/src/test/scala/geotrellis/util/util.scala
@@ -1,10 +1,10 @@
 package geotrellis.util
 
-import org.scalatest.Spec
+import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class UtilSpec extends Spec with MustMatchers {
+class UtilSpec extends FunSpec with MustMatchers {
   describe("Util package") {
     it("implements time()") {
       val (n, t) = Timer.time { Thread.sleep(100); 99 }


### PR DESCRIPTION
This pull request updates all tests to scalatest 2.0.  This was motivated primarily by the improved integration in the scala IDE for eclipse.
