### PR TITLE
Exclude com.google.code.findbugs jsr305 dependency.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -371,10 +371,15 @@ object GeotrellisBuild extends Build {
           "xerces" % "xercesImpl" % "2.9.1",
           "xalan" % "xalan" % "2.7.1",
           "org.apache.spark" %% "spark-core" % sparkVersion excludeAll (
-            ExclusionRule(organization = "org.apache.hadoop")),
+            ExclusionRule(organization = "org.apache.hadoop"),
+            ExclusionRule(organization = "com.google.code.findbugs")
+          ),
           "org.apache.hadoop" % "hadoop-client" % hadoopVersion excludeAll (
-	          ExclusionRule(organization = "hsqldb")),
-          "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.3.0",
+	    ExclusionRule(organization = "hsqldb")
+          ),
+          "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.3.0" excludeAll (
+            ExclusionRule(organization = "com.google.code.findbugs")
+          ),
           "com.quantifind" %% "sumac" % "0.2.3",
           scalatest % "test",
           spire, sprayRouting, sprayCan

--- a/spark/src/test/scala/geotrellis/spark/cmd/NoDataHandlerSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/cmd/NoDataHandlerSpec.scala
@@ -14,10 +14,9 @@ import geotrellis.raster.FloatArrayTile
 import geotrellis.raster.IntArrayTile
 import geotrellis.raster.ShortArrayTile
 
-import org.scalatest.FunSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
-class NoDataHandlerSpec extends FunSpec with ShouldMatchers {
+class NoDataHandlerSpec extends FunSpec with Matchers {
   describe("add/remove user nodata") {
 
     val cols = 2

--- a/spark/src/test/scala/geotrellis/spark/formats/ArgWritableSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/formats/ArgWritableSpec.scala
@@ -30,11 +30,9 @@ import geotrellis.raster.FloatArrayTile
 import geotrellis.raster.IntArrayTile
 import geotrellis.raster.ShortArrayTile
 
-import org.scalatest.FunSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
-
-class ArgWritableSpec extends FunSpec with ShouldMatchers {
+class ArgWritableSpec extends FunSpec with Matchers {
   describe("conversion from/to ArgWritable") {
 
     val cols = 2


### PR DESCRIPTION
This dependency is part of spark, contributes one annotation (javax.annotations.Nullable) that is not needed, and was rejected by the Eclipse IP team. Exclude it.

Also fixed some warnings in tests.
