### PR TITLE
Improve usability of raster rendering operations.

### DIFF
--- a/src/main/scala/geotrellis/data/ColorRamps.scala
+++ b/src/main/scala/geotrellis/data/ColorRamps.scala
@@ -1,0 +1,56 @@
+package geotrellis.data
+
+import scala.math.round
+
+import geotrellis._
+
+abstract class ColorRamp {
+  val colors:Array[Int]
+}
+
+object ColorRamps {
+  /**
+   * A 6 color sequential red-amber-green color ramp. 
+   */ 
+  case object RedToAmberToGreen extends ColorRamp {
+    val colors = Array(0xFA0000, 0xFB3300, 0xFC6600, 0xFD9900, 
+                       0xFECC00, 0xCCFF00, 0x99FF00, 0x66FF00, 
+                       0x33FF00, 0x00FF00).map(Color.rgbToRgba(_))
+  }
+
+  /**
+   * A 9 class divergent Blue to Yellow to Red color ramp.
+   */
+  case object BlueToYellowToRed extends ColorRamp { 
+    val colors = Array(0x4575B4,0x74ADD1,0xABD9E9,0xE0F3F8,0xFFFFBF,0xFEE090,0xFDAE61,0xF46D43,0xD73027)
+  }
+
+  /**
+   * 9 class divergent cold to hot color ramp.
+   */
+  case object ColdToHot {
+    val colors = Array(0x3288BD,0x66C2A5,0xABDDA4,0xE6F598,0xFFFFBF,0xFEE08B,0xFDAE61,0xF46D43,0xD53E4F)
+  }
+
+  /**
+   * 9 class sequential orange to red color ramp.
+   */
+  case object OrangeToRed {
+    val colors = Array(0xFFFFCC,0xFFEDA0, 0xFED976,0xFEB24C,0xFD8D3C,0xFC4E2A,0xE31A1C,0xBD0026,0x800026)
+  }
+
+  /**
+   * 9 class sequential blue to purple color ramp.
+   */
+  case object BlueToPurple extends ColorRamp {
+    val colors = Array(0xFCFBFD, 0xEFEDF5, 0xDADAEB, 0xBCBDDC, 0x9E9AC8, 0x807DBA, 0x6A51A3, 0x54278F,0x3F007D)
+  }
+
+  /**
+   * 9 class divergent purple to orange color ramp.
+   */
+  case object PurpleToOrange extends ColorRamp {
+    val colors = Array(0xB35806,0xE08214,0xFDB863,0xFEE0B6,0xF7F7F7,0xD8DAEB,0xB2ABD2,0x8073AC,0x542788)
+  }
+  
+}

--- a/src/main/scala/geotrellis/data/color.scala
+++ b/src/main/scala/geotrellis/data/color.scala
@@ -39,6 +39,9 @@ object Color {
   // combine three color bands into one color value
   @inline final def zip(r:Int, g:Int, b:Int, a:Int) = (r << 24) + (g << 16) + (b << 8) + a
 
+  // convert an RGB color integer to an opaque RGBA color integer
+  def rgbToRgba(rgb:Int) = { (rgb << 8) + 0xff }
+
   /**
    * This method is used for cases in which we are provided with a different
    * number of colors than we need.  This method will return a smaller list
@@ -256,3 +259,4 @@ case class MultiColorRangeChooser(colors:Array[Int]) extends ColorRangeChooser {
     }
   }
 }
+

--- a/src/main/scala/geotrellis/io/RenderPng.scala
+++ b/src/main/scala/geotrellis/io/RenderPng.scala
@@ -3,7 +3,9 @@ package geotrellis.io
 import geotrellis._
 import geotrellis.data._
 import geotrellis.data.png._
-import geotrellis.statistics._
+import geotrellis.statistics.op._
+import geotrellis.statistics.Histogram
+
 
 /**
  * Generate a PNG image from a raster.
@@ -44,19 +46,3 @@ extends Op4(r, colorBreaks, h, noDataColor)({
   }
 })
 
-/**
- * Generate a PNG from a raster of RGBA integer values.
- *
- * Use this operation when you have created a raster whose values are already
- * RGBA color values that you wish to render into a PNG.  If you have a raster
- * with data that you wish to render, you should use RenderPng instead.
- *
- * An RGBA value is a 32 bit integer with 8 bits used for each component:
- * the first 8 bits are the red value (between 0 and 255), then green, blue,
- * and alpha (with 0 being transparent and 255 being opaque).
- */
-case class RenderPngRgba(r:Op[Raster]) extends Op1(r)({
-  r =>
-    val bytes = new Encoder(Settings(Rgba, PaethFilter)).writeByteArray(r)
-    Result(bytes)
-})

--- a/src/main/scala/geotrellis/io/RenderRGBARasterToPng.scala
+++ b/src/main/scala/geotrellis/io/RenderRGBARasterToPng.scala
@@ -1,0 +1,23 @@
+package geotrellis.io
+
+import geotrellis._
+import geotrellis.data._
+import geotrellis.data.png._
+
+
+/**
+ * Generate a PNG from a raster of RGBA integer values.
+ *
+ * Use this operation when you have created a raster whose values are already
+ * RGBA color values that you wish to render into a PNG.  If you have a raster
+ * with data that you wish to render, you should use RenderPng instead.
+ *
+ * An RGBA value is a 32 bit integer with 8 bits used for each component:
+ * the first 8 bits are the red value (between 0 and 255), then green, blue,
+ * and alpha (with 0 being transparent and 255 being opaque).
+ */
+case class RenderPngRgba(r:Op[Raster]) extends Op1(r)({
+  r =>
+    val bytes = new Encoder(Settings(Rgba, PaethFilter)).writeByteArray(r)
+    Result(bytes)
+})

--- a/src/main/scala/geotrellis/io/SimpleRenderPng.scala
+++ b/src/main/scala/geotrellis/io/SimpleRenderPng.scala
@@ -1,0 +1,43 @@
+package geotrellis.io
+
+import geotrellis._
+import geotrellis.data._
+import geotrellis.data.png._
+import geotrellis.statistics.op._
+import geotrellis.statistics.Histogram
+
+/**
+ * Generate a PNG image from a data raster.
+ *
+ * This operation is designed to provide a simple interface to generate a
+ * colored image from a data raster.  The data values in your raster will
+ * be classified into a number of ranges, and cells in each range will be
+ * rendered with a unique color.  You can select the number of ranges that
+ * will be used, and the color ramp from which the colors will be selected.
+ *
+ * There are some color ramps you can select in geotrellis.data, and the
+ * default ramp (if you do not provide one) ranges from red to yellow to green.
+ *
+ * @param r   Raster to vizualize as an image
+ * @param numberOfBreaks  The number of colors (and value ranges) to use
+ * @param colorRamp   Colors to select from
+ */
+case class SimpleRenderPng(r:Op[Raster],numberOfColors:Op[Int],colorRamp:Op[ColorRamp] = ColorRamps.RedToAmberToGreen) extends Op[Array[Byte]] {
+    def _run(context:Context) = runAsync('step1 :: r :: Nil)
+    val nextSteps:Steps = {
+      case 'step1 :: (r:Raster) :: Nil => step2(r)
+      case 'step2 :: (h:Histogram) :: (r:Raster) :: (n:Int) :: (c:ColorRamp) :: Nil => step3(h, r, n,c)
+      case 'result :: (bytes:Array[_]) :: Nil => Result(bytes.asInstanceOf[Array[Byte]])
+    }
+    def step2(r:Raster) = {
+      val histogramOp = stat.GetHistogram(r)
+      runAsync('step2 :: histogramOp :: r :: numberOfColors :: colorRamp :: Nil)
+    } 
+    def step3(histogram:Histogram, r:Raster, numberOfBreaks:Int, colorRamp:ColorRamp) = {
+      val breaksOp = stat.GetColorBreaks(histogram, colorRamp.colors)
+      val renderOp = io.RenderPng(r, breaksOp, histogram, 0) 
+      runAsync('result :: renderOp :: Nil)
+    }
+}
+
+


### PR DESCRIPTION
This pull request adds some helper operations to make it easier for a new GeoTrellis developer to render a raster.  It adds a new SimpleRenderPng operation that simply takes a color ramp and a number of class breaks, which it uses to generate quantile class breaks and the color ramps behind the scenes.  It also adds a set of default color ramps.

This pull request also adds comments and scaladoc to existing operations, and renames the render operation that expects a raster with RGBA integer values.
