### PR TITLE
Fractional-Pixel Polygon Rasterizer

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizerSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizerSpec.scala
@@ -91,5 +91,57 @@ class FractionalRasterizerSpec extends FunSpec with Matchers {
       round(actual * 1000000) should be (round(expected * 1000000))
     }
 
+    it("should efficiently handle a long diagonal line (1/4)") {
+      val re = RasterExtent(e, 30, 30)
+      val poly = Polygon(Point(0,0), Point(3,0), Point(3,3), Point(0,0))
+      var actual = 0.0
+      val expected = (30*30)/2.0
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        actual += p
+      }
+
+      round(actual * 1000000) should be (round(expected * 1000000))
+    }
+
+    it("should efficiently handle a long diagonal line (2/4)") {
+      val re = RasterExtent(e, 30, 30)
+      val poly = Polygon(Point(0,0), Point(3,0), Point(0,3), Point(0,0))
+      var actual = 0.0
+      val expected = (30*30)/2.0
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        actual += p
+      }
+
+      round(actual * 1000000) should be (round(expected * 1000000))
+    }
+
+    it("should efficiently handle a long diagonal line (3/4)") {
+      val re = RasterExtent(Extent(0, 0, 3, 3.1), 30, 30)
+      val poly = Polygon(Point(0,0), Point(3,0), Point(0,3), Point(0,0))
+      var actual = 0.0
+      val expected = 435.483871
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        actual += p
+      }
+
+      round(actual * 1000000) should be (round(expected * 1000000))
+    }
+
+    it("should efficiently handle a long diagonal line (4/4)") {
+      val re = RasterExtent(Extent(0, 0, 3.1, 3), 30, 30)
+      val poly = Polygon(Point(0,0), Point(3,0), Point(0,3), Point(0,0))
+      var actual = 0.0
+      val expected = 435.483871
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        actual += p
+      }
+
+      round(actual * 1000000) should be (round(expected * 1000000))
+    }
+
   }
 }

--- a/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizerSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizerSpec.scala
@@ -35,10 +35,12 @@ class FractionalRasterizerSpec extends FunSpec with Matchers {
       val poly = Polygon(Point(1,1), Point(1,2), Point(2,2), Point(2,1), Point(1,1))
       var actual = Double.NaN
       val expected = 1.0
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        if (col == 1 && row == 1) actual = p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          if (col == 1 && row == 1) actual = p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       actual should be (expected)
     }
@@ -47,10 +49,12 @@ class FractionalRasterizerSpec extends FunSpec with Matchers {
       val poly = Polygon(Point(1,1), Point(1,2), Point(2,2), Point(2,1), Point(1,1))
       var actual = 0.0
       val expected = 0.0
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        if (col != 1 && row != 1) actual += p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          if (col != 1 && row != 1) actual += p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       actual should be (expected)
     }
@@ -59,10 +63,12 @@ class FractionalRasterizerSpec extends FunSpec with Matchers {
       val poly = Polygon(Point(1,1), Point(1,2), Point(2,2), Point(1,1))
       var actual = Double.NaN
       val expected = 0.5
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        if (col == 1 && row == 1) actual = p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          if (col == 1 && row == 1) actual = p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       actual should be (expected)
     }
@@ -71,10 +77,12 @@ class FractionalRasterizerSpec extends FunSpec with Matchers {
       val poly = Polygon(Point(1.2,1.2), Point(1.2,1.8), Point(1.8,1.8), Point(1.8,1.2), Point(1.2,1.2))
       var actual = Double.NaN
       val expected = 0.36
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        if (col == 1 && row == 1) actual = p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          if (col == 1 && row == 1) actual = p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       round(actual * 1000000) should be (round(expected * 1000000))
     }
@@ -83,62 +91,102 @@ class FractionalRasterizerSpec extends FunSpec with Matchers {
       val poly = Polygon(Point(0.1,0.1), Point(0.1,2.9), Point(2.9,2.9), Point(2.9,0.1), Point(0.1,0.1))
       var actual = 0.0
       val expected = 2.8 * 2.8
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        actual += p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          actual += p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       round(actual * 1000000) should be (round(expected * 1000000))
     }
 
-    it("should efficiently handle a long diagonal line (1/4)") {
+    it("should efficiently handle a long diagonal line (1/6)") {
       val re = RasterExtent(e, 30, 30)
       val poly = Polygon(Point(0,0), Point(3,0), Point(3,3), Point(0,0))
       var actual = 0.0
       val expected = (30*30)/2.0
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        actual += p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          actual += p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       round(actual * 1000000) should be (round(expected * 1000000))
     }
 
-    it("should efficiently handle a long diagonal line (2/4)") {
+    it("should efficiently handle a long diagonal line (2/6)") {
       val re = RasterExtent(e, 30, 30)
       val poly = Polygon(Point(0,0), Point(3,0), Point(0,3), Point(0,0))
       var actual = 0.0
       val expected = (30*30)/2.0
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        actual += p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          actual += p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       round(actual * 1000000) should be (round(expected * 1000000))
     }
 
-    it("should efficiently handle a long diagonal line (3/4)") {
+    it("should efficiently handle a long diagonal line (3/6)") {
       val re = RasterExtent(Extent(0, 0, 3, 3.1), 30, 30)
       val poly = Polygon(Point(0,0), Point(3,0), Point(0,3), Point(0,0))
       var actual = 0.0
       val expected = 435.483871
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        actual += p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          actual += p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       round(actual * 1000000) should be (round(expected * 1000000))
     }
 
-    it("should efficiently handle a long diagonal line (4/4)") {
+    it("should efficiently handle a long diagonal line (4/6)") {
       val re = RasterExtent(Extent(0, 0, 3.1, 3), 30, 30)
       val poly = Polygon(Point(0,0), Point(3,0), Point(0,3), Point(0,0))
       var actual = 0.0
       val expected = 435.483871
-
-      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
-        actual += p
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          actual += p
       }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
+
+      round(actual * 1000000) should be (round(expected * 1000000))
+    }
+
+    it("should efficiently handle a long diagonal line (5/6)") {
+      val re = RasterExtent(Extent(0, 0, 3, 3.1), 30, 30)
+      val poly = Polygon(Point(0,0), Point(3,0), Point(0,3.1), Point(0,0))
+      var actual = 0.0
+      val expected = (30*30)/2.0
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          actual += p
+      }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
+
+      round(actual * 1000000) should be (round(expected * 1000000))
+    }
+
+    it("should efficiently handle a long diagonal line (6/6)") {
+      val re = RasterExtent(Extent(0, 0, 3.1, 3), 30, 30)
+      val poly = Polygon(Point(0,0), Point(3.1,0), Point(0,3), Point(0,0))
+      var actual = 0.0
+      val expected = (30*30)/2.0
+      val cb = new FractionCallback {
+        def callback(col: Int, row: Int, p: Double): Unit =
+          actual += p
+      }
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re)(cb)
 
       round(actual * 1000000) should be (round(expected * 1000000))
     }

--- a/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizerSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizerSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.rasterize.polygon
+
+import geotrellis.raster._
+import geotrellis.raster.rasterize._
+import geotrellis.vector._
+
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.math.round
+
+
+class FractionalRasterizerSpec extends FunSpec with Matchers {
+
+  describe("Fractional-Pixel Polygon Rasterizer") {
+    val e = Extent(0, 0, 3, 3)
+    val re = RasterExtent(e, 3, 3)
+
+    it("should correctly report full pixels") {
+      val poly = Polygon(Point(1,1), Point(1,2), Point(2,2), Point(2,1), Point(1,1))
+      var actual = Double.NaN
+      val expected = 1.0
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        if (col == 1 && row == 1) actual = p
+      }
+
+      actual should be (expected)
+    }
+
+    it("should correctly not report disjoint pixels") {
+      val poly = Polygon(Point(1,1), Point(1,2), Point(2,2), Point(2,1), Point(1,1))
+      var actual = 0.0
+      val expected = 0.0
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        if (col != 1 && row != 1) actual += p
+      }
+
+      actual should be (expected)
+    }
+
+    it("should correctly report partial pixels") {
+      val poly = Polygon(Point(1,1), Point(1,2), Point(2,2), Point(1,1))
+      var actual = Double.NaN
+      val expected = 0.5
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        if (col == 1 && row == 1) actual = p
+      }
+
+      actual should be (expected)
+    }
+
+    it("should handle sub-pixel activity") {
+      val poly = Polygon(Point(1.2,1.2), Point(1.2,1.8), Point(1.8,1.8), Point(1.8,1.2), Point(1.2,1.2))
+      var actual = Double.NaN
+      val expected = 0.36
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        if (col == 1 && row == 1) actual = p
+      }
+
+      round(actual * 1000000) should be (round(expected * 1000000))
+    }
+
+    it("should handle a mix of partial and complete pixels") {
+      val poly = Polygon(Point(0.1,0.1), Point(0.1,2.9), Point(2.9,2.9), Point(2.9,0.1), Point(0.1,0.1))
+      var actual = 0.0
+      val expected = 2.8 * 2.8
+
+      FractionalRasterizer.foreachCellByPolygon(poly, re) { (col: Int, row: Int, p: Double) =>
+        actual += p
+      }
+
+      round(actual * 1000000) should be (round(expected * 1000000))
+    }
+
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/rasterize/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/package.scala
@@ -21,4 +21,10 @@ package object rasterize {
   /** Callback for given row and column (compatible with previous definition). */
   type Callback = (Int, Int) => Unit
 
+  /**
+    * A call back which accepts a col-row-fraction triple.  The
+    * fraction is the fraction of the pixel which is covered by the
+    * query object.
+    */
+  type FractionCallback = (Int, Int, Double) => Unit
 }

--- a/raster/src/main/scala/geotrellis/raster/rasterize/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/package.scala
@@ -26,5 +26,7 @@ package object rasterize {
     * fraction is the fraction of the pixel which is covered by the
     * query object.
     */
-  type FractionCallback = (Int, Int, Double) => Unit
+  trait FractionCallback {
+    def callback(col: Int, row: Int, fraction: Double): Unit
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizer.scala
@@ -1,0 +1,110 @@
+package geotrellis.raster.rasterize.polygon
+
+import geotrellis.raster._
+import geotrellis.raster.rasterize._
+import geotrellis.vector._
+
+import com.vividsolutions.jts.geom.Envelope
+import spire.syntax.cfor._
+
+import scala.collection.mutable
+import scala.math.{min, max, ceil, floor}
+
+
+object FractionalRasterizer {
+
+  private type Segment = (Double, Double, Double, Double)
+
+  private def polygonToEdges(poly: Polygon, re: RasterExtent): Seq[Segment] = {
+
+    val arrayBuffer = mutable.ArrayBuffer.empty[Segment]
+
+    /** Find the outer ring's segments */
+    val coords = poly.jtsGeom.getExteriorRing.getCoordinates
+    cfor(1)(_ < coords.length, _ + 1) { ci =>
+      val coord1 = coords(ci - 1)
+      val coord2 = coords(ci)
+
+      val col1 = re.mapXToGridDouble(coord1.x)
+      val row1 = re.mapYToGridDouble(coord1.y)
+      val col2 = re.mapXToGridDouble(coord2.x)
+      val row2 = re.mapYToGridDouble(coord2.y)
+
+      val segment =
+        if (row1 < row2) (col1, row1, col2, row2)
+        else (col2, row2, col1, row1)
+
+      arrayBuffer += segment
+    }
+
+    /** Find the segments for the holes */
+    cfor(0)(_ < poly.numberOfHoles, _ + 1) { i =>
+      val coords = poly.jtsGeom.getInteriorRingN(i).getCoordinates
+      cfor(1)(_ < coords.length, _ + 1) { ci =>
+        val coord1 = coords(ci - 1)
+        val coord2 = coords(ci)
+
+        val col1 = re.mapXToGridDouble(coord1.x)
+        val row1 = re.mapYToGridDouble(coord1.y)
+        val col2 = re.mapXToGridDouble(coord2.x)
+        val row2 = re.mapYToGridDouble(coord2.y)
+
+        val segment =
+          if (row1 < row2) (col1, row1, col2, row2)
+          else (col2, row2, col1, row1)
+
+        arrayBuffer += segment
+      }
+    }
+
+    arrayBuffer
+  }
+
+  private def renderEdge(
+    edge: Segment,
+    poly: Polygon,
+    set: mutable.Set[(Int, Int)],
+    fn: FractionCallback
+  ): Unit = {
+    val xmin = floor(min(edge._1, edge._3)).toInt
+    val ymin = floor(min(edge._2, edge._4)).toInt
+    val xmax = ceil(max(edge._1, edge._3)).toInt
+    val ymax = ceil(max(edge._2, edge._4)).toInt
+
+    val envelope = Polygon(Point(xmin, ymin), Point(xmin, ymax), Point(xmax, ymax), Point(xmax, ymin), Point(xmin, ymin)).jtsGeom
+    val localPoly = poly.jtsGeom.intersection(envelope)
+
+    var x = xmin; while (x <= xmax) {
+      var y = ymin; while (y <= ymax) {
+        val pair = (x, y)
+        if (!set.contains(pair)) {
+          val pixel = Polygon(Point(x, y), Point(x, y+1), Point(x+1, y+1), Point(x+1, y), Point(x, y)).jtsGeom
+          val fraction = (pixel.intersection(localPoly)).getArea
+
+          if (fraction > 0.0) {
+            fn(x, y, fraction)
+            set += ((x, y))
+          }
+        }
+        y += 1
+      }
+      x += 1
+    }
+  }
+
+  def foreachCellByPolygon(
+    poly: Polygon,
+    re: RasterExtent
+  )(fn: FractionCallback): Unit = {
+    val seen = mutable.Set.empty[(Int, Int)]
+    val option = Rasterizer.Options(includePartial = false, sampleType = PixelIsArea)
+
+    polygonToEdges(poly, re).foreach({ edge => renderEdge(edge, poly, seen, fn) })
+
+    PolygonRasterizer.foreachCellByPolygon(poly, re) {(col: Int, row: Int) =>
+      val pair = (col, row)
+      if (!seen.contains(pair)) fn(col, row, 1.0)
+    }
+  }
+
+}

--- a/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
@@ -123,7 +123,7 @@ object PolygonRasterizer {
 
     val rtree = new STRtree
 
-    /* Find the outer ring's segments */
+    /** Find the outer ring's segments */
     val coords = poly.jtsGeom.getExteriorRing.getCoordinates
     cfor(1)(_ < coords.length, _ + 1) { ci =>
       val coord1 = coords(ci - 1)
@@ -364,7 +364,11 @@ object PolygonRasterizer {
    * @param re       A raster extent to rasterize the polygon into
    * @param options  The options parameter controls whether to treat pixels as points or areas and whether to report partially-intersected areas.
    */
-  def foreachCellByPolygon(poly: Polygon, re: RasterExtent, options: Options = Options.DEFAULT)(f: Callback): Unit = {
+  def foreachCellByPolygon(
+    poly: Polygon,
+    re: RasterExtent,
+    options: Options = Options.DEFAULT
+  )(f: Callback): Unit = {
     val sampleType = options.sampleType
     val partial = options.includePartial
 


### PR DESCRIPTION
In this changeset, a polygon rasterizer which reports partial pixels and the respective fractions of those pixels that are covered by the polygon is presented.  The approach used seems to be the most efficient that is practical if sub-pixel geometries are to be supported.

   - [x] Bresenham or similar for generating partial pixels

 [This resource](https://gis.stackexchange.com/questions/59821/how-to-calculate-volume-from-a-raster-file) recommends the same method for volumetric calculation as we are envisioning.  I have not found any contradictory resources.