### PR TITLE
Add cascaded polygon union method to (multi)polygon seq

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/Geometry.scala
+++ b/vector/src/main/scala/geotrellis/vector/Geometry.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,10 +32,10 @@ trait Geometry {
     jtsGeom.isWithinDistance(other.jtsGeom, dist)
 
   def centroid: PointOrNoResult =
-    jtsGeom.getCentroid 
+    jtsGeom.getCentroid
 
   def interiorPoint: PointOrNoResult =
-    jtsGeom.getInteriorPoint 
+    jtsGeom.getInteriorPoint
 
   override
   def equals(other: Any): Boolean =

--- a/vector/src/main/scala/geotrellis/vector/MultiPolygon.scala
+++ b/vector/src/main/scala/geotrellis/vector/MultiPolygon.scala
@@ -17,6 +17,7 @@
 package geotrellis.vector
 
 import GeomFactory._
+import geotrellis.vector._
 
 import com.vividsolutions.jts.{geom => jts}
 
@@ -25,7 +26,7 @@ import spire.syntax.cfor._
 object MultiPolygon {
   lazy val EMPTY = MultiPolygon(Seq[Polygon]())
 
-  def apply(ps: Polygon*): MultiPolygon = 
+  def apply(ps: Polygon*): MultiPolygon =
     apply(ps)
 
   def apply(ps: Traversable[Polygon]): MultiPolygon =
@@ -34,7 +35,7 @@ object MultiPolygon {
   implicit def jts2MultiPolygon(jtsGeom: jts.MultiPolygon): MultiPolygon = apply(jtsGeom)
 }
 
-case class MultiPolygon(jtsGeom: jts.MultiPolygon) extends MultiGeometry 
+case class MultiPolygon(jtsGeom: jts.MultiPolygon) extends MultiGeometry
                                                    with Relatable
                                                    with TwoDimensions {
 
@@ -101,6 +102,7 @@ case class MultiPolygon(jtsGeom: jts.MultiPolygon) extends MultiGeometry
 
   def |(p: Point): PointMultiPolygonUnionResult =
     union(p)
+
   def union(p: Point): PointMultiPolygonUnionResult =
     jtsGeom.union(p.jtsGeom)
 
@@ -111,8 +113,9 @@ case class MultiPolygon(jtsGeom: jts.MultiPolygon) extends MultiGeometry
 
   def |(p: Polygon): TwoDimensionsTwoDimensionsUnionResult =
     union(p)
+
   def union(p: Polygon): TwoDimensionsTwoDimensionsUnionResult =
-    p.union(this)
+    Seq(this, MultiPolygon(p)).unioned
 
   def |(ps: MultiPoint): LineMultiPolygonUnionResult =
     union(ps)
@@ -126,7 +129,10 @@ case class MultiPolygon(jtsGeom: jts.MultiPolygon) extends MultiGeometry
   def |(ps: MultiPolygon): TwoDimensionsTwoDimensionsUnionResult =
     union(ps)
   def union(ps: MultiPolygon): TwoDimensionsTwoDimensionsUnionResult =
-    jtsGeom.union(ps.jtsGeom)
+    Seq(this, ps).unioned
+
+  def union: TwoDimensionsTwoDimensionsUnionResult =
+    polygons.toSeq.unioned
 
   // -- Difference
 

--- a/vector/src/main/scala/geotrellis/vector/Polygon.scala
+++ b/vector/src/main/scala/geotrellis/vector/Polygon.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 Azavea.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@ package geotrellis.vector
 
 import com.vividsolutions.jts.{geom => jts}
 import GeomFactory._
+import geotrellis.vector._
 
 import spire.syntax.cfor._
 
@@ -218,10 +219,15 @@ case class Polygon(jtsGeom: jts.Polygon) extends Geometry
 
   /**
    * Computes a Result that represents a Geometry made up of all the points in
-   * this Polygon and g.
+   * this Polygon and g. Uses cascaded polygon union if g is a (multi)polygon
+   * else falls back to default jts union method.
    */
-  def union(g: TwoDimensions): TwoDimensionsTwoDimensionsUnionResult =
-    jtsGeom.union(g.jtsGeom)
+  def union(g: TwoDimensions): TwoDimensionsTwoDimensionsUnionResult = g match {
+    case p:Polygon => Seq(this, p).unioned
+    case mp:MultiPolygon => Seq(MultiPolygon(this), mp).unioned
+    case _ => jtsGeom.union(g.jtsGeom)
+  }
+
 
 
   // -- Difference

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -17,8 +17,10 @@
 package geotrellis
 
 import com.vividsolutions.jts.{geom => jts}
+import com.vividsolutions.jts.operation.union.{CascadedPolygonUnion => jtsCascadedPolygonUnion}
 
 import scala.collection.mutable
+import scala.collection.JavaConversions._
 
 package object vector extends op.LineDissolve.Implicits {
 
@@ -119,4 +121,18 @@ package object vector extends op.LineDissolve.Implicits {
   }
 
   implicit def featureToGeometry(f: Feature[_]): Geometry = f.geom
+
+  trait PolygonUnion {
+    val geoms:Seq[Geometry]
+
+    def unioned: TwoDimensionsTwoDimensionsUnionResult = {
+      val cascadedPolygonUnion = new jtsCascadedPolygonUnion(geoms.map(geom => geom.jtsGeom))
+      cascadedPolygonUnion.union()
+    }
+  }
+
+  implicit class CascadedPolygonUnion(val geoms: Seq[Polygon]) extends PolygonUnion
+
+  implicit class CascadedMultiPolygonUnion(val geoms: Seq[MultiPolygon]) extends PolygonUnion
+
 }


### PR DESCRIPTION
This wraps JTS' `CascadedPolygonUnion` as a method on a sequence of `Polygon` or `MultiPolygon`.

I wasn't too sure about the return type to use, so I used what the existing binary union was using - seemed appropriate. Tests mimic the binary union tests since both should have the same results.

I tried to find other operations looking at JTS/PostGIS docs that would operate on sequences of (multi)polygons, but couldn't find any.
