### PR TITLE
Gave the ability to have zonal summary use cached results.

### DIFF
--- a/src/main/scala/geotrellis/raster/op/zonal/summary/Histogram.scala
+++ b/src/main/scala/geotrellis/raster/op/zonal/summary/Histogram.scala
@@ -1,0 +1,35 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.source._
+import geotrellis.feature._
+import geotrellis.feature.rasterize._
+import geotrellis.statistics._
+
+object Histogram extends TileSummary[Histogram,Histogram,ValueSource[Histogram]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):Histogram = {
+    val PartialTileIntersection(r,polygons) = pt
+    val histogram = FastMapHistogram()
+    for(p <- polygons.asInstanceOf[List[Polygon[D]]]) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply (col:Int, row:Int, g:Geometry[D]) {
+            val z = r.get(col,row)
+            if (isData(z)) histogram.countItem(z, 1)
+          }
+        }
+      )
+    }
+
+    histogram
+  }
+
+  def handleFullTile(ft:FullTileIntersection):Histogram = {
+    val histogram = FastMapHistogram()
+    ft.tile.foreach((z:Int) => if (isData(z)) histogram.countItem(z, 1))
+    histogram
+  }
+
+  def converge(ds:DataSource[Histogram,_]) =
+    ds.map(x=>x).converge // Map to kick in the CanBuildFrom for HistogramDS
+}

--- a/src/main/scala/geotrellis/raster/op/zonal/summary/Max.scala
+++ b/src/main/scala/geotrellis/raster/op/zonal/summary/Max.scala
@@ -1,0 +1,71 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.source._
+import geotrellis.feature._
+import geotrellis.feature.rasterize._
+
+object Max extends TileSummary[Int,Int,ValueSource[Int]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):Int = {
+    val PartialTileIntersection(r,polygons) = pt
+    var max = NODATA
+    for(p <- polygons.asInstanceOf[List[Polygon[D]]]) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply(col:Int, row:Int, g:Geometry[D]) {
+            val z = r.get(col,row)
+            if (isData(z) && (z > max || isNoData(max)) ) { max = z }
+          }
+        }
+      )
+    }
+    max
+  }
+
+  def handleFullTile(ft:FullTileIntersection):Int = {
+    var max = NODATA
+    ft.tile.foreach { (x:Int) =>
+      if (isData(x) && (x > max || isNoData(max))) { max = x }
+    }
+    max
+  }
+
+  def converge(ds:DataSource[Int,_]) =
+    ds.reduce { (a,b) => 
+      if(isNoData(a)) { b } 
+      else if(isNoData(b)) { a }
+      else { math.max(a,b) }
+    }
+}
+
+object MaxDouble extends TileSummary[Double,Double,ValueSource[Double]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):Double = {
+    val PartialTileIntersection(r,polygons) = pt
+    var max = Double.NaN
+    for(p <- polygons.asInstanceOf[List[Polygon[D]]]) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply(col:Int, row:Int, g:Geometry[D]) {
+            val z = r.getDouble(col,row)
+            if (isData(z) && (z > max || isNoData(max))) { max = z }
+          }
+        }
+      )
+    }
+
+    max
+  }
+
+  def handleFullTile(ft:FullTileIntersection):Double = {
+    var max = Double.NaN
+    ft.tile.foreach((x:Int) => if (isData(x) && (x > max || isNoData(max))) { max = x })
+    max
+  }
+
+  def converge(ds:DataSource[Double,_]) =
+    ds.reduce { (a,b) =>
+      if(isNoData(a)) { b } 
+      else if(isNoData(b)) { a }
+      else { math.max(a,b) }
+    }
+}

--- a/src/main/scala/geotrellis/raster/op/zonal/summary/Mean.scala
+++ b/src/main/scala/geotrellis/raster/op/zonal/summary/Mean.scala
@@ -1,0 +1,81 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.source._
+import geotrellis.feature._
+import geotrellis.feature.rasterize._
+
+case class MeanResult(sum: Double, count: Long) {
+  def mean:Double = if (count == 0) {
+    Double.NaN
+  } else {
+    sum/count
+  }
+  def +(b: MeanResult) = MeanResult(sum + b.sum,count + b.count)
+}
+
+object MeanResult {
+  def fromFullTile(tile:Raster) = {
+    var s = 0
+    var c = 0L
+    tile.foreach((x:Int) => if (isData(x)) { s = s + x; c = c + 1 })
+    MeanResult(s,c)
+  }
+
+  def fromFullTileDouble(tile:Raster) = {
+    var s = 0.0
+    var c = 0L
+    tile.foreachDouble((x:Double) => if (isData(x)) { s = s + x; c = c + 1 })
+    MeanResult(s,c)
+  }
+}
+
+object Mean extends TileSummary[MeanResult,Double,ValueSource[Double]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):MeanResult = {
+    val PartialTileIntersection(r,polygons) = pt
+    var sum = 0.0
+    var count = 0L
+    for(p <- polygons) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply(col:Int, row:Int, g:Geometry[D]) {
+            val z = r.get(col,row)
+            if (isData(z)) { sum = sum + z; count = count + 1 }
+          }
+        }
+      )
+    }
+    MeanResult(sum,count)
+  }
+
+  def handleFullTile(ft:FullTileIntersection):MeanResult =
+    MeanResult.fromFullTile(ft.tile)
+
+  def converge(ds:DataSource[MeanResult,_]) =
+    ds.reduce(_+_).map(_.mean)
+}
+
+object MeanDouble extends TileSummary[MeanResult,Double,ValueSource[Double]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):MeanResult = {
+    val PartialTileIntersection(r,polygons) = pt
+    var sum = 0.0
+    var count = 0L
+    for(p <- polygons) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply(col:Int, row:Int, g:Geometry[D]) {
+            val z = r.getDouble(col,row)
+            if (isData(z)) { sum = sum + z; count = count + 1 }
+          }
+        }
+      )
+    }
+    MeanResult(sum,count)
+  }
+
+  def handleFullTile(ft:FullTileIntersection):MeanResult =
+    MeanResult.fromFullTileDouble(ft.tile)
+
+  def converge(ds:DataSource[MeanResult,_]) =
+    ds.reduce(_+_).map(_.mean)
+}

--- a/src/main/scala/geotrellis/raster/op/zonal/summary/Min.scala
+++ b/src/main/scala/geotrellis/raster/op/zonal/summary/Min.scala
@@ -1,0 +1,71 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.source._
+import geotrellis.feature._
+import geotrellis.feature.rasterize._
+
+object Min extends TileSummary[Int,Int,ValueSource[Int]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):Int = {
+    val PartialTileIntersection(r,polygons) = pt
+    var min = NODATA
+    for(p <- polygons.asInstanceOf[List[Polygon[D]]]) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply(col:Int, row:Int, g:Geometry[D]) {
+            val z = r.get(col,row)
+            if (isData(z) && (z < min || isNoData(min)) ) { min = z }
+          }
+        }
+      )
+    }
+    min
+  }
+
+  def handleFullTile(ft:FullTileIntersection):Int = {
+    var min = NODATA
+    ft.tile.foreach { (x:Int) =>
+      if (isData(x) && (x < min || isNoData(min))) { min = x }
+    }
+    min
+  }
+
+  def converge(ds:DataSource[Int,_]) =
+    ds.reduce { (a,b) => 
+      if(isNoData(a)) { b } 
+      else if(isNoData(b)) { a }
+      else { math.min(a,b) }
+    }
+}
+
+object MinDouble extends TileSummary[Double,Double,ValueSource[Double]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):Double = {
+    val PartialTileIntersection(r,polygons) = pt
+    var min = Double.NaN
+    for(p <- polygons.asInstanceOf[List[Polygon[D]]]) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply(col:Int, row:Int, g:Geometry[D]) {
+            val z = r.getDouble(col,row)
+            if (isData(z) && (z < min || isNoData(min))) { min = z }
+          }
+        }
+      )
+    }
+
+    min
+  }
+
+  def handleFullTile(ft:FullTileIntersection):Double = {
+    var min = Double.NaN
+    ft.tile.foreach((x:Int) => if (isData(x) && (x < min || isNoData(min))) { min = x })
+    min
+  }
+
+  def converge(ds:DataSource[Double,_]) =
+    ds.reduce { (a,b) =>
+      if(isNoData(a)) { b } 
+      else if(isNoData(b)) { a }
+      else { math.min(a,b) }
+    }
+}

--- a/src/main/scala/geotrellis/raster/op/zonal/summary/Sum.scala
+++ b/src/main/scala/geotrellis/raster/op/zonal/summary/Sum.scala
@@ -1,0 +1,62 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.source._
+import geotrellis.feature._
+import geotrellis.feature.rasterize._
+
+object Sum extends TileSummary[Long,Long,ValueSource[Long]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):Long = {
+    val PartialTileIntersection(r,polygons) = pt
+    var sum: Long = 0L
+    for(p <- polygons.asInstanceOf[List[Polygon[D]]]) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply(col:Int, row:Int, g:Geometry[D]) {
+            val z = r.get(col,row)
+            if (isData(z)) { sum = sum + z }
+          }
+        }
+      )
+    }
+
+    sum
+  }
+
+  def handleFullTile(ft:FullTileIntersection):Long = {
+    var s = 0L
+    ft.tile.foreach((x:Int) => if (isData(x)) s = s + x)
+    s
+  }
+
+  def converge(ds:DataSource[Long,_]) =
+    ds.reduce(_+_)
+}
+
+object SumDouble extends TileSummary[Double,Double,ValueSource[Double]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):Double = {
+    val PartialTileIntersection(r,polygons) = pt
+    var sum = 0.0
+    for(p <- polygons.asInstanceOf[List[Polygon[D]]]) {
+      Rasterizer.foreachCellByFeature(p, r.rasterExtent)(
+        new Callback[Geometry,D] {
+          def apply(col:Int, row:Int, g:Geometry[D]) {
+            val z = r.getDouble(col,row)
+            if(isData(z)) { sum = sum + z }
+          }
+        }
+      )
+    }
+
+    sum
+  }
+
+  def handleFullTile(ft:FullTileIntersection):Double = {
+    var s = 0.0
+    ft.tile.foreachDouble((x:Double) => if (isData(x)) s = s + x)
+    s
+  }
+
+  def converge(ds:DataSource[Double,_]) =
+    ds.reduce(_+_)
+}

--- a/src/main/scala/geotrellis/raster/op/zonal/summary/TileSummary.scala
+++ b/src/main/scala/geotrellis/raster/op/zonal/summary/TileSummary.scala
@@ -1,0 +1,10 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.source._
+
+trait TileSummary[T,V,That <: DataSource[_,V]] {
+  def handlePartialTile[D](pt:PartialTileIntersection[D]):T
+  def handleFullTile(pt:FullTileIntersection):T
+  def converge(ds: DataSource[T,_]):That
+}

--- a/src/main/scala/geotrellis/source/CanBuildSourceFrom.scala
+++ b/src/main/scala/geotrellis/source/CanBuildSourceFrom.scala
@@ -36,11 +36,7 @@ trait Priority1Implicits extends Priority2Implicits { this: CanBuildSourceFrom.t
 
 trait Priority2Implicits { this: CanBuildSourceFrom.type =>
   implicit def canBuildSeq[E]:CanBuildSourceFrom[DataSource[_,_], E, DataSource[E,Seq[E]]] = new CanBuildSourceFrom[DataSource[_,_], E, DataSource[E,Seq[E]]] {
-    def apply = new DataSourceBuilder(convergeSeq)
-    def apply(ds:DataSource[_,_]) = new DataSourceBuilder(convergeSeq)
-  }
-
-  def convergeSeq[A](elementOps:(Op[Seq[Op[A]]])) = {
-    logic.Collect(elementOps)
+    def apply = new DataSourceBuilder(DataSource.convergeSeq)
+    def apply(ds:DataSource[_,_]) = new DataSourceBuilder(DataSource.convergeSeq)
   }
 }

--- a/src/main/scala/geotrellis/source/DataSource.scala
+++ b/src/main/scala/geotrellis/source/DataSource.scala
@@ -12,3 +12,21 @@ import geotrellis.statistics._
   */
 trait DataSource[+T,+V] extends DataSourceLike[T,V,DataSource[T,V]] {
 }
+
+object DataSource {
+  def convergeSeq[A](elementOps:(Op[Seq[Op[A]]])) = {
+    logic.Collect(elementOps)
+  }
+
+  def fromValues[T](elements:T*):DataSource[T,Seq[T]] =
+    fromValues(elements)
+
+  def fromValues[T](elements:Seq[T])(implicit d:DI):DataSource[T,Seq[T]] =
+    apply(Literal(elements.map(Literal(_))))
+
+  def apply[T](elements:Op[Seq[Op[T]]]):DataSource[T,Seq[T]] = {
+    val builder:DataSourceBuilder[T,Seq[T]] = new DataSourceBuilder(convergeSeq)
+    builder.setOp(elements)
+    builder.result
+  }
+}

--- a/src/main/scala/geotrellis/source/DataSourceLike.scala
+++ b/src/main/scala/geotrellis/source/DataSourceLike.scala
@@ -106,4 +106,12 @@ trait DataSourceLike[+T,+V,+Repr <: DataSource[T,V]] { self:Repr =>
 
   def run(implicit server:process.Server) = server.run(this)
   def get(implicit server:process.Server) = server.get(this)
+
+  def cached[R1 >: Repr,T1 >: T](implicit server:process.Server, bf:CanBuildSourceFrom[Repr,T1,R1]) = {
+    val elementOps = server.get(elements) 
+    val newElements = Literal(elementOps.map { op => Literal(server.get(op)) })
+    val builder = bf.apply(this)
+    builder.setOp(newElements)
+    builder.result
+  }
 }

--- a/src/test/scala/geotrellis/raster/op/zonal/summary/HistogramSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/zonal/summary/HistogramSpec.scala
@@ -1,0 +1,55 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.feature._
+import geotrellis.process._
+import geotrellis.testutil._
+
+import org.scalatest.FunSpec
+import org.scalatest.matchers._
+
+class HistogramSpec extends ZonalSummarySpec {
+  describe("zonalHistogram") {
+    it("computes Histogram") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val histOp = rData.zonalHistogram(zone)
+      run(histOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result.getItemCount(1) should equal (40)
+          result.getItemCount(2) should equal (0)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes Histogram for raster source and 5 edge polygon") {
+      val h = statistics.FastMapHistogram()
+
+      for(z <- containedCells.map { case (col,row) => tiledR.get(col,row) }) {
+        if (isData(z)) { h.countItem(z, 1) }
+      }
+
+      run(tiledRS.zonalHistogram(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          for(row <- 0 until tiledR.rows) {
+            for(col <- 0 until tiledR.cols) {
+              val v = tiledR.get(col,row)
+              if(isData(v)) {
+                result.getItemCount(v) should be (h.getItemCount(v))
+              }
+            }
+          }
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+  }
+}

--- a/src/test/scala/geotrellis/raster/op/zonal/summary/MaxSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/zonal/summary/MaxSpec.scala
@@ -1,0 +1,79 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.feature._
+import geotrellis.process._
+import geotrellis.testutil._
+
+import org.scalatest.FunSpec
+import org.scalatest.matchers._
+
+class MaxSpec extends ZonalSummarySpec {
+  describe("Max") {
+    it("computes Maximum") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val maxOp = rData.zonalMax(zone)
+      run(maxOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (1)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes max on raster source and 5 edge polygon") {
+      val max = 
+        containedCells
+          .map { case (col,row) => tiledR.get(col,row) }
+          .foldLeft(Int.MinValue) { (a,b) => if(isNoData(b)) a else math.max(a, b) }
+
+      run(tiledRS.zonalMax(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (max)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes Double Maximum") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val maxDOp = rData.zonalMaxDouble(zone)
+      run(maxDOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (1.0)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes max on double raster source and 5 edge polygon") {
+      val max = 
+        containedCells
+          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
+          .foldLeft(Double.MinValue) { (a,b) => if(isNoData(b)) a else math.max(a, b) }
+
+      run(tiledRSDouble.zonalMaxDouble(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (max)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+  }
+}

--- a/src/test/scala/geotrellis/raster/op/zonal/summary/MeanSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/zonal/summary/MeanSpec.scala
@@ -1,0 +1,89 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.feature._
+import geotrellis.process._
+import geotrellis.testutil._
+
+import org.scalatest.FunSpec
+import org.scalatest.matchers._
+
+class MeanSpec extends ZonalSummarySpec {
+  describe("Mean") {
+    it("computes Mean") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val meanOp = rData.zonalMean(zone)
+      run(meanOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (1.0)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes sum on raster source and 5 edge polygon") {
+      val vals =
+        containedCells
+          .map { case (col,row) => tiledR.getDouble(col,row) }
+      val sum =
+        vals
+          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + b }
+      val count =
+        vals
+          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + 1.0 }
+
+      run(tiledRS.zonalMean(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (sum / count)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes Double Mean") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val meanDOp = rData.zonalMeanDouble(zone)
+      run(meanDOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (1.0)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes mean on double raster source and 5 edge polygon") {
+      val vals =
+        containedCells
+          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
+      val sum =
+        vals
+          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + b }
+      val count =
+        vals
+          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + 1.0 }
+
+      run(tiledRSDouble.zonalMeanDouble(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (sum / count.toDouble)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+  }
+}

--- a/src/test/scala/geotrellis/raster/op/zonal/summary/MinSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/zonal/summary/MinSpec.scala
@@ -1,0 +1,79 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.feature._
+import geotrellis.process._
+import geotrellis.testutil._
+
+import org.scalatest.FunSpec
+import org.scalatest.matchers._
+
+class MinSpec extends ZonalSummarySpec {
+  describe("Min") {
+    it("computes Minimum") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val minOp = rData.zonalMin(zone)
+      run(minOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (1)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes min on raster source and 5 edge polygon") {
+      val min =
+        containedCells
+          .map { case (col,row) => tiledR.get(col,row) }
+          .foldLeft(Int.MaxValue) { (a,b) => if(isNoData(b)) a else math.min(a, b) }
+
+      run(tiledRS.zonalMin(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (min)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes Double Minimum") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val minDOp = rData.zonalMinDouble(zone)
+      run(minDOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (1.0)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes min on double raster source and 5 edge polygon") {
+      val min =
+        containedCells
+          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
+          .foldLeft(Double.MaxValue) { (a,b) => if(isNoData(b)) a else math.min(a, b) }
+
+      run(tiledRSDouble.zonalMinDouble(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (min)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+  }
+}

--- a/src/test/scala/geotrellis/raster/op/zonal/summary/SumSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/zonal/summary/SumSpec.scala
@@ -1,0 +1,94 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.feature._
+import geotrellis.process._
+import geotrellis.testutil._
+
+import org.scalatest.FunSpec
+import org.scalatest.matchers._
+
+class SumSpec extends ZonalSummarySpec {
+  describe("Sum") {
+    it("computes Sum") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val sumOp = rData.zonalSum(zone)
+      run(sumOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (40)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("fails on nonintersecting zone") {
+      // Test non-intersecting polygons (issue #412)
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val nonintersecting = Extent(100,120,100,120).asFeature(())
+      val sumOp2 = rData.zonalSum(nonintersecting)
+      run(sumOp2) match {
+        case Complete(result,success) =>
+          assert(false)
+        case Error(msg,failure) =>
+          msg should equal ("empty.reduceLeft")
+      }
+    }
+
+    it("computes sum on raster source and 5 edge polygon") {
+      val sum = 
+        containedCells
+          .map { case (col,row) => tiledR.get(col,row) }
+          .foldLeft(0) { (a,b) => if(isNoData(b)) a else a + b }
+
+      run(tiledRS.zonalSum(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (sum)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes Double Sum") {
+      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+      val zone = Extent(10,-10,30,10).asFeature()
+
+      val sumDOp = rData.zonalSumDouble(zone)
+      run(sumDOp) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (40.0)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("computes Double sum on raster source and 5 edge polygon") {
+      val sum = 
+        containedCells
+          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
+          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + b }
+
+      run(tiledRSDouble.zonalSumDouble(poly)) match {
+        case Complete(result,success) =>
+          //           println(success)
+          result should equal (sum)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+  }
+}

--- a/src/test/scala/geotrellis/raster/op/zonal/summary/ZonalSummaryOpMethodsSpec.scala
+++ b/src/test/scala/geotrellis/raster/op/zonal/summary/ZonalSummaryOpMethodsSpec.scala
@@ -12,437 +12,184 @@ class ZonalSummaryOpMethodsSpec extends FunSpec
                                    with ShouldMatchers
                                    with TestServer
                                    with RasterBuilders {
-  val tiledRS = 
-    createRasterSource(
-      Array(  1, 2, 3,   4, 5, 6,   7, 8, 9,
-              1, 2, 3,   4, 5, 6,   7, 8, 9,
-
-             10,11,12,  13,nd,14,  nd,15,16,
-             11,12,13,  nd,15,nd,  17,18,19
-      ),
-      3,2,3,2)
-
-  val tiledRSDouble = 
-    createRasterSource(
-      Array(  0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
-              0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
-
-             0.11,0.12,0.13,   0.14,NaN,0.15,   NaN, 0.16,0.17,
-             0.11,0.12,0.13,    NaN,0.15,NaN,  0.17, 0.18,0.19
-      ),
-      3,2,3,2)
-
-
-  val tiledR = get(tiledRS)
-  val tiledRDouble = get(tiledRSDouble)
-
-  val poly = {
-    val re = tiledR.rasterExtent
-    val polyPoints = Seq(
-      re.gridToMap(2,1), re.gridToMap(4,0),re.gridToMap(7,2),
-      re.gridToMap(5,3), re.gridToMap(2,2),re.gridToMap(2,1)
-    )
-    Polygon(polyPoints, 0)
-  }
-
-  val containedCells = Seq(
-    (3,1),(4,1),(5,1),
-    (3,2),(4,2),(5,2),(6,2)
-  )
   
-//      Polygon vertices are 0's (not contianed cells)
-//      X's are contained cells
-// 
-//       *  *  *    *  *  *    *  *  *
-//       *  *  0    X  X  X    *  *  *
-// 
-//       *  *  0    X  X  X    X  0  *
-//       *  *  *    *  *  *    *  *  *  
-// 
+  // describe("zonalMin") {
+  //   it("computes Minimum") {
+  //     val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+  //     val zone = Extent(10,-10,30,10).asFeature()
 
-  describe("test case") {
-    it("is as we think. Make sure we understand what cells are contained in the poly") {
-      val re = tiledR.rasterExtent
-      for(row <- 0 until 4) {
-        for(col <- 0 until 9) {
-          val p = Point(re.gridColToMap(col),re.gridRowToMap(row),0)
-          if(containedCells.contains((col,row))) {
-            withClue(s"$col,$row should be not be included") {
-              poly.geom.contains(p.geom) should be (true)
-            }
-          } else {
-            withClue(s"$col,$row should be included") {
-              poly.geom.contains(p.geom) should be (false)
-            }
-          }
-        }
-      }
-    }
-  }
+  //     val minOp = rData.zonalMin(zone)
+  //     run(minOp) match {
+  //       case Complete(result,success) =>
+  //         //           println(success)
+  //         result should equal (1)
+  //       case Error(msg,failure) =>
+  //         println(msg)
+  //         println(failure)
+  //         assert(false)
+  //     }
+  //   }
 
-  describe("zonalSum") {
-    it("computes Sum") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
+  //   it("computes min on raster source and 5 edge polygon") {
+  //     val min = 
+  //       containedCells
+  //         .map { case (col,row) => tiledR.get(col,row) }
+  //         .foldLeft(Int.MaxValue) { (a,b) => if(isNoData(b)) a else math.min(a, b) }
 
-      val sumOp = rData.zonalSum(zone)
-      run(sumOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (40)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
+  //     run(tiledRS.zonalMin(poly)) match {
+  //       case Complete(result,success) =>
+  //         //           println(success)
+  //         result should equal (min)
+  //       case Error(msg,failure) =>
+  //         println(msg)
+  //         println(failure)
+  //         assert(false)
+  //     }
+  //   }
+  // }
 
-    it("fails on nonintersecting zone") {
-      // Test non-intersecting polygons (issue #412)
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
+  // describe("zonalMinDouble") {
+  //   it("computes Double Minimum") {
+  //     val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+  //     val zone = Extent(10,-10,30,10).asFeature()
 
-      val nonintersecting = Extent(100,120,100,120).asFeature(())
-      val sumOp2 = rData.zonalSum(nonintersecting)
-      run(sumOp2) match {
-        case Complete(result,success) =>
-          assert(false)
-        case Error(msg,failure) =>
-          msg should equal ("empty.reduceLeft")
-      }
-    }
+  //     val minDOp = rData.zonalMinDouble(zone)
+  //     run(minDOp) match {
+  //       case Complete(result,success) =>
+  //         //           println(success)
+  //         result should equal (1.0)
+  //       case Error(msg,failure) =>
+  //         println(msg)
+  //         println(failure)
+  //         assert(false)
+  //     }
+  //   }
 
-    it("computes sum on raster source and 5 edge polygon") {
-      val sum = 
-        containedCells
-          .map { case (col,row) => tiledR.get(col,row) }
-          .foldLeft(0) { (a,b) => if(isNoData(b)) a else a + b }
+  //   it("computes min on double raster source and 5 edge polygon") {
+  //     val min = 
+  //       containedCells
+  //         .map { case (col,row) => tiledRDouble.getDouble(col,row) }
+  //         .foldLeft(Double.MaxValue) { (a,b) => if(isNoData(b)) a else math.min(a, b) }
 
-      run(tiledRS.zonalSum(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (sum)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-  }
+  //     run(tiledRSDouble.zonalMinDouble(poly)) match {
+  //       case Complete(result,success) =>
+  //         //           println(success)
+  //         result should equal (min)
+  //       case Error(msg,failure) =>
+  //         println(msg)
+  //         println(failure)
+  //         assert(false)
+  //     }
+  //   }
+  // }
 
-  describe("zonalSumDouble") {
-    it("computes Double Sum") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
+  // describe("zonalMax") {
+  //   it("computes Maximum") {
+  //     val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+  //     val zone = Extent(10,-10,30,10).asFeature()
 
-      val sumDOp = rData.zonalSumDouble(zone)
-      run(sumDOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (40.0)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
+  //     val maxOp = rData.zonalMax(zone)
+  //     run(maxOp) match {
+  //       case Complete(result,success) =>
+  //         //           println(success)
+  //         result should equal (1)
+  //       case Error(msg,failure) =>
+  //         println(msg)
+  //         println(failure)
+  //         assert(false)
+  //     }
+  //   }
 
-    it("computes Double sum on raster source and 5 edge polygon") {
-      val sum = 
-        containedCells
-          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
-          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + b }
+  //   it("computes max on raster source and 5 edge polygon") {
+  //     val max = 
+  //       containedCells
+  //         .map { case (col,row) => tiledR.get(col,row) }
+  //         .foldLeft(Int.MinValue) { (a,b) => if(isNoData(b)) a else math.max(a, b) }
 
-      run(tiledRSDouble.zonalSumDouble(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (sum)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-  }
+  //     run(tiledRS.zonalMax(poly)) match {
+  //       case Complete(result,success) =>
+  //         //           println(success)
+  //         result should equal (max)
+  //       case Error(msg,failure) =>
+  //         println(msg)
+  //         println(failure)
+  //         assert(false)
+  //     }
+  //   }
+  // }
 
-  describe("zonalMin") {
-    it("computes Minimum") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
+  // describe("zonalMaxDouble") {
+  //   it("computes Double Maximum") {
+  //     val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
+  //     val zone = Extent(10,-10,30,10).asFeature()
 
-      val minOp = rData.zonalMin(zone)
-      run(minOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (1)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
+  //     val maxDOp = rData.zonalMaxDouble(zone)
+  //     run(maxDOp) match {
+  //       case Complete(result,success) =>
+  //         //           println(success)
+  //         result should equal (1.0)
+  //       case Error(msg,failure) =>
+  //         println(msg)
+  //         println(failure)
+  //         assert(false)
+  //     }
+  //   }
 
-    it("computes min on raster source and 5 edge polygon") {
-      val min = 
-        containedCells
-          .map { case (col,row) => tiledR.get(col,row) }
-          .foldLeft(Int.MaxValue) { (a,b) => if(isNoData(b)) a else math.min(a, b) }
+  //   it("computes max on double raster source and 5 edge polygon") {
+  //     val max = 
+  //       containedCells
+  //         .map { case (col,row) => tiledRDouble.getDouble(col,row) }
+  //         .foldLeft(Double.MinValue) { (a,b) => if(isNoData(b)) a else math.max(a, b) }
 
-      run(tiledRS.zonalMin(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (min)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-  }
+  //     run(tiledRSDouble.zonalMaxDouble(poly)) match {
+  //       case Complete(result,success) =>
+  //         //           println(success)
+  //         result should equal (max)
+  //       case Error(msg,failure) =>
+  //         println(msg)
+  //         println(failure)
+  //         assert(false)
+  //     }
+  //   }
+  // }
 
-  describe("zonalMinDouble") {
-    it("computes Double Minimum") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
+  describe("ZonalSummaryOpMethods") {
+    it("computes mean on double raster source with cached results") {
+      val rs =
+        createRasterSource(
+          Array(  0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
+            0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
 
-      val minDOp = rData.zonalMinDouble(zone)
-      run(minDOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (1.0)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
+            0.11,0.12,0.13,   0.14,NaN,0.15,   NaN, 0.16,0.17,
+            0.11,0.12,0.13,    NaN,0.15,NaN,  0.17, 0.18,0.19,
 
-    it("computes min on double raster source and 5 edge polygon") {
-      val min = 
-        containedCells
-          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
-          .foldLeft(Double.MaxValue) { (a,b) => if(isNoData(b)) a else math.min(a, b) }
+            0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
+            0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
 
-      run(tiledRSDouble.zonalMinDouble(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (min)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-  }
+            0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
+            0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9
+          ),
+          3,4,3,2)
 
-  describe("zonalMax") {
-    it("computes Maximum") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
+      val tr = rs.get
 
-      val maxOp = rData.zonalMax(zone)
-      run(maxOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (1)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-
-    it("computes max on raster source and 5 edge polygon") {
-      val max = 
-        containedCells
-          .map { case (col,row) => tiledR.get(col,row) }
-          .foldLeft(Int.MinValue) { (a,b) => if(isNoData(b)) a else math.max(a, b) }
-
-      run(tiledRS.zonalMax(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (max)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-  }
-
-  describe("zonalMaxDouble") {
-    it("computes Double Maximum") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
-
-      val maxDOp = rData.zonalMaxDouble(zone)
-      run(maxDOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (1.0)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-
-    it("computes max on double raster source and 5 edge polygon") {
-      val max = 
-        containedCells
-          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
-          .foldLeft(Double.MinValue) { (a,b) => if(isNoData(b)) a else math.max(a, b) }
-
-      run(tiledRSDouble.zonalMaxDouble(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (max)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-  }
-
-  describe("zonalHistogram") {
-    it("computes Histogram") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
-
-      val histOp = rData.zonalHistogram(zone)
-      run(histOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result.getItemCount(1) should equal (40)
-          result.getItemCount(2) should equal (0)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-
-    it("computes Histogram for raster source and 5 edge polygon") {
-      val h = statistics.FastMapHistogram()
-
-      for(z <- containedCells.map { case (col,row) => tiledR.get(col,row) }) {
-        if (isData(z)) { h.countItem(z, 1) }
+      val p = {
+        val re = tr.rasterExtent
+        val polyPoints = Seq(
+          re.gridToMap(1,1),re.gridToMap(2,0), re.gridToMap(4,0),re.gridToMap(7,2),
+          re.gridToMap(6,6), re.gridToMap(1,6),re.gridToMap(0,3),re.gridToMap(1,1)
+        )
+        Polygon(polyPoints, 0)
       }
 
-      run(tiledRS.zonalHistogram(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          for(row <- 0 until tiledR.rows) {
-            for(col <- 0 until tiledR.cols) {
-              val v = tiledR.get(col,row)
-              if(isData(v)) {
-                result.getItemCount(v) should be (h.getItemCount(v))
-              }
-            }
-          }
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-  }
+      val cached =
+        rs.map(tile => { println("using cached result") ; MeanResult.fromFullTileDouble(tile)})
+          .cached
 
-  describe("zonalMean") {
-    it("computes Mean") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
+      val withCached = rs.zonalMeanDouble(p,cached)
+      val withoutCached = rs.zonalMeanDouble(p)
 
-      val meanOp = rData.zonalMean(zone)
-      run(meanOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (1.0)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-
-    it("computes sum on raster source and 5 edge polygon") {
-      val vals = 
-        containedCells
-          .map { case (col,row) => tiledR.getDouble(col,row) }
-      val sum = 
-        vals
-          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + b }
-      val count = 
-        vals
-          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + 1.0 }
-
-      run(tiledRS.zonalMean(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (sum / count)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-  }
-
-  describe("zonalMeanDouble") {
-    it("computes Double Mean") {
-      val rData = createRasterSource(Array.fill(40*40)(1),4,4,10,10)
-      val zone = Extent(10,-10,30,10).asFeature()
-
-      val meanDOp = rData.zonalMeanDouble(zone)
-      run(meanDOp) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (1.0)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-
-    it("computes Double sum on raster source and 5 edge polygon") {
-      val sum = 
-        containedCells
-          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
-          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + b }
-
-      run(tiledRSDouble.zonalSumDouble(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (sum)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
-    }
-
-    it("computes mean on double raster source and 5 edge polygon") {
-      val vals = 
-        containedCells
-          .map { case (col,row) => tiledRDouble.getDouble(col,row) }
-      val sum = 
-        vals
-          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + b }
-      val count = 
-        vals
-          .foldLeft(0.0) { (a,b) => if(isNoData(b)) a else a + 1.0 }
-
-      run(tiledRSDouble.zonalMeanDouble(poly)) match {
-        case Complete(result,success) =>
-          //           println(success)
-          result should equal (sum / count.toDouble) 
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
-      }
+      withCached.get should be (withoutCached.get)
     }
   }
 }

--- a/src/test/scala/geotrellis/raster/op/zonal/summary/ZonalSummarySpec.scala
+++ b/src/test/scala/geotrellis/raster/op/zonal/summary/ZonalSummarySpec.scala
@@ -1,0 +1,61 @@
+package geotrellis.raster.op.zonal.summary
+
+import geotrellis._
+import geotrellis.feature._
+import geotrellis.process._
+import geotrellis.testutil._
+
+import org.scalatest.FunSpec
+import org.scalatest.matchers._
+
+trait ZonalSummarySpec extends FunSpec
+                          with ShouldMatchers
+                          with TestServer
+                          with RasterBuilders {
+  val tiledRS = 
+    createRasterSource(
+      Array(  1, 2, 3,   4, 5, 6,   7, 8, 9,
+              1, 2, 3,   4, 5, 6,   7, 8, 9,
+
+             10,11,12,  13,nd,14,  nd,15,16,
+             11,12,13,  nd,15,nd,  17,18,19
+      ),
+      3,2,3,2)
+
+  val tiledRSDouble = 
+    createRasterSource(
+      Array(  0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
+              0.1, 0.2, 0.3,   0.4, 0.5, 0.6,   0.7, 0.8, 0.9,
+
+             0.11,0.12,0.13,   0.14,NaN,0.15,   NaN, 0.16,0.17,
+             0.11,0.12,0.13,    NaN,0.15,NaN,  0.17, 0.18,0.19
+      ),
+      3,2,3,2)
+
+  val tiledR = get(tiledRS)
+  val tiledRDouble = get(tiledRSDouble)
+
+  val poly = {
+    val re = tiledR.rasterExtent
+    val polyPoints = Seq(
+      re.gridToMap(2,1), re.gridToMap(4,0),re.gridToMap(7,2),
+      re.gridToMap(5,3), re.gridToMap(2,2),re.gridToMap(2,1)
+    )
+    Polygon(polyPoints, 0)
+  }
+
+//      Polygon vertices are 0's (not contianed cells)
+//      X's are contained cells
+// 
+//       *  *  *    *  *  *    *  *  *
+//       *  *  0    X  X  X    *  *  *
+// 
+//       *  *  0    X  X  X    X  0  *
+//       *  *  *    *  *  *    *  *  *  
+// 
+
+  val containedCells = Seq(
+    (3,1),(4,1),(5,1),
+    (3,2),(4,2),(5,2),(6,2)
+  )
+}

--- a/src/test/scala/geotrellis/source/DataSourceSpec.scala
+++ b/src/test/scala/geotrellis/source/DataSourceSpec.scala
@@ -13,102 +13,27 @@ class DataSourceSpec extends FunSpec
                         with ShouldMatchers 
                         with TestServer 
                         with RasterBuilders {
-  def getRasterSource = 
-    RasterSource("mtsthelens_tiled_cached")
+  describe("DataSource") {
+    it("should cache") {
+      case class MockOperation(f:()=>Unit) extends Op1(f)({ f => f(); Result(true) })
 
-  def getSmallRasterSource =
-    RasterSource("quad_tiled")
+      val wasRan = Array.fill[Int](4)(0)
+      val mockOps = 
+        (0 until 4).map { i =>
+          MockOperation { () => wasRan(i) += 1 } 
+        }
 
-  describe("RasterSource") {
-    it("should print history") { 
-      val r1 = RasterSource("quad_tiled")
-      val r2 = RasterSource("quad_tiled2")
-      run(r1 + r2) match {
-        case Complete(value,success) =>
-          println(success.toString)
-        case Error(msg,failure) =>
-          println(msg)
-          println(failure)
-          assert(false)
+      val ds = DataSource(mockOps.toSeq)
+      wasRan should be (Array(0,0,0,0))
+      val dsCached = ds.cached
+      wasRan should be (Array(1,1,1,1))
+      dsCached.run match {
+        case Complete(v,_) =>
+          v.toArray should be (Array(true,true,true,true))
+          wasRan should be (Array(1,1,1,1))
+        case Error(msg,_) =>
+          sys.error(msg)
       }
-    }
-
-    it("should converge a tiled raster") {
-      val s = 
-        RasterSource("mtsthelens_tiled_cached")
-          .renderPng
-
-      get(s)
-
-    }
-
-    it("should return a RasterSource when possible") { 
-      val d1 = getRasterSource
-
-      val d2:RasterSource = d1.localAdd(3)
-      val d3:RasterSource  = d2 mapOp(local.Add(_, 3))
-      val d4:RasterSource = d3 map(r => r.map(z => z + 3))
-      val d5:DataSource[Int,Seq[Int]] = d3 map(r => r.findMinMax._2)
-      
-      val result1 = get(d1)
-      val result2 = get(d2)
-      val result3 = get(d3)
-      val result4 = get(d4)
-      val result5 = get(d5)
-
-      result1.get(100,100) should be (3233)
-      result2.get(100,100) should be (3236)
-      result3.get(100,100) should be (3239)
-      result4.get(100,100) should be (3242)
-      result5.head should be (6026)
-    }
-
-    it("should return a RasterSource when calling .distribute") {
-      val d1:RasterSource = (getRasterSource + 3).distribute
-    }
-
-    it("should handle a histogram result") {
-      val d = getRasterSource
-
-      val hist = d.tileHistograms
-      val hist2:DataSource[Histogram,Histogram] = d.map( (h:Raster) => FastMapHistogram() )
-      case class MinFromHistogram(h:Op[Histogram]) extends Op1(h)({
-        (h) => Result(h.getMinValue)
-      })
-
-      case class FindMin(ints:Op[Seq[Int]]) extends Op1(ints)({
-        (ints) => Result(ints.reduce(math.min(_,_)))
-      })
-
-      val ints:DataSource[Int,Seq[Int]] = hist.mapOp(MinFromHistogram(_))
-     
-      val seqIntVS:ValueSource[Seq[Int]] = ints.converge
-
-      val intVS:ValueSource[Int] = seqIntVS.map( seqInt => seqInt.reduce(math.min(_,_)))
-      val intVS2 = ints.reduce(math.min(_,_))
-
-      val histogramResult = get(hist)
-      val intsResult = get(ints)
-
-      val intResult = get(intVS)
-      val directIntResult = get(intVS2)
-
-      histogramResult.getMinValue should be (2231)
-      histogramResult.getMaxValue should be (8367)
-      intsResult.length should be (12)
-      intResult should be (directIntResult)
-      
-    }
-
-    it("should handle combine") {
-      val d = getRasterSource
-      val d2 = getRasterSource
-
-      val combineDS:RasterSource = d.localCombine(d2)(_+_)
-      val initial = get(d)
-      val result = get(combineDS)
-
-      result.get(3,3) should be (initial.get(3,3) * 2)
     }
   }
 }

--- a/src/test/scala/geotrellis/source/RasterSourceSpec.scala
+++ b/src/test/scala/geotrellis/source/RasterSourceSpec.scala
@@ -13,6 +13,12 @@ class RasterSourceSpec extends FunSpec
                         with ShouldMatchers 
                         with TestServer 
                         with RasterBuilders {
+  def getRasterSource = 
+    RasterSource("mtsthelens_tiled_cached")
+
+  def getSmallRasterSource =
+    RasterSource("quad_tiled")
+
   describe("RasterSource") {
     it("should load a tiled raster with a target extent") {
       val RasterExtent(Extent(xmin,_,_,ymax),cw,ch,_,_) =
@@ -36,6 +42,97 @@ class RasterSourceSpec extends FunSpec
           }
         }
       }
+    }
+
+    it("should print history") { 
+      val r1 = RasterSource("quad_tiled")
+      val r2 = RasterSource("quad_tiled2")
+      run(r1 + r2) match {
+        case Complete(value,success) =>
+          println(success.toString)
+        case Error(msg,failure) =>
+          println(msg)
+          println(failure)
+          assert(false)
+      }
+    }
+
+    it("should converge a tiled raster") {
+      val s = 
+        RasterSource("mtsthelens_tiled_cached")
+          .renderPng
+
+      get(s)
+
+    }
+
+    it("should return a RasterSource when possible") { 
+      val d1 = getRasterSource
+
+      val d2:RasterSource = d1.localAdd(3)
+      val d3:RasterSource  = d2 mapOp(local.Add(_, 3))
+      val d4:RasterSource = d3 map(r => r.map(z => z + 3))
+      val d5:DataSource[Int,Seq[Int]] = d3 map(r => r.findMinMax._2)
+      
+      val result1 = get(d1)
+      val result2 = get(d2)
+      val result3 = get(d3)
+      val result4 = get(d4)
+      val result5 = get(d5)
+
+      result1.get(100,100) should be (3233)
+      result2.get(100,100) should be (3236)
+      result3.get(100,100) should be (3239)
+      result4.get(100,100) should be (3242)
+      result5.head should be (6026)
+    }
+
+    it("should return a RasterSource when calling .distribute") {
+      val d1:RasterSource = (getRasterSource + 3).distribute
+    }
+
+    it("should handle a histogram result") {
+      val d = getRasterSource
+
+      val hist = d.tileHistograms
+      val hist2:DataSource[Histogram,Histogram] = d.map( (h:Raster) => FastMapHistogram() )
+      case class MinFromHistogram(h:Op[Histogram]) extends Op1(h)({
+        (h) => Result(h.getMinValue)
+      })
+
+      case class FindMin(ints:Op[Seq[Int]]) extends Op1(ints)({
+        (ints) => Result(ints.reduce(math.min(_,_)))
+      })
+
+      val ints:DataSource[Int,Seq[Int]] = hist.mapOp(MinFromHistogram(_))
+     
+      val seqIntVS:ValueSource[Seq[Int]] = ints.converge
+
+      val intVS:ValueSource[Int] = seqIntVS.map( seqInt => seqInt.reduce(math.min(_,_)))
+      val intVS2 = ints.reduce(math.min(_,_))
+
+      val histogramResult = get(hist)
+      val intsResult = get(ints)
+
+      val intResult = get(intVS)
+      val directIntResult = get(intVS2)
+
+      histogramResult.getMinValue should be (2231)
+      histogramResult.getMaxValue should be (8367)
+      intsResult.length should be (12)
+      intResult should be (directIntResult)
+      
+    }
+
+    it("should handle combine") {
+      val d = getRasterSource
+      val d2 = getRasterSource
+
+      val combineDS:RasterSource = d.localCombine(d2)(_+_)
+      val initial = get(d)
+      val result = get(combineDS)
+
+      result.get(3,3) should be (initial.get(3,3) * 2)
     }
   }
 }


### PR DESCRIPTION
- Added a .cached method to DataSourceLike that caches the results
  of the elements on the local machine.
- Refactored zonal summary methods to take in cached results
  to be used on the full tile intersections.

Fixes #626
