### PR TITLE
Extend WebRunner & JettyServer API for custom init parameters.

### DIFF
--- a/server/src/main/scala/geotrellis/rest/JettyServer.scala
+++ b/server/src/main/scala/geotrellis/rest/JettyServer.scala
@@ -37,11 +37,16 @@ class JettyServer(config:JettyConfig) {
 
   val staticResources = mutable.ListBuffer[String]()
   
-  def withPackages(packages:Seq[String], contextPath:String = "/gt/*") = {
+  def withPackages(packages:Seq[String], contextPath:String = "/gt/*", initParameters:Map[String,String]=Map()) = {
     val holder = new ServletHolder(classOf[ServletContainer])
     holder.setInitParameter("com.sun.jersey.config.property.resourceConfigClass",
                             "com.sun.jersey.api.core.PackagesResourceConfig")
     holder.setInitParameter("com.sun.jersey.config.property.packages", packages.mkString(";"))
+
+    initParameters foreach {
+      case (key, value) => holder.setInitParameter(key, value)
+    }
+
     context.addServlet(holder, contextPath)
     this
   }

--- a/server/src/main/scala/geotrellis/rest/WebRunner.scala
+++ b/server/src/main/scala/geotrellis/rest/WebRunner.scala
@@ -8,6 +8,10 @@ package geotrellis.rest
  */
 
 object WebRunner {
+
+  def createJettyServer(config:ServerConfig, contextPath:String) = 
+    new JettyServer(config.jetty).withPackages(config.packages, contextPath)
+
   def main(args: Array[String]) {
     printWelcome()
 
@@ -15,9 +19,7 @@ object WebRunner {
 
     try {
       val config = ServerConfig.init()
-      
-      val server = new JettyServer(config.jetty)
-      .withPackages(config.packages, "/gt/*")
+      val server = createJettyServer(config, "/gt/*")
       
       config.staticContentPath match {
         case Some(path) => 


### PR DESCRIPTION
JettyServer withPackages now accepts an optional initParameters argument for additional
Jetty parameters that may be required by jersey resources specified in the configuration.

The instantiation of WebRunner now includes a call to createJettyServer that can be overwritten
by a subclass of WebRunner to include custom initialization parameters.

In particular, this change is designed to make it possible to use external jetty resources for
service documentation (e.g. swagger's jetty/jaxrs module).
