### PR TITLE
Ensure that remote operations are not only lazily evaluated.

### DIFF
--- a/src/main/scala/geotrellis/Operation.scala
+++ b/src/main/scala/geotrellis/Operation.scala
@@ -115,7 +115,7 @@ abstract class OperationWrapper[+T](op:Op[T]) extends Operation[T] {
 }
 
 case class DispatchedOperation[+T](val op:Op[T], val dispatcher:ActorRef)
-extends OperationWrapper(op) {}
+extends OperationWrapper(logic.Force(op)) {}
 
 object Operation {
   implicit def implicitLiteral[A:Manifest](a:A):Operation[A] = Literal(a)

--- a/src/main/scala/geotrellis/logic/Force.scala
+++ b/src/main/scala/geotrellis/logic/Force.scala
@@ -1,0 +1,26 @@
+package geotrellis.logic
+
+import geotrellis._
+import geotrellis._
+import geotrellis.process._
+
+/**
+ * Ensure that the result of the operation will be evaluated.
+ * 
+ * Some raster operations are lazily evaluated, which means that the
+ * operations will defer their execution until the
+ * moment where execution is necessary.  This allows, for example,
+ * some raster operations to be combined and executed at the same
+ * time instead of in sequence. 
+ *
+ * Force will evaluate a lazily evaluated operation if it has not 
+ * yet been evaluated.
+ * 
+ */
+case class Force[A](op:Op[A]) extends Op[A] {
+  def _run(context:Context) = runAsync(op :: Nil)
+  val nextSteps:Steps = {
+    case (r:Raster) :: Nil => Result(r.force.asInstanceOf[A])
+    case a :: Nil => Result(a.asInstanceOf[A])
+  }
+}


### PR DESCRIPTION
This checkin adds a Force() operation that will force the evaluation
of any operation, although at the moment that only applies to
Raster operations.
