### PR TITLE
Resolve feature serialization issues.

### DIFF
--- a/src/main/scala/geotrellis/feature/feature.scala
+++ b/src/main/scala/geotrellis/feature/feature.scala
@@ -17,7 +17,7 @@ import geotrellis._
  * The data component is generic.
  *
  */
-trait Feature[+G <: jts.Geometry, D] {
+trait Feature[+G <: jts.Geometry, D] extends Serializable {
 
   /**
    * Returns geometry as a JTS Geometry object.
@@ -133,7 +133,7 @@ object Point {
    * @param   y   y coordinate
    */
   def apply(x: Double, y: Double) = {
-    JtsPoint(factory.createPoint(new jts.Coordinate(x, y)), Unit)
+    JtsPoint(factory.createPoint(new jts.Coordinate(x, y)), None)
   } 
   /**
    * Create a point feature from a JTS point instance.

--- a/src/main/scala/geotrellis/feature/op/geometry/geometry.scala
+++ b/src/main/scala/geotrellis/feature/op/geometry/geometry.scala
@@ -11,7 +11,7 @@ import scala.reflect.runtime.universe._
 package object geometry {
 
   val GetExtent = liftOp { (a: Raster) => a.rasterExtent.extent }
-  val AsFeature = liftOp { (e: Extent) => e.asFeature(()) }
+  val AsFeature = liftOp { (e: Extent) => e.asFeature(None) }
 
 
   /**

--- a/src/main/scala/geotrellis/feature/rasterize/PolygonRasterizer.scala
+++ b/src/main/scala/geotrellis/feature/rasterize/PolygonRasterizer.scala
@@ -11,7 +11,7 @@ object PolygonRasterizer {
    */
   def foreachCellByPolygon[D](p:Polygon[D], re:RasterExtent, includeExterior:Boolean=false)( f:Callback[Polygon,D]) {
     // If polygon does not intersect with this raster's extent, skip.
-    val rasterGeom = re.extent.asFeature(()).geom
+    val rasterGeom = re.extent.asFeature(None).geom
     if (! p.geom.intersects(rasterGeom)) { return }
 
     processPolygon( p, re:RasterExtent, includeExterior )(f)

--- a/src/test/scala/geotrellis/SerializationTest.scala
+++ b/src/test/scala/geotrellis/SerializationTest.scala
@@ -11,6 +11,7 @@ import geotrellis._
 import geotrellis.testutil._
 import geotrellis.raster.op._
 import geotrellis.statistics._
+import geotrellis.feature._
 
 @RunWith(classOf[JUnitRunner])
 class SerializationTest extends FunSuite 
@@ -27,6 +28,8 @@ class SerializationTest extends FunSuite
     pickle(local.Add(addOp, 2))
     pickle(FastMapHistogram())
     pickle(Statistics(0,0,0,0,0,0))
+    pickle(Point(0,0, None))
+    pickle(Polygon( (1,9) :: (1,6) :: (4,6) :: (4,9) :: (1,9) :: Nil, None ))
   }
 
   test("Tile Rasters are serializable") {


### PR DESCRIPTION
All feature classes must be serializable, and their data classes as well.  Our use of
scala.Unit for features without a data component was causing problems as scala.Unit isn't
serializable.
