### PR TITLE
Close lines of a polygon when reading GeoJSON.

### DIFF
--- a/feature-test/src/test/scala/geotrellis/feature/spec/LineSpec.scala
+++ b/feature-test/src/test/scala/geotrellis/feature/spec/LineSpec.scala
@@ -74,6 +74,17 @@ class LineSpec extends FunSpec with ShouldMatchers {
       l.length should be (2)
     }
 
+    it ("should close a line") {
+      val l = Line(Point(0,0), Point(2,0), Point(2,2), Point(0,2))
+      l.closed should be (Line(Point(0,0), Point(2,0), Point(2,2), Point(0,2), Point(0,0)))
+    }
+
+    it ("should close a line if already closed") {
+      val l = Line(Point(0,0), Point(2,0), Point(2,2), Point(0,2), Point(0,0))
+      l.closed should be (Line(Point(0,0), Point(2,0), Point(2,2), Point(0,2), Point(0,0)))
+    }
+
+
     // -- Intersection
 
     it ("should intersect with a Point and return a PointResult") {

--- a/feature/src/main/scala/geotrellis/feature/Line.scala
+++ b/feature/src/main/scala/geotrellis/feature/Line.scala
@@ -89,6 +89,12 @@ case class Line(jtsGeom: jts.LineString) extends Geometry
   lazy val length: Double =
     jtsGeom.getLength
 
+  /** Returns a closed version of the line. If already closed, just return this. */
+  def closed(): Line =
+    if(isClosed) this
+    else {
+      Line(points :+ points.head)
+    }
 
   // -- Intersection
 


### PR DESCRIPTION
This comes from a leaflet draw plugin translating to GeoJSON with polygons who's borders are not closed.
