### PR TITLE
Narrow type of AsPolygonSet to Op[List[Polygon[D]]].

### DIFF
--- a/src/main/scala/geotrellis/feature/op/geometry/geometry.scala
+++ b/src/main/scala/geotrellis/feature/op/geometry/geometry.scala
@@ -50,12 +50,12 @@ package object geometry {
       })
 
 
-  case class AsPolygonSet[D](g: Op[Geometry[D]]) extends Operation[List[Geometry[D]]] {    
+  case class AsPolygonSet[D](g: Op[Geometry[D]]) extends Operation[List[Polygon[D]]] {    
     val compositeOp = FilterGeometry[jts.Polygon,D](FlattenGeometry(g))
 
     def _run(context:Context) = runAsync(List(compositeOp))
     val nextSteps:Steps = {
-      case a :: Nil => Result(a.asInstanceOf[List[Geometry[D]]])
+      case a :: Nil => Result(a.asInstanceOf[List[Polygon[D]]])
     }
   }
 }


### PR DESCRIPTION
AsPolygonSet used to return a List of Features, even though we can return the more specific Polygon type.
