### PR TITLE
Reproject points using PDAL pipeline

### DIFF
--- a/pointcloud/src/main/scala/geotrellis/spark/io/hadoop/HadoopPointCloudRDD.scala
+++ b/pointcloud/src/main/scala/geotrellis/spark/io/hadoop/HadoopPointCloudRDD.scala
@@ -38,7 +38,8 @@ object HadoopPointCloudRDD {
     filesExtensions: Seq[String] = Seq(".las", ".laz"),
     tmpDir: Option[String] = None,
     filterExtent: Option[Extent] = None,
-    dimTypes: Option[Iterable[String]] = None
+    dimTypes: Option[Iterable[String]] = None,
+    targetCrs: Option[String] = None
   )
 
   object Options {
@@ -60,6 +61,10 @@ object HadoopPointCloudRDD {
 
     options.dimTypes.foreach { dt =>
       PointCloudInputFormat.setDimTypes(conf, dt)
+    }
+
+    options.targetCrs.foreach { crs =>
+      PointCloudInputFormat.setTargetCrs(conf, crs)
     }
 
     options.filterExtent match {

--- a/pointcloud/src/main/scala/geotrellis/spark/io/s3/S3PointCloudInputFormat.scala
+++ b/pointcloud/src/main/scala/geotrellis/spark/io/s3/S3PointCloudInputFormat.scala
@@ -19,7 +19,6 @@ package geotrellis.spark.io.s3
 import geotrellis.spark.io.hadoop.formats.PointCloudInputFormat
 import geotrellis.spark.pointcloud.json._
 import geotrellis.util.Filesystem
-import geotrellis.vector.Extent
 
 import io.pdal._
 import org.apache.hadoop.mapreduce.{InputSplit, TaskAttemptContext}
@@ -47,7 +46,7 @@ class S3PointCloudInputFormat extends S3InputFormat[S3PointCloudHeader, Iterator
 
         try {
 
-          val pipeline = Pipeline(fileToPipelineJson(localPath).toString)
+          val pipeline = Pipeline(getPipelineJson(localPath, PointCloudInputFormat.getTargetCrs(context)).toString)
 
           // PDAL itself is not threadsafe
           AnyRef.synchronized { pipeline.execute }

--- a/pointcloud/src/main/scala/geotrellis/spark/io/s3/S3PointCloudRDD.scala
+++ b/pointcloud/src/main/scala/geotrellis/spark/io/s3/S3PointCloudRDD.scala
@@ -41,7 +41,8 @@ object S3PointCloudRDD {
     getS3Client: () => S3Client = () => S3Client.DEFAULT,
     tmpDir: Option[String] = None,
     filterExtent: Option[Extent] = None,
-    dimTypes: Option[Iterable[String]] = None
+    dimTypes: Option[Iterable[String]] = None,
+    targetCrs: Option[String] = None
   )
 
   object Options {
@@ -71,6 +72,10 @@ object S3PointCloudRDD {
 
     options.dimTypes.foreach { dt =>
       PointCloudInputFormat.setDimTypes(conf, dt)
+    }
+
+    options.targetCrs.foreach { crs =>
+      PointCloudInputFormat.setTargetCrs(conf, crs)
     }
 
     options.filterExtent match {

--- a/pointcloud/src/main/scala/geotrellis/spark/pointcloud/json/package.scala
+++ b/pointcloud/src/main/scala/geotrellis/spark/pointcloud/json/package.scala
@@ -16,12 +16,34 @@
 
 package geotrellis.spark.pointcloud
 
-import java.io.File
-
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
+import java.io.File
+
 package object json extends MetadataFormat {
-  def fileToPipelineJson(localPath: File): JsObject =
-    JsObject("pipeline" -> JsArray(JsObject("filename" -> localPath.getAbsolutePath.toJson)))
+  def getPipelineJson(localPath: File, targetCrs: Option[String] = None): JsObject = {
+    targetCrs match {
+      case Some(crs) =>
+        JsObject(
+          "pipeline" -> JsArray(
+            JsObject(
+              "filename" -> localPath.getAbsolutePath.toJson
+            ),
+            JsObject(
+              "type" -> "filters.reprojection".toJson,
+              "out_srs" -> crs.toJson
+            )
+          )
+        )
+
+      case _ => JsObject(
+        "pipeline" -> JsArray(
+          JsObject(
+            "filename" -> localPath.getAbsolutePath.toJson
+          )
+        )
+      )
+    }
+  }
 }


### PR DESCRIPTION
We can reproject points before reading them into JVM memory.

Signed-off-by: Grigory Pomadchin <gr.pomadchin@gmail.com>