### PR TITLE
Fix support for slick WKB reading

### DIFF
--- a/slick/src/main/scala/geotrellis/slick/PostGisProjectionSupport.scala
+++ b/slick/src/main/scala/geotrellis/slick/PostGisProjectionSupport.scala
@@ -115,9 +115,12 @@ object PostGisProjectionSupportUtils {
         Projected(geom, geom.jtsGeom.getSRID).asInstanceOf[T]
     }
 
-  def readWktOrWkb(s: String): Geometry =
-    if (s.startsWith("00") || s.startsWith("01"))
+  def readWktOrWkb(s: String): Geometry = {
+    if (s.startsWith("\\x"))
+      WKB.read(s.drop(2))
+    else if (s.startsWith("00") || s.startsWith("01"))
       WKB.read(s)
     else
       WKT.read(s)
+  }
 }

--- a/slick/src/test/scala/geotrellis/slick/PostGisProjectionSupportSpec.scala
+++ b/slick/src/test/scala/geotrellis/slick/PostGisProjectionSupportSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest._
 import slick.driver.PostgresDriver
 import util._
 
-class ProjectedSpec extends FlatSpec with Matchers with TestDatabase with ScalaFutures {
+class PostGisProjectionSupportSpec extends FlatSpec with Matchers with TestDatabase with ScalaFutures {
   implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds))
 
   object driver extends PostgresDriver with PostGisProjectionSupport {
@@ -89,6 +89,22 @@ class ProjectedSpec extends FlatSpec with Matchers with TestDatabase with ScalaF
     } yield {mp.geom.centroid}
 
     db.run(q.result).futureValue.toList.head should equal ( Projected(Point(1.5, 1.5), 3131) )
+  }
+
+  it should "handle hex strings starting with \\x" in {
+    val wkb ="\\x002000000300000f110000000100000005c170b8793ccc8e80415ca9f4683a18dcc170b8793ccc8e8041631bf8457c1091c16ca9f4683a18dc41631bf8457c1091c16ca9f4683a18dc415ca9f4683a18dcc170b8793ccc8e80415ca9f4683a18dc"
+    val interpreted = PostGisProjectionSupportUtils.readWktOrWkb(wkb)
+    val poly = Polygon(Point(-17532819.799940586, 7514065.628545966), Point(-17532819.799940586, 10018754.171394618), Point(-15028131.257091932, 10018754.171394618), Point(-15028131.257091932, 7514065.628545966), Point(-17532819.799940586, 7514065.628545966))
+
+    interpreted should be (poly)
+  }
+
+  it should "handle hex strings starting with 00" in {
+    val wkb ="002000000300000f110000000100000005c170b8793ccc8e80415ca9f4683a18dcc170b8793ccc8e8041631bf8457c1091c16ca9f4683a18dc41631bf8457c1091c16ca9f4683a18dc415ca9f4683a18dcc170b8793ccc8e80415ca9f4683a18dc"
+    val interpreted = PostGisProjectionSupportUtils.readWktOrWkb(wkb)
+    val poly = Polygon(Point(-17532819.799940586, 7514065.628545966), Point(-17532819.799940586, 10018754.171394618), Point(-15028131.257091932, 10018754.171394618), Point(-15028131.257091932, 7514065.628545966), Point(-17532819.799940586, 7514065.628545966))
+
+    interpreted should be (poly)
   }
 
 }

--- a/vector/build.sbt
+++ b/vector/build.sbt
@@ -4,5 +4,6 @@ name := "geotrellis-vector"
 libraryDependencies ++= Seq(
   jts,
   sprayJson,
+  logging,
   apacheMath,
   spire)

--- a/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
@@ -19,22 +19,25 @@ package geotrellis.vector.io.wkb
 import com.vividsolutions.jts.io.WKBReader
 import com.vividsolutions.jts.{geom => jts}
 import geotrellis.vector._
+import com.typesafe.scalalogging.LazyLogging
 
 /** A thread-safe wrapper for the [https://en.wikipedia.org/wiki/Well-known_text#Well-known_binary WKB]
   * Writer and Reader
   */
-object WKB {
+object WKB extends LazyLogging {
   private val readerBox = new ThreadLocal[WKBReader]
   private val writerBox = new ThreadLocal[WKBWriter]
 
   /** Convert Well Known Binary to Geometry */
   def read(value: Array[Byte]): Geometry = {
+    logger.debug(s"Reading WKB from bytes: ${value.toList}")
     if (readerBox.get == null) readerBox.set(new WKBReader(GeomFactory.factory))
     Geometry(readerBox.get.read(value))
   }
 
   /** Convert Well Known Binary to Geometry */
   def read(hex: String): Geometry = {
+    logger.debug(s"Reading WKB from hex: ${hex}")
     if (readerBox.get == null) readerBox.set(new WKBReader(GeomFactory.factory))
     Geometry(readerBox.get.read(WKBReader.hexToBytes(hex)))
   }

--- a/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
@@ -19,13 +19,15 @@ package geotrellis.vector.io.wkt
 import com.vividsolutions.jts.io.{WKTReader, WKTWriter}
 import com.vividsolutions.jts.{geom => jts}
 import geotrellis.vector._
+import com.typesafe.scalalogging.LazyLogging
 
 /** A thread-safe wrapper for the WKT Writer and Reader */
-object WKT {
+object WKT extends LazyLogging {
   private val readerBox = new ThreadLocal[WKTReader]
   private val writerBox = new ThreadLocal[WKTWriter]
 
   def read(value: String): Geometry = {
+    logger.debug(s"Reading WKT from string: ${value}")
     if (readerBox.get == null) readerBox.set(new WKTReader(GeomFactory.factory))
     Geometry(readerBox.get.read(value))
   }


### PR DESCRIPTION
Currently, a hex string starting with `\x` will be interpreted as well known text rather than well known binary which breaks PostGIS support. This PR introduces support for such hex strings.