### PR TITLE
Add operation to create histograms from double values.

### DIFF
--- a/src/main/scala/geotrellis/statistics/FastMapHistogram.scala
+++ b/src/main/scala/geotrellis/statistics/FastMapHistogram.scala
@@ -27,6 +27,27 @@ object FastMapHistogram {
     hs.foreach(h => total.update(h))
     total
   }
+
+  
+  /**
+   * Create a histogram from double values in a raster.
+   *
+   * FastMapHistogram only works with integer values, which is good for performance
+   * but means that, in order to use FastMapHistogram with double values, each value 
+   * must be multiplied by a power of ten to preserve significant fractional digits.
+   *
+   * For example, if you want to save one significant digit (2.1 from 2.123), set
+   * sigificantDigits to 1, and the histogram will save 2.1 as "21".
+   *
+   * Important: Be sure that the maximum value in the rater multiplied by 
+   *            10 ^ significantDigits does not overflow Int.MaxValue (2,147,483,647). 
+   */ 
+  def fromRasterDouble(r:Raster, significantDigits:Int) = {
+    val h = FastMapHistogram()
+    val multiplier = math.pow(10, significantDigits)
+    r.foreachDouble(z => if (z != Double.NaN) h.countItem( (z * multiplier).toInt, 1))
+    h
+  }
 }
 
 class FastMapHistogram(_size:Int, _buckets:Array[Int], _used:Int, _total:Int) extends Histogram {

--- a/src/main/scala/geotrellis/statistics/op/stat/GetHistogram.scala
+++ b/src/main/scala/geotrellis/statistics/op/stat/GetHistogram.scala
@@ -31,3 +31,29 @@ case class GetHistogramArray(r:Op[Raster], n:Op[Int]) extends Reducer2(r, n)({
 })({
   (hs, n) => ArrayHistogram.fromHistograms(hs, n)
 })
+
+
+/**
+ * Create a histogram from double values in a raster.
+ *
+ * FastMapHistogram only works with integer values, which is great for performance
+ * but means that, in order to use FastMapHistogram with double values, each value 
+ * must be multiplied by a power of ten to preserve significant fractional digits.
+ *
+ * For example, if you want to save one significant digit (2.1 from 2.123), set
+ * sigificantDigits to 1, and the histogram will save 2.1 as "21" by multiplying
+ * each value by 10.  The multiplier is 10 raised to the power of significant digits
+ * (e.g. 1 digit: 10, 2 digits: 100, and so on).
+ *
+ * Important: Be sure that the maximum value in the rater multiplied by 
+ *            10 ^ significantDigits does not overflow Int.MaxValue (2,147,483,647). 
+ *
+ * @param r                   Raster to create histogram from
+ * @param significantDigits   Number of significant digits to preserve by multiplying 
+ */ 
+case class GetDoubleHistogram(r:Op[Raster], significantDigits:Int) extends Reducer1(r)({
+  r => FastMapHistogram.fromRasterDouble(r.force, significantDigits)
+})({
+  hs => FastMapHistogram.fromHistograms(hs)
+})
+


### PR DESCRIPTION
FastMapHistogram only works with integer values, which is good for performance
but means that, in order to use FastMapHistogram with double values, each value
must be multiplied by a power of ten to preserve significant fractional digits.
This checkin adds an operation and a static method to make this easier.

For example, if you want to save one significant digit (2.1 from 2.123), set
sigificantDigits to 1, and the histogram will save 2.1 as "21".

This does require the user to  sure that the maximum value in the raster multiplied
10 ^ significantDigits does not overflow Int.MaxValue (2,147,483,647).
