### PR TITLE
Add into() method to Operation.

### DIFF
--- a/src/main/scala/geotrellis/Operation.scala
+++ b/src/main/scala/geotrellis/Operation.scala
@@ -82,7 +82,15 @@ abstract class Operation[+T] extends Product with Serializable {
  //TODO: how should filter be implemented for list comprehensions?
  def filter(f:(T) => Boolean) = this
 
-  def andThen[U](f:T => Op[U]) = flatMap(f)
+ def andThen[U](f:T => Op[U]) = flatMap(f)
+
+ /** Call the given function with this operation as its argument.
+   *
+   * This is primarily useful for code readability.
+   * @see http://debasishg.blogspot.com/2009/09/thrush-combinator-in-scala.html
+   */
+ def into[U] (f: (Operation[T]) => U):U = f(this)
+
 }
 
 

--- a/src/test/scala/geotrellis/OperationsTest.scala
+++ b/src/test/scala/geotrellis/OperationsTest.scala
@@ -73,6 +73,8 @@ class OperationsTest extends FunSuite {
   run("int", r9 / r3, r3)
   run("int", r3 - r2, r1)
 
+  // test Operation.into()
+  run("int", Literal(r2).into(Multiply(_, 3)), r6) 
 
   // doubles
 


### PR DESCRIPTION
The into() method is a method that allows operations to be composed
in a clean pipeline expression instead of inverting the order between
method invocations and class construction.

For example,

io.LoadRaster("foo")
  .into(Multiply(_, 3))
  .into(...)

instead of Multiply(io.LoadRaster("foo"))
