### PR TITLE
Add configuration options for Jetty threadpool.

### DIFF
--- a/demo/src/main/scala/demo/Tutorial.scala
+++ b/demo/src/main/scala/demo/Tutorial.scala
@@ -81,7 +81,7 @@ class SimpleDrawRaster {
   @Path("/{name}")
   def get(@PathParam("name") name:String) = {
     val rasterOp:Op[Raster] = io.LoadRaster(name)
-    val pngOp:Op[Array[Byte]] = io.SimpleRenderPng(rasterOp, Literal(BlueToYellowToRed))
+    val pngOp:Op[Array[Byte]] = io.SimpleRenderPng(rasterOp, BlueToYellowToRed)
     // run the operation
     try {
       val img:Array[Byte] = Demo.server.run(pngOp)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,3 +6,11 @@ geotrellis.host = "0.0.0.0"
 geotrellis.port = 8000
 geotrellis.rest-package = "demo"
 geotrellis.tmp = "/tmp"
+
+# minimum number of jetty threads
+geotrellis.jetty.corePoolSize = 10
+
+# maximum number of jetty threads
+geotrellis.jetty.maximumPoolSize = 20
+
+geotrellis.jetty.keepAliveMilliseconds = 30000

--- a/src/main/scala/geotrellis/rest/WebRunner.scala
+++ b/src/main/scala/geotrellis/rest/WebRunner.scala
@@ -3,9 +3,9 @@ package geotrellis.rest
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.nio.SelectChannelConnector
 import org.eclipse.jetty.servlet.{ServletHolder, ServletContextHandler}
-import org.eclipse.jetty.util.thread.QueuedThreadPool
+import org.eclipse.jetty.util.thread.{QueuedThreadPool,ExecutorThreadPool}
 import com.sun.jersey.spi.container.servlet.ServletContainer
-
+import java.util.concurrent.TimeUnit
 import com.typesafe.config.ConfigFactory
 
 /**
@@ -24,9 +24,13 @@ object WebRunner {
     val host = config.getString("geotrellis.host")
     val port = config.getInt("geotrellis.port")
 
+    val corePoolSize = config.getInt("geotrellis.jetty.corePoolSize")
+    val maximumPoolSize = config.getInt("geotrellis.jetty.maximumPoolSize")
+    val keepAliveTime =  config.getLong("geotrellis.jetty.keepAliveMilliseconds")
+
     println("Starting server on port %d.".format(port))
     val server = new Server()
-
+    server.setThreadPool(new ExecutorThreadPool(corePoolSize, maximumPoolSize, keepAliveTime, TimeUnit.MILLISECONDS))
     val connector = new SelectChannelConnector()
     connector.setHost(host)
     connector.setPort(port)


### PR DESCRIPTION
This pull request adds configuration options for the Jetty WebRunner to the GeoTrellis configuration. You can set minimum & maximum number of Jetty threads, as well as the keep alive time.
