### PR TITLE
Removed 'Try' from Catalog design.

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/ingest/AccumuloIngestCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/AccumuloIngestCommand.scala
@@ -41,9 +41,9 @@ object AccumuloIngestCommand extends ArgMain[AccumuloIngestArgs] with Logging {
       accumulo.catalog.save(LayerId(args.layerName, level.zoom), args.table, rdd, args.clobber)
     }
     if (args.pyramid) {
-      Pyramid.saveLevels(rdd, level, layoutScheme)(save).get // expose exceptions
+      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
     } else{
-      save(rdd, level).get
+      save(rdd, level)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/AccumuloPyramidCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/AccumuloPyramidCommand.scala
@@ -25,7 +25,7 @@ object AccumuloPyramidCommand extends ArgMain[AccumuloPyramidArgs] with Logging 
     val accumulo = AccumuloInstance(args.instance, args.zookeeper, args.user, new PasswordToken(args.password))
     val catalog = accumulo.catalog
 
-    val rdd = catalog.load[SpatialKey](LayerId(args.layerName, args.startLevel)).get
+    val rdd = catalog.load[SpatialKey](LayerId(args.layerName, args.startLevel))
 
     val layoutScheme = ZoomedLayoutScheme(256)
     val level = layoutScheme.levelFor(args.startLevel)

--- a/spark/src/main/scala/geotrellis/spark/ingest/HadoopIngestCommand.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/HadoopIngestCommand.scala
@@ -33,9 +33,9 @@ object HadoopIngestCommand extends ArgMain[HadoopIngestArgs] with Logging {
     }
 
     if (args.pyramid) {
-      Pyramid.saveLevels(rdd, level, layoutScheme)(save).get // expose exceptions
+      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
     } else{
-      save(rdd, level).get
+      save(rdd, level)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/NetCDFIngest.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/NetCDFIngest.scala
@@ -45,9 +45,9 @@ object NetCDFIngestCommand extends ArgMain[AccumuloIngestArgs] with Logging {
     }
 
     if (args.pyramid) {
-      Pyramid.saveLevels(rdd, level, layoutScheme)(save).get // expose exceptions
+      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
     } else{
-      save(rdd, level).get
+      save(rdd, level)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/NetCDFIngestHDFS.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/NetCDFIngestHDFS.scala
@@ -41,9 +41,9 @@ object NetCDFIngestHDFSCommand extends ArgMain[HadoopIngestArgs] with Logging {
     }
 
     if (args.pyramid) {
-      Pyramid.saveLevels(rdd, level, layoutScheme)(save) // expose exceptions
+      Pyramid.saveLevels(rdd, level, layoutScheme)(save)
     } else{
-      save(rdd, level).get
+      save(rdd, level)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/ingest/Pyramid.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/Pyramid.scala
@@ -12,7 +12,6 @@ import monocle._
 import monocle.syntax._
 
 import scala.reflect.ClassTag
-import scala.util.Try
 
 object Pyramid extends Logging {
   /**
@@ -22,9 +21,9 @@ object Pyramid extends Logging {
    * @param save          Function(rdd, layoutLevel) that will be called for zoom each level, including original
    */
   def saveLevels[K: SpatialComponent: ClassTag](rdd: RasterRDD[K], level: LayoutLevel, layoutScheme: LayoutScheme)
-                                               (save: (RasterRDD[K], LayoutLevel) => Try[Unit]): Try[Unit] = Try {
+                                               (save: (RasterRDD[K], LayoutLevel) => Unit): Unit = {
     logInfo(s"Saving raster at $level")
-    save(rdd, level).get // force errors on save
+    save(rdd, level)
     if (level.zoom > 1) {
       val (nextRdd, nextLevel) = Pyramid.up(rdd, level, layoutScheme)
       saveLevels(nextRdd, nextLevel, layoutScheme)(save)

--- a/spark/src/main/scala/geotrellis/spark/io/Catalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/Catalog.scala
@@ -4,8 +4,6 @@ import geotrellis.spark._
 
 import scala.reflect.ClassTag
 
-import scala.util.Try
-
 trait Catalog {
   type Params
   type SupportedKey[K]
@@ -14,34 +12,33 @@ trait Catalog {
 
   def paramsFor[K: SupportedKey: ClassTag](layerId: LayerId): Params
 
-  def load[K: SupportedKey: ClassTag](id: LayerId): Try[RasterRDD[K]] =
+  def load[K: SupportedKey: ClassTag](id: LayerId): RasterRDD[K] =
     load(id, new FilterSet[K])
 
-  def load[K: SupportedKey: ClassTag](id: LayerId, params: Params): Try[RasterRDD[K]] =
+  def load[K: SupportedKey: ClassTag](id: LayerId, params: Params): RasterRDD[K] =
     load(id, params, new FilterSet[K])
 
-  def load[K: SupportedKey: ClassTag](id: LayerId, filters: FilterSet[K]): Try[RasterRDD[K]] =
-    metaDataCatalog.load(id).flatMap { case (metaData, params) =>
-      load(id, metaData.rasterMetaData, params, filters)
-    }
-
-  def load[K: SupportedKey: ClassTag](id: LayerId, params: Params, filters: FilterSet[K]): Try[RasterRDD[K]] = {
-    metaDataCatalog.load(id, params).flatMap { metaData =>
-      load(id, metaData.rasterMetaData, params, filters)
-    }
+  def load[K: SupportedKey: ClassTag](id: LayerId, filters: FilterSet[K]): RasterRDD[K] = {
+    val (metaData, params) = metaDataCatalog.load(id)
+    load(id, metaData.rasterMetaData, params, filters)
   }
 
-  def load[K: SupportedKey: ClassTag](id: LayerId, metaData: RasterMetaData, params: Params, filters: FilterSet[K]): Try[RasterRDD[K]]
+  def load[K: SupportedKey: ClassTag](id: LayerId, params: Params, filters: FilterSet[K]): RasterRDD[K] = {
+    val metaData = metaDataCatalog.load(id, params)
+    load(id, metaData.rasterMetaData, params, filters)
+  }
 
-  def save[K: SupportedKey: ClassTag](id: LayerId, rdd: RasterRDD[K]): Try[Unit] =
+  def load[K: SupportedKey: ClassTag](id: LayerId, metaData: RasterMetaData, params: Params, filters: FilterSet[K]): RasterRDD[K]
+
+  def save[K: SupportedKey: ClassTag](id: LayerId, rdd: RasterRDD[K]): Unit =
     save(id, rdd, false)
 
-  def save[K: SupportedKey: ClassTag](id: LayerId, rdd: RasterRDD[K], clobber: Boolean): Try[Unit] =
+  def save[K: SupportedKey: ClassTag](id: LayerId, rdd: RasterRDD[K], clobber: Boolean): Unit =
     save(id, paramsFor(id), rdd, clobber)
 
-  def save[K: SupportedKey: ClassTag](id: LayerId, params: Params, rdd: RasterRDD[K]): Try[Unit] =
+  def save[K: SupportedKey: ClassTag](id: LayerId, params: Params, rdd: RasterRDD[K]): Unit =
     save(id, params, rdd, false)
 
   /** The implementer of this method is responsible for saving the metaData to the metaDataCatalog */
-  def save[K: SupportedKey: ClassTag](id: LayerId, params: Params, rdd: RasterRDD[K], clobber: Boolean): Try[Unit]
+  def save[K: SupportedKey: ClassTag](id: LayerId, params: Params, rdd: RasterRDD[K], clobber: Boolean): Unit
 }

--- a/spark/src/main/scala/geotrellis/spark/io/MetaDataCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/MetaDataCatalog.scala
@@ -9,15 +9,13 @@ import org.apache.hadoop.io.Text
 import org.apache.spark.Logging
 import spray.json.RootJsonFormat
 
-import scala.util.Try
-
 trait MetaDataCatalog[Params] {
   /** Return [[geotrellis.spark.RasterMetaData]] and matching Params if unique match is found based on [[LayerId]] */
-  def load(layerId: LayerId): Try[(LayerMetaData, Params)]
+  def load(layerId: LayerId): (LayerMetaData, Params)
 
   /** Return [[geotrellis.spark.RasterMetaData]] matching both LayerId and params. */
-  def load(layerId: LayerId, params: Params): Try[LayerMetaData]
+  def load(layerId: LayerId, params: Params): LayerMetaData
 
   /** Save [[geotrellis.spark.RasterMetaData]] such that it can be found by the load functions */
-  def save(layerId: LayerId, params: Params,  metaData: LayerMetaData, clobber: Boolean): Try[Unit]
+  def save(layerId: LayerId, params: Params,  metaData: LayerMetaData, clobber: Boolean): Unit
 }

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloCatalog.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloCatalog.scala
@@ -20,14 +20,14 @@ class AccumuloCatalog(sc: SparkContext, instance: AccumuloInstance,
       case None => sys.error(s"Default Params for '$id' not found.")
     }
 
-  def load[K: AccumuloDriver: ClassTag](id: LayerId, metaData: RasterMetaData, table: String, filters: FilterSet[K]): Try[RasterRDD[K]] = {
+  def load[K: AccumuloDriver: ClassTag](id: LayerId, metaData: RasterMetaData, table: String, filters: FilterSet[K]): RasterRDD[K] = {
     val driver = implicitly[AccumuloDriver[K]]
     driver.load(sc, instance)(id, metaData, table, filters)
   }
 
-  def save[K: SupportedKey : ClassTag](id: LayerId, table: String, rdd: RasterRDD[K], clobber: Boolean): Try[Unit] = {
+  def save[K: SupportedKey : ClassTag](id: LayerId, table: String, rdd: RasterRDD[K], clobber: Boolean): Unit = {
     val driver = implicitly[AccumuloDriver[K]]
-    driver.save(sc, instance)(id, rdd, table, clobber).get
+    driver.save(sc, instance)(id, rdd, table, clobber)
 
     val metaData = LayerMetaData(
       rasterMetaData = rdd.metaData,

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloDriver.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloDriver.scala
@@ -10,7 +10,6 @@ import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import scala.collection.mutable
-import scala.util.{ Failure, Try }
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
 
@@ -22,39 +21,37 @@ trait AccumuloDriver[K] extends Serializable {
   def setFilters(job: Job, layerId: LayerId, filters: FilterSet[K])
   def rowId(id: LayerId, key: K): String
   
-  def load(sc: SparkContext, accumulo: AccumuloInstance)(id: LayerId, metaData: RasterMetaData, table: String, filters: FilterSet[K]): Try[RasterRDD[K]] =
-    Try {
-      val job = Job.getInstance(sc.hadoopConfiguration)
-      accumulo.setAccumuloConfig(job)
-      InputFormatBase.setInputTableName(job, table)
-      setFilters(job, id, filters)
-      val rdd = sc.newAPIHadoopRDD(job.getConfiguration, classOf[AccumuloInputFormat], classOf[Key], classOf[Value])
-      decode(rdd, metaData)
-    }
+  def load(sc: SparkContext, accumulo: AccumuloInstance)(id: LayerId, metaData: RasterMetaData, table: String, filters: FilterSet[K]): RasterRDD[K] = {
+    val job = Job.getInstance(sc.hadoopConfiguration)
+    accumulo.setAccumuloConfig(job)
+    InputFormatBase.setInputTableName(job, table)
+    setFilters(job, id, filters)
+    val rdd = sc.newAPIHadoopRDD(job.getConfiguration, classOf[AccumuloInputFormat], classOf[Key], classOf[Value])
+    decode(rdd, metaData)
+  }
 
   /** NOTE: Accumulo will always perform destructive update, clobber param is not followed */
-  def save(sc: SparkContext, accumulo: AccumuloInstance)(layerId: LayerId, raster: RasterRDD[K], table: String, clobber: Boolean): Try[Unit] =
-    Try {
-      // Create table if it doesn't exist.
-      if (!accumulo.connector.tableOperations().exists(table))
-        accumulo.connector.tableOperations().create(table)
+  def save(sc: SparkContext, accumulo: AccumuloInstance)(layerId: LayerId, raster: RasterRDD[K], table: String, clobber: Boolean): Unit = {
+    // Create table if it doesn't exist.
+    if (!accumulo.connector.tableOperations().exists(table))
+      accumulo.connector.tableOperations().create(table)
 
-      val ops = accumulo.connector.tableOperations()
-      val groups = ops.getLocalityGroups(table)
-      val newGroup: java.util.Set[Text] = Set(new Text(layerId.name))
-      ops.setLocalityGroups(table, groups.updated(table, newGroup))
-             
+    val ops = accumulo.connector.tableOperations()
+    val groups = ops.getLocalityGroups(table)
+    val newGroup: java.util.Set[Text] = Set(new Text(layerId.name))
+    ops.setLocalityGroups(table, groups.updated(table, newGroup))
+    
 
-      val splits = getSplits(layerId, raster)
-      accumulo.connector.tableOperations().addSplits(table, new java.util.TreeSet(splits.map(new Text(_))))
+    val splits = getSplits(layerId, raster)
+    accumulo.connector.tableOperations().addSplits(table, new java.util.TreeSet(splits.map(new Text(_))))
 
-      val job = Job.getInstance(sc.hadoopConfiguration)
-      accumulo.setAccumuloConfig(job)
-      AccumuloOutputFormat.setBatchWriterOptions(job, new BatchWriterConfig())
-      AccumuloOutputFormat.setDefaultTableName(job, table)
-      encode(layerId, raster)
-        .saveAsNewAPIHadoopFile(accumulo.instanceName, classOf[Text], classOf[Mutation], classOf[AccumuloOutputFormat], job.getConfiguration)
-    }
+    val job = Job.getInstance(sc.hadoopConfiguration)
+    accumulo.setAccumuloConfig(job)
+    AccumuloOutputFormat.setBatchWriterOptions(job, new BatchWriterConfig())
+    AccumuloOutputFormat.setDefaultTableName(job, table)
+    encode(layerId, raster)
+      .saveAsNewAPIHadoopFile(accumulo.instanceName, classOf[Text], classOf[Mutation], classOf[AccumuloOutputFormat], job.getConfiguration)
+  }
 
  def getSplits(id: LayerId, rdd: RasterRDD[K], num: Int = 24): Seq[String] = {
     import org.apache.spark.SparkContext._

--- a/spark/src/main/scala/geotrellis/spark/service/TmsHttpService.scala
+++ b/spark/src/main/scala/geotrellis/spark/service/TmsHttpService.scala
@@ -39,7 +39,7 @@ trait TmsHttpService extends HttpService {
 
   def rootRoute =
     pathPrefix("tms" / Segment / Segment / IntNumber / IntNumber / IntNumber ) { (layer, timeStr, zoom, x , y) =>
-      val rdd: Try[RasterRDD[SpaceTimeKey]] = {
+      val rdd: RasterRDD[SpaceTimeKey] = {
         val time = DateTime.parse(timeStr)
         val filters =  new FilterSet[SpaceTimeKey]
           .withFilter(SpaceFilter[SpaceTimeKey](x, y))
@@ -49,7 +49,7 @@ trait TmsHttpService extends HttpService {
       }
 
       respondWithMediaType(MediaTypes.`image/png`) { complete {
-        val tile = rdd.get.first.tile
+        val tile = rdd.first.tile
         Encoder(Settings(Rgba, PaethFilter)).writeByteArray(tile)
       } }
     }

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloCatalogSpec.scala
@@ -22,7 +22,6 @@ import org.scalatest.Matchers._
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 
 import org.apache.hadoop.fs.Path
-import scala.util.{Try, Success, Failure}
 
 class AccumuloCatalogSpec extends FunSpec
   with Matchers
@@ -50,24 +49,24 @@ class AccumuloCatalogSpec extends FunSpec
       val (level, onesRdd) = Ingest(source, LatLng, layoutScheme)
 
       it("should succeed writing to a table"){
-        catalog.save(LayerId("ones", level.zoom), "tiles", onesRdd).get
+        catalog.save(LayerId("ones", level.zoom), "tiles", onesRdd)
       }
 
       it("should load out saved tiles"){
-        catalog.load[SpatialKey](LayerId("ones", 10)).get.count should be > 0l
+        catalog.load[SpatialKey](LayerId("ones", 10)).count should be > 0l
       }
 
       it("should load out saved tiles, but only for the right zoom"){
         intercept[LayerNotFoundError] {
-          catalog.load[SpatialKey](LayerId("ones", 9)).get.count()
+          catalog.load[SpatialKey](LayerId("ones", 9)).count()
         }
       }
 
       it("fetch a TileExtent from catalog"){
         val tileBounds = GridBounds(915,305,916,306)
         val filters = new FilterSet[SpatialKey] withFilter SpaceFilter(tileBounds)
-        val rdd1 = catalog.load[SpatialKey](LayerId("ones", 10), filters).get
-        val rdd2 = catalog.load[SpatialKey](LayerId("ones", 10), filters).get
+        val rdd1 = catalog.load[SpatialKey](LayerId("ones", 10), filters)
+        val rdd2 = catalog.load[SpatialKey](LayerId("ones", 10), filters)
 
         val out = rdd1.combinePairs(rdd2){case (tms1, tms2) =>
           require(tms1.id == tms2.id)

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopCatalogSpec.scala
@@ -12,7 +12,6 @@ import geotrellis.raster.op.local._
 import geotrellis.proj4.LatLng
 import org.scalatest._
 import org.apache.hadoop.fs.Path
-import scala.util.{Try, Success, Failure}
 
 class HadoopCatalogSpec extends FunSpec
 with Matchers
@@ -35,44 +34,44 @@ with OnlyIfCanRunSpark
 
 
       it("should succeed saving with default Props"){
-        catalog.save(LayerId("ones", level.zoom), onesRdd).get
+        catalog.save(LayerId("ones", level.zoom), onesRdd)
         assert(fs.exists(new Path(catalogPath, "ones")))
       }
 
       it("should succeed saving with single path Props"){
-        catalog.save(LayerId("ones", level.zoom), "sub1", onesRdd).get
+        catalog.save(LayerId("ones", level.zoom), "sub1", onesRdd)
         assert(fs.exists(new Path(catalogPath, "sub1/ones")))
       }
 
       it("should succeed saving with double path Props"){
-        catalog.save(LayerId("ones", level.zoom), "sub1/sub2", onesRdd).get
+        catalog.save(LayerId("ones", level.zoom), "sub1/sub2", onesRdd)
         assert(fs.exists(new Path(catalogPath, "sub1/sub2/ones")))
       }
 
       it("should load out saved tiles"){
-        catalog.load[SpatialKey](LayerId("ones", 10)).get.count should be > 0l
+        catalog.load[SpatialKey](LayerId("ones", 10)).count should be > 0l
       }
 
       it("should succeed loading with single path Props"){
-        catalog.load[SpatialKey](LayerId("ones", level.zoom), "sub1").get.count should be > 0l
+        catalog.load[SpatialKey](LayerId("ones", level.zoom), "sub1").count should be > 0l
       }
 
       it("should succeed loading with double path Props"){
-        catalog.load[SpatialKey](LayerId("ones", level.zoom), "sub1/sub2").get.count should be > 0l
+        catalog.load[SpatialKey](LayerId("ones", level.zoom), "sub1/sub2").count should be > 0l
       }
 
 
       it("should load out saved tiles, but only for the right zoom"){
         intercept[LayerNotFoundError] {
-          catalog.load[SpatialKey](LayerId("ones", 9)).get.count()
+          catalog.load[SpatialKey](LayerId("ones", 9)).count()
         }
       }
 
       it("fetch a TileExtent from catalog"){
         val tileBounds = GridBounds(915,611,917,616)
         val filters = new FilterSet[SpatialKey] withFilter SpaceFilter(tileBounds)
-        val rdd1 = catalog.load[SpatialKey](LayerId("ones", 10), filters).get
-        val rdd2 = catalog.load[SpatialKey](LayerId("ones", 10), filters).get
+        val rdd1 = catalog.load[SpatialKey](LayerId("ones", 10), filters)
+        val rdd2 = catalog.load[SpatialKey](LayerId("ones", 10), filters)
         val out = rdd1.combinePairs(rdd2){case (tms1, tms2) =>
           require(tms1.id == tms2.id)
           val res = tms1.tile.localAdd(tms2.tile)
@@ -86,7 +85,7 @@ with OnlyIfCanRunSpark
       it("should find default params based on key") {
         val defaultParams = HadoopCatalog.BaseParams.withKeyParams[SpatialKey]("spatial-layers")
         val cat: HadoopCatalog = HadoopCatalog(sc, catalogPath, defaultParams)
-        cat.save(LayerId("spatial-ones", level.zoom), onesRdd).get
+        cat.save(LayerId("spatial-ones", level.zoom), onesRdd)
         assert(fs.exists(new Path(catalogPath, "spatial-layers/spatial-ones")))
       }
 
@@ -97,7 +96,7 @@ with OnlyIfCanRunSpark
 
         //LayerParams should take priority
         val cat: HadoopCatalog = HadoopCatalog(sc, catalogPath, defaultParams)
-        cat.save(LayerId("onesSpecial", level.zoom), onesRdd).get
+        cat.save(LayerId("onesSpecial", level.zoom), onesRdd)
         assert(fs.exists(new Path(catalogPath, "special/onesSpecial")))
       }
     }

--- a/spark/src/test/scala/geotrellis/spark/testfiles/GenerateTestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/GenerateTestFiles.scala
@@ -91,7 +91,7 @@ object GenerateTestFiles {
           sc.parallelize(tmsTiles)
         }
 
-      catalog.save(LayerId(name, 10), rdd, clobber = true).get
+      catalog.save(LayerId(name, 10), rdd, clobber = true)
     }
 
   }

--- a/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
@@ -29,7 +29,7 @@ trait TestFiles { self: OnlyIfCanRunSpark =>
   lazy val testCatalog = TestFiles.catalog
 
   def testFile(layerName: String): RasterRDD[SpatialKey] = {
-    testCatalog.load[SpatialKey](LayerId(layerName, 10)).get.cache
+    testCatalog.load[SpatialKey](LayerId(layerName, 10)).cache
   }
 
   def AllOnesTestFile =


### PR DESCRIPTION
The use of `Try` in dealing with Catalog errors has wasted a good amount of developer time, when errors were swallowed rather than thrown and seen. Now we just throw exceptions.
