### PR TITLE
Allow thoroughput limit value to be modified.

### DIFF
--- a/src/main/scala/geotrellis/raster/op/tiles/ThoroughputLimitedReducer1.scala
+++ b/src/main/scala/geotrellis/raster/op/tiles/ThoroughputLimitedReducer1.scala
@@ -12,7 +12,7 @@ trait ThroughputLimitedReducer1[C] extends Op[C] {
   type B
   
   val r: Op[Raster]
-  val limit: Int = 30
+  var limit: Int = 30
 
   def loadTileExtent:Option[Op[Polygon[_]]] = None
 


### PR DESCRIPTION
Allowing the thoroughput limit (the number of operations to be run in parallel)
to be changed on the operation greatly simplifies the interface.  Once we can
clone any operation this can be modified to an immutable interface.
