### PR TITLE
added CellType.fromString("float32")

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/CellType.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellType.scala
@@ -65,6 +65,15 @@ object CellType {
     case _                      => sys.error(s"Oops type $awtType is not supported")
   }
 
+  def fromString(name: String): CellType = name match {
+    case "int8"     => TypeByte
+    case "int16"    => TypeShort
+    case "int32"    => TypeInt
+    case "float32"  => TypeFloat
+    case "float64"  => TypeDouble
+    case _ => sys.error(s"Oops type $name is not supported")
+  }
+
   def toAwtType(cellType: CellType): Int = cellType match {
     case TypeBit | TypeByte => DataBuffer.TYPE_BYTE
     case TypeDouble         => DataBuffer.TYPE_DOUBLE


### PR DESCRIPTION
to facilitate reading from bytes: 
ArrayTile.fromBytes(buffer, CellType.fromString(“float32”), 255, 255)
