### PR TITLE
Added +,-,/,* to Raster

### DIFF
--- a/src/main/scala/geotrellis/Raster.scala
+++ b/src/main/scala/geotrellis/Raster.scala
@@ -1,6 +1,7 @@
 package geotrellis
 
 import geotrellis.raster._
+import geotrellis.raster.op._
 import scalaxy.loops._
 
 object Raster {
@@ -20,7 +21,10 @@ object Raster {
 /**
  * Base trait for the Raster data type.
  */
-trait Raster {
+trait Raster extends local.AddMethods
+                with local.SubtractMethods
+                with local.MultiplyMethods
+                with local.DivideMethods {
   val rasterExtent:RasterExtent
   lazy val cols = rasterExtent.cols
   lazy val rows = rasterExtent.rows

--- a/src/main/scala/geotrellis/raster/op/local/Add.scala
+++ b/src/main/scala/geotrellis/raster/op/local/Add.scala
@@ -43,3 +43,26 @@ trait AddOpMethods[+Repr <: RasterSource] { self: Repr =>
   /** Add the values of each cell in each raster. */
   def +(rss:Seq[RasterSource]) = localAdd(rss)
 }
+
+trait AddMethods { self: Raster =>
+  /** Add a constant Int value to each cell. */
+  def localAdd(i: Int) = Add(self, i)
+  /** Add a constant Int value to each cell. */
+  def +(i: Int) = localAdd(i)
+  /** Add a constant Int value to each cell. */
+  def +:(i: Int) = localAdd(i)
+  /** Add a constant Double value to each cell. */
+  def localAdd(d: Double) = Add(self, d)
+  /** Add a constant Double value to each cell. */
+  def +(d: Double) = localAdd(d)
+  /** Add a constant Double value to each cell. */
+  def +:(d: Double) = localAdd(d)
+  /** Add the values of each cell in each raster.  */
+  def localAdd(r: Raster) = Add(self, r)
+  /** Add the values of each cell in each raster. */
+  def +(r: Raster) = localAdd(r)
+  /** Add the values of each cell in each raster.  */
+  def localAdd(rs: Seq[Raster]) = Add(self +: rs)
+  /** Add the values of each cell in each raster. */
+  def +(rs: Seq[Raster]) = localAdd(rs)
+}

--- a/src/main/scala/geotrellis/raster/op/local/Divide.scala
+++ b/src/main/scala/geotrellis/raster/op/local/Divide.scala
@@ -46,3 +46,30 @@ trait DivideOpMethods[+Repr <: RasterSource] { self: Repr =>
   /** Divide the values of each cell in each raster. */
   def /(rss:Seq[RasterSource]) = localDivide(rss)
 }
+
+trait DivideMethods { self: Raster =>
+  /** Divide each value of the raster by a constant value.*/
+  def localDivide(i: Int) = Divide(self, i)
+  /** Divide each value of the raster by a constant value.*/
+  def /(i: Int) = localDivide(i)
+  /** Divide a constant value by each cell value.*/
+  def localDivideValue(i: Int) = Divide(i,self)
+  /** Divide a constant value by each cell value.*/
+  def /:(i: Int) = localDivideValue(i)
+  /** Divide each value of a raster by a double constant value.*/
+  def localDivide(d: Double) = Divide(self, d)
+  /** Divide each value of a raster by a double constant value.*/
+  def /(d: Double) = localDivide(d)
+  /** Divide a double constant value by each cell value.*/
+  def localDivideValue(d: Double) = Divide(d,self)
+  /** Divide a double constant value by each cell value.*/
+  def /:(d: Double) = localDivideValue(d)
+  /** Divide the values of each cell in each raster. */
+  def localDivide(r:Raster) = Divide(self, r)
+  /** Divide the values of each cell in each raster. */
+  def /(r: Raster) = localDivide(r)
+  /** Divide the values of each cell in each raster. */
+  def localDivide(rs: Seq[Raster]) = Divide(self +: rs)
+  /** Divide the values of each cell in each raster. */
+  def /(rs: Seq[Raster]) = localDivide(rs)
+}

--- a/src/main/scala/geotrellis/raster/op/local/LocalRasterBinaryOp.scala
+++ b/src/main/scala/geotrellis/raster/op/local/LocalRasterBinaryOp.scala
@@ -9,49 +9,71 @@ trait LocalRasterBinaryOp extends Serializable {
     else n
   }
 
+  // Raster - Constant combinations
+
   /** Apply to the value from each cell and a constant Int. */
   def apply(r:Op[Raster], c:Op[Int]):Op[Raster] = 
-    (r,c).map { (r,c) => 
-            r.dualMap(combine(_,c))({
-              val d = i2d(c)
-              (z:Double) => combine(z,d)
-            })
-          }
+    (r,c).map(apply)
          .withName(s"$name[ConstantInt]")
 
   /** Apply to the value from each cell and a constant Double. */
   def apply(r:Op[Raster], c:Op[Double])(implicit d:DI):Op[Raster] = 
-    (r,c).map { (r,c) => 
-            r.dualMap({z => d2i(combine(i2d(z),c))})(combine(_,c))
-          }
+    (r,c).map(apply)
          .withName(s"$name[ConstantDouble]")
 
   /** Apply to a constant Int and the value from each cell. */
   def apply(c:Op[Int],r:Op[Raster])(implicit d:DI,d2:DI,d3:DI):Op[Raster] = 
-    (r,c).map { (r,c) => 
-            r.dualMap(combine(c,_))({
-              val d = i2d(c)
-              (z:Double) => combine(d,z)
-            })
-          }
+    (c,r).map(apply)
          .withName(s"$name[ConstantInt]")
 
   /** Apply to a constant Double and the value from each cell. */
   def apply(c:Op[Double],r:Op[Raster])(implicit d:DI,d2:DI,d3:DI,d4:DI):Op[Raster] = 
-    (r,c).map { (r,c) => 
-            r.dualMap({z => d2i(combine(c,i2d(z)))})(combine(c,_))
-          }
+    (c,r).map(apply)
          .withName(s"$name[ConstantDouble]")
+
+  /** Apply to the value from each cell and a constant Int. */
+  def apply(r: Raster, c: Int): Raster =
+    r.dualMap(combine(_,c))({
+      val d = i2d(c)
+      (z:Double) => combine(z,d)
+    })
+
+  /** Apply to the value from each cell and a constant Double. */
+  def apply(r: Raster, c: Double): Raster =
+    r.dualMap({z => d2i(combine(i2d(z),c))})(combine(_,c))
+
+  /** Apply to a constant Int and the value from each cell. */
+  def apply(c: Int, r: Raster): Raster =
+    r.dualMap(combine(c,_))({
+      val d = i2d(c)
+      (z:Double) => combine(d,z)
+    })
+
+  /** Apply to a constant Double and the value from each cell. */
+  def apply(c: Double, r: Raster): Raster =
+    r.dualMap({z => d2i(combine(c,i2d(z)))})(combine(c,_))
+
+  // Raster - Raster combinations
 
   /** Apply this operation to the values of each cell in each raster.  */
   def apply(r1:Op[Raster],r2:Op[Raster])(implicit d:DI,d2:DI):Op[Raster] = 
-    (r1,r2).map(_.dualCombine(_)(combine)(combine))
+    (r1,r2).map(apply)
            .withName(s"$name[Rasters]")
 
   /** Apply this operation to the values of each cell in each raster.  */
+  def apply(r1: Raster,r2: Raster): Raster = 
+    r1.dualCombine(r2)(combine)(combine)
+
+  // Combine a sequence of rasters
+
+  /** Apply this operation to the values of each cell in each raster.  */
   def apply(rs:Seq[Op[Raster]]):Op[Raster] = 
-    rs.mapOps(rasters => new RasterReducer(combine)(combine)(rasters))
+    rs.mapOps(apply)
       .withName(s"$name[Rasters]")
+
+  /** Apply this operation to a Seq of rasters */
+  def apply(rs:Seq[Raster]):Raster = 
+    new RasterReducer(combine)(combine)(rs)
 
   /** Apply this operation to the values of each cell in each raster.  */
   def apply(rs:Array[Op[Raster]]):Op[Raster] = 
@@ -75,10 +97,6 @@ trait LocalRasterBinaryOp extends Serializable {
   def apply(rs:Op[Raster]*)(implicit d:DI,d2:DI,d3:DI):Op[Raster] = {
     apply(rs)
   }
-
-  /** Apply this operation to a Seq of raw rasters */
-  def apply(seq:Seq[Raster]):Raster =
-    new RasterReducer(combine)(combine)(seq)
 
   def combine(z1:Int,z2:Int):Int
   def combine(z1:Double,z2:Double):Double

--- a/src/main/scala/geotrellis/raster/op/local/Multiply.scala
+++ b/src/main/scala/geotrellis/raster/op/local/Multiply.scala
@@ -41,3 +41,26 @@ trait MultiplyOpMethods[+Repr <: RasterSource] { self: Repr =>
   /** Multiply the values of each cell in each raster. */
   def *(rss:Seq[RasterSource]) = localMultiply(rss)
 }
+
+trait MultiplyMethods { self: Raster =>
+  /** Multiply a constant value from each cell.*/
+  def localMultiply(i: Int) = Multiply(self, i)
+  /** Multiply a constant value from each cell.*/
+  def *(i: Int) = localMultiply(i)
+  /** Multiply a constant value from each cell.*/
+  def *:(i: Int) = localMultiply(i)
+  /** Multiply a double constant value from each cell.*/
+  def localMultiply(d: Double) = Multiply(self, d)
+  /** Multiply a double constant value from each cell.*/
+  def *(d: Double) = localMultiply(d)
+  /** Multiply a double constant value from each cell.*/
+  def *:(d: Double) = localMultiply(d)
+  /** Multiply the values of each cell in each raster. */
+  def localMultiply(r: Raster) = Multiply(self,r)
+  /** Multiply the values of each cell in each raster. */
+  def *(r: Raster) = localMultiply(r)
+  /** Multiply the values of each cell in each raster. */
+  def localMultiply(rs: Seq[Raster]) = Multiply(self +: rs)
+  /** Multiply the values of each cell in each raster. */
+  def *(rs: Seq[Raster]) = localMultiply(rs)
+}

--- a/src/main/scala/geotrellis/raster/op/local/Subtract.scala
+++ b/src/main/scala/geotrellis/raster/op/local/Subtract.scala
@@ -36,7 +36,7 @@ trait SubtractOpMethods[+Repr <: RasterSource] { self: Repr =>
   /** Subtract each value of a cell from a double constant value. */
   def localSubtractFrom(d: Double) = self.mapOp(Subtract(d, _))
   /** Subtract each value of a cell from a double constant value. */
-  def -:(d:Double) = localSubtract(d)
+  def -:(d:Double) = localSubtractFrom(d)
   /** Subtract the values of each cell in each raster. */
   def localSubtract(rs:RasterSource) = self.combineOp(rs)(Subtract(_,_))
   /** Subtract the values of each cell in each raster. */
@@ -45,4 +45,31 @@ trait SubtractOpMethods[+Repr <: RasterSource] { self: Repr =>
   def localSubtract(rss:Seq[RasterSource]) = self.combineOp(rss)(Subtract(_))
   /** Subtract the values of each cell in each raster. */
   def -(rss:Seq[RasterSource]) = localSubtract(rss)
+}
+
+trait SubtractMethods { self: Raster =>
+  /** Subtract a constant value from each cell.*/
+  def localSubtract(i: Int) = Subtract(self, i)
+  /** Subtract a constant value from each cell.*/
+  def -(i: Int) = localSubtract(i)
+  /** Subtract each value of a cell from a constant value. */
+  def localSubtractFrom(i: Int) = Subtract(i, self)
+  /** Subtract each value of a cell from a constant value. */
+  def -:(i: Int) = localSubtract(i)
+  /** Subtract a double constant value from each cell.*/
+  def localSubtract(d: Double) = Subtract(self, d)
+  /** Subtract a double constant value from each cell.*/
+  def -(d: Double) = localSubtract(d)
+  /** Subtract each value of a cell from a double constant value. */
+  def localSubtractFrom(d: Double) = Subtract(d, self)
+  /** Subtract each value of a cell from a double constant value. */
+  def -:(d: Double) = localSubtractFrom(d)
+  /** Subtract the values of each cell in each raster. */
+  def localSubtract(r: Raster) = Subtract(self, r)
+  /** Subtract the values of each cell in each raster. */
+  def -(r: Raster) = localSubtract(r)
+  /** Subtract the values of each cell in each raster. */
+  def localSubtract(rs: Seq[Raster]) = Subtract(self +: rs)
+  /** Subtract the values of each cell in each raster. */
+  def -(rs: Seq[Raster]) = localSubtract(rs)
 }


### PR DESCRIPTION
This is a start to adding operations (little 'o' operations, not geotrellis.Operation Operations) to Raster directly. This will allow both the spark and Akka execution engines to take advantage of the operations on the core data types.
