### PR TITLE
Add serialization trait to Operation and Histogram.

### DIFF
--- a/src/main/scala/geotrellis/Operation.scala
+++ b/src/main/scala/geotrellis/Operation.scala
@@ -10,7 +10,7 @@ import akka.actor._
  * Base Operation for all GeoTrellis functionality. All other operations must
  * extend this trait.
  */
-abstract class Operation[+T] extends Product {
+abstract class Operation[+T] extends Product with Serializable {
   type Steps = PartialFunction[Any, StepOutput[T]]
   type Args = List[Any]
   val nextSteps:PartialFunction[Any,StepOutput[T]]

--- a/src/main/scala/geotrellis/statistics/Histogram.scala
+++ b/src/main/scala/geotrellis/statistics/Histogram.scala
@@ -5,7 +5,7 @@ import math.{abs, round, sqrt}
 /**
   * Data object representing a histogram of values.
   */
-abstract trait Histogram {
+abstract trait Histogram extends Serializable {
   /**
    * Note the occurance of 'item''.
    *

--- a/src/test/scala/geotrellis/SerializationTest.scala
+++ b/src/test/scala/geotrellis/SerializationTest.scala
@@ -1,0 +1,35 @@
+package geotrellis
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.matchers.ShouldMatchers
+import java.io._
+
+
+import geotrellis._
+import geotrellis.testutil._
+import geotrellis.raster.op._
+import geotrellis.statistics._
+
+@RunWith(classOf[JUnitRunner])
+class SerializationTest extends FunSuite 
+                        with ShouldMatchers 
+                        with RasterBuilders {
+
+  // Operations and data objects that may be sent remotely must be serializable.
+  test("Operation and data object serialization test") {
+    pickle(Literal(1))
+    pickle(byteRaster)
+    val addOp = local.Add(byteRaster, 1)
+    pickle(addOp)
+    pickle(local.Add(addOp, 2))
+    pickle(FastMapHistogram())
+    pickle(Statistics(0,0,0,0,0,0))
+  }
+
+  def pickle(o:AnyRef) = {
+    val stream = new ObjectOutputStream(new ByteArrayOutputStream())
+    stream.writeObject(o)
+  } 
+}


### PR DESCRIPTION
All operations (and arguments to operations) must be serializable
for remote execution.  While case classes are automatically serializable,
some classes were being created that did not properly inherit Serializable.
