### PR TITLE
Empty geometries are now a noop for the rasterizer.

### DIFF
--- a/src/main/scala/geotrellis/feature/rasterize/Rasterizer.scala
+++ b/src/main/scala/geotrellis/feature/rasterize/Rasterizer.scala
@@ -73,6 +73,7 @@ object Rasterizer {
       case p:LineString[_] => foreachCellByLineString[D](p.asInstanceOf[LineString[D]],re)(f.asInstanceOf[Callback[LineString,D]])
       case p:Polygon[_] => PolygonRasterizer.foreachCellByPolygon[D](p.asInstanceOf[Polygon[D]],re)(f.asInstanceOf[Callback[Polygon,D]])
       case p:MultiPolygon[_] => foreachCellByMultiPolygon[D](p.asInstanceOf[MultiPolygon[D]],re)(f.asInstanceOf[Callback[Polygon,D]])
+      case _ => ()
     }
   }
   

--- a/src/test/scala/geotrellis/feature/RasterizePolygonSpec.scala
+++ b/src/test/scala/geotrellis/feature/RasterizePolygonSpec.scala
@@ -109,6 +109,12 @@ class RasterizePolygonSpec extends FunSuite {
       val r6 = Rasterizer.rasterizeWithValue(envelopingSquare, re)((a:Unit) => 0x66)
       println(r6.asciiDraw())            
 
+      val emptyGeom = outsideSquare.geom.intersection(envelopingSquare.geom)
+
+      val r7 = Rasterizer.rasterizeWithValue(Feature(emptyGeom, ()), re)((a:Unit) => 0x77)
+      sum = 0
+      r7.foreach(f => if (f != NODATA) sum = sum + 1 )
+      assert(sum === 0)
      // LoadWKT()
   }
 


### PR DESCRIPTION
Fixes #407, in which empty geometries would cause a match error in the rasterizer.
