### PR TITLE
Remediate VectorJoin

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/join/VectorJoin.scala
+++ b/spark/src/main/scala/geotrellis/spark/join/VectorJoin.scala
@@ -65,12 +65,12 @@ object VectorJoin {
     right: RDD[R],
     pred: (Geometry, Geometry) => Boolean
   )(implicit sc: SparkContext): RDD[(L, R)] = {
-    val leftm  =  left.mapPartitions(calculateEnvelope[L], preservesPartitioning = true)
-    val rightm = right.mapPartitions(calculateEnvelope[R], preservesPartitioning = true)
-    val prePred: (Envelope, Envelope) => Boolean = { (l, r) => l.intersects(r) }
+    val metaleft  =  left.mapPartitions(calculateEnvelope[L], preservesPartitioning = true)
+    val metaright = right.mapPartitions(calculateEnvelope[R], preservesPartitioning = true)
+    val metapred: (Envelope, Envelope) => Boolean = { (l, r) => l.intersects(r) }
+    val _pred: (L, R) => Boolean = { (l, r) => pred(l, r) }
 
-    (new FilteredCartesianRDD(sc, prePred, left, leftm, right, rightm))
-      .filter({ case (l: L, r: R) => pred(l, r) })
+    new FilteredCartesianRDD(sc, _pred, metapred, left, metaleft, right, metaright)
   }
 
   /**

--- a/spark/src/main/scala/geotrellis/spark/join/VectorJoin.scala
+++ b/spark/src/main/scala/geotrellis/spark/join/VectorJoin.scala
@@ -73,24 +73,4 @@ object VectorJoin {
     new FilteredCartesianRDD(sc, _pred, metapred, left, metaleft, right, metaright)
   }
 
-  /**
-    * Perform the vector join operation over an RDD[L] and and RDD[R],
-    * where both L and R are viewble as Geometry.
-    *
-    * @param  left   An RDD[L], where L is viewable as a Geometry
-    * @param  right  An RDD[R], where R is viewable as a Geometry
-    * @param  pred   A predicate which answers whether an L and an R should be joined
-    * @return        An RDD of L-R pairs
-    */
-  def naive[
-    L: ClassTag : ? => Geometry,
-    R: ClassTag : ? => Geometry
-  ](
-    left: RDD[L],
-    right: RDD[R],
-    pred: (Geometry, Geometry) => Boolean
-  )(implicit sc: SparkContext): RDD[(L, R)] =
-    left.cartesian(right)
-      .filter({ case (left: L, right: R) => pred(left, right) })
-
 }

--- a/spark/src/main/scala/geotrellis/spark/join/VectorJoin.scala
+++ b/spark/src/main/scala/geotrellis/spark/join/VectorJoin.scala
@@ -18,63 +18,88 @@ package geotrellis.spark.join
 
 import geotrellis.spark._
 import geotrellis.spark.tiling._
-import geotrellis.util.annotations.experimental
 import geotrellis.vector._
 
-import com.vividsolutions.jts.geom.{ Envelope => JtsEnvelope }
-import com.vividsolutions.jts.index.strtree.STRtree
 import org.apache.spark._
 import org.apache.spark.rdd._
-import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
+import com.vividsolutions.jts.geom.Envelope
 
-import scala.collection.JavaConverters._
 import scala.reflect._
 
-@experimental
+
 object VectorJoin {
-  @experimental
-  def unflattened[
-    L: ClassTag : ? => Geometry,
-    R: ClassTag : ? => Geometry
-  ](
-    shorter: RDD[L],
-    longer: RDD[R],
-    pred: (Geometry, Geometry) => Boolean
-  )(implicit sc: SparkContext): RDD[(L, Seq[R])] = {
-    val rtrees = longer.mapPartitions({ partition =>
-      val rtree = new STRtree
 
-      partition.foreach({ r =>
-        val Extent(xmin, ymin, xmax, ymax) = r.envelope
-        val envelope = new JtsEnvelope(xmin, xmax, ymin, ymax)
-        rtree.insert(envelope, r)
-      })
-
-      Iterator(rtree)
-    }, preservesPartitioning = true)
-
-    shorter.cartesian(rtrees).map({ case (left, tree) =>
-      val Extent(xmin, ymin, xmax, ymax) = left.envelope
-      val envelope = new JtsEnvelope(xmin, xmax, ymin, ymax)
-      val rights = tree.query(envelope)
-        .asScala
-        .map({ right: Any => right.asInstanceOf[R] })
-        .filter({ right => pred(left, right) })
-
-      (left, rights)
+  /**
+    * A function which calculates the envelope of a partition.
+    *
+    * @param  i   The index of the partition
+    * @param  gs  An iterator containing the contents of the RDD
+    * @return     An Iterator containing one index-envelope pair
+    */
+  def calculateEnvelope[T : ? => Geometry](
+    i: Int,
+    gs: Iterator[T]
+  ): Iterator[(Int, Envelope)] = {
+    val env = gs.foldLeft(new Envelope)({ (env: Envelope, g: T) =>
+      val Extent(xmin, ymin, xmax, ymax) = g.envelope
+      val env2 = new Envelope(xmin, xmax, ymin, ymax)
+      env.expandToInclude(env2)
+      env
     })
+
+    Iterator((i, env))
   }
 
+  /**
+    * Perform the vector join operation over an RDD[L] and and RDD[R],
+    * where both L and R are viewble as Geometry.  This makes use of
+    * the FilteredCartesianRDD type to accelerate the process
+    * (relative to plain-old CartesianRDD).
+    *
+    * @param  left   An RDD[L], where L is viewable as a Geometry
+    * @param  right  An RDD[R], where R is viewable as a Geometry
+    * @param  pred   A predicate which answers whether an L and an R should be joined
+    * @return        An RDD of L-R pairs
+    */
   def apply[
     L: ClassTag : ? => Geometry,
     R: ClassTag : ? => Geometry
   ](
-    shorter: RDD[L],
-    longer: RDD[R],
+    left: RDD[L],
+    right: RDD[R],
+    pred: (Geometry, Geometry) => Boolean
+  )(implicit sc: SparkContext): RDD[(L, R)] = {
+
+    val leftEnvs = left.mapPartitionsWithIndex(calculateEnvelope[L], true).collect.toMap
+    val rightEnvs = right.mapPartitionsWithIndex(calculateEnvelope[R], true).collect.toMap
+    val prePred: (Int, Int) => Boolean = { (i, j) =>
+      val env1 = leftEnvs.getOrElse(i, new Envelope)
+      val env2 = rightEnvs.getOrElse(j, new Envelope)
+      env1.intersects(env2)
+    }
+
+    (new FilteredCartesianRDD(sc, prePred, left, right))
+      .filter({ case (left: L, right: R) => pred(left, right) })
+  }
+
+  /**
+    * Perform the vector join operation over an RDD[L] and and RDD[R],
+    * where both L and R are viewble as Geometry.
+    *
+    * @param  left   An RDD[L], where L is viewable as a Geometry
+    * @param  right  An RDD[R], where R is viewable as a Geometry
+    * @param  pred   A predicate which answers whether an L and an R should be joined
+    * @return        An RDD of L-R pairs
+    */
+  def naive[
+    L: ClassTag : ? => Geometry,
+    R: ClassTag : ? => Geometry
+  ](
+    left: RDD[L],
+    right: RDD[R],
     pred: (Geometry, Geometry) => Boolean
   )(implicit sc: SparkContext): RDD[(L, R)] =
-    unflattened(shorter, longer, pred)
-      .flatMap({ case (left, rights) => rights.map({ right => (left, right) }) })
+    left.cartesian(right)
+      .filter({ case (left: L, right: R) => pred(left, right) })
 
 }

--- a/spark/src/main/scala/geotrellis/spark/join/VectorJoin.scala
+++ b/spark/src/main/scala/geotrellis/spark/join/VectorJoin.scala
@@ -65,12 +65,10 @@ object VectorJoin {
     right: RDD[R],
     pred: (Geometry, Geometry) => Boolean
   )(implicit sc: SparkContext): RDD[(L, R)] = {
-    val metaleft  =  left.mapPartitions(calculateEnvelope[L], preservesPartitioning = true)
-    val metaright = right.mapPartitions(calculateEnvelope[R], preservesPartitioning = true)
     val metapred: (Envelope, Envelope) => Boolean = { (l, r) => l.intersects(r) }
     val _pred: (L, R) => Boolean = { (l, r) => pred(l, r) }
 
-    new FilteredCartesianRDD(sc, _pred, metapred, left, metaleft, right, metaright)
+    new FilteredCartesianRDD(sc, _pred, metapred, left, calculateEnvelope[L], right, calculateEnvelope[R])
   }
 
 }

--- a/spark/src/main/scala/org/apache/spark/rdd/FilteredCartesianRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/rdd/FilteredCartesianRDD.scala
@@ -15,6 +15,11 @@
  * limitations under the License.
  */
 
+/**
+  * Adapted from [1] by Azavea, Inc.
+  *
+  * 1. https://github.com/apache/spark/blob/2f8776ccad532fbed17381ff97d302007918b8d8/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+  */
 package org.apache.spark.rdd
 
 import java.io.{IOException, ObjectOutputStream}

--- a/spark/src/main/scala/org/apache/spark/rdd/FilteredCartesianRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/rdd/FilteredCartesianRDD.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import java.io.{IOException, ObjectOutputStream}
+
+import scala.reflect.ClassTag
+
+import org.apache.spark._
+import org.apache.spark.util.Utils
+
+
+sealed class FilteredCartesianRDD[T: ClassTag, U: ClassTag](
+    sc: SparkContext,
+    val pred: (Int, Int) => Boolean,
+    var rdd1 : RDD[T],
+    var rdd2 : RDD[U])
+  extends RDD[(T, U)](sc, Nil)
+  with Serializable {
+
+  val numPartitionsInRdd2 = rdd2.partitions.length
+
+  override def getPartitions: Array[Partition] = {
+    // create the cross product split
+    val array = new Array[Partition](rdd1.partitions.length * rdd2.partitions.length)
+    for (s1 <- rdd1.partitions; s2 <- rdd2.partitions) {
+      val idx = s1.index * numPartitionsInRdd2 + s2.index
+      array(idx) = new CartesianPartition(idx, rdd1, rdd2, s1.index, s2.index)
+    }
+    array
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = {
+    val currSplit = split.asInstanceOf[CartesianPartition]
+    (rdd1.preferredLocations(currSplit.s1) ++ rdd2.preferredLocations(currSplit.s2)).distinct
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[(T, U)] = {
+    val currSplit = split.asInstanceOf[CartesianPartition]
+    if (pred(currSplit.s1.index, currSplit.s2.index)) {
+      for (x <- rdd1.iterator(currSplit.s1, context);
+           y <- rdd2.iterator(currSplit.s2, context)) yield (x, y)
+    }
+    else Iterator.empty
+  }
+
+  override def getDependencies: Seq[Dependency[_]] = List(
+    new NarrowDependency(rdd1) {
+      def getParents(id: Int): Seq[Int] = List(id / numPartitionsInRdd2)
+    },
+    new NarrowDependency(rdd2) {
+      def getParents(id: Int): Seq[Int] = List(id % numPartitionsInRdd2)
+    }
+  )
+
+  override def clearDependencies() {
+    super.clearDependencies()
+    rdd1 = null
+    rdd2 = null
+  }
+}


### PR DESCRIPTION
A new RDD type has been defined, which is similar to the existing `CartesianRDD` type, but which allows short-circuiting of communication when a partition can be demonstrated to be disjoint from another (the word  "disjoint" is defined by a predicate function).  This behavior is useful for performing vector joins.

   - [x] Further optimization possible

When joining an RDD of 10,000 elements (split into 32 partitions) to itself (giving the driver 32GB of memory, running locally on 32 cores), I get the following results:
```
vector join apply: count=88804   millis=17014
vector join naive: count=88804   millis=43075
```

10,000 (64 partitions):
```
vector join apply: count=88804   millis=25334
vector join naive: count=88804   millis=42647
```

10,000 (128 partitions):
```
vector join apply: count=88804   millis=32060
vector join naive: count=88804   millis=43319
```

40,000 (32 partitions):
```
vector join apply: count=357604          millis=83635
vector join naive: count=357604          millis=566942
```

40,000 (256 partitions):
```
vector join apply: count=357604          millis=171588
vector join naive: count=357604          millis=622096
```

Fixes #1795