### PR TITLE
WIP: Tiling documentation and clean-up refactor

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/tiling/IndexGridTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/IndexGridTransform.scala
@@ -3,6 +3,11 @@ package geotrellis.spark.tiling
 import geotrellis.spark._
 import geotrellis.raster._
 
+
+/**
+ * Allows extending classes to act as [[IndexGridTransform]],
+ *  using their <code>indexGridTransform</code> field as a delegate
+ */
 trait IndexGridTransformDelegate extends IndexGridTransform {
   val indexGridTransform: IndexGridTransform
 
@@ -13,6 +18,10 @@ trait IndexGridTransformDelegate extends IndexGridTransform {
     indexGridTransform.gridToIndex(col, row)
 }
 
+/**
+ * Transforms between grid coordinates, which always have upper left as origin,
+ * to tiling scheme coordinates, which may have different origin and axis orientation.
+ */
 trait IndexGridTransform extends Serializable {
   def indexToGrid(tileId: TileId): GridCoord
   def gridToIndex(col: Int, row: Int): TileId

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapGridTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapGridTransform.scala
@@ -6,6 +6,10 @@ import geotrellis.vector.Extent
 import geotrellis.vector.reproject._
 import geotrellis.proj4._
 
+/**
+ * Allows extending classes to act as a [[MapGridTransform]],
+ *  using their <code>mapGridTransform</code> field as a delegate
+ */
 trait MapGridTransformDelegate extends MapGridTransform {
   val mapGridTransform: MapGridTransform
 
@@ -33,6 +37,12 @@ object MapGridTransform {
     new DefaultMapGridTransform(extent, tileCols, tileRows)
 }
 
+/**
+ * Transforms between geographic map coordinates and tile grid coordinates.
+ * Since geographic point can only be mapped to a grid tile that contains that point,
+ * transformation from [[Extent]] to [[GridBounds]] to [[Extent]] will likely not
+ * produce the original geographic extent, but a larger one.
+ */
 trait MapGridTransform extends Serializable {
   def mapToGrid(extent: Extent): GridBounds
   def mapToGrid(coord: MapCoord): GridCoord =

--- a/spark/src/main/scala/geotrellis/spark/tiling/TileCoordScheme.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TileCoordScheme.scala
@@ -12,11 +12,16 @@ object TileCoordScheme {
     }
 }
 
+/**
+ * Tile Coordinate Scheme provides an object that is able to map from
+ * a given Tile Coordinate Scheme to a Grid Coordinate, where the
+ * origin is upper left corner and tuple (x, y) represents (col, row).
+ */
 trait TileCoordScheme extends Serializable { 
   def tag: String 
 
-  def apply(tileDimensions: Dimensions): TileGridTransform = 
-    apply(tileDimensions._1, tileDimensions._2)
+  def apply(gridDimensions: Dimensions): TileGridTransform =
+    apply(gridDimensions._1, gridDimensions._2)
 
   def apply(tileCols: Int, tileRows: Int): TileGridTransform
 }

--- a/spark/src/main/scala/geotrellis/spark/tiling/TileGridTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TileGridTransform.scala
@@ -3,6 +3,10 @@ package geotrellis.spark.tiling
 import geotrellis.spark._
 import geotrellis.raster._
 
+/**
+ * Allows extending classes to act as [[TileGridTransform]],
+ *  using their <code>tileGridTransform</code> field as a delegate
+ */
 trait TileGridTransformDelegate extends TileGridTransform {
   val tileGridTransform: TileGridTransform
 
@@ -13,6 +17,13 @@ trait TileGridTransformDelegate extends TileGridTransform {
     tileGridTransform.gridToTile(col, row)
 }
 
+/**
+ * Transforms between grid coordinates, which always have upper left as origin,
+ * to tiling scheme coordinates, which may have different origin and axis orientation.
+ *
+ *  ex: TMS tiling scheme has lower left as it's origin
+ *      Bing tiling scheme has upper left as it's origin
+ */
 trait TileGridTransform extends Serializable {
   def tileToGrid(coord: TileCoord): GridCoord =
     tileToGrid(coord._1, coord._2)

--- a/spark/src/main/scala/geotrellis/spark/tiling/TileIndexScheme.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TileIndexScheme.scala
@@ -11,6 +11,11 @@ object TileIndexScheme {
     }
 }
 
+/**
+ * Tile Index Scheme provides an object that is able to map from
+ * a given Grid Coordinate, where the origin is upper left corner
+ * and tuple (x, y) represents (col, row), to a linear index.
+ */
 trait TileIndexScheme extends Serializable {
   def tag: String
 

--- a/spark/src/main/scala/geotrellis/spark/tiling/TileIndexTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TileIndexTransform.scala
@@ -4,19 +4,21 @@ import geotrellis.spark._
 import geotrellis.raster._
 import geotrellis.vector.Extent
 
-trait TileIndexTransform extends Serializable {
-  val tileGridTransform: TileGridTransform
-  val indexGridTransform: IndexGridTransform 
-
+/**
+ * Transforms between linear tile index and a tiling scheme tile coordinates
+ * through the grid coordinates, using the transitive property by chaining
+ * the transformations of its abstract members.
+ */
+trait TileIndexTransform extends Serializable {self: TileGridTransform with IndexGridTransform =>
   def tileToIndex(coord: TileCoord): TileId =
     tileToIndex(coord._1, coord._2)
 
   def tileToIndex(tx: Int, ty: Int): TileId =
-    tileGridTransform.tileToGrid(tx, ty) |> indexGridTransform.gridToIndex
+    tileToGrid(tx, ty) |> gridToIndex
 
   def tileToIndex(tileBounds: TileBounds): Array[TileId] =
-    tileGridTransform.tileToGrid(tileBounds) |> indexGridTransform.gridToIndex
+    tileToGrid(tileBounds) |> gridToIndex
 
   def indexToTile(tileId: TileId): TileCoord =
-    indexGridTransform.indexToGrid(tileId) |> tileGridTransform.gridToTile
+    indexToGrid(tileId) |> gridToTile
 }

--- a/spark/src/main/scala/geotrellis/spark/tiling/TileMapTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/TileMapTransform.scala
@@ -4,25 +4,22 @@ import geotrellis.spark._
 import geotrellis.raster._
 import geotrellis.vector.Extent
 
-trait TileMapTransform {
-  val tileGridTransform: TileGridTransform
-  val mapGridTransform: MapGridTransform
-
+trait TileMapTransform extends Serializable { self: TileGridTransform with MapGridTransform =>
   def tileToMap(coord: TileCoord): Extent =
     tileToMap(coord._1, coord._2)
 
   def tileToMap(tx: Int, ty: Int): Extent =
-    tileGridTransform.tileToGrid(tx, ty) |> mapGridTransform.gridToMap
+    tileToGrid(tx, ty) |> gridToMap
 
   def tileToMap(tileBounds: TileBounds): Extent =
-    tileGridTransform.tileToGrid(tileBounds) |> mapGridTransform.gridToMap
+    tileToGrid(tileBounds) |> gridToMap
 
   def mapToTile(coord: MapCoord): TileCoord =
     mapToTile(coord._1, coord._2)
 
   def mapToTile(x: Double, y: Double): TileCoord =
-    mapGridTransform.mapToGrid(x, y) |> tileGridTransform.gridToTile
+    mapToGrid(x, y) |> gridToTile
 
   def mapToTile(extent: Extent): TileBounds =
-    mapGridTransform.mapToGrid(extent) |> tileGridTransform.gridToTile
+    mapToGrid(extent) |> gridToTile
 }

--- a/spark/src/main/scala/geotrellis/spark/tiling/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/package.scala
@@ -4,9 +4,34 @@ import geotrellis.vector.Extent
 import geotrellis.vector.reproject._
 import geotrellis.proj4._
 
+/**
+ * This package is concerned with translation of coordinates or extents between:
+ *  - geographic extents
+ *  - arbitrary tiling scheme, which defines origin and and axis
+ *  - arbitrary indexing scheme which linearize two dimensional tiling space
+ *
+ *  In order to facilitate these transformations each of the above spaces maps to
+ *  a "Grid Space" which is a special case of a tiling scheme with the origin
+ *  defined as upper left and (x, y) coordinate representing (col, row), Java array order.
+ *
+ *  @see [[geotrellis.spark.tiling.MapGridTransform]]
+ *  @see [[geotrellis.spark.tiling.TileGridTransform]]
+ *  @see [[geotrellis.spark.tiling.IndexGridTransform]]
+ */
 package object tiling {
+  /**
+   * Tile Coordinate in a tiling scheme. The origin and axes
+   * are defined by the scheme.
+   */
   type TileCoord = (Int, Int)
+  /**
+   * Grid Coordinate always has the upper left as the origin.
+   * The tuple always interpreted a (col, row)
+   */
   type GridCoord = (Int, Int)
+  /**
+   * Geographic Map Coordinate, uses left is the origin
+   */
   type MapCoord = (Double, Double)
 
   private final val WORLD_WSG84 = Extent(-180, -90, 179.99999, 89.99999)
@@ -43,11 +68,69 @@ package object tiling {
     }
   }
 
-  // Provides implicits to delegate transform functions
-  implicit def hasIndexGridTransformToDelegate(hasTransform: { val indexGridTransform: IndexGridTransform }): IndexGridTransformDelegate =
-    new IndexGridTransformDelegate { val indexGridTransform = hasTransform.indexGridTransform }
 
-  implicit def hasMapGridTransformToDelegate(hasTransform: { val mapGridTransform: MapGridTransform }): MapGridTransformDelegate =
-    new MapGridTransformDelegate { val mapGridTransform = hasTransform.mapGridTransform }
+
+  class TileIndexMapTransformTuple(
+      val tileGridTransform: TileGridTransform,
+      val indexGridTransform: IndexGridTransform,
+      val mapGridTransform: MapGridTransform)
+    extends TileGridTransformDelegate
+    with IndexGridTransformDelegate
+    with MapGridTransformDelegate
+    with MapIndexTransform
+    with TileIndexTransform
+    with TileMapTransform
+
+  // Provides implicits to delegate transform functions
+  implicit class TileIndexMapTransform1(tup: (TileGridTransform, IndexGridTransform, MapGridTransform))
+    extends TileIndexMapTransformTuple(tup._1, tup._2, tup._3)
+  implicit class TileIndexMapTransform2(tup: (TileGridTransform, MapGridTransform, IndexGridTransform))
+    extends TileIndexMapTransformTuple(tup._1, tup._3, tup._2)
+  implicit class TileIndexMapTransform3(tup: (IndexGridTransform, TileGridTransform, MapGridTransform))
+    extends TileIndexMapTransformTuple(tup._2, tup._1, tup._3)
+  implicit class TileIndexMapTransform4(tup: (MapGridTransform, TileGridTransform, IndexGridTransform))
+    extends TileIndexMapTransformTuple(tup._2, tup._3, tup._1)
+  implicit class TileIndexMapTransform5(tup: (IndexGridTransform, MapGridTransform, TileGridTransform))
+    extends TileIndexMapTransformTuple(tup._3, tup._1, tup._2)
+  implicit class TileIndexMapTransform6(tup: (MapGridTransform, IndexGridTransform, TileGridTransform ))
+    extends TileIndexMapTransformTuple(tup._3, tup._2, tup._1)
+
+  class TileIndexTransformTuple(
+      val tileGridTransform: TileGridTransform,
+      val indexGridTransform: IndexGridTransform)
+    extends TileGridTransformDelegate
+    with IndexGridTransformDelegate
+    with TileIndexTransform
+
+  implicit class TileIndexTransform1(tup: (TileGridTransform, IndexGridTransform))
+    extends TileIndexTransformTuple(tup._1, tup._2)
+  implicit class TileIndexTransform2(tup: (IndexGridTransform, TileGridTransform))
+    extends TileIndexTransformTuple(tup._2, tup._1)
+  
+  
+  class MapIndexTransformTuple(
+      val indexGridTransform: IndexGridTransform,
+      val mapGridTransform: MapGridTransform)
+    extends IndexGridTransformDelegate
+    with MapGridTransformDelegate
+    with MapIndexTransform
+
+  implicit class MapIndexTransform1(tup: (IndexGridTransform, MapGridTransform))
+    extends MapIndexTransformTuple(tup._1, tup._2)
+  implicit class MapIndexTransform2(tup: (MapGridTransform, IndexGridTransform))
+    extends MapIndexTransformTuple(tup._2, tup._1)
+
+
+  class TileMapTransformTuple(
+      val tileGridTransform: TileGridTransform,
+      val mapGridTransform: MapGridTransform)
+    extends TileGridTransformDelegate
+    with MapGridTransformDelegate
+    with TileMapTransform
+
+  implicit class TileMapTransform1(tup: (TileGridTransform, MapGridTransform))
+    extends TileMapTransformTuple(tup._1, tup._2)
+  implicit class TileMapTransform2(tup: (MapGridTransform, TileGridTransform))
+    extends TileMapTransformTuple(tup._2, tup._1)
 
 }


### PR DESCRIPTION
- doc strings for transformer and package
- "Transitive" transformers declare a dependency of their components, a tuple that has a delegate should extend the delegate directly in order to be given with it's powers
- implicit conversions for the tuples of transformers to objects that have the transform functions
