### PR TITLE
Improvements and bugfix to remote execution of operations.

### DIFF
--- a/src/main/scala/geotrellis/Operation.scala
+++ b/src/main/scala/geotrellis/Operation.scala
@@ -43,9 +43,26 @@ abstract class Operation[+T] extends Product with Serializable {
 
   def processNextSteps(args:Args):StepOutput[T] = nextSteps(args)
 
-  def dispatch(dispatcher:ActorRef) = {
-    DispatchedOperation(this, dispatcher)    
-  }
+  /** Returns an operation whose children will be executed on a remote cluster.
+   * 
+   *  This method will cause the operations executed as a result of this operation
+   *  (input operations and any operations necessary for this computation) to be 
+   *  dispatched to and executed on a remote cluster.
+   *
+   */
+  def dispatch(cluster:ActorRef) = 
+    DispatchedOperation(this, cluster)    
+
+  /** Returns an operation that will be executed on a remote cluster.
+   *
+   *  This method will cause the specified operation to be executed on a remote
+   *  cluster.
+   *
+   *  Note that if you wish to distribute the work of a single operation, you
+   *  should probably be using dispatch() instead of remote().
+   */
+  def remote(cluster:ActorRef) = logic.Do1(this)(x => x).dispatch(cluster)
+  
 
  /**
   * Create a new operation with a function that takes the result of this operation


### PR DESCRIPTION
This checkin resolves one bug where operations designed for remote
execution were not being dispatched, adds a "remote()" method to
operations for sending an operation for remote execution (as opposed
to dispatch() which sends an operation's children), and adds some
documentation.
