### PR TITLE
Add configuration for demo resource package.

### DIFF
--- a/demo/src/main/resources/application.conf
+++ b/demo/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+# A semicolon-separated list of packages that Jetty will
+# search for services.
+geotrellis.rest-package = "demo"


### PR DESCRIPTION
The demo project isn't currently configured to load Jersey
resources from the "demo" package where the services in the
demo subproject live.  This commit just restores the one line
config:

geotrellis.rest-package = "demo"
