### PR TITLE
Removed slf4j-nop as a dependency in slick and jetty projects

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -304,7 +304,6 @@ object GeotrellisBuild extends Build {
         jettyWebapp,
         jerseyBundle,
         slf4jApi,
-        slf4jNop,
         asm
       )
     ) ++
@@ -322,7 +321,7 @@ object GeotrellisBuild extends Build {
       libraryDependencies := Seq(
         slick,
         postgresql,
-        slf4jNop,
+        slf4jApi,
         scalatest % "test"
       )
     ) ++

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,6 @@ object Dependencies {
   val jettyWebapp   = "org.eclipse.jetty" % "jetty-webapp" % "8.1.0.RC4"
   val jerseyBundle  = "com.sun.jersey"    % "jersey-bundle" % "1.11"
   val slf4jApi      = "org.slf4j"         % "slf4j-api" % "1.6.0"
-  val slf4jNop      = "org.slf4j"         % "slf4j-nop" % "1.6.0"
   val asm           = "asm"               % "asm"       % "3.3.1"
 
   val jcommander    = "com.beust"       % "jcommander"    % "1.23"


### PR DESCRIPTION
"Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding but only depend on slf4j-api. When a library declares a compile-time dependency on a SLF4J binding, it imposes that binding on the end-user, thus negating SLF4J's purpose."

http://www.slf4j.org/codes.html#multiple_bindings
