### PR TITLE
Benchmarks now use singleton Server.

### DIFF
--- a/benchmark/src/main/scala/geotrellis/benchmark/Benchmarks.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/Benchmarks.scala
@@ -80,10 +80,7 @@ trait OperationBenchmark extends SimpleBenchmark {
   /**
    * Load a server with the GeoTrellis benchmarking catalog.
    */
-  def initServer():Server = {
-    val catalog = Catalog.fromPath("src/main/resources/catalog.json")
-    Server("demo", catalog)
-  }
+  def initServer():Server = BenchmarkServer.server
 
   /**
    * Sugar for building arrays using a per-cell init function.
@@ -102,6 +99,11 @@ trait OperationBenchmark extends SimpleBenchmark {
     while (i < reps) { f; i += 1 }
   }
 }
+
+object BenchmarkServer {
+  val server = Server("demo", Catalog.fromPath("src/main/resources/catalog.json"))
+}
+
 
 /**
  * Extend this to create a main object which will run 'cls' (a benchmark).


### PR DESCRIPTION
The benchmarks were broken because multiple Server instances with the same
identifier were being instantiated at the same time.  This fix allows
the benchmarks to run once again.

Fixes #547.
