### PR TITLE
Add operation for parallel execution of focal operations.

### DIFF
--- a/src/main/scala/geotrellis/raster/TileNeighborhood.scala
+++ b/src/main/scala/geotrellis/raster/TileNeighborhood.scala
@@ -1,0 +1,124 @@
+/**
+ *
+ */
+package geotrellis.raster
+
+import geotrellis._
+import scala.collection.concurrent.Map
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable._
+
+object TileCache {
+  // relative coordinate of each neighbor
+  val neighborTuples = (for (i <- -1 to 1; j <- -1 to 1) yield (i, j)).filter(_ != (0, 0))
+
+}
+class TileCache(tiles: TiledRasterData, loader:((Int,Int)) => Raster) {
+  val tileCounts = Map[(Int, Int), AtomicInteger]().withDefaultValue(new AtomicInteger())
+  val rasterCache = Map[(Int,Int), Raster]().withDefault(loader)
+  private def withinBounds(col: Int, row: Int): Boolean =
+    (col >= 0 && col < tiles.cols && row >= 0 && row < tiles.rows)
+
+  def register(tileCol: Int, tileRow: Int) {
+    TileCache.neighborTuples
+      .filter((n) => tiles.withinBounds(n._1, n._2))
+      .foreach {
+        case n => {
+          tileCounts.get(n).map(_.getAndIncrement())
+        }
+       } 
+  }
+  
+  //Note: This function could be rewritten to accept a loadFunction and
+  //      then curry it for passing to getOrElseUpdate
+  def getTile(tileCol: Int, tileRow: Int):Raster = {
+    val tuple = (tileCol,tileRow)
+    val raster = rasterCache.get((tileCol,tileRow)) match {
+      case Some(r) => r
+      case None => throw new Exception("RasterCache no longer has raster at ${tileCol},${tileRow}")
+    }
+    val count:Option[Int] = tileCounts.get(tuple).map(_.getAndDecrement())
+    count match {
+      case Some(0) => {
+        rasterCache.remove((tileCol,tileRow))
+      }
+      case _ => 
+    }
+    raster
+  }
+  
+}
+
+object TileNeighborhood {
+  // relative coordinates of neighbors
+  val C  = (0, 0)   // center (focus tile)
+  val UL = (-1, -1) // upper left neighbor
+  val U  = ( 0, -1) // upper neighbor
+  val UR = ( 1, -1) // upper right neighbor
+  val R  = ( 1,  0) // right neighbor
+  val DR = ( 1,  1) // down (lower) right neighbor
+  val D  = ( 0,  1) // down (lower) neighbor
+  val DL = (-1,  1) // down (lower) right neighbor
+  val L  = (-1,  0) // left neighbor
+  
+  def buildTileNeighborhood(trd: TiledRasterData, re:RasterExtent, col: Int, row: Int):TileArrayRasterData = {
+    val tileLayout = trd.tileLayout
+    val rl = tileLayout.getResolutionLayout(re)
+
+    val colMax = tileLayout.tileCols - 1
+    val rowMax = tileLayout.tileRows - 1
+
+    // get tileCols, tileRows, & list of relative neighbor coordinate tuples
+    val (tileCols:Int, tileRows:Int, neighbors:List[(Int,Int)]) = 
+      if (col == 0 && row == 0) { // top left corner
+        (2,2, List(C, R, D, DR))
+      } else if (col == 0 && row == rowMax) { // bottom left corner
+        (2,2, List(U, UR, C, R)) 
+      } else if (col == colMax && row == 0) { // top right corner
+        (2,2, List(L, C, DL, D))
+      } else if (col == colMax && row == rowMax) { // bottom right corner
+        (2,2, List(UL, U, L, C))
+      } else if (col == 0) { // left border
+        (2,3, List(U, UR, C, R, D, DR))
+      } else if (col == colMax) { // right border
+        (2,3, List(UL, U, L, C, DL, D))
+      } else if (row == 0) { // top border
+        (3,2, List(L, C, R, DL, D, DR))
+      } else if (row == rowMax) { // bottom border
+        (3,2, List(UL, U, UR, L, C, R))
+      } else {
+        (3,3, List(UL, U, UR, L, C, R, DL, D, DR))
+      }
+
+    val neighborTiles = for( (colDelta, rowDelta) <- neighbors) yield { 
+      val nTileCol = col + colDelta
+      val nTileRow = row + rowDelta
+      val nTile = trd.getTileRaster(rl, nTileCol, nTileRow)
+      nTile
+    }
+
+    val (nwColD, nwRowD) = neighbors.head
+    val nwExtent = rl.getExtent(col + nwColD, row + nwRowD)
+    //val nwExtent = neighborTiles.head.rasterExtent.extent
+    val xmin = nwExtent.xmin
+    val ymax = nwExtent.ymax
+    //val seExtent = neighborTiles.last.rasterExtent.extent
+    val (seColD, seRowD) = neighbors.last
+    val seExtent = rl.getExtent(col + seColD, row + seRowD)
+    val xmax = seExtent.xmax
+    val ymin = seExtent.ymin
+     
+    val nTileLayout = TileLayout(tileCols, tileRows, tileLayout.pixelCols, tileLayout.pixelRows)
+    val extent = Extent(xmin, ymin, xmax, ymax)
+    val nRasterExtent = RasterExtent(
+      extent, 
+      re.cellwidth, 
+      re.cellheight, 
+      tileLayout.pixelCols * tileCols,
+      tileLayout.pixelRows * tileRows
+    )
+ 
+    val nRasterData = new TileArrayRasterData(neighborTiles.toArray, nTileLayout, nRasterExtent)
+    nRasterData
+  }
+}

--- a/src/main/scala/geotrellis/raster/TiledRasterData.scala
+++ b/src/main/scala/geotrellis/raster/TiledRasterData.scala
@@ -183,7 +183,7 @@ trait TiledRasterData extends RasterData {
 
       if (tilePolygon.geom.intersects(clipExtent.geom)) {
         tiles = getTileOp(rl, c, r) :: tiles
-      } 
+      }
     }
     tiles
   }
@@ -242,8 +242,9 @@ trait TiledRasterData extends RasterData {
     if (lengthLong > 2147483647L) None
     val len = length
     val d = IntArrayRasterData.ofDim(cols, rows)
-    var i = 0
-    foreach { z => d(i) = z; i += 1 }
+    for( r <- 0 until rows; c <- 0 until cols) {
+      d(r * cols + c) = get(c,r)
+    }
     Some(d)
   }
 

--- a/src/main/scala/geotrellis/raster/op/focal/Aspect.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Aspect.scala
@@ -32,6 +32,6 @@ case class Aspect(r:Op[Raster]) extends FocalOp[Raster](r,Square(1))({
       data.setDouble(x,y,degrees(s.aspect))
     }
   }
-})
+}) with HasAnalysisArea[Aspect]
 
 

--- a/src/main/scala/geotrellis/raster/op/focal/Cursor.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Cursor.scala
@@ -62,8 +62,8 @@ object Cursor {
 class Cursor(r:Raster,  val extent:Int, reOpt:Option[RasterExtent] = None) {
   val analysisArea = FocalOperation.calculateAnalysisArea(r, reOpt)
 
-  private val rows = analysisArea.rasterExtent.rows
-  private val cols = analysisArea.rasterExtent.cols
+  private val rows = r.rasterExtent.rows
+  private val cols = r.rasterExtent.cols
 
   // How many columns from the left/top of the input raster does the analysis area begin?
   val analysisOffsetCols = analysisArea.colMin

--- a/src/main/scala/geotrellis/raster/op/focal/FocalOp.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/FocalOp.scala
@@ -101,6 +101,15 @@ class FocalOp4[A,B,C,D,T](r:Op[Raster],n:Op[Neighborhood],a:Op[A],b:Op[B],c:Op[C
   def getCalculation(r:Raster,n:Neighborhood) = { getCalc(r,n) }
 }
 
+trait HasAnalysisArea[SELF <: FocalOperationBase] extends Cloneable { this:SELF =>
+  def makeClone() = super.clone().asInstanceOf[SELF]
+  def setAnalysisArea(op:Operation[Option[RasterExtent]]) = {
+    val clone = this.makeClone()
+    clone.analysisAreaOp = op
+    clone
+  }
+}
+
 trait FocalOperationBase {
   var analysisAreaOp:Operation[Option[RasterExtent]]
 } 

--- a/src/main/scala/geotrellis/raster/op/focal/Max.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Max.scala
@@ -17,4 +17,4 @@ case class Max(r:Op[Raster],n:Op[Neighborhood]) extends FocalOp(r,n)({
       data.set(cursor.col,cursor.row,m)
     }
   }
-})
+}) with HasAnalysisArea[Max]

--- a/src/main/scala/geotrellis/raster/op/focal/Mean.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Mean.scala
@@ -20,7 +20,7 @@ case class Mean(r:Op[Raster],n:Op[Neighborhood]) extends FocalOp[Raster](r,n)({
       case Square(ext) => new CellwiseMeanCalc
       case _ => new CursorMeanCalc
     }
-})
+}) with HasAnalysisArea[Mean]
 
 case class CellwiseMeanCalc() extends CellwiseCalculation[Raster] with DoubleRasterDataResult {
   var count:Int = 0

--- a/src/main/scala/geotrellis/raster/op/focal/Median.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Median.scala
@@ -14,7 +14,7 @@ case class Median(r:Op[Raster],n:Op[Neighborhood]) extends FocalOp[Raster](r,n)(
       case Square(ext) => new CellwiseMedianCalc(ext)
       case _ => new CursorMedianCalc(n.extent)
     }
-})
+}) with HasAnalysisArea[Median]
 
 class CursorMedianCalc(extent:Int) extends CursorCalculation[Raster] with IntRasterDataResult 
                                                                      with MedianModeCalculation {

--- a/src/main/scala/geotrellis/raster/op/focal/Min.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Min.scala
@@ -12,9 +12,15 @@ import scala.math._
 case class Min(r:Op[Raster],n:Op[Neighborhood]) extends FocalOp[Raster](r,n)({
   (r,n) => new CursorCalculation[Raster] with IntRasterDataResult {
     def calc(r:Raster,cursor:Cursor) = {
+  
       var m = Int.MaxValue
-      cursor.allCells.foreach { (col,row) => m = min(m,r.get(col,row)) }
+      //cursor.allCells.foreach { (col,row) => m = min(m,r.get(col,row)) }
+      cursor.allCells.foreach { 
+        (col,row) => {
+          m = min(m,r.get(col,row))
+        }
+      }
       data.set(cursor.col,cursor.row,m)
     }
   }
-})
+}) with HasAnalysisArea[Min]

--- a/src/main/scala/geotrellis/raster/op/focal/Mode.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Mode.scala
@@ -15,7 +15,7 @@ case class Mode(r:Op[Raster],n:Op[Neighborhood]) extends FocalOp[Raster](r,n)({
       case Square(ext) => new CellwiseModeCalc(ext)
       case _ => new CursorModeCalc(n.extent)
     }
-})
+}) with HasAnalysisArea[Mode]
 
 class CursorModeCalc(extent:Int) extends CursorCalculation[Raster] with IntRasterDataResult 
                                                                    with MedianModeCalculation {

--- a/src/main/scala/geotrellis/raster/op/focal/Slope.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Slope.scala
@@ -65,4 +65,4 @@ class Slope(r:Op[Raster], zFactor:Op[Double]) extends FocalOp1[Double,Raster](r,
       data.setDouble(x,y,degrees(s.slope(zFactor)))
     }
   }
-})
+}) with HasAnalysisArea[Slope]

--- a/src/main/scala/geotrellis/raster/op/focal/Sum.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/Sum.scala
@@ -18,7 +18,7 @@ case class Sum(r:Op[Raster], n:Op[Neighborhood]) extends FocalOp[Raster](r,n)({
       case Square(ext) => new CellwiseSumCalc
       case _ => new CursorSumCalc
     }
-})
+}) with HasAnalysisArea[Sum]
 
 class CursorSumCalc extends CursorCalculation[Raster] 
     with IntRasterDataResult {

--- a/src/main/scala/geotrellis/raster/op/focal/TileFocalOp.scala
+++ b/src/main/scala/geotrellis/raster/op/focal/TileFocalOp.scala
@@ -1,0 +1,56 @@
+package geotrellis.raster.op.focal
+
+import scala.math.{ min, max }
+
+import geotrellis._
+import geotrellis.process._
+import geotrellis.statistics._
+import geotrellis.raster._
+import geotrellis.feature.Polygon
+
+object TileFocalOp {
+  def makeFocalOp[T <: Op[Raster] with FocalOperationBase with HasAnalysisArea[T]](makeOp:Op[Raster] => T) = 
+  (_r:Op[Raster], _re:Op[Option[RasterExtent]]) => {
+    val op = makeOp(_r)
+    op.setAnalysisArea(_re)
+  }
+}
+case class TileFocalOp[T <:Op[Raster] with FocalOperationBase with HasAnalysisArea[T]](r: Op[Raster], zonalOp:(Op[Raster]) => T) extends Op[Raster] {
+  def _run(context: Context) = runAsync('init :: r :: Nil)
+
+  val nextSteps: Steps = {
+    case 'init :: (r: Raster) :: Nil => init(r)
+    case 'untiled :: (r:Raster) :: Nil => Result(r)
+    //case 'reduce :: (bs:  List[_]) => Result(reducer(bs.asInstanceOf[List[B]]))
+    case 'results :: (tileLayout:TileLayout) :: (re:RasterExtent) :: (r:List[_]) => { 
+        val tiles = r.asInstanceOf[List[Raster]] 
+        val firstTile = tiles.head
+        val data = TileArrayRasterData(tiles.toArray, tileLayout, re)
+        Result(Raster(data, re))
+      }
+  }
+
+  def init(r: Raster) = {
+    r.data match {
+      case trd: TiledRasterData => tileFocalOp(r, trd, TileFocalOp.makeFocalOp(zonalOp))
+      case _ => throw new Exception("TileFocalOp not implemented for non-tiled rasters")
+    }
+  }
+  
+  def tileFocalOp[T](raster:Raster, trd:TiledRasterData, makeFocalOp: (Op[Raster], Op[Option[RasterExtent]]) => Op[Raster]) = {
+    val tileLayout = trd.tileLayout
+    val re = raster.rasterExtent
+    val rl = tileLayout.getResolutionLayout(re)
+    val tileTuples = for (r <- 0 until tileLayout.tileRows; c <- 0 until tileLayout.tileCols)
+      yield (c,r,rl.getRasterExtent(c,r))
+
+    val ops = for ( (c:Int,r:Int,tileRe:RasterExtent) <- tileTuples) yield {
+      val nRasterData = TileNeighborhood.buildTileNeighborhood(trd, re, c, r)
+      val neighborhoodRaster = Raster(nRasterData, nRasterData.rasterExtent)
+      val zOp = makeFocalOp(neighborhoodRaster, Some(tileRe)) 
+      zOp
+    }
+    runAsync('results :: tileLayout :: re ::  ops.toList)
+  }
+}
+

--- a/src/test/scala/geotrellis/raster/op/focal/MinSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/focal/MinSpec.scala
@@ -96,5 +96,6 @@ class MinSpec extends FunSpec with FocalOpSpec
         getMinResult(Square(1),MockCursor.fromAll(s:_*)) should equal (s.min)
       }
     }
+
   }
 }

--- a/src/test/scala/geotrellis/raster/op/focal/TiledFocalSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/focal/TiledFocalSpec.scala
@@ -1,0 +1,43 @@
+package geotrellis.raster.op.focal
+
+import geotrellis._
+import geotrellis.raster._
+
+import geotrellis.testutil._
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSpec
+import org.scalatest.matchers._
+
+import org.scalatest.junit.JUnitRunner
+
+// 0  1  2  3
+// 4  5  6  7
+// 8  9 10 11
+//12 13 14 15
+
+@RunWith(classOf[JUnitRunner])
+class TiledZonalSpec extends FunSpec with FocalOpSpec
+                              with ShouldMatchers
+                              with TestServer {
+  describe("normal min") {
+    it("square min r=1") {
+      val r = createRaster((0 until 16).toArray)
+      assertEqual(Min(r, Square(1)), Array(0, 0, 1, 2,
+                                           0, 0, 1, 2,
+                                           4, 4, 5, 6,
+                                           8, 8, 9, 10))
+    }
+  }
+  describe("Min on a tiled raster") {
+    it("square min r=1") {
+      val r = createRaster((0 until 16).toArray)
+      val tiledR = Tiler.createTiledRaster(r, 2, 2)
+      val tileFocalOp = TileFocalOp(tiledR, Min(_, Square(1)))
+      assertEqual(tileFocalOp, Array(0, 0, 1, 2,
+                                     0, 0, 1, 2,
+                                     4, 4, 5, 6,
+                                     8, 8, 9, 10))
+    }
+  }
+}


### PR DESCRIPTION
This checkin implements the necessary infrastructure to execute a
focal operation in parallel over a tiled raster.

This checkin does not include sufficient tests and this implementation
still needs to be refined and further tested.  It adds a HasAnalysisArea
trait to zonal operations required for TileFocalOp.
