### PR TITLE
Fix bug in MultiplyDoubleConstant.

### DIFF
--- a/src/main/scala/geotrellis/raster/op/local/Multiply.scala
+++ b/src/main/scala/geotrellis/raster/op/local/Multiply.scala
@@ -30,7 +30,7 @@ case class MultiplyConstant2(c:Op[Int], r:Op[Raster]) extends Op2(c, r)({
  * Create with MultiplyConstant(raster, doubleValue).
  */
 case class MultiplyDoubleConstant(r:Op[Raster], c:Op[Double]) extends Op2(r, c)({
-  (r, c) => Result(r.dualMapIfSet(_ * c.toInt)(_ * c))
+  (r, c) => Result(r.dualMapIfSet((_ * c).toInt)(_ * c))
 })
 
 /**


### PR DESCRIPTION
We should floor the result of multiplying the raster value with a double
constant -- not floor the double constant.
