### PR TITLE
Bump Accumulo version to 1.5.2

### DIFF
--- a/scripts/deploy-ec2/roles/accumulo/defaults/main.yml
+++ b/scripts/deploy-ec2/roles/accumulo/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
-accumulo_deb: accumulo-1.5.1-bin.deb
-accumulo_url: http://apache.mesi.com.ar/accumulo/1.5.1/{{accumulo_deb}}
+accumulo_deb: accumulo-1.5.2-bin.deb
+accumulo_url: http://apache.mesi.com.ar/accumulo/1.5.2/{{accumulo_deb}}
 
 
 accumulo:


### PR DESCRIPTION
The packages for 1.5.1 no longer exist.
