### PR TITLE
Add a note to "Setting up GeoTrellis" about catalog.json location 

### DIFF
--- a/docs/04.md
+++ b/docs/04.md
@@ -52,6 +52,8 @@ which any .arg files with accompanying .json metadata will be loaded.
 }
 ```
 
+NOTE: GeoTrellis will attempt to parse any .json files in the directory specified by the `path` property as raster metadata. You must keep your `catalog.json` file *outside* of this directory.
+
 ### Importing Raster Data
 
 GeoTrellis uses a custom raster format, ARG (Azavea Raster Grid), to encode


### PR DESCRIPTION
In an attempt to be tidy I tried to store a catalog.json file
for a project in the same directroy as the rasters and metadata files
for that project. This caused a service failure because GeoTrellis
attempted to read the catalog.json as raster metadata.

This commit adds a note to the documentation explaining that the
catalog file must be kept out of the data directory.
