### PR TITLE
Remove slick project's sl4j exclusion

### DIFF
--- a/slick/build.sbt
+++ b/slick/build.sbt
@@ -2,7 +2,6 @@ import Dependencies._
 
 name := "geotrellis-slick"
 libraryDependencies := Seq(
-  slick exclude("org.slf4j", "slf4j-api"),
   slickPG,
   postgresql,
   slf4jApi,


### PR DESCRIPTION
We're currently seeing a weird failure on hudson builds related to a logging class not being found in Slick. This _may_ fix that problem