### PR TITLE
removed extra stars from license headers

### DIFF
--- a/admin/src/main/scala/geotrellis/admin/AdminServiceActor.scala
+++ b/admin/src/main/scala/geotrellis/admin/AdminServiceActor.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.admin
 

--- a/admin/src/main/scala/geotrellis/admin/Main.scala
+++ b/admin/src/main/scala/geotrellis/admin/Main.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.admin
 

--- a/admin/src/test/scala/geotrellis/admin/AdminServiceActorSpec.scala
+++ b/admin/src/test/scala/geotrellis/admin/AdminServiceActorSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.admin
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/AddRasters.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/AddRasters.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/ConstantAdd.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/ConstantAdd.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/DataMap.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/DataMap.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/Divide.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/Divide.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/FastFocalMean.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/FastFocalMean.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/FocalBenchmarks.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/FocalBenchmarks.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/GenericRaster.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/GenericRaster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/IO.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/IO.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/MinNBenchmark.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/MinNBenchmark.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014 Azavea.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.benchmark
 
 import geotrellis._

--- a/benchmark/src/main/scala/geotrellis/benchmark/MiniWeightedOverlay.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/MiniWeightedOverlay.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/OperationBenchmark.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/OperationBenchmark.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/RasterForEach.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/RasterForEach.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/RasterMap.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/RasterMap.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/RasterizerBenchmark.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/RasterizerBenchmark.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/RenderPng.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/RenderPng.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/Rescale.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/Rescale.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/WeightedAdd.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/WeightedAdd.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/WeightedOverlay.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/WeightedOverlay.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/io/ArgReader.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/io/ArgReader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark.io
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/io/FloatNReadState.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/io/FloatNReadState.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark.io
 

--- a/benchmark/src/main/scala/geotrellis/benchmark/io/IntNReadState.scala
+++ b/benchmark/src/main/scala/geotrellis/benchmark/io/IntNReadState.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.benchmark.io
 

--- a/core-test/src/test/scala/geotrellis/ExtentTest.scala
+++ b/core-test/src/test/scala/geotrellis/ExtentTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/LiteralSpec.scala
+++ b/core-test/src/test/scala/geotrellis/LiteralSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/OperationSpec.scala
+++ b/core-test/src/test/scala/geotrellis/OperationSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/PackageTest.scala
+++ b/core-test/src/test/scala/geotrellis/PackageTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/RasterExtentSpec.scala
+++ b/core-test/src/test/scala/geotrellis/RasterExtentSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/RasterSpec.scala
+++ b/core-test/src/test/scala/geotrellis/RasterSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/SerializationTest.scala
+++ b/core-test/src/test/scala/geotrellis/SerializationTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/TileRasterSpec.scala
+++ b/core-test/src/test/scala/geotrellis/TileRasterSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/core/AndThen.scala
+++ b/core-test/src/test/scala/geotrellis/core/AndThen.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core-test/src/test/scala/geotrellis/core/SimpleOpSyntaxSpec.scala
+++ b/core-test/src/test/scala/geotrellis/core/SimpleOpSyntaxSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.core
 

--- a/core-test/src/test/scala/geotrellis/core/histo.scala
+++ b/core-test/src/test/scala/geotrellis/core/histo.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.core
 

--- a/core-test/src/test/scala/geotrellis/data/ArgTest.scala
+++ b/core-test/src/test/scala/geotrellis/data/ArgTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core-test/src/test/scala/geotrellis/data/ExtentSpec.scala
+++ b/core-test/src/test/scala/geotrellis/data/ExtentSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core-test/src/test/scala/geotrellis/data/arg/ArgTest.scala
+++ b/core-test/src/test/scala/geotrellis/data/arg/ArgTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.arg
 

--- a/core-test/src/test/scala/geotrellis/data/arg/BoolTest.scala
+++ b/core-test/src/test/scala/geotrellis/data/arg/BoolTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.arg
 

--- a/core-test/src/test/scala/geotrellis/data/ascii.scala
+++ b/core-test/src/test/scala/geotrellis/data/ascii.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core-test/src/test/scala/geotrellis/data/geojson/GeoJsonReaderSpec.scala
+++ b/core-test/src/test/scala/geotrellis/data/geojson/GeoJsonReaderSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geojson
 

--- a/core-test/src/test/scala/geotrellis/data/geojson/GeoJsonWriterSpec.scala
+++ b/core-test/src/test/scala/geotrellis/data/geojson/GeoJsonWriterSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geojson
 

--- a/core-test/src/test/scala/geotrellis/extent/extent.scala
+++ b/core-test/src/test/scala/geotrellis/extent/extent.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.extent
 

--- a/core-test/src/test/scala/geotrellis/feature/FeatureSpec.scala
+++ b/core-test/src/test/scala/geotrellis/feature/FeatureSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core-test/src/test/scala/geotrellis/feature/RasterizePolygonSpec.scala
+++ b/core-test/src/test/scala/geotrellis/feature/RasterizePolygonSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.rasterize
 

--- a/core-test/src/test/scala/geotrellis/feature/RasterizeSpec.scala
+++ b/core-test/src/test/scala/geotrellis/feature/RasterizeSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core-test/src/test/scala/geotrellis/feature/SemivariogramSpec.scala
+++ b/core-test/src/test/scala/geotrellis/feature/SemivariogramSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core-test/src/test/scala/geotrellis/feature/op/geometry/CountPointsSpec.scala
+++ b/core-test/src/test/scala/geotrellis/feature/op/geometry/CountPointsSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core-test/src/test/scala/geotrellis/feature/op/geometry/IDWInterpolateSpec.scala
+++ b/core-test/src/test/scala/geotrellis/feature/op/geometry/IDWInterpolateSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core-test/src/test/scala/geotrellis/feature/op/geometry/KernelDensitySpec.scala
+++ b/core-test/src/test/scala/geotrellis/feature/op/geometry/KernelDensitySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core-test/src/test/scala/geotrellis/io/LoadFileSpec.scala
+++ b/core-test/src/test/scala/geotrellis/io/LoadFileSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core-test/src/test/scala/geotrellis/io/LoadRasterLayerInfoSpec.scala
+++ b/core-test/src/test/scala/geotrellis/io/LoadRasterLayerInfoSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core-test/src/test/scala/geotrellis/logic/CollectSpec.scala
+++ b/core-test/src/test/scala/geotrellis/logic/CollectSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core-test/src/test/scala/geotrellis/logic/FilterSpec.scala
+++ b/core-test/src/test/scala/geotrellis/logic/FilterSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core-test/src/test/scala/geotrellis/logic/ForEach.scala
+++ b/core-test/src/test/scala/geotrellis/logic/ForEach.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core-test/src/test/scala/geotrellis/logic/IfSpec.scala
+++ b/core-test/src/test/scala/geotrellis/logic/IfSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core-test/src/test/scala/geotrellis/logic/MapOpSpec.scala
+++ b/core-test/src/test/scala/geotrellis/logic/MapOpSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core-test/src/test/scala/geotrellis/process/ArgRasterLayerSpec.scala
+++ b/core-test/src/test/scala/geotrellis/process/ArgRasterLayerSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core-test/src/test/scala/geotrellis/process/ArgUrlRasterLayerSpec.scala
+++ b/core-test/src/test/scala/geotrellis/process/ArgUrlRasterLayerSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core-test/src/test/scala/geotrellis/process/CatalogSpec.scala
+++ b/core-test/src/test/scala/geotrellis/process/CatalogSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core-test/src/test/scala/geotrellis/process/TileSetRasterLayerSpec.scala
+++ b/core-test/src/test/scala/geotrellis/process/TileSetRasterLayerSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core-test/src/test/scala/geotrellis/process/cache.scala
+++ b/core-test/src/test/scala/geotrellis/process/cache.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 
 package geotrellis.process

--- a/core-test/src/test/scala/geotrellis/process/error.scala
+++ b/core-test/src/test/scala/geotrellis/process/error.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core-test/src/test/scala/geotrellis/raster/BitArrayRasterDataSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/BitArrayRasterDataSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core-test/src/test/scala/geotrellis/raster/CroppedArrayRasterDataSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/CroppedArrayRasterDataSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core-test/src/test/scala/geotrellis/raster/DoubleArrayRasterDataSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/DoubleArrayRasterDataSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core-test/src/test/scala/geotrellis/raster/DoubleConstantTest.scala
+++ b/core-test/src/test/scala/geotrellis/raster/DoubleConstantTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core-test/src/test/scala/geotrellis/raster/IntConstantTest.scala
+++ b/core-test/src/test/scala/geotrellis/raster/IntConstantTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core-test/src/test/scala/geotrellis/raster/RasterDataSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/RasterDataSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core-test/src/test/scala/geotrellis/raster/ResampledArrayRasterDataTest.scala
+++ b/core-test/src/test/scala/geotrellis/raster/ResampledArrayRasterDataTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core-test/src/test/scala/geotrellis/raster/TileLayoutSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/TileLayoutSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core-test/src/test/scala/geotrellis/raster/op/AverageLotsOfRasters.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/AverageLotsOfRasters.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op
 

--- a/core-test/src/test/scala/geotrellis/raster/op/ConvertTypeSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/ConvertTypeSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/AspectSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/AspectSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/ConwaySpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/ConwaySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/CursorMaskSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/CursorMaskSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/CursorSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/CursorSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/FocalOpMethodsSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/FocalOpMethodsSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/FocalStrategySpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/FocalStrategySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/FocalTestUtils.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/FocalTestUtils.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/HillshadeSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/HillshadeSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/MaxSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/MaxSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/MeanSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/MeanSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/MedianSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/MedianSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/MinSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/MinSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/ModeSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/ModeSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/MoranSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/MoranSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/NeighborhoodSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/NeighborhoodSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/SlopeSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/SlopeSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/StandardDeviationSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/StandardDeviationSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/SumSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/SumSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/SurfacePointCalculationSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/SurfacePointCalculationSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/TestCursor.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/TestCursor.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/TileWithNeighborsSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/TileWithNeighborsSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/focal/TiledFocalSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/focal/TiledFocalSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/global/AsArraySpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/global/AsArraySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core-test/src/test/scala/geotrellis/raster/op/global/ConvolveSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/global/ConvolveSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core-test/src/test/scala/geotrellis/raster/op/global/CostDistanceSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/global/CostDistanceSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core-test/src/test/scala/geotrellis/raster/op/global/GlobalOpMethodsSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/global/GlobalOpMethodsSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core-test/src/test/scala/geotrellis/raster/op/global/RegionGroupSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/global/RegionGroupSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core-test/src/test/scala/geotrellis/raster/op/global/ToVectorSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/global/ToVectorSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core-test/src/test/scala/geotrellis/raster/op/global/VerticalFlipTest.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/global/VerticalFlipTest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core-test/src/test/scala/geotrellis/raster/op/hydrology/AccumulationSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/hydrology/AccumulationSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.hydrology
 

--- a/core-test/src/test/scala/geotrellis/raster/op/hydrology/FillSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/hydrology/FillSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.hydrology
 

--- a/core-test/src/test/scala/geotrellis/raster/op/hydrology/FlowDirectionSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/hydrology/FlowDirectionSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.hydrology
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/AbsSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/AbsSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/AcosSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/AcosSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/AddSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/AddSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/AndSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/AndSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/AsinSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/AsinSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/Atan2Spec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/Atan2Spec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/AtanSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/AtanSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/CeilSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/CeilSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/CombinationSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/CombinationSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/CosSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/CosSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/CoshSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/CoshSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/DefinedSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/DefinedSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/DivideSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/DivideSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/EqualSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/EqualSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/FloorSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/FloorSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/GreaterOrEqualSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/GreaterOrEqualSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/GreaterSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/GreaterSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/InverseMaskSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/InverseMaskSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/LessOrEqualSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/LessOrEqualSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/LessSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/LessSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/LocalMapSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/LocalMapSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/Log10Spec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/Log10Spec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/LogSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/LogSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MajoritySpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MajoritySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MaskSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MaskSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MaxNSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MaxNSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014 Azavea.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.raster.op.local
 
 import geotrellis._

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MaxSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MaxSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MeanSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MeanSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MinNSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MinNSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014 Azavea.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.raster.op.local
 
 import geotrellis._

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MinSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MinSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MinoritySpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MinoritySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/MultiplySpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/MultiplySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/NegateSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/NegateSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/NotSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/NotSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/OrSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/OrSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/PowSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/PowSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/RoundSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/RoundSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/SinSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/SinSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/SinhSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/SinhSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/SqrtSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/SqrtSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/SubtractSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/SubtractSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/TanSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/TanSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/TanhSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/TanhSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/UndefinedSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/UndefinedSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/UnequalSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/UnequalSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/VarietySpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/VarietySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/XorSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/XorSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/local/conditionalSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/local/conditionalSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core-test/src/test/scala/geotrellis/raster/op/transform/CropSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/transform/CropSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.transform
 

--- a/core-test/src/test/scala/geotrellis/raster/op/transform/DownsampleSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/transform/DownsampleSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.transform
 

--- a/core-test/src/test/scala/geotrellis/raster/op/transform/RescaleSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/transform/RescaleSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.transform
 

--- a/core-test/src/test/scala/geotrellis/raster/op/transform/ResizeSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/transform/ResizeSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.transform
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/ZonalHistogramSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/ZonalHistogramSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/ZonalPercentageSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/ZonalPercentageSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/HistogramSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/HistogramSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/MaxSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/MaxSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/MeanSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/MeanSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/MinSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/MinSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/SumSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/SumSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/ZonalSummaryOpMethodsSpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/ZonalSummaryOpMethodsSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/ZonalSummarySpec.scala
+++ b/core-test/src/test/scala/geotrellis/raster/op/zonal/summary/ZonalSummarySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core-test/src/test/scala/geotrellis/render/color.scala
+++ b/core-test/src/test/scala/geotrellis/render/color.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render
 

--- a/core-test/src/test/scala/geotrellis/render/op/ColorRasterSpec.scala
+++ b/core-test/src/test/scala/geotrellis/render/op/ColorRasterSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.op
 

--- a/core-test/src/test/scala/geotrellis/render/op/GetColorBreaksSpec.scala
+++ b/core-test/src/test/scala/geotrellis/render/op/GetColorBreaksSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.op
 

--- a/core-test/src/test/scala/geotrellis/render/png/EncoderSpec.scala
+++ b/core-test/src/test/scala/geotrellis/render/png/EncoderSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core-test/src/test/scala/geotrellis/render/png/RendererSpec.scala
+++ b/core-test/src/test/scala/geotrellis/render/png/RendererSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core-test/src/test/scala/geotrellis/source/DataSourceSpec.scala
+++ b/core-test/src/test/scala/geotrellis/source/DataSourceSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core-test/src/test/scala/geotrellis/source/RasterSourceSpec.scala
+++ b/core-test/src/test/scala/geotrellis/source/RasterSourceSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core-test/src/test/scala/geotrellis/statistics/FastMapHistogramSpec.scala
+++ b/core-test/src/test/scala/geotrellis/statistics/FastMapHistogramSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core-test/src/test/scala/geotrellis/statistics/op/stat/GetClassBreaksSpec.scala
+++ b/core-test/src/test/scala/geotrellis/statistics/op/stat/GetClassBreaksSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core-test/src/test/scala/geotrellis/statistics/op/stat/GetHistogramSpec.scala
+++ b/core-test/src/test/scala/geotrellis/statistics/op/stat/GetHistogramSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core-test/src/test/scala/geotrellis/statistics/op/stat/GetStandardDeviationSpec.scala
+++ b/core-test/src/test/scala/geotrellis/statistics/op/stat/GetStandardDeviationSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core-test/src/test/scala/geotrellis/statistics/op/stat/GetStatisticsSpec.scala
+++ b/core-test/src/test/scala/geotrellis/statistics/op/stat/GetStatisticsSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core-test/src/test/scala/geotrellis/statistics/op/stat/StatOpMethodsSpec.scala
+++ b/core-test/src/test/scala/geotrellis/statistics/op/stat/StatOpMethodsSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core-test/src/test/scala/geotrellis/util/FilesystemSpec.scala
+++ b/core-test/src/test/scala/geotrellis/util/FilesystemSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util
 

--- a/core-test/src/test/scala/geotrellis/util/UtilSpec.scala
+++ b/core-test/src/test/scala/geotrellis/util/UtilSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util
 

--- a/core-test/src/test/scala/geotrellis/util/srs/SpatialReferenceSystemSpec.scala
+++ b/core-test/src/test/scala/geotrellis/util/srs/SpatialReferenceSystemSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util.srs
 

--- a/core/src/main/scala/geotrellis/ArrayRaster.scala
+++ b/core/src/main/scala/geotrellis/ArrayRaster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/CroppedRaster.scala
+++ b/core/src/main/scala/geotrellis/CroppedRaster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/Extent.scala
+++ b/core/src/main/scala/geotrellis/Extent.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/GeoTrellis.scala
+++ b/core/src/main/scala/geotrellis/GeoTrellis.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/Implicits.scala
+++ b/core/src/main/scala/geotrellis/Implicits.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/Literal.scala
+++ b/core/src/main/scala/geotrellis/Literal.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/Operation.scala
+++ b/core/src/main/scala/geotrellis/Operation.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/Raster.scala
+++ b/core/src/main/scala/geotrellis/Raster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/RasterExtent.scala
+++ b/core/src/main/scala/geotrellis/RasterExtent.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/RasterLike.scala
+++ b/core/src/main/scala/geotrellis/RasterLike.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/RasterType.scala
+++ b/core/src/main/scala/geotrellis/RasterType.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/StepOutput.scala
+++ b/core/src/main/scala/geotrellis/StepOutput.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/TileRaster.scala
+++ b/core/src/main/scala/geotrellis/TileRaster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/config.scala
+++ b/core/src/main/scala/geotrellis/config.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/data/AsciiRasterLayer.scala
+++ b/core/src/main/scala/geotrellis/data/AsciiRasterLayer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core/src/main/scala/geotrellis/data/FileExtensionRegexes.scala
+++ b/core/src/main/scala/geotrellis/data/FileExtensionRegexes.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core/src/main/scala/geotrellis/data/FileReader.scala
+++ b/core/src/main/scala/geotrellis/data/FileReader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core/src/main/scala/geotrellis/data/IntReadState.scala
+++ b/core/src/main/scala/geotrellis/data/IntReadState.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core/src/main/scala/geotrellis/data/ReadState.scala
+++ b/core/src/main/scala/geotrellis/data/ReadState.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core/src/main/scala/geotrellis/data/Writer.scala
+++ b/core/src/main/scala/geotrellis/data/Writer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core/src/main/scala/geotrellis/data/arg/ArgReader.scala
+++ b/core/src/main/scala/geotrellis/data/arg/ArgReader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.arg
 

--- a/core/src/main/scala/geotrellis/data/arg/ArgWriter.scala
+++ b/core/src/main/scala/geotrellis/data/arg/ArgWriter.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.arg
 

--- a/core/src/main/scala/geotrellis/data/arg/CellWriter.scala
+++ b/core/src/main/scala/geotrellis/data/arg/CellWriter.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.arg
 

--- a/core/src/main/scala/geotrellis/data/ascii.scala
+++ b/core/src/main/scala/geotrellis/data/ascii.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/core/src/main/scala/geotrellis/data/geojson/GeoJsonReader.scala
+++ b/core/src/main/scala/geotrellis/data/geojson/GeoJsonReader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geojson
 

--- a/core/src/main/scala/geotrellis/data/geojson/GeoJsonWriter.scala
+++ b/core/src/main/scala/geotrellis/data/geojson/GeoJsonWriter.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geojson
 

--- a/core/src/main/scala/geotrellis/data/geotiff/Compression.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/Compression.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/data/geotiff/Const.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/Const.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/data/geotiff/Encoder.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/Encoder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/data/geotiff/LzwEncoder.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/LzwEncoder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/data/geotiff/Nodata.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/Nodata.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/data/geotiff/RawEncoder.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/RawEncoder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/data/geotiff/SampleFormat.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/SampleFormat.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/data/geotiff/SampleSize.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/SampleSize.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/data/geotiff/Settings.scala
+++ b/core/src/main/scala/geotrellis/data/geotiff/Settings.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data.geotiff
 

--- a/core/src/main/scala/geotrellis/feature/Feature.scala
+++ b/core/src/main/scala/geotrellis/feature/Feature.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/Geometry.scala
+++ b/core/src/main/scala/geotrellis/feature/Geometry.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/GeometryCollection.scala
+++ b/core/src/main/scala/geotrellis/feature/GeometryCollection.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/LineString.scala
+++ b/core/src/main/scala/geotrellis/feature/LineString.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/MultiLineString.scala
+++ b/core/src/main/scala/geotrellis/feature/MultiLineString.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/MultiPoint.scala
+++ b/core/src/main/scala/geotrellis/feature/MultiPoint.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/MultiPolygon.scala
+++ b/core/src/main/scala/geotrellis/feature/MultiPolygon.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/Point.scala
+++ b/core/src/main/scala/geotrellis/feature/Point.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/Polygon.scala
+++ b/core/src/main/scala/geotrellis/feature/Polygon.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/Semivariogram.scala
+++ b/core/src/main/scala/geotrellis/feature/Semivariogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/SpatialIndex.scala
+++ b/core/src/main/scala/geotrellis/feature/SpatialIndex.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/VectorToRaster.scala
+++ b/core/src/main/scala/geotrellis/feature/VectorToRaster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/AsPolygonSet.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/AsPolygonSet.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Buffer.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Buffer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Contains.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Contains.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/ConvexHull.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/ConvexHull.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/CountPoints.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/CountPoints.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Covers.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Covers.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Disjoint.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Disjoint.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Equals.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Equals.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Erase.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Erase.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/FilterGeometry.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/FilterGeometry.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/FlattenGeometry.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/FlattenGeometry.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/GetArea.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/GetArea.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/GetCentroid.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/GetCentroid.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/GetDistance.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/GetDistance.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/GetEnvelope.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/GetEnvelope.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/GetSymDifference.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/GetSymDifference.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/IDWInterpolate.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/IDWInterpolate.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Intersect.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Intersect.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Intersects.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Intersects.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/KernelDensity.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/KernelDensity.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Overlaps.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Overlaps.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Simplify.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Simplify.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/Union.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/Union.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/geometry.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/geometry.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op
 

--- a/core/src/main/scala/geotrellis/feature/op/geometry/rasterize.scala
+++ b/core/src/main/scala/geotrellis/feature/op/geometry/rasterize.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.op.geometry
 

--- a/core/src/main/scala/geotrellis/feature/package.scala
+++ b/core/src/main/scala/geotrellis/feature/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 import com.vividsolutions.jts.{ geom => jts }

--- a/core/src/main/scala/geotrellis/feature/rasterize/PolygonRasterizer.scala
+++ b/core/src/main/scala/geotrellis/feature/rasterize/PolygonRasterizer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.rasterize
 

--- a/core/src/main/scala/geotrellis/feature/rasterize/Rasterizer.scala
+++ b/core/src/main/scala/geotrellis/feature/rasterize/Rasterizer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.rasterize
 

--- a/core/src/main/scala/geotrellis/io/CSVIntMap.scala
+++ b/core/src/main/scala/geotrellis/io/CSVIntMap.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/IoOpMethods.scala
+++ b/core/src/main/scala/geotrellis/io/IoOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadFile.scala
+++ b/core/src/main/scala/geotrellis/io/LoadFile.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadGeoJson.scala
+++ b/core/src/main/scala/geotrellis/io/LoadGeoJson.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadGeoJsonFeature.scala
+++ b/core/src/main/scala/geotrellis/io/LoadGeoJsonFeature.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadRaster.scala
+++ b/core/src/main/scala/geotrellis/io/LoadRaster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadRasterDefinition.scala
+++ b/core/src/main/scala/geotrellis/io/LoadRasterDefinition.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadRasterExtentFromFile.scala
+++ b/core/src/main/scala/geotrellis/io/LoadRasterExtentFromFile.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadRasterLayer.scala
+++ b/core/src/main/scala/geotrellis/io/LoadRasterLayer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadRasterLayerInfo.scala
+++ b/core/src/main/scala/geotrellis/io/LoadRasterLayerInfo.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadRasterUrl.scala
+++ b/core/src/main/scala/geotrellis/io/LoadRasterUrl.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadTile.scala
+++ b/core/src/main/scala/geotrellis/io/LoadTile.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/LoadWKT.scala
+++ b/core/src/main/scala/geotrellis/io/LoadWKT.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/RenderGeoTiff.scala
+++ b/core/src/main/scala/geotrellis/io/RenderGeoTiff.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/ToGeoJson.scala
+++ b/core/src/main/scala/geotrellis/io/ToGeoJson.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/io/WritePng.scala
+++ b/core/src/main/scala/geotrellis/io/WritePng.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.io
 

--- a/core/src/main/scala/geotrellis/logic/AsList.scala
+++ b/core/src/main/scala/geotrellis/logic/AsList.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/Collect.scala
+++ b/core/src/main/scala/geotrellis/logic/Collect.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/Filter.scala
+++ b/core/src/main/scala/geotrellis/logic/Filter.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/ForEach.scala
+++ b/core/src/main/scala/geotrellis/logic/ForEach.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/Force.scala
+++ b/core/src/main/scala/geotrellis/logic/Force.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/If.scala
+++ b/core/src/main/scala/geotrellis/logic/If.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/MapOp.scala
+++ b/core/src/main/scala/geotrellis/logic/MapOp.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/TileReducer1.scala
+++ b/core/src/main/scala/geotrellis/logic/TileReducer1.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/WithResult.scala
+++ b/core/src/main/scala/geotrellis/logic/WithResult.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/logic/applicative/Apply.scala
+++ b/core/src/main/scala/geotrellis/logic/applicative/Apply.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic.applicative
 

--- a/core/src/main/scala/geotrellis/logic/applicative/Fmap.scala
+++ b/core/src/main/scala/geotrellis/logic/applicative/Fmap.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic.applicative
 

--- a/core/src/main/scala/geotrellis/logic/applicative/Implicits.scala
+++ b/core/src/main/scala/geotrellis/logic/applicative/Implicits.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic.applicative
 

--- a/core/src/main/scala/geotrellis/logic/applicative/Pure.scala
+++ b/core/src/main/scala/geotrellis/logic/applicative/Pure.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic.applicative
 

--- a/core/src/main/scala/geotrellis/logic/raster.scala
+++ b/core/src/main/scala/geotrellis/logic/raster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.logic
 

--- a/core/src/main/scala/geotrellis/package.scala
+++ b/core/src/main/scala/geotrellis/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 import geotrellis.source.CanBuildSourceFrom
 import geotrellis.statistics.Histogram

--- a/core/src/main/scala/geotrellis/process/ArgFileRasterLayer.scala
+++ b/core/src/main/scala/geotrellis/process/ArgFileRasterLayer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/ArgUrlRasterLayer.scala
+++ b/core/src/main/scala/geotrellis/process/ArgUrlRasterLayer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/Catalog.scala
+++ b/core/src/main/scala/geotrellis/process/Catalog.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/ConstantRasterLayer.scala
+++ b/core/src/main/scala/geotrellis/process/ConstantRasterLayer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/DataStore.scala
+++ b/core/src/main/scala/geotrellis/process/DataStore.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/History.scala
+++ b/core/src/main/scala/geotrellis/process/History.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/LayerId.scala
+++ b/core/src/main/scala/geotrellis/process/LayerId.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/LayerLoader.scala
+++ b/core/src/main/scala/geotrellis/process/LayerLoader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/OperationResult.scala
+++ b/core/src/main/scala/geotrellis/process/OperationResult.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/RasterLayer.scala
+++ b/core/src/main/scala/geotrellis/process/RasterLayer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/RasterLayerBuilder.scala
+++ b/core/src/main/scala/geotrellis/process/RasterLayerBuilder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/RasterLayerInfo.scala
+++ b/core/src/main/scala/geotrellis/process/RasterLayerInfo.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/RasterLayerType.scala
+++ b/core/src/main/scala/geotrellis/process/RasterLayerType.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/Server.scala
+++ b/core/src/main/scala/geotrellis/process/Server.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/TileSetRasterLayer.scala
+++ b/core/src/main/scala/geotrellis/process/TileSetRasterLayer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/actors/ResultHandler.scala
+++ b/core/src/main/scala/geotrellis/process/actors/ResultHandler.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process.actors
 

--- a/core/src/main/scala/geotrellis/process/actors/ServerActor.scala
+++ b/core/src/main/scala/geotrellis/process/actors/ServerActor.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process.actors
 

--- a/core/src/main/scala/geotrellis/process/actors/StepAggregator.scala
+++ b/core/src/main/scala/geotrellis/process/actors/StepAggregator.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process.actors
 

--- a/core/src/main/scala/geotrellis/process/actors/Worker.scala
+++ b/core/src/main/scala/geotrellis/process/actors/Worker.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process.actors
 

--- a/core/src/main/scala/geotrellis/process/actors/messages.scala
+++ b/core/src/main/scala/geotrellis/process/actors/messages.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process.actors
 

--- a/core/src/main/scala/geotrellis/process/cache.scala
+++ b/core/src/main/scala/geotrellis/process/cache.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process
 

--- a/core/src/main/scala/geotrellis/process/json/CatalogParser.scala
+++ b/core/src/main/scala/geotrellis/process/json/CatalogParser.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process.json
 

--- a/core/src/main/scala/geotrellis/process/json/RasterLayerParser.scala
+++ b/core/src/main/scala/geotrellis/process/json/RasterLayerParser.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process.json
 

--- a/core/src/main/scala/geotrellis/process/json/Rec.scala
+++ b/core/src/main/scala/geotrellis/process/json/Rec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.process.json
 

--- a/core/src/main/scala/geotrellis/process/package.scala
+++ b/core/src/main/scala/geotrellis/process/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/raster/BitArrayRasterData.scala
+++ b/core/src/main/scala/geotrellis/raster/BitArrayRasterData.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/BitConstant.scala
+++ b/core/src/main/scala/geotrellis/raster/BitConstant.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/ByteArrayRasterData.scala
+++ b/core/src/main/scala/geotrellis/raster/ByteArrayRasterData.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/Convolver.scala
+++ b/core/src/main/scala/geotrellis/raster/Convolver.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/DoubleArrayRasterData.scala
+++ b/core/src/main/scala/geotrellis/raster/DoubleArrayRasterData.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/DoubleBasedArray.scala
+++ b/core/src/main/scala/geotrellis/raster/DoubleBasedArray.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/DoubleConstant.scala
+++ b/core/src/main/scala/geotrellis/raster/DoubleConstant.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/FloatArrayRasterData.scala
+++ b/core/src/main/scala/geotrellis/raster/FloatArrayRasterData.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/IntArrayRasterData.scala
+++ b/core/src/main/scala/geotrellis/raster/IntArrayRasterData.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/IntBasedArray.scala
+++ b/core/src/main/scala/geotrellis/raster/IntBasedArray.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/IntConstant.scala
+++ b/core/src/main/scala/geotrellis/raster/IntConstant.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/Kernel.scala
+++ b/core/src/main/scala/geotrellis/raster/Kernel.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/LazyConvert.scala
+++ b/core/src/main/scala/geotrellis/raster/LazyConvert.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/MutableRasterData.scala
+++ b/core/src/main/scala/geotrellis/raster/MutableRasterData.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/RasterData.scala
+++ b/core/src/main/scala/geotrellis/raster/RasterData.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/ShortArrayRasterData.scala
+++ b/core/src/main/scala/geotrellis/raster/ShortArrayRasterData.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/TileLayout.scala
+++ b/core/src/main/scala/geotrellis/raster/TileLayout.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/TileNeighbors.scala
+++ b/core/src/main/scala/geotrellis/raster/TileNeighbors.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/Warp.scala
+++ b/core/src/main/scala/geotrellis/raster/Warp.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster
 

--- a/core/src/main/scala/geotrellis/raster/op/ConvertType.scala
+++ b/core/src/main/scala/geotrellis/raster/op/ConvertType.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Aspect.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Aspect.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Conway.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Conway.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Cursor.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Cursor.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/CursorMask.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/CursorMask.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/FocalCalculation.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/FocalCalculation.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/FocalOp.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/FocalOp.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/FocalOpMethods.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/FocalOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/FocalStrategy.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/FocalStrategy.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Hillshade.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Hillshade.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Max.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Max.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Mean.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Mean.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Median.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Median.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/MedianModeCalculation.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/MedianModeCalculation.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Min.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Min.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Mode.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Mode.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Moran.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Moran.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Neighborhood.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Neighborhood.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Slope.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Slope.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/StandardDeviation.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/StandardDeviation.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/Sum.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/Sum.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/SurfacePointCalculation.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/SurfacePointCalculation.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/focal/TileWithNeighbors.scala
+++ b/core/src/main/scala/geotrellis/raster/op/focal/TileWithNeighbors.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.focal
 

--- a/core/src/main/scala/geotrellis/raster/op/global/AsArray.scala
+++ b/core/src/main/scala/geotrellis/raster/op/global/AsArray.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core/src/main/scala/geotrellis/raster/op/global/Convolve.scala
+++ b/core/src/main/scala/geotrellis/raster/op/global/Convolve.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core/src/main/scala/geotrellis/raster/op/global/CostDistance.scala
+++ b/core/src/main/scala/geotrellis/raster/op/global/CostDistance.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core/src/main/scala/geotrellis/raster/op/global/GlobalOpMethods.scala
+++ b/core/src/main/scala/geotrellis/raster/op/global/GlobalOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core/src/main/scala/geotrellis/raster/op/global/RegionGroup.scala
+++ b/core/src/main/scala/geotrellis/raster/op/global/RegionGroup.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core/src/main/scala/geotrellis/raster/op/global/Rescale.scala
+++ b/core/src/main/scala/geotrellis/raster/op/global/Rescale.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core/src/main/scala/geotrellis/raster/op/global/ToVector.scala
+++ b/core/src/main/scala/geotrellis/raster/op/global/ToVector.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core/src/main/scala/geotrellis/raster/op/global/VerticalFlip.scala
+++ b/core/src/main/scala/geotrellis/raster/op/global/VerticalFlip.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.global
 

--- a/core/src/main/scala/geotrellis/raster/op/hydrology/Accumulation.scala
+++ b/core/src/main/scala/geotrellis/raster/op/hydrology/Accumulation.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.hydrology
 

--- a/core/src/main/scala/geotrellis/raster/op/hydrology/Fill.scala
+++ b/core/src/main/scala/geotrellis/raster/op/hydrology/Fill.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.hydrology
 

--- a/core/src/main/scala/geotrellis/raster/op/hydrology/FlowDirection.scala
+++ b/core/src/main/scala/geotrellis/raster/op/hydrology/FlowDirection.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.hydrology
 

--- a/core/src/main/scala/geotrellis/raster/op/hydrology/HydrologyOpMethods.scala
+++ b/core/src/main/scala/geotrellis/raster/op/hydrology/HydrologyOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.hydrology
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Abs.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Abs.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Acos.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Acos.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Add.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Add.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/And.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/And.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Asin.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Asin.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Atan.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Atan.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Atan2.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Atan2.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Ceil.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Ceil.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Cos.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Cos.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Cosh.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Cosh.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Defined.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Defined.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Divide.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Divide.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Equal.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Equal.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Floor.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Floor.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Greater.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Greater.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/GreaterOrEqual.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/GreaterOrEqual.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/InverseMask.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/InverseMask.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Less.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Less.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/LessOrEqual.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/LessOrEqual.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/LocalMap.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/LocalMap.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/LocalMethods.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/LocalMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/LocalOpMethods.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/LocalOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/LocalRasterBinaryOp.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/LocalRasterBinaryOp.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Log.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Log.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Majority.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Majority.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Mask.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Mask.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Max.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Max.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/MaxN.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/MaxN.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014 Azavea.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.raster.op.local
 
 import geotrellis._

--- a/core/src/main/scala/geotrellis/raster/op/local/Mean.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Mean.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Min.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Min.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/MinN.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/MinN.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014 Azavea.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.raster.op.local
 
 import geotrellis._

--- a/core/src/main/scala/geotrellis/raster/op/local/Minority.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Minority.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Multiply.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Multiply.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Negate.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Negate.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Not.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Not.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Or.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Or.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Pow.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Pow.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/RasterReducer.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/RasterReducer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Round.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Round.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Sin.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Sin.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Sinh.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Sinh.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Sqrt.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Sqrt.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Subtract.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Subtract.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Tan.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Tan.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Tanh.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Tanh.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Undefined.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Undefined.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Unequal.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Unequal.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Variety.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Variety.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/Xor.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/Xor.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/local/conditional.scala
+++ b/core/src/main/scala/geotrellis/raster/op/local/conditional.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.local
 

--- a/core/src/main/scala/geotrellis/raster/op/transform/Crop.scala
+++ b/core/src/main/scala/geotrellis/raster/op/transform/Crop.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.transform
 

--- a/core/src/main/scala/geotrellis/raster/op/transform/Downsample.scala
+++ b/core/src/main/scala/geotrellis/raster/op/transform/Downsample.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.transform
 

--- a/core/src/main/scala/geotrellis/raster/op/transform/Rescale.scala
+++ b/core/src/main/scala/geotrellis/raster/op/transform/Rescale.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.transform
 

--- a/core/src/main/scala/geotrellis/raster/op/transform/Resize.scala
+++ b/core/src/main/scala/geotrellis/raster/op/transform/Resize.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.transform
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/ZonalHistograms.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/ZonalHistograms.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/ZonalOpMethods.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/ZonalOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/ZonalPercentage.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/ZonalPercentage.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/summary/Histogram.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/summary/Histogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/summary/Max.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/summary/Max.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/summary/Mean.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/summary/Mean.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/summary/Min.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/summary/Min.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/summary/Sum.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/summary/Sum.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/summary/TileSummary.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/summary/TileSummary.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core/src/main/scala/geotrellis/raster/op/zonal/summary/ZonalSummaryOpMethods.scala
+++ b/core/src/main/scala/geotrellis/raster/op/zonal/summary/ZonalSummaryOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.raster.op.zonal.summary
 

--- a/core/src/main/scala/geotrellis/render/Color.scala
+++ b/core/src/main/scala/geotrellis/render/Color.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render
 

--- a/core/src/main/scala/geotrellis/render/ColorBreaks.scala
+++ b/core/src/main/scala/geotrellis/render/ColorBreaks.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render
 

--- a/core/src/main/scala/geotrellis/render/ColorMap.scala
+++ b/core/src/main/scala/geotrellis/render/ColorMap.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render
 

--- a/core/src/main/scala/geotrellis/render/ColorRamp.scala
+++ b/core/src/main/scala/geotrellis/render/ColorRamp.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render
 

--- a/core/src/main/scala/geotrellis/render/ColorRamps.scala
+++ b/core/src/main/scala/geotrellis/render/ColorRamps.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render
 

--- a/core/src/main/scala/geotrellis/render/op/ColorRaster.scala
+++ b/core/src/main/scala/geotrellis/render/op/ColorRaster.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.op
 

--- a/core/src/main/scala/geotrellis/render/op/GetColorBreaks.scala
+++ b/core/src/main/scala/geotrellis/render/op/GetColorBreaks.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.op
 

--- a/core/src/main/scala/geotrellis/render/op/RenderOpMethods.scala
+++ b/core/src/main/scala/geotrellis/render/op/RenderOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.op
 

--- a/core/src/main/scala/geotrellis/render/op/RenderPng.scala
+++ b/core/src/main/scala/geotrellis/render/op/RenderPng.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.op
 

--- a/core/src/main/scala/geotrellis/render/op/RenderPngRgba.scala
+++ b/core/src/main/scala/geotrellis/render/op/RenderPngRgba.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.op
 

--- a/core/src/main/scala/geotrellis/render/op/SimpleRenderPng.scala
+++ b/core/src/main/scala/geotrellis/render/op/SimpleRenderPng.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.op
 

--- a/core/src/main/scala/geotrellis/render/png/Chunk.scala
+++ b/core/src/main/scala/geotrellis/render/png/Chunk.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core/src/main/scala/geotrellis/render/png/ColorType.scala
+++ b/core/src/main/scala/geotrellis/render/png/ColorType.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core/src/main/scala/geotrellis/render/png/Encoder.scala
+++ b/core/src/main/scala/geotrellis/render/png/Encoder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core/src/main/scala/geotrellis/render/png/Filter.scala
+++ b/core/src/main/scala/geotrellis/render/png/Filter.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core/src/main/scala/geotrellis/render/png/Renderer.scala
+++ b/core/src/main/scala/geotrellis/render/png/Renderer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core/src/main/scala/geotrellis/render/png/Settings.scala
+++ b/core/src/main/scala/geotrellis/render/png/Settings.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core/src/main/scala/geotrellis/render/png/Util.scala
+++ b/core/src/main/scala/geotrellis/render/png/Util.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.render.png
 

--- a/core/src/main/scala/geotrellis/rest/ParamParser.scala
+++ b/core/src/main/scala/geotrellis/rest/ParamParser.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.rest
 

--- a/core/src/main/scala/geotrellis/rest/op/string/Concat.scala
+++ b/core/src/main/scala/geotrellis/rest/op/string/Concat.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.rest.op.string
 

--- a/core/src/main/scala/geotrellis/rest/op/string/ParseColor.scala
+++ b/core/src/main/scala/geotrellis/rest/op/string/ParseColor.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.rest.op.string
 

--- a/core/src/main/scala/geotrellis/rest/op/string/ParseDouble.scala
+++ b/core/src/main/scala/geotrellis/rest/op/string/ParseDouble.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.rest.op.string
 

--- a/core/src/main/scala/geotrellis/rest/op/string/ParseExtent.scala
+++ b/core/src/main/scala/geotrellis/rest/op/string/ParseExtent.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.rest.op.string
 

--- a/core/src/main/scala/geotrellis/rest/op/string/ParseInt.scala
+++ b/core/src/main/scala/geotrellis/rest/op/string/ParseInt.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.rest.op.string
 

--- a/core/src/main/scala/geotrellis/rest/op/string/ParseRasterExtent.scala
+++ b/core/src/main/scala/geotrellis/rest/op/string/ParseRasterExtent.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.rest.op.string
 

--- a/core/src/main/scala/geotrellis/rest/op/string/Split.scala
+++ b/core/src/main/scala/geotrellis/rest/op/string/Split.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.rest.op.string
 

--- a/core/src/main/scala/geotrellis/source/CanBuildSourceFrom.scala
+++ b/core/src/main/scala/geotrellis/source/CanBuildSourceFrom.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/DataSource.scala
+++ b/core/src/main/scala/geotrellis/source/DataSource.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/DataSourceBuilder.scala
+++ b/core/src/main/scala/geotrellis/source/DataSourceBuilder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/DataSourceLike.scala
+++ b/core/src/main/scala/geotrellis/source/DataSourceLike.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/RasterDefinition.scala
+++ b/core/src/main/scala/geotrellis/source/RasterDefinition.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/RasterSource.scala
+++ b/core/src/main/scala/geotrellis/source/RasterSource.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/RasterSourceBuilder.scala
+++ b/core/src/main/scala/geotrellis/source/RasterSourceBuilder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
   

--- a/core/src/main/scala/geotrellis/source/RasterSourceLike.scala
+++ b/core/src/main/scala/geotrellis/source/RasterSourceLike.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/RasterSourceSeq.scala
+++ b/core/src/main/scala/geotrellis/source/RasterSourceSeq.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/SourceBuilder.scala
+++ b/core/src/main/scala/geotrellis/source/SourceBuilder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/ValueSource.scala
+++ b/core/src/main/scala/geotrellis/source/ValueSource.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/ValueSourceBuilder.scala
+++ b/core/src/main/scala/geotrellis/source/ValueSourceBuilder.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.source
 

--- a/core/src/main/scala/geotrellis/source/package.scala
+++ b/core/src/main/scala/geotrellis/source/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/statistics/ArrayHistogram.scala
+++ b/core/src/main/scala/geotrellis/statistics/ArrayHistogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core/src/main/scala/geotrellis/statistics/CompressedArrayHistogram.scala
+++ b/core/src/main/scala/geotrellis/statistics/CompressedArrayHistogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core/src/main/scala/geotrellis/statistics/ConstantHistogram.scala
+++ b/core/src/main/scala/geotrellis/statistics/ConstantHistogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core/src/main/scala/geotrellis/statistics/FastMapHistogram.scala
+++ b/core/src/main/scala/geotrellis/statistics/FastMapHistogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core/src/main/scala/geotrellis/statistics/Histogram.scala
+++ b/core/src/main/scala/geotrellis/statistics/Histogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core/src/main/scala/geotrellis/statistics/MapHistogram.scala
+++ b/core/src/main/scala/geotrellis/statistics/MapHistogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core/src/main/scala/geotrellis/statistics/MutableHistogram.scala
+++ b/core/src/main/scala/geotrellis/statistics/MutableHistogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core/src/main/scala/geotrellis/statistics/Statistics.scala
+++ b/core/src/main/scala/geotrellis/statistics/Statistics.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics
 

--- a/core/src/main/scala/geotrellis/statistics/op/stat/GetClassBreaks.scala
+++ b/core/src/main/scala/geotrellis/statistics/op/stat/GetClassBreaks.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core/src/main/scala/geotrellis/statistics/op/stat/GetHistogram.scala
+++ b/core/src/main/scala/geotrellis/statistics/op/stat/GetHistogram.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core/src/main/scala/geotrellis/statistics/op/stat/GetMinMax.scala
+++ b/core/src/main/scala/geotrellis/statistics/op/stat/GetMinMax.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core/src/main/scala/geotrellis/statistics/op/stat/GetStandardDeviation.scala
+++ b/core/src/main/scala/geotrellis/statistics/op/stat/GetStandardDeviation.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core/src/main/scala/geotrellis/statistics/op/stat/GetStatistics.scala
+++ b/core/src/main/scala/geotrellis/statistics/op/stat/GetStatistics.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core/src/main/scala/geotrellis/statistics/op/stat/StatOpMethods.scala
+++ b/core/src/main/scala/geotrellis/statistics/op/stat/StatOpMethods.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.statistics.op.stat
 

--- a/core/src/main/scala/geotrellis/util/Filesystem.scala
+++ b/core/src/main/scala/geotrellis/util/Filesystem.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util
 

--- a/core/src/main/scala/geotrellis/util/Timer.scala
+++ b/core/src/main/scala/geotrellis/util/Timer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util
 

--- a/core/src/main/scala/geotrellis/util/Units.scala
+++ b/core/src/main/scala/geotrellis/util/Units.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util
 

--- a/core/src/main/scala/geotrellis/util/package.scala
+++ b/core/src/main/scala/geotrellis/util/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/core/src/main/scala/geotrellis/util/srs/LatLng.scala
+++ b/core/src/main/scala/geotrellis/util/srs/LatLng.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util.srs
 

--- a/core/src/main/scala/geotrellis/util/srs/SpatialReferenceSystem.scala
+++ b/core/src/main/scala/geotrellis/util/srs/SpatialReferenceSystem.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util.srs
 

--- a/core/src/main/scala/geotrellis/util/srs/WebMercator.scala
+++ b/core/src/main/scala/geotrellis/util/srs/WebMercator.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util.srs
 

--- a/core/src/main/scala/geotrellis/util/srs/package.scala
+++ b/core/src/main/scala/geotrellis/util/srs/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.util
 

--- a/demo/src/main/scala/demo/Demo.scala
+++ b/demo/src/main/scala/demo/Demo.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package demo
 

--- a/demo/src/main/scala/demo/Main.scala
+++ b/demo/src/main/scala/demo/Main.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package demo
 

--- a/demo/src/main/scala/demo/Tutorial.scala
+++ b/demo/src/main/scala/demo/Tutorial.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package demo
 

--- a/dev/src/main/scala/geotrellis/dev/RemoteClient.scala
+++ b/dev/src/main/scala/geotrellis/dev/RemoteClient.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.dev
 

--- a/dev/src/main/scala/geotrellis/dev/RemoteServer.scala
+++ b/dev/src/main/scala/geotrellis/dev/RemoteServer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.dev
 

--- a/feature-benchmark/src/main/scala/geotrellis/feature/benchmark/Main.scala
+++ b/feature-benchmark/src/main/scala/geotrellis/feature/benchmark/Main.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.benchmark
 

--- a/feature/src/main/scala/geotrellis/feature/Dimension.scala
+++ b/feature/src/main/scala/geotrellis/feature/Dimension.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/Factory.scala
+++ b/feature/src/main/scala/geotrellis/feature/Factory.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/Feature.scala
+++ b/feature/src/main/scala/geotrellis/feature/Feature.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/Geometry.scala
+++ b/feature/src/main/scala/geotrellis/feature/Geometry.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/GeometryCollection.scala
+++ b/feature/src/main/scala/geotrellis/feature/GeometryCollection.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/Line.scala
+++ b/feature/src/main/scala/geotrellis/feature/Line.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/Main.scala
+++ b/feature/src/main/scala/geotrellis/feature/Main.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/MultiLine.scala
+++ b/feature/src/main/scala/geotrellis/feature/MultiLine.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/MultiPoint.scala
+++ b/feature/src/main/scala/geotrellis/feature/MultiPoint.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/MultiPolygon.scala
+++ b/feature/src/main/scala/geotrellis/feature/MultiPolygon.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/Point.scala
+++ b/feature/src/main/scala/geotrellis/feature/Point.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/Polygon.scala
+++ b/feature/src/main/scala/geotrellis/feature/Polygon.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/Results.scala
+++ b/feature/src/main/scala/geotrellis/feature/Results.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature
 

--- a/feature/src/main/scala/geotrellis/feature/package.scala
+++ b/feature/src/main/scala/geotrellis/feature/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/feature/src/test/scala/geotrellis/feature/check/Generators.scala
+++ b/feature/src/test/scala/geotrellis/feature/check/Generators.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.check
 

--- a/feature/src/test/scala/geotrellis/feature/check/jts/Generators.scala
+++ b/feature/src/test/scala/geotrellis/feature/check/jts/Generators.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.check.jts
 

--- a/feature/src/test/scala/geotrellis/feature/check/jts/LineStringCheck.scala
+++ b/feature/src/test/scala/geotrellis/feature/check/jts/LineStringCheck.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.check.jts
 

--- a/feature/src/test/scala/geotrellis/feature/check/jts/MultiLineStringCheck.scala
+++ b/feature/src/test/scala/geotrellis/feature/check/jts/MultiLineStringCheck.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.check.jts
 

--- a/feature/src/test/scala/geotrellis/feature/check/jts/MultiPointCheck.scala
+++ b/feature/src/test/scala/geotrellis/feature/check/jts/MultiPointCheck.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.check.jts
 

--- a/feature/src/test/scala/geotrellis/feature/check/jts/PointCheck.scala
+++ b/feature/src/test/scala/geotrellis/feature/check/jts/PointCheck.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.check.jts
 

--- a/feature/src/test/scala/geotrellis/feature/check/jts/PolygonCheck.scala
+++ b/feature/src/test/scala/geotrellis/feature/check/jts/PolygonCheck.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.check.jts
 

--- a/feature/src/test/scala/geotrellis/feature/spec/LineSpec.scala
+++ b/feature/src/test/scala/geotrellis/feature/spec/LineSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.spec
 

--- a/feature/src/test/scala/geotrellis/feature/spec/PointSpec.scala
+++ b/feature/src/test/scala/geotrellis/feature/spec/PointSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.spec
 

--- a/feature/src/test/scala/geotrellis/feature/spec/PolygonSpec.scala
+++ b/feature/src/test/scala/geotrellis/feature/spec/PolygonSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.feature.spec
 

--- a/geotools/src/main/scala/geotrellis/data/GeoTiff.scala
+++ b/geotools/src/main/scala/geotrellis/data/GeoTiff.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/geotools/src/main/scala/geotrellis/data/GeoTiffDoubleReadState.scala
+++ b/geotools/src/main/scala/geotrellis/data/GeoTiffDoubleReadState.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/geotools/src/main/scala/geotrellis/data/GeoTiffIntReadState.scala
+++ b/geotools/src/main/scala/geotrellis/data/GeoTiffIntReadState.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/geotools/src/main/scala/geotrellis/data/GeoTiffRasterLayer.scala
+++ b/geotools/src/main/scala/geotrellis/data/GeoTiffRasterLayer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/geotools/src/main/scala/geotrellis/data/GeoTiffReader.scala
+++ b/geotools/src/main/scala/geotrellis/data/GeoTiffReader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/geotools/src/main/scala/geotrellis/data/GeoTiffWriter.scala
+++ b/geotools/src/main/scala/geotrellis/data/GeoTiffWriter.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/geotools/src/main/scala/geotrellis/data/ShapeFileReader.scala
+++ b/geotools/src/main/scala/geotrellis/data/ShapeFileReader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/geotools/src/test/scala/geotrellis/data/geotiff.scala
+++ b/geotools/src/test/scala/geotrellis/data/geotiff.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.data
 

--- a/jetty/src/main/scala/geotrellis/jetty/JettyServer.scala
+++ b/jetty/src/main/scala/geotrellis/jetty/JettyServer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.jetty
 

--- a/jetty/src/main/scala/geotrellis/jetty/Response.scala
+++ b/jetty/src/main/scala/geotrellis/jetty/Response.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.jetty
 

--- a/jetty/src/main/scala/geotrellis/jetty/WebRunner.scala
+++ b/jetty/src/main/scala/geotrellis/jetty/WebRunner.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.jetty
 

--- a/jetty/src/main/scala/geotrellis/jetty/config.scala
+++ b/jetty/src/main/scala/geotrellis/jetty/config.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.jetty
 

--- a/jetty/src/main/scala/geotrellis/jetty/services/Catalog.scala
+++ b/jetty/src/main/scala/geotrellis/jetty/services/Catalog.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.jetty.service
 

--- a/jetty/src/main/scala/geotrellis/jetty/services/Color.scala
+++ b/jetty/src/main/scala/geotrellis/jetty/services/Color.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.jetty.service
 

--- a/macros/src/main/scala/geotrellis/macros.scala
+++ b/macros/src/main/scala/geotrellis/macros.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/notes/api.scala
+++ b/notes/api.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 // Getting min of raster
 val r = io.LoadRaster("")  // RasterSource extends DataSource[Raster,Raster]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 import sbt._
 import sbt.Keys._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 import sbt._
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 object Version {
   val geotrellis  = "0.10.0-SNAPSHOT"

--- a/scripts/insert-copyright-header.py
+++ b/scripts/insert-copyright-header.py
@@ -34,10 +34,10 @@ max_width = max(map(lambda x: len(x), license.split('\n')))
 
 def c_style_comment(text):
   commented = [ ]
-  commented.append("/**" + ('*' * max_width))
+  commented.append("/*")
   for line in text.split("\n"):
     commented.append(" * " + line)
-  commented.append(" **" + ('*' * max_width) + "/")
+  commented.append(" */")
   return '\n'.join(commented)
 
 def python_comment(text):

--- a/services/src/main/scala/geotrellis/services/CatalogService.scala
+++ b/services/src/main/scala/geotrellis/services/CatalogService.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.services
 

--- a/services/src/main/scala/geotrellis/services/ColorRampMap.scala
+++ b/services/src/main/scala/geotrellis/services/ColorRampMap.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.services
 

--- a/services/src/main/scala/geotrellis/services/Json.scala
+++ b/services/src/main/scala/geotrellis/services/Json.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.services
 

--- a/services/src/main/scala/geotrellis/services/LayerService.scala
+++ b/services/src/main/scala/geotrellis/services/LayerService.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.services
 

--- a/spark/src/main/scala/geotrellis/spark/KryoRegistrator.scala
+++ b/spark/src/main/scala/geotrellis/spark/KryoRegistrator.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark
 

--- a/spark/src/main/scala/geotrellis/spark/Tile.scala
+++ b/spark/src/main/scala/geotrellis/spark/Tile.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark
 

--- a/spark/src/main/scala/geotrellis/spark/cmd/CommandArguments.scala
+++ b/spark/src/main/scala/geotrellis/spark/cmd/CommandArguments.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.cmd
 

--- a/spark/src/main/scala/geotrellis/spark/cmd/Export.scala
+++ b/spark/src/main/scala/geotrellis/spark/cmd/Export.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.cmd
 import geotrellis._

--- a/spark/src/main/scala/geotrellis/spark/cmd/Ingest.scala
+++ b/spark/src/main/scala/geotrellis/spark/cmd/Ingest.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.cmd
 import geotrellis._

--- a/spark/src/main/scala/geotrellis/spark/cmd/NoDataHandler.scala
+++ b/spark/src/main/scala/geotrellis/spark/cmd/NoDataHandler.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.cmd
 

--- a/spark/src/main/scala/geotrellis/spark/formats/ArgWritable.scala
+++ b/spark/src/main/scala/geotrellis/spark/formats/ArgWritable.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.formats
 

--- a/spark/src/main/scala/geotrellis/spark/formats/TileIdWritable.scala
+++ b/spark/src/main/scala/geotrellis/spark/formats/TileIdWritable.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.formats
 

--- a/spark/src/main/scala/geotrellis/spark/formats/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/formats/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark
 

--- a/spark/src/main/scala/geotrellis/spark/metadata/Context.scala
+++ b/spark/src/main/scala/geotrellis/spark/metadata/Context.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.metadata
 

--- a/spark/src/main/scala/geotrellis/spark/metadata/JacksonWrapper.scala
+++ b/spark/src/main/scala/geotrellis/spark/metadata/JacksonWrapper.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.metadata
 

--- a/spark/src/main/scala/geotrellis/spark/metadata/PyramidMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/metadata/PyramidMetadata.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.metadata
 import geotrellis._

--- a/spark/src/main/scala/geotrellis/spark/old/ArgHadoopDriver.scala
+++ b/spark/src/main/scala/geotrellis/spark/old/ArgHadoopDriver.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.old
 

--- a/spark/src/main/scala/geotrellis/spark/old/GeneratePartitionedMapFiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/old/GeneratePartitionedMapFiles.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark
 

--- a/spark/src/main/scala/geotrellis/spark/old/InputOutputDriver.scala
+++ b/spark/src/main/scala/geotrellis/spark/old/InputOutputDriver.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.old
 

--- a/spark/src/main/scala/geotrellis/spark/op/local/Add.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/Add.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.op.local
 

--- a/spark/src/main/scala/geotrellis/spark/op/local/Divide.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/Divide.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.op.local
 

--- a/spark/src/main/scala/geotrellis/spark/op/local/Multiply.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/Multiply.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.op.local
 

--- a/spark/src/main/scala/geotrellis/spark/op/local/Subtract.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/Subtract.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.op.local
 

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis
 

--- a/spark/src/main/scala/geotrellis/spark/rdd/RasterHadoopRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/rdd/RasterHadoopRDD.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.rdd
 

--- a/spark/src/main/scala/geotrellis/spark/rdd/RasterRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/rdd/RasterRDD.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.rdd
 

--- a/spark/src/main/scala/geotrellis/spark/rdd/SaveRasterFunctions.scala
+++ b/spark/src/main/scala/geotrellis/spark/rdd/SaveRasterFunctions.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.rdd
 

--- a/spark/src/main/scala/geotrellis/spark/rdd/SplitGenerator.scala
+++ b/spark/src/main/scala/geotrellis/spark/rdd/SplitGenerator.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014 DigitalGlobe.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** ************************************************************************
  *  Copyright (c) 2014 DigitalGlobe.
  *

--- a/spark/src/main/scala/geotrellis/spark/rdd/TileIdPartitioner.scala
+++ b/spark/src/main/scala/geotrellis/spark/rdd/TileIdPartitioner.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.rdd
 import geotrellis.spark.formats.TileIdWritable

--- a/spark/src/main/scala/geotrellis/spark/storage/RasterReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/storage/RasterReader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.storage
 

--- a/spark/src/main/scala/geotrellis/spark/storage/SimpleRasterReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/storage/SimpleRasterReader.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.storage
 

--- a/spark/src/main/scala/geotrellis/spark/tiling/Tiling.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/Tiling.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.tiling
 

--- a/spark/src/main/scala/geotrellis/spark/tiling/TmsTiling.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TmsTiling.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.tiling
 

--- a/spark/src/main/scala/geotrellis/spark/tiling/TmsTilingConvert.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TmsTilingConvert.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.tiling
 import geotrellis.raster.TileLayout

--- a/spark/src/main/scala/geotrellis/spark/utils/HdfsUtils.scala
+++ b/spark/src/main/scala/geotrellis/spark/utils/HdfsUtils.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.utils
 import org.apache.hadoop.conf.Configuration

--- a/spark/src/main/scala/geotrellis/spark/utils/SparkUtils.scala
+++ b/spark/src/main/scala/geotrellis/spark/utils/SparkUtils.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.utils
 import org.apache.hadoop.conf.Configuration

--- a/spark/src/test/scala/geotrellis/spark/RDDMatchers.scala
+++ b/spark/src/test/scala/geotrellis/spark/RDDMatchers.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark
 

--- a/spark/src/test/scala/geotrellis/spark/SharedSparkContext.scala
+++ b/spark/src/test/scala/geotrellis/spark/SharedSparkContext.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark
 import org.apache.spark.SparkContext

--- a/spark/src/test/scala/geotrellis/spark/TestEnvironment.scala
+++ b/spark/src/test/scala/geotrellis/spark/TestEnvironment.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark
 import geotrellis.spark.utils.SparkUtils

--- a/spark/src/test/scala/geotrellis/spark/cmd/IngestSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/cmd/IngestSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.cmd
 import geotrellis.Extent

--- a/spark/src/test/scala/geotrellis/spark/formats/ArgWritableSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/formats/ArgWritableSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.formats
 

--- a/spark/src/test/scala/geotrellis/spark/metadata/ContextSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/metadata/ContextSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.metadata
 

--- a/spark/src/test/scala/geotrellis/spark/metadata/PyramidMetadataSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/metadata/PyramidMetadataSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.metadata
 import geotrellis.Extent

--- a/spark/src/test/scala/geotrellis/spark/op/local/AddSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/AddSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.op.local
 

--- a/spark/src/test/scala/geotrellis/spark/op/local/DivideSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/DivideSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.op.local
 

--- a/spark/src/test/scala/geotrellis/spark/op/local/MultiplySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/MultiplySpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.op.local
 

--- a/spark/src/test/scala/geotrellis/spark/op/local/SubtractSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/op/local/SubtractSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.op.local
 

--- a/spark/src/test/scala/geotrellis/spark/rdd/RasterSplitGeneratorSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/rdd/RasterSplitGeneratorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014 DigitalGlobe.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** ************************************************************************
  *  Copyright (c) 2014 DigitalGlobe.
  *

--- a/spark/src/test/scala/geotrellis/spark/rdd/TileIdPartitionerSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/rdd/TileIdPartitionerSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.rdd
 import geotrellis.spark.TestEnvironment

--- a/spark/src/test/scala/geotrellis/spark/storage/RasterReaderSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/storage/RasterReaderSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.storage
 import geotrellis.spark.TestEnvironment

--- a/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.testfiles
 import geotrellis.spark.metadata.PyramidMetadata

--- a/spark/src/test/scala/geotrellis/spark/tiling/TmsTilingConvertSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/tiling/TmsTilingConvertSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.tiling
 import geotrellis.RasterExtent

--- a/spark/src/test/scala/geotrellis/spark/tiling/TmsTilingSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/tiling/TmsTilingSpec.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 DigitalGlobe.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.spark.tiling
 import geotrellis.Extent

--- a/tasks/src/main/scala/geotrellis/run/DiffTask.scala
+++ b/tasks/src/main/scala/geotrellis/run/DiffTask.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.run
 

--- a/tasks/src/main/scala/geotrellis/run/ExportTask.scala
+++ b/tasks/src/main/scala/geotrellis/run/ExportTask.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.run
 

--- a/tasks/src/main/scala/geotrellis/run/FocalTask.scala
+++ b/tasks/src/main/scala/geotrellis/run/FocalTask.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.run
 

--- a/tasks/src/main/scala/geotrellis/run/InfoTask.scala
+++ b/tasks/src/main/scala/geotrellis/run/InfoTask.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.run
 

--- a/tasks/src/main/scala/geotrellis/run/Tasks.scala
+++ b/tasks/src/main/scala/geotrellis/run/Tasks.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.run
 

--- a/testkit/src/main/scala/geotrellis/testkit/AssertAreEqual.scala
+++ b/testkit/src/main/scala/geotrellis/testkit/AssertAreEqual.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.testkit
 

--- a/testkit/src/main/scala/geotrellis/testkit/RasterBuilders.scala
+++ b/testkit/src/main/scala/geotrellis/testkit/RasterBuilders.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.testkit
 

--- a/testkit/src/main/scala/geotrellis/testkit/TestServer.scala
+++ b/testkit/src/main/scala/geotrellis/testkit/TestServer.scala
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  * Copyright (c) 2014 Azavea.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **************************************************************************/
+ */
 
 package geotrellis.testkit
 


### PR DESCRIPTION
Removed extra stars in the first and last line of headers. My copy/paste screws up formatting, so please see this pastebin for the after and before respectively:
http://pastebin.com/y9YX0AF6
