### PR TITLE
History now includes node identification information.

### DIFF
--- a/src/main/scala/geotrellis/process/History.scala
+++ b/src/main/scala/geotrellis/process/History.scala
@@ -18,6 +18,9 @@ object History {
   def apply(op:Op[_]) =
     new History(op.name,Nil,None,System.currentTimeMillis,0)
 
+  def apply(op:Op[_],system:String) =
+    new History(op.name,Nil,None,System.currentTimeMillis,0,system)
+
   def literal[T](v:T) =
     new History("Literal",Nil,None,System.currentTimeMillis,0).withResult(v)
 
@@ -46,7 +49,8 @@ case class History(id:String,
                    steps:List[StepHistory],
                    result:Option[HistoryResult],
                    startTime:Long,
-                   endTime:Long) {
+                   endTime:Long,
+                   system:String = "unknown") {
   val elapsedTime = endTime - startTime
 
   def withResult[T](value:T) = {
@@ -79,25 +83,25 @@ case class History(id:String,
           sb.toString
         case _ => value.getClass.getSimpleName
       }
-    new History(id,steps,Some(Success(s)),startTime,now)
+    new History(id,steps,Some(Success(s)),startTime,now,system)
   }
 
   def withError(msg:String,trace:String) = {
     val now = System.currentTimeMillis
-    new History(id,steps,Some(Failure(msg,trace)),startTime,now)
+    new History(id,steps,Some(Failure(msg,trace)),startTime,now,system)
   }
 
   def withStep(step:StepHistory) =
-    new History(id,step :: steps,result,startTime,endTime)
+    new History(id,step :: steps,result,startTime,endTime,system)
 
   def withStep(stepHistorys:List[History]) =
-    new History(id,StepHistory(stepHistorys) :: steps,result,startTime,endTime)
+    new History(id,StepHistory(stepHistorys) :: steps,result,startTime,endTime,system)
 
   override
   def toString:String = 
     toString("",false)
 
-  def toString(indentString:String,initialIndent:Boolean):String = {
+  def toString(indentString:String,initialIndent:Boolean,includeSystem:Boolean=true):String = {
     val halfLen = id.length/2
     val sb = new StringBuilder
     if(initialIndent) {
@@ -120,6 +124,9 @@ case class History(id:String,
         s"ERROR: $msg (in $elapsedTime ms): \n" + trace + "\n"
       case None => "No Result"
     })
+    if (includeSystem && system != "") {
+      sb.append("[" + system + "]")
+    }
     sb.append("\n")
     sb.toString
   }

--- a/src/main/scala/geotrellis/process/Server.scala
+++ b/src/main/scala/geotrellis/process/Server.scala
@@ -27,6 +27,12 @@ class Server (id:String, val catalog:Catalog) extends Serializable {
   Server.startActorSystem
   def system = Server.actorSystem
 
+  val fullExternalId = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress.toString
+  val externalId = if (fullExternalId.startsWith("akka.tcp://GeoTrellis@")) 
+    fullExternalId.substring(22)
+  else 
+    ""
+
   def startUp:Unit = ()
 
   def shutdown():Unit = { 

--- a/src/main/scala/geotrellis/process/actors/StepAggregator.scala
+++ b/src/main/scala/geotrellis/process/actors/StepAggregator.scala
@@ -42,7 +42,7 @@ case class StepAggregator[T](val server:Server,
       args(i) match {
         case lit:Literal[_] =>
           val v = lit.value
-          results(i) = Some(Complete(v,History.literal(v)))
+          results(i) = Some(Complete(v,History.literal(v,server.externalId)))
         case op:Operation[_] =>
           dispatcher ! RunOperation(op, i, self, None)
         case value =>

--- a/src/main/scala/geotrellis/process/actors/Worker.scala
+++ b/src/main/scala/geotrellis/process/actors/Worker.scala
@@ -35,8 +35,9 @@ case class Worker(val server: Server) extends Actor {
 
       val handler = new ResultHandler(server,client,dispatcher,pos)
       val geotrellisContext = new Context(server)
+      val history = History(op,server.externalId)
 
-      val history = History(op)
+
       try {
         handler.handleResult(op.run(geotrellisContext),history)
       } catch {


### PR DESCRIPTION
The History object now includes a string which identifies the node that
an operation was executed on, if a node has a default external address.

The toString() method will include the system id string, but has an optional
boolean argument to exclude it.
