### PR TITLE
Improve ArgWriter.write() documentation and fix bug.

### DIFF
--- a/src/main/scala/geotrellis/data/arg/ArgWriter.scala
+++ b/src/main/scala/geotrellis/data/arg/ArgWriter.scala
@@ -20,14 +20,26 @@ case class ArgWriter(typ:RasterType) extends Writer {
 
   /**
    * Write a raster in ARG format to the specified path.
-   * 
-   * @param path: Path to write arg files including base filename but not extension
+   *
+   * The outputFilePath argument should be the full file path (including file name and extension)
+   * to which the raster file should be written.  For example, "/var/data/geotrellis/myraster.arg".
+   *
+   * The metadataName argument is a logical name for the raster that will be included in the raster's
+   * metadata.  It does not have to match the output filename.  This filename is used by the catalog
+   * when a raster is loaded by name as opposed to filepath.
+   *
+   * @param outputFilePath: File path to which to write out arg file (can include .arg extension)
    * @param raster: Raster to write to disk
-   * @param name: Name to be included in json metadata as 'layer', used in catalog
+   * @param metadataName: Name to be included in json metadata as 'layer', used in catalog
    */
-  def write(path:String, raster:Raster, name:String) {
-    val base = path.substring(0, path.lastIndexOf("."))
-    writeMetadataJSON(base + ".json", name, raster.rasterExtent)
+  def write(outputFilePath:String, raster:Raster, metadataName:String) {
+    val path = outputFilePath
+    val base:String = if (path.endsWith(".arg") || path.endsWith(".")) {
+      path.substring(0, path.lastIndexOf("."))
+    } else {
+      path 
+    }
+    writeMetadataJSON(base + ".json", metadataName, raster.rasterExtent)
     writeData(base + ".arg", raster)
   }
 

--- a/src/test/scala/geotrellis/data/arg32.scala
+++ b/src/test/scala/geotrellis/data/arg32.scala
@@ -50,8 +50,6 @@ class Arg32Spec extends FunSpec with MustMatchers with ShouldMatchers {
     it("should write to full paths ") {
       val fh = java.io.File.createTempFile("foog", ".arg")
       val path = fh.getPath
-      val base = path.substring(0, path.length - 4)
-      println("base path: " + base)
 
       ArgWriter(TypeInt).write(path, raster, "foog")
 
@@ -60,6 +58,17 @@ class Arg32Spec extends FunSpec with MustMatchers with ShouldMatchers {
     
       //new java.io.File(base + ".arg").delete() must be === true
       //new java.io.File(base + ".json").delete() must be === true
+      data1 must be === data2
+    }
+
+    it("should allow file extension to be excluded") {
+      val fh = java.io.File.createTempFile("testraster2", ".arg")
+      val path = fh.getPath
+      val base = path.substring(0, path.length - 4)
+      ArgWriter(TypeInt).write(base, raster, "foog2")
+
+      val data1 = scala.io.Source.fromFile(path).mkString
+      val data2 = scala.io.Source.fromFile("src/test/resources/fake.img32.arg").mkString
       data1 must be === data2
     }
 


### PR DESCRIPTION
Previously, ArgWriter.write() required a filepath that included the .arg
extension (or at least a period) or else it would fail.  It now will accept
".arg" extensions but does not require it.  It allows a "." extension for
backwards compatability.

This commit also updates the write() documentation and the names of its
arguments for greater clarity about the meaning of the arguments.

Fixes #421
