### PR TITLE
Add Vagrant cache directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ _SUCCESS
 *.swp
 *.swo
 *.sublime-*
+.vagrant


### PR DESCRIPTION
Resolving a minor annoyance of having this directory show up in the untracked files.
