### PR TITLE
Fix jetty runner by adding asm dependency.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -186,7 +186,8 @@ object GeotrellisBuild extends Build {
         "org.eclipse.jetty" % "jetty-webapp" % "8.1.0.RC4",
         "com.sun.jersey" % "jersey-bundle" % "1.11",
         "org.slf4j" % "slf4j-api" % "1.6.0",
-        "org.slf4j" % "slf4j-nop" % "1.6.0")
+        "org.slf4j" % "slf4j-nop" % "1.6.0",
+        "asm" % "asm" % "3.3.1" )
     ) ++
     defaultAssemblySettings
 


### PR DESCRIPTION
The dependency "asm" % "asm" % "3.3.1" is missing, which causes jetty
to fail to start under the geotrellis-jetty or dependent projects.
This commit adds the dependency to the jetty project.
