### PR TITLE
Add in Convolution Operation

### DIFF
--- a/src/main/scala/geotrellis/raster/op/focal/Convolve.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Convolve.scala
@@ -1,0 +1,100 @@
+package geotrellis.raster.op.focal
+
+import geotrellis._
+import scala.math.{max,min}
+
+case class Gaussian(size: Op[Int], cellWidth: Op[Double], sigma: Op[Double], amp: Op[Double]) 
+     extends Op4[Int,Double,Double,Double,Raster](size, cellWidth, sigma, amp)((n,w,sigma,amp) => {
+       val extent = Extent(0,0,n*w,n*w)
+       val rasterExtent = RasterExtent(extent, w, w, n, n)
+       val outputR = Raster.empty(rasterExtent)
+       val output = outputR.data.mutable.get
+
+       var r = 0
+       var c = 0
+       while(r < n) {
+         while(c < n) {
+           val rsqr = (c - n/2)*(c - n/2) + (r - n/2)*(r - n/2)
+           val g = (amp * (math.exp(-rsqr / (2.0*sigma*sigma)))).toInt
+           output.set(c,r,g)
+
+           c += 1
+         }
+         c = 0
+         r += 1
+       }
+
+       Result(outputR)
+     })
+
+case class Convolve(raster: Op[Raster], kernel: Op[Raster]) 
+     extends Op2[Raster, Raster, Raster](raster, kernel)((raster, kernel) => {
+
+       val e = raster.rasterExtent
+       val outputR = Raster.empty(e);
+       val output = outputR.data.mutable.get
+
+       var r = 0
+       var c = 0
+       var r2 = 0 
+       var c2 = 0 
+       var kc = 0 
+       var kr = 0
+
+       val rows = raster.rows
+       val cols = raster.cols
+
+       val rowsk = kernel.rows
+       val colsk = kernel.cols
+
+       while(r < rows) {
+         while(c < cols) {
+           val z = raster.get(c,r)
+
+           if (z != NODATA && z != 0) {
+             r2 = r - rowsk / 2
+             val c2base = c - colsk / 2
+             c2 = c2base
+             kc = 0
+             kr = 0
+
+             val maxr = math.min(r + rowsk / 2 + 1,rows)
+             val maxc = math.min(c + colsk / 2 + 1,cols)
+
+             while(r2 < maxr) {
+               while(c2 < maxc) {               
+                 if (r2 >= 0 && c2 >= 0 && r2 < e.rows && c2 < e.cols &&
+                     kc >= 0 && kr >= 0 && kc < colsk && kr < rowsk) {
+                   val k = kernel.get(kc,kr)
+                   if (k != NODATA) {
+                     val o = output.get(c2,r2)
+                     val w = if (o == NODATA) {
+                       k * z
+                     } else {
+                       o + k*z
+                     }
+                     
+                     output.set(c2,r2,w)
+                   }
+                 } 
+
+                 c2 += 1
+                 kc += 1
+               }
+               kc = 0
+               c2 = c2base
+               r2 += 1
+               kr += 1
+             }
+           }
+
+           c += 1           
+         }
+         c = 0
+         r += 1
+       }
+
+
+       Result(outputR)
+     }) 
+

--- a/src/test/scala/geotrellis/op/raster/ConvolveTest.scala
+++ b/src/test/scala/geotrellis/op/raster/ConvolveTest.scala
@@ -1,0 +1,106 @@
+package geotrellis.raster.op.focal
+
+import geotrellis._
+import geotrellis.process._
+import geotrellis.raster._
+import geotrellis.raster.op.VerticalFlip
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ConvolveTest extends FunSuite {
+  val server = TestServer("src/test/resources/catalog.json")
+
+  def doit(in1: Array[Int], in2: Array[Int], out: Array[Int]) = {
+    val size1 = math.sqrt(in1.length).toInt    
+    assert(size1*size1 === in1.length)
+
+    val size2 = math.sqrt(in2.length).toInt
+    assert(size2*size2 === in2.length)
+
+    val e1 = Extent(0,0,10*size1,10*size1)
+    val e2 = Extent(0,0,10*size2,10*size2)
+    val re1 = RasterExtent(e1, 10,10,size1,size1)
+    val re2 = RasterExtent(e2, 10,10,size2,size2)
+
+    val data1 = IntArrayRasterData(in1, size1, size1)
+    val data2 = IntArrayRasterData(in2, size2, size2)
+
+    val r1 = new Raster(data1, re1)
+    val r2 = new Raster(data2, re2)
+
+    val op = Convolve(r1, r2)
+    val r3 = server.run(op)
+
+    val r3d = r3.data.asArray.get.asInstanceOf[IntArrayRasterData].array
+    assert(r3d === out)
+  }
+  
+  test("gaussian") {
+    // Create and sample a 5x5 guassian
+    val op = Gaussian(5,5.0,2.0,100.0)
+    val r1 = server.run(op)
+    val r1d = r1.data.asArray.get
+
+    // (3,1) => (1,1) => r = sqrt(1*1 + 1*1) = sqrt(2)
+    // 100*exp(-(sqrt(2)^2)/(2*(2.0^2))) = 77.88 = 77
+    assert(r1d.get(3,1) === 77)
+
+    // Should also be symmetric
+    assert(r1d.get(3,3) === 77)
+    assert(r1d.get(3,1) === 77)
+    assert(r1d.get(1,3) === 77)
+    assert(r1d.get(1,1) === 77)
+
+    // Make sure amp and sigma do stuff
+    val op2 = Gaussian(5,5.0,4.0,50.0)
+    val r2 = server.run(op2)
+    val r2d = r2.data.asArray.get
+
+    // (3,1) => (1,1) => r = sqrt(1*1 + 1*1) = sqrt(2)
+    // 50*exp(-(sqrt(2)^2)/(2*(4.0^2))) = 46.97 = 46
+    assert(r2d.get(3,1) === 46)
+  }
+ 
+
+  test("simple convolve") {
+    /* http://www.songho.ca/dsp/convolution/convolution2d_example.html */
+    doit(Array(1,2,3,
+               4,5,6,
+               7,8,9),
+         Array(-1,-2,-1,
+               0,0,0,
+               1,2,1),
+         Array(-13,-20,-17,
+               -18,-24,-18,
+               13,20,17))
+  }
+
+  test("impulse") {
+    // Impulse test
+    val a = Array(1,2,3,4,
+               5,6,7,8,
+               9,10,11,12,
+               13,14,15,16)
+    doit(a,
+         Array(0,0,0,
+               0,1,0,
+               0,0,0),
+         a)
+  }
+
+  test("even kernel") {
+    doit(Array(1,2,3,4,
+               5,6,7,8,
+               9,10,11,12,
+               13,14,15,16),
+         Array(1,2,
+               3,4),
+         Array(26, 36, 46, 32, 
+               66, 76, 86, 56, 
+               106, 116, 126, 80, 
+               94, 101, 108, 64))
+  }
+}


### PR DESCRIPTION
Adds an operation that will convolve a given point spread fn
(kernel) with a raster. It also include a simple Gaussian
operation to create a raster with a Gaussian distribution

This commit also gives trellis the ability to perform kernel
density operations on rasters (the previous kernel density
operation only burned points onto the raster)

Also includes tests.

This is the first of a few commits that will hopefully replace
the old kernel density with a better tested implementation
