### PR TITLE
Remove gwave tests from CI run

### DIFF
--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geowave" compile test:compile || { exit 1; }
+# Removing until the geowave API we need solidifies
+#./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geowave" compile test:compile || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project cassandra" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project vector-test" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project raster-test" test || { exit 1; }

--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -5,7 +5,7 @@
 ./sbt -J-Xmx2G "project doc-examples" compile || { exit 1; }
 ./sbt -J-Xmx2G "project geomesa" test || { exit 1; }
 ./sbt -J-Xmx2G "project geotools" test || { exit 1; }
-HOSTALIASES=/tmp/hostaliases ./sbt -J-Xmx2G "project geowave" test || { exit 1; }
+# HOSTALIASES=/tmp/hostaliases ./sbt -J-Xmx2G "project geowave" test || { exit 1; }
 ./sbt -J-Xmx2G "project hbase" test  || { exit 1; }
 ./sbt -J-Xmx2G "project proj4" test || { exit 1; }
 ./sbt -J-Xmx2G "project raster-test" test || { exit 1; }

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -20,7 +20,7 @@
 ./sbt "project cassandra" publish-local && \
 ./sbt "project geomesa" publish-local && \
 ./sbt "project geotools" publish-local && \
-./sbt "project geowave" publish-local && \
+# ./sbt "project geowave" publish-local && \
 ./sbt "project hbase" publish-local && \
 ./sbt "project s3" publish-local && \
 ./sbt "project s3-testkit" publish-local

--- a/scripts/publish-m2.sh
+++ b/scripts/publish-m2.sh
@@ -4,7 +4,7 @@
       "project cassandra" +publish-m2 \
       "project geomesa" +publish-m2 \
       "project geotools" +publish-m2 \
-      "project geowave" +publish-m2 \
+      # "project geowave" +publish-m2 \
       "project hbase" +publish-m2 \
       "project macros" +publish-m2 \
       "project proj4" +publish-m2 \

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -4,7 +4,7 @@
       "project cassandra" publish \
       "project geomesa" publish \
       "project geotools" publish \
-      "project geowave" publish \
+      # "project geowave" publish \
       "project hbase" publish \
       "project macros" publish \
       "project proj4" publish \
@@ -12,7 +12,6 @@
       "project raster-testkit" publish \
       "project s3" publish \
       "project s3-testkit" publish \
-      "project geowave" publish \
       "project accumulo" publish \
       "project cassandra" publish \
       "project hbase" publish \

--- a/scripts/runTestDBs.sh
+++ b/scripts/runTestDBs.sh
@@ -3,4 +3,4 @@
 ./slickTestDB.sh
 ./cassandraTestDB.sh
 ./hbaseTestDB.sh
-./geowaveTestDB.sh
+# ./geowaveTestDB.sh


### PR DESCRIPTION
The GeoWave API has changed and broken our support for them - this will suppress travis failures while we await solidification of the API