### PR TITLE
Make GeoTrellis actor system a singleton.

### DIFF
--- a/src/main/scala/geotrellis/process/Server.scala
+++ b/src/main/scala/geotrellis/process/Server.scala
@@ -22,15 +22,18 @@ import com.typesafe.config.ConfigFactory
 import scala.util.{Try,Success => TrySuccess, Failure => TryFailure}
 import geotrellis.util.Filesystem
 
+//class Server (id:String, val catalog:Catalog) extends FileCaching {
 class Server (id:String, val catalog:Catalog) {
   val debug = false
 
-  var system:akka.actor.ActorSystem = akka.actor.ActorSystem(id, ConfigFactory.load())
-  var actor:akka.actor.ActorRef = system.actorOf(Props(new ServerActor(id, this)), "server")
+  var actor:akka.actor.ActorRef = Server.actorSystem.actorOf(Props(new ServerActor(id, this)), id)
 
   private[this] val staticCache = mutable.Map.empty[String, Array[Byte]]
 
   initStaticCache()
+
+  Server.startActorSystem
+  def system = Server.actorSystem
 
   def startUp:Unit = ()
 
@@ -50,7 +53,10 @@ class Server (id:String, val catalog:Catalog) {
     }
   }
 
-  def shutdown():Unit = system.shutdown()
+  def shutdown():Unit = { 
+    //Server.actorSystem.shutdown()
+    //Server.actorSystem.awaitTermination()
+  }
 
   def log(msg:String) = if(debug) println(msg)
 
@@ -67,6 +73,7 @@ class Server (id:String, val catalog:Catalog) {
   private[process] def _run[T:Manifest](op:Op[T]) = {
     log("server._run called with %s" format op)
 
+//    implicit val timeout = Timeout(Duration(3600, "millis"))
     val d = Duration.create(600, TimeUnit.SECONDS)
     implicit val t = Timeout(d)
     val future = op match {
@@ -149,6 +156,13 @@ object Server {
   def apply(id:String) = new Server(id, Catalog.fromPath(catalogPath))
   def apply(id:String, path:String) = new Server(id, Catalog.fromPath(path))
   def apply(id:String, catalog:Catalog) = new Server(id, catalog)
-
   def empty(id:String) = new Server(id, Catalog.empty(id))
+
+  var actorSystem:akka.actor.ActorSystem = akka.actor.ActorSystem("GeoTrellis", ConfigFactory.load())
+
+  def startActorSystem {
+    if (actorSystem.isTerminated) {
+      actorSystem = akka.actor.ActorSystem("GeoTrellis", ConfigFactory.load())
+    } 
+  }
 }

--- a/src/test/scala/geotrellis/Literal.scala
+++ b/src/test/scala/geotrellis/Literal.scala
@@ -2,6 +2,7 @@ package geotrellis
 
 import geotrellis.process._
 import geotrellis._
+import geotrellis.testutil._
 
 import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
@@ -9,7 +10,7 @@ import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class LiteralSpec extends FunSpec with MustMatchers with ShouldMatchers {
-  val server = TestServer()
+  val server = TestServer.server
 
   describe("The Literal operation") {
     it("should work with Int") {

--- a/src/test/scala/geotrellis/OperationsTest.scala
+++ b/src/test/scala/geotrellis/OperationsTest.scala
@@ -5,6 +5,7 @@ import geotrellis.raster.op.local._
 import geotrellis.process._
 import geotrellis.raster._
 import geotrellis.Implicits._
+import geotrellis.testutil._
 
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -12,7 +13,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class OperationsTest extends FunSuite {
-  val server = TestServer()
+  val server = TestServer.server
 
   var counter = 1
   def run(prefix:String, op:Op[Raster], expected:Raster) {

--- a/src/test/scala/geotrellis/core/SimpleOpSyntaxSpec.scala
+++ b/src/test/scala/geotrellis/core/SimpleOpSyntaxSpec.scala
@@ -2,6 +2,7 @@ package geotrellis.core
 
 import geotrellis._
 import geotrellis.process._
+import geotrellis.testutil._
 
 import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
@@ -9,7 +10,7 @@ import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class SimpleOpSyntaxSpec extends FunSpec with MustMatchers with ShouldMatchers {
-  val server = TestServer()
+  val server = TestServer.server
   def testOp[T:Manifest](op:Op[T], expected:T){
     server.run(op) must be === expected
   }

--- a/src/test/scala/geotrellis/data/ExtentSpec.scala
+++ b/src/test/scala/geotrellis/data/ExtentSpec.scala
@@ -1,9 +1,9 @@
 package geotrellis.data
 
 import geotrellis._
-import geotrellis._
 import geotrellis.process._
 import geotrellis.raster.op._
+import geotrellis.testutil._
 
 import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
@@ -30,7 +30,7 @@ class ExtentSpec extends FunSpec with MustMatchers with ShouldMatchers {
   }
 
   describe("An Extent") {
-    val server = TestServer("src/test/resources/catalog.json")
+    val server = TestServer.server
 
     def confirm(op:Op[Raster], expected:Array[Int]) {
       val r = server.run(op)

--- a/src/test/scala/geotrellis/data/arg.scala
+++ b/src/test/scala/geotrellis/data/arg.scala
@@ -7,14 +7,14 @@ import org.scalatest.matchers.ShouldMatchers
 import scala.math.abs
 
 import geotrellis._
-import geotrellis.process.TestServer
+import geotrellis.testutil._
 import geotrellis.raster._
 import geotrellis.data._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ArgSpec extends FunSpec with MustMatchers with ShouldMatchers {
   describe("An ArgReader") {
-    val server = TestServer()
+    val server = TestServer.server
     val path1 = "src/test/resources/fake.img8.arg"
     	 
     it("should build a valid raster") {

--- a/src/test/scala/geotrellis/data/arg/ArgTest.scala
+++ b/src/test/scala/geotrellis/data/arg/ArgTest.scala
@@ -4,6 +4,7 @@ import geotrellis._
 import geotrellis.data._
 import geotrellis.data.arg._
 import geotrellis._
+import geotrellis.testutil._
 
 import geotrellis.process._
 import geotrellis.raster._
@@ -14,7 +15,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ArgTest extends FunSuite {
-  val server = TestServer()
+  val server = TestServer.server
 
   val data = IntArrayRasterData(Array(NODATA, -1, 2, -3,
                                       4, -5, 6, -7,

--- a/src/test/scala/geotrellis/data/arg/BoolTest.scala
+++ b/src/test/scala/geotrellis/data/arg/BoolTest.scala
@@ -5,6 +5,7 @@ import geotrellis.data._
 import geotrellis.data.arg._
 import geotrellis._
 import geotrellis.process._
+import geotrellis.testutil._
 
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -12,7 +13,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class Int1Test extends FunSuite {
-  val server = TestServer()
+  val server = TestServer.server
 
   val arr = Array[Byte]((1 + 0 + 4 + 0 + 0 + 32 + 64 + 128).toByte,
                         (0 + 0 + 0 + 8 + 16 + 0 + 64 + 128).toByte)

--- a/src/test/scala/geotrellis/data/arg32.scala
+++ b/src/test/scala/geotrellis/data/arg32.scala
@@ -3,6 +3,7 @@ package geotrellis.data.arg
 import geotrellis._
 import geotrellis.process._
 import geotrellis.raster._
+import geotrellis.testutil._
 
 import java.io.{DataInputStream, FileInputStream}
 
@@ -17,7 +18,7 @@ class Arg32Spec extends FunSpec with MustMatchers with ShouldMatchers {
   val nd = NODATA
 
   describe("An Arg32Reader") {
-    val server = TestServer()
+    val server = TestServer.server
 
     val path1 = "src/test/resources/fake.img32.arg"
 

--- a/src/test/scala/geotrellis/data/ascii.scala
+++ b/src/test/scala/geotrellis/data/ascii.scala
@@ -1,10 +1,10 @@
 package geotrellis.data
 
-import geotrellis.process.TestServer
 import geotrellis._
 import geotrellis.raster._
 
 import geotrellis._
+import geotrellis.testutil._
 
 import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
@@ -12,7 +12,7 @@ import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class AsciiSpec extends FunSpec with MustMatchers with ShouldMatchers {
-  val server = TestServer()
+  val server = TestServer.server
 
   val data:Array[Int] = (1 to 100).toArray
 

--- a/src/test/scala/geotrellis/data/intraster.scala
+++ b/src/test/scala/geotrellis/data/intraster.scala
@@ -5,8 +5,8 @@ import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 import Console.printf
-import geotrellis.process.TestServer
 import geotrellis.{Extent,RasterExtent}
+import geotrellis.testutil._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class RasterReaderSpec extends FunSpec with MustMatchers with ShouldMatchers {
@@ -15,7 +15,7 @@ class RasterReaderSpec extends FunSpec with MustMatchers with ShouldMatchers {
       val e = Extent(-9.5, 3.8, 80 + -9.5, 80 + 3.8)
       val geo = RasterExtent(e, 8.0, 8.0, 10, 10)
 
-      val server = TestServer()
+      val server = TestServer.server
       val raster = server.loadRaster("src/test/resources/quad8.arg", geo)
 
       val raster2 = RasterReader.read(raster, None)

--- a/src/test/scala/geotrellis/example/example.scala_nocomp
+++ b/src/test/scala/geotrellis/example/example.scala_nocomp
@@ -43,7 +43,7 @@ class ExampleSpec extends Spec with MustMatchers {
     // pre-process the total weights
     val weightsum:Int = weights.foldLeft(0.toInt) { (a, b) => (a + b).toInt }
 
-    val server = TestServer()
+    val server = TestServer.server
     it("should work") {
 
       val geo = server.run(LoadRasterExtentFromFile(paths(0)))

--- a/src/test/scala/geotrellis/example/example2.scala_nocomp
+++ b/src/test/scala/geotrellis/example/example2.scala_nocomp
@@ -25,7 +25,7 @@ class ExampleTwoSpec extends Spec with MustMatchers {
   //  val weightsum:Int = weights.foldLeft(0.toInt) { (a, b) => (a + b).toInt }
   //
   //  it("should work with a subextent that once crashed") {
-  //    val server = TestServer()
+  //    val server = TestServer.server
   //  
   //    //val geo = LoadRasterExtentFromArgFile(paths(0)).run(server)
   // 

--- a/src/test/scala/geotrellis/feature/RasterizePolygonSpec.scala
+++ b/src/test/scala/geotrellis/feature/RasterizePolygonSpec.scala
@@ -4,6 +4,7 @@ import geotrellis._
 import geotrellis.feature.op.geometry.{Buffer,GetCentroid}
 import geotrellis.process._
 import geotrellis.feature._
+import geotrellis.testutil._
 import math.{max,min,round}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -121,7 +122,7 @@ class RasterizePolygonSpec extends FunSuite {
   test("failing example should work") {
     val geojson = """{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[35.092945313732635,-85.4351806640625],[35.06147690849717,-85.440673828125],[35.08620310578525,-85.37200927734375]]]}}"""
     val fOp = io.LoadGeoJsonFeature(geojson)
-    val f = TestServer().run(fOp)
+    val f = TestServer.server.run(fOp)
     val p = Polygon(List((-9510600.807354769, 4176519.1962707597), (-9511212.30358105,4172238.854275199), (-9503568.600752532,4175602.1747499597), (-9510600.807354769,4176519.1962707597)),())
     val re = RasterExtent(Extent(-9509377.814902207,4174073.2405969054,-9508766.318675926,4174684.736823185),2.3886571339098737,2.3886571339044167,256,256)
     val r = Rasterizer.rasterizeWithValue(p, re)( (a:Unit) => 1 )
@@ -216,7 +217,7 @@ object RasterizePolygonSpec {
     println("Testing rasterization: " + filename)
     val count = Integer.parseInt(wktFile.getName().subSequence(0, filename.length - 4).toString.split("_").last)
     println("count: " + count)
-    val g1 = TestServer().run(io.LoadWkt(json))
+    val g1 = TestServer.server.run(io.LoadWkt(json))
     val p1 = Polygon(g1.geom, ())
     var sum = 0
     val re = RasterExtent( Extent(0, 0, 300, 300), 1, 1, 300, 300)

--- a/src/test/scala/geotrellis/feature/RasterizeSpec.scala
+++ b/src/test/scala/geotrellis/feature/RasterizeSpec.scala
@@ -4,6 +4,7 @@ import geotrellis._
 import geotrellis.feature.op.geometry.{Buffer,GetCentroid}
 import geotrellis.process._
 import geotrellis.feature._
+import geotrellis.testutil._
 import math.{max,min,round}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -15,7 +16,7 @@ import geotrellis.feature.rasterize.Rasterizer
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class RasterizeSpec extends FunSuite {
   test("Point Rasterization") {
-      val s = TestServer()
+      val s = TestServer.server
       val e = Extent(0.0, 0.0, 10.0, 10.0)
       val g = RasterExtent(e, 1.0, 1.0, 10, 10)
 
@@ -76,7 +77,7 @@ class RasterizeSpec extends FunSuite {
 
   test("linestring rasterization") {
       // setup test objects
-      val s = TestServer()
+      val s = TestServer.server
       val e = Extent(0.0, 0.0, 10.0, 10.0)
       val g = RasterExtent(e, 1.0, 1.0, 10, 10)
 

--- a/src/test/scala/geotrellis/feature/feature.scala
+++ b/src/test/scala/geotrellis/feature/feature.scala
@@ -4,6 +4,7 @@ import geotrellis._
 import geotrellis.feature.op.geometry._
 import geotrellis.process._
 import geotrellis.feature._
+import geotrellis.testutil._
 import math.{max,min,round}
 import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
@@ -14,7 +15,7 @@ import geotrellis.feature.op.geometry.Intersect
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class FeatureSpec extends FunSpec with MustMatchers with ShouldMatchers {
 
-  val s = TestServer()
+  val s = TestServer.server
   val p = Point(1.0,2.0,"hi")
   val b = Buffer(p, 5.0, 8, EndCapRound) // same as Buffer(p, 5.0)
   val p2 = Point (3.0,2.0,"goodbye")

--- a/src/test/scala/geotrellis/logic/ForEach.scala
+++ b/src/test/scala/geotrellis/logic/ForEach.scala
@@ -10,13 +10,15 @@ import geotrellis.statistics._
 import geotrellis.process._
 import geotrellis._
 
+import geotrellis.testutil._
+
 import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class ForEachSpec extends FunSpec with MustMatchers with ShouldMatchers {
-  val server = TestServer()
+  val server = TestServer.server
 
   describe("The ForEach operation") {
     it("should work with Array[Int]") {

--- a/src/test/scala/geotrellis/logic/If.scala
+++ b/src/test/scala/geotrellis/logic/If.scala
@@ -1,13 +1,14 @@
 package geotrellis.logic
 
 import geotrellis._
+import geotrellis.testutil._
 
 import org.scalatest.FunSpec
 import org.scalatest.matchers.ShouldMatchers
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
 class IfSpec extends FunSpec with ShouldMatchers {
-  val server = process.TestServer()
+  val server = TestServer.server
 
   describe("the if operation should only eval 1 argument") {
     val ErrorOp = op { (x:Int) => { sys.error("execute this op"); x } }

--- a/src/test/scala/geotrellis/process/error.scala
+++ b/src/test/scala/geotrellis/process/error.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.MustMatchers
 
 import geotrellis._
 import geotrellis.process._
+import geotrellis.testutil._
 
 case class Defenestrator(msg:String) extends Operation[Unit] {
   def _run(context:Context) = {
@@ -38,7 +39,7 @@ class FailingOpSpec extends FunSpec with MustMatchers {
 
 describe("A failing operation") {
     it("should return a StepError") {
-      val server = TestServer()
+      val server = TestServer.server
       val op = Defenestrator("Ermintrude Inch")
       val op2 = Window("extremely high")
       val op3 = LargeWindow(Literal(Unit), op2)

--- a/src/test/scala/geotrellis/process/server.scala
+++ b/src/test/scala/geotrellis/process/server.scala
@@ -4,6 +4,7 @@ import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
 
 import geotrellis.{Extent,RasterExtent}
+import geotrellis.testutil._
 
 class ServerSpec extends FunSpec with MustMatchers {
 
@@ -11,7 +12,7 @@ describe("A Server") {
 
     it("should use caching for LoadRaster") {
       val path = "src/test/resources/quadborder8.arg"
-      val server = TestServer()
+      val server = TestServer.server
       val geo = RasterExtent(Extent(-9.5, 3.8, 150.5, 163.8), 8.0, 8.0, 20, 20)
 
       val r1 = server.loadRaster(path, geo)

--- a/src/test/scala/geotrellis/raster/op/AddArrayTest.scala
+++ b/src/test/scala/geotrellis/raster/op/AddArrayTest.scala
@@ -4,6 +4,7 @@ import geotrellis._
 import geotrellis.process._
 import geotrellis.raster._
 import geotrellis.raster.op.local.AddArray
+import geotrellis.testutil._
 
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -14,7 +15,7 @@ class AddArrayTest extends FunSuite {
   val e = Extent(0.0, 0.0, 10.0, 10.0)
   val re = RasterExtent(e, 1.0, 1.0, 10, 10)
 
-  val server = TestServer()
+  val server = TestServer.server
 
   def r(n:Int) = Raster(Array.fill(100)(n), re)
   def r(n:Double) = Raster(Array.fill(100)(n), re)

--- a/src/test/scala/geotrellis/raster/op/AddTest.scala
+++ b/src/test/scala/geotrellis/raster/op/AddTest.scala
@@ -3,6 +3,8 @@ package geotrellis.raster.op
 import geotrellis._
 import geotrellis.process._
 import geotrellis.raster._
+import geotrellis.testutil._
+
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -17,7 +19,7 @@ class AddTest extends FunSuite {
   val r2 = Raster(Array.fill(100)(6), re).defer
   val r3 = Raster(Array.fill(100)(9), re)
 
-  val server = TestServer()
+  val server = TestServer.server
 
   test("add correctly") {
     val rr = server.run(Add(r1, r2))

--- a/src/test/scala/geotrellis/raster/op/AverageLotsOfRasters.scala
+++ b/src/test/scala/geotrellis/raster/op/AverageLotsOfRasters.scala
@@ -3,6 +3,7 @@ package geotrellis.raster.op
 import geotrellis._
 import geotrellis.process._
 import geotrellis.raster.op._
+import geotrellis.testutil._
 
 import geotrellis.raster.op.local.AddArray
 import geotrellis.{op => liftOp}
@@ -16,7 +17,7 @@ class AverageLotsOfRastersTest extends FunSuite {
   val e = Extent(0.0, 0.0, 10.0, 10.0)
   val re = RasterExtent(e, 1.0, 1.0, 10, 10)
 
-  val server = TestServer()
+  val server = TestServer.server
 
   def r(n:Int) = Raster(Array.fill(100)(n), re)
   def r(n:Double) = Raster(Array.fill(100)(n), re)
@@ -35,7 +36,7 @@ class AverageLotsOfRastersTest extends FunSuite {
     val groups = dividedOps.tail.grouped(limit).map { _.toArray }.toList
 
     val rOps:Op[Raster] = groups.foldLeft (firstRaster) ((oldResult:Op[Raster], newOps:Array[Op[Raster]]) => (logic.WithResult(oldResult)({ oldResult => local.Add( local.AddRasters(newOps:_*), oldResult) })) )
-    val s = process.TestServer()
+    val s = TestServer.server
     val output = s.run(rOps)
   }
 
@@ -50,7 +51,7 @@ class AverageLotsOfRastersTest extends FunSuite {
     val groups = dividedOps.tail.grouped(limit).map { _.toArray }.map(local.AddRasters( _:_* ) ) 
     val ops2 = local.AddArray( logic.CollectArray( groups.toArray ) )
 
-    val s = process.TestServer()
+    val s = TestServer.server
     val output = s.run(ops2)
   }
 }

--- a/src/test/scala/geotrellis/raster/op/BinaryLocalSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/BinaryLocalSpec.scala
@@ -5,6 +5,7 @@ import geotrellis.raster.op._
 import geotrellis.raster.op.local.{AddConstant,MultiplyConstant}
 import geotrellis.raster._
 import geotrellis._
+import geotrellis.testutil._
 
 import org.scalatest.FunSpec
 import org.scalatest.matchers.MustMatchers
@@ -18,7 +19,7 @@ class BinaryLocalSpec extends FunSpec with MustMatchers with ShouldMatchers {
     val cols = 100
     val rows = 100
 
-    val server = TestServer()
+    val server = TestServer.server
     val e = Extent(0.0, 0.0, 100.0, 100.0)
     val re = RasterExtent(e, e.width / cols, e.height / rows, cols, rows)
 

--- a/src/test/scala/geotrellis/raster/op/LoadRasterTest.scala
+++ b/src/test/scala/geotrellis/raster/op/LoadRasterTest.scala
@@ -3,6 +3,7 @@ package geotrellis.raster.op
 import geotrellis._
 import geotrellis.process._
 import geotrellis.raster._
+import geotrellis.testutil._
 
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -10,7 +11,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class LoadRasterTest extends FunSuite {
-  val server = TestServer("src/test/resources/catalog.json")
+  val server = TestServer.server
 
   test("load valid raster") {
     server.run(io.LoadRaster("quadborder"))

--- a/src/test/scala/geotrellis/raster/op/UnaryLocalSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/UnaryLocalSpec.scala
@@ -3,6 +3,7 @@ package geotrellis.raster.op
 import geotrellis.process._
 import geotrellis._
 import geotrellis.raster.op.local._
+import geotrellis.testutil._
 
 import geotrellis.raster._
 import geotrellis._
@@ -19,7 +20,7 @@ class UnaryLocalSpec extends FunSpec with MustMatchers with ShouldMatchers {
     val cols = 1000
     val rows = 1000
 
-    val server = TestServer()
+    val server = TestServer.server
     val e = Extent(0.0, 0.0, 100.0, 100.0)
     val re = RasterExtent(e, e.width / cols, e.height / rows, cols, rows)
     val data = Array.fill(re.cols * re.rows)(100)

--- a/src/test/scala/geotrellis/raster/op/VerticalFlipTest.scala
+++ b/src/test/scala/geotrellis/raster/op/VerticalFlipTest.scala
@@ -4,6 +4,7 @@ package geotrellis.raster.op
 import geotrellis._
 import geotrellis.process._
 import geotrellis.raster._
+import geotrellis.testutil._
 
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -11,7 +12,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class VerticalFlipTest extends FunSuite {
-  val server = TestServer("src/test/resources/catalog.json")
+  val server = TestServer.server
 
   test("load valid raster") {
     val op1 = io.LoadRaster("quadborder")

--- a/src/test/scala/geotrellis/raster/op/focal/HillshadeSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/focal/HillshadeSpec.scala
@@ -49,7 +49,6 @@ class HillshadeSpec extends FunSuite with TestServer {
   
     println("Starting test Hillshade operation.")
     println("Loading raster")
-    val server = TestServer()
   
     val t0 = time()
     val r = server.run(io.LoadFile(path))

--- a/src/test/scala/geotrellis/raster/op/focal/SurfacePointCalculationSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/focal/SurfacePointCalculationSpec.scala
@@ -3,6 +3,7 @@ package geotrellis.raster.op.focal
 import geotrellis._
 import geotrellis.process._
 import geotrellis.raster.op._
+import geotrellis.testutil._
 
 import org.junit.runner.RunWith
 import org.scalatest.FunSpec
@@ -13,7 +14,7 @@ import scala.math._
 
 @RunWith(classOf[JUnitRunner])
 class SlopeAspectTests extends FunSpec with ShouldMatchers {
-  val server = TestServer("src/test/resources/catalog.json")
+  val server = TestServer.server
 
   describe("SurfacePoint") {
     it("should calculate trig values correctly") {

--- a/src/test/scala/geotrellis/raster/op/zonal/TiledPolygonalZonalSummarySpec.scala
+++ b/src/test/scala/geotrellis/raster/op/zonal/TiledPolygonalZonalSummarySpec.scala
@@ -4,6 +4,7 @@ import geotrellis._
 import geotrellis.process._
 import geotrellis.raster._
 import geotrellis.feature._
+import geotrellis.testutil._
 
 import geotrellis.raster.op.zonal.summary._
 
@@ -15,7 +16,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TiledPolygonalZonalSummarySpec extends FunSpec with ShouldMatchers {
-  val server = TestServer()
+  val server = TestServer.server
 
   sealed trait TestResultTile
 

--- a/src/test/scala/geotrellis/testutil/TestServer.scala
+++ b/src/test/scala/geotrellis/testutil/TestServer.scala
@@ -7,19 +7,21 @@ import geotrellis.process._
 import org.scalatest.{BeforeAndAfter,Suite}
 import org.scalatest.matchers._
 
+object TestServer {
+  lazy val server:Server = new Server("testutil", Catalog.fromPath("src/test/resources/catalog.json"))
+}
 /*
  * Mixin to provide a server that is reset for each test
  */
 trait TestServer extends Suite with BeforeAndAfter with ShouldMatchers {
-  var server:Server = null
-
+  var server = TestServer.server 
   before {
-    server = geotrellis.process.TestServer("src/test/resources/catalog.json")  
+    //server = geotrellis.process.TestServer("src/test/resources/catalog.json")  
   }
 
   after {
-    server.shutdown()
-    server = null
+    //server.shutdown()
+    //server = null
   }
 
   def run[T:Manifest](op:Op[T]):T = server.run(op)


### PR DESCRIPTION
This commit turns the GeoTrellis akka actor system into a singleton for
purposes of the clustering mechanism.  The actor system is given a single
name ("GeoTrellis") and the tests are changed to no longer create many
servers.  The TestServer class is removed entirely, and the tests are updated
to import from testutils.

In the future, the actor system could be made specific to each server by
having the ServerActor pass its context system into the new server, but that
is not currently implemented.
