### PR TITLE
Update PDAL version

### DIFF
--- a/pointcloud/src/main/scala/geotrellis/spark/io/hadoop/formats/PointCloudInputFormat.scala
+++ b/pointcloud/src/main/scala/geotrellis/spark/io/hadoop/formats/PointCloudInputFormat.scala
@@ -28,6 +28,7 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.input._
 
 import java.io.{BufferedOutputStream, File, FileOutputStream}
+import scala.collection.JavaConversions._
 
 object PointCloudInputFormat {
   final val POINTCLOUD_TMP_DIR = "POINTCLOUD_TMP_DIR"

--- a/pointcloud/src/main/scala/geotrellis/spark/io/s3/S3PointCloudInputFormat.scala
+++ b/pointcloud/src/main/scala/geotrellis/spark/io/s3/S3PointCloudInputFormat.scala
@@ -24,6 +24,7 @@ import io.pdal._
 import org.apache.hadoop.mapreduce.{InputSplit, TaskAttemptContext}
 
 import java.io.{BufferedOutputStream, File, FileOutputStream}
+import scala.collection.JavaConversions._
 
 /** Process files from the path through PDAL, and reads all files point data as an Array[Byte] **/
 class S3PointCloudInputFormat extends S3InputFormat[S3PointCloudHeader, Iterator[PointCloud]] {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,5 +63,5 @@ object Dependencies {
 
   val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.14.3"
 
-  val pdal         = "io.pdal" %% "pdal" % "1.4.0-M7"
+  val pdal         = "io.pdal" %% "pdal" % "1.4.0-M9"
 }


### PR DESCRIPTION
WARN: rebuild your local PDAL to use this update
But it may work without rebuild; as only one not important func call was redesigned

P.S. (not caused by my commit, double checked it) 
```
[info] - should be able to produce a tile *** FAILED ***
[info]   420.506564462933 was not greater than 435.49 (PointCloudDemSpec.scala:60)
```

Signed-off-by: Grigory Pomadchin <gr.pomadchin@gmail.com>