### PR TITLE
Make mkfs.ext3 step idempotent

### DIFF
--- a/scripts/deploy-ec2/roles/hadoop/tasks/datanode.yml
+++ b/scripts/deploy-ec2/roles/hadoop/tasks/datanode.yml
@@ -23,11 +23,20 @@
   # Needed until is in a release:
   #   https://github.com/ansible/ansible/pull/8002
   #
+- name: Check if device already has a file system
+  command: blkid -c /dev/null -o value -s TYPE {{ item.device }}
+  with_items: hdfs.volumes
+  register: existing_fs
+  changed_when: existing_fs.rc == 2
+  failed_when: False
+  sudo: yes
+  when: '"development" in group_names'
+
 - name: Format Vagrant Hadoop data partitions as ext3
   command: "mkfs.ext3 {{ item.device }} -F"
   with_items: hdfs.volumes
   sudo: yes
-  when: '"development" in group_names'
+  when: '"development" in group_names and existing_fs|changed'
 
 - name: Mount Hadoop data partitions
   mount: name="{{item.mount}}" src="{{item.device}}" fstype=ext3 state=mounted


### PR DESCRIPTION
Before this change set, the `mkfs` step would blindly attempt to format the specified devices without checking if they had already been formatted. Now there is a check that uses `blkid` to determine if the file system is formatted. The `mkfs` step now only attempts to format the device if `blkid` doesn't report `ext3` as the device's file system.
