### PR TITLE
[WIP] New and improved Delaunay triangulation

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/mesh/FacetMap.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/FacetMap.scala
@@ -1,0 +1,9 @@
+package geotrellis.vector.mesh
+
+trait FacetMap[HE <: HalfEdge, F] {
+  def +=(keyValue: (F, HE)): Unit
+  //def +=(edge: HE)(implicit nav: mesh.HalfEdgeNavigation[HE, V, F])
+  def -=(idx: F): Unit
+  //def -=(edge: HE)
+  def facets(): Map[F, HE]
+}

--- a/vector/src/main/scala/geotrellis/vector/mesh/HalfEdge.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/HalfEdge.scala
@@ -1,0 +1,3 @@
+package geotrellis.vector.mesh
+
+trait HalfEdge extends Any

--- a/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeIndex.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeIndex.scala
@@ -1,0 +1,3 @@
+package geotrellis.vector.mesh
+
+class HalfEdgeIndex(val i: Int) extends AnyVal with HalfEdge

--- a/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeIndexNavigation.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeIndexNavigation.scala
@@ -1,0 +1,332 @@
+package geotrellis.vector.mesh
+
+import scala.reflect.ClassTag
+
+/** Mutable, non-thread safe class to keep track of half edges
+  * during Delaunay triangulation.
+  *
+  * Edge table contains an Array[Int] of triples:
+  *       [i,e1,e2] where i is the vertex of the halfedge (where the half edge 'points' to)
+  *                       e1 is the halfedge index of the flip of the halfedge
+  *                          (the halfedge that points to the source)
+  *                       e2 is the halfedge index of the next half edge
+  *                          (counter-clockwise of the triangle)
+  */
+class HalfEdgeIndexNavigation(_size: Int) extends HalfEdgeNavigation[HalfEdgeIndex, Int, Unit] {
+  private var size: Int = _size
+  private var idx = 0
+  private var edgeCount = 0
+
+  // private var fsize: Int = _size / 3
+  // private var fidx = 0
+  // private var faceCount = 0
+
+  private final val ENTRIES = 4
+
+  // This array will hold the packed arrays of the halfedge table.
+  private var table = Array.ofDim[Int](size * ENTRIES)
+
+  // private var ftable = Array.ofDim[F](fsize)
+
+  // Since the underlying implementation uses an array we can only
+  // store so many unique values. 1<<30 is the largest power of two
+  // that can be allocated as an array. since each halfedge
+  // takes up three slots in our array, the maximum number of those we
+  // can store is Int.MaxValue / ENTRIES. so that is the maximum size 
+  // we can allocate for our table.
+  private final val MAXSIZE: Int = Int.MaxValue / ENTRIES
+
+  // Once our buckets get 80% full, we need to resize
+  private final val FACTOR: Double = 0.8
+
+  private var limit = (size * FACTOR).toInt
+  // private var flimit = (fsize * FACTOR).toInt
+
+  /** Create an edge pointing to single vertex.
+    * This edge will have no flip or next set.
+    */
+  def createHalfEdge(v: Int): HalfEdgeIndex = {
+    val e = edgeCount
+    table(idx) = v
+    idx += ENTRIES
+    edgeCount += 1
+    if (edgeCount > limit) resize()
+    new HalfEdgeIndex(e)
+  }
+
+  /** Create an edge for a single vertex,
+    * with the specified flip and next set.
+    */
+  override def createHalfEdge(v: Int, flip: HalfEdgeIndex, next: HalfEdgeIndex): HalfEdgeIndex = {
+    val e = edgeCount
+    table(idx) = v
+    table(idx + 1) = flip.i
+    table(idx + 2) = next.i
+    idx += ENTRIES
+    edgeCount += 1
+    if (edgeCount > limit) { resize() }
+    new HalfEdgeIndex(e)
+  }
+
+  /** Create two half edges that
+    * both flip and point to each other
+    *
+    * @return the half edge point at v2
+    */
+  // def createHalfEdges(v1: Int, v2: Int): HalfEdgeIndex = {
+  //   val e1 = createHalfEdge(v1)
+  //   val e2 = createHalfEdge(v2)
+
+  //   setFlip(e2, e1)
+  //   setNext(e2, e1)
+
+  //   setFlip(e1, e2)
+  //   setNext(e1, e2)
+  //   e2
+  // }
+
+  /** Create three half edges that
+    * flip and point to each other
+    * in a triangle.
+    *
+    * @return   The outer halfedge pointing at v1
+    *
+    * @note It's up to the caller to set these edges in counter clockwise order
+    */
+  // def createHalfEdges(v1: Int, v2: Int, v3: Int): HalfEdgeIndex = {
+  //   //println(s"DELAUNAY2 - HE $v1 $v2 $v3")
+  //   val inner1 = createHalfEdge(v1)
+  //   val inner2 = createHalfEdge(v2)
+  //   val inner3 = createHalfEdge(v3)
+
+  //   val outer1 = createHalfEdge(v1)
+  //   val outer2 = createHalfEdge(v2)
+  //   val outer3 = createHalfEdge(v3)
+
+  //   setNext(inner1, inner2)
+  //   setNext(inner2, inner3)
+  //   setNext(inner3, inner1)
+
+  //   setFlip(inner1, outer3)
+  //   setFlip(inner2, outer1)
+  //   setFlip(inner3, outer2)
+
+  //   setNext(outer1, outer3)
+  //   setNext(outer3, outer2)
+  //   setNext(outer2, outer1)
+
+  //   setFlip(outer1, inner2)
+  //   setFlip(outer2, inner3)
+  //   setFlip(outer3, inner1)
+
+  //   outer1
+  // }
+
+  // def createHalfEdges(vs: Seq[Int]): HalfEdgeIndex = {
+  //   val inner = vs.map(createHalfEdge(_))
+  //   val outer = vs.map(createHalfEdge(_))
+
+  //   def mkloop[T](l: Seq[HalfEdgeIndex], fst: HalfEdgeIndex): Unit = {
+  //     l match {
+  //       case Nil => ()
+  //       case List(x) => setNext(x, fst)
+  //       case x1 :: x2 :: xs => 
+  //         setNext(x1, x2)
+  //         mkloop(x2 :: xs, fst)
+  //     }
+  //   }
+  //   mkloop(inner, inner.head)
+  //   mkloop(outer.reverse, outer.reverse.head)
+
+  //   inner.zip(outer.last +: outer).foreach{ case (e1, e2) =>
+  //     setFlip(e1, e2)
+  //     setFlip(e2, e1)
+  //   }
+
+  //   outer.head
+  // }
+
+  // // TODO: Make this match the implementation of join() in HalfEdge.scala
+  // def join(e1: HalfEdgeIndex, e2: HalfEdgeIndex): Unit = {
+  //   // flip.prev.next = that.flip.next
+  //   setNext(getPrev(getFlip(e1)), getNext(getFlip(e2)))
+
+  //   // that.flip.prev.next = flip.next
+  //   setNext(getPrev(getFlip(e2)), getNext(getFlip(e1)))
+
+  //   //flip = that
+  //   setFlip(e1, e2)
+
+  //   //that.flip = this
+  //   setFlip(e2, e1)
+  // }
+
+  /** Sets a half edge's flip half edge
+    */
+  def setFlip(e: HalfEdgeIndex, flip: HalfEdgeIndex): Unit =
+    table(e.i * ENTRIES + 1) = flip.i
+
+  /** Sets a half edge's next half edge
+    */
+  def setNext(e: HalfEdgeIndex, next: HalfEdgeIndex): Unit =
+    table(e.i * ENTRIES + 2) = next.i
+
+  def getFlip(e: HalfEdgeIndex): HalfEdgeIndex =
+    new HalfEdgeIndex(table(e.i * ENTRIES + 1))
+
+  def getNext(e: HalfEdgeIndex): HalfEdgeIndex =
+    new HalfEdgeIndex(table(e.i * ENTRIES + 2))
+
+  // def getPrev(e: Int): Int = {
+  //   var p = getNext(getFlip(e))
+  //   while (getNext(getFlip(p)) != e) {
+  //     p = getNext(getFlip(p))
+  //   }
+  //   getFlip(p)
+  // }
+
+  /** Returns the vertex index for this half edge
+    * (the one in which it points to)
+    */
+  def getDest(e: HalfEdgeIndex): Int =
+    table(e.i * ENTRIES)
+
+  /** Sets the vertex index for this half edge
+      * (the one in which it points to)
+      */
+  def setDest(e: HalfEdgeIndex, v: Int): Unit =
+    table(e.i * ENTRIES) = v
+
+  /** Returns the source vertex index for this half edge
+    * (the one in which it points from)
+    */
+  override def getSrc(e: HalfEdgeIndex): Int = {
+    val f = getFlip(e)
+    table(f.i * ENTRIES)
+  }
+
+  /** Sets the source vertex index for this half edge
+    * (the one in which it points from)
+    */
+  override def setSrc(e: HalfEdgeIndex, v: Int): Unit =
+    table(getFlip(e).i * ENTRIES) = v
+
+  /** Returns the halfedge index of the halfedge you get
+    * from rotating this halfedge clockwise from it's source
+    * along the triangulation
+    */
+  // def rotCWSrc(e: Int): Int =
+  //   getNext(getFlip(e))
+
+  /** Returns the halfedge index of the halfedge you get
+    * from rotating this halfedge counter-clockwise from it's source
+    * along the triangulation
+    */
+  // def rotCCWSrc(e: Int): Int =
+  //   getFlip(getPrev(e))
+
+  /** Returns the halfedge index of the halfedge you get
+    * from rotating this halfedge clockwise from it's destination
+    * along the triangulation
+    */
+  // def rotCWDest(e: Int): Int =
+  //   getFlip(getNext(e))
+
+  /** Returns the halfedge index of the halfedge you get
+    * from rotating this halfedge counter-clockwise from it's destination
+    * along the triangulation
+    */
+  // def rotCCWDest(e: Int): Int =
+  //   getPrev(getFlip(e))
+
+  def getFaceInfo(edge: HalfEdgeIndex): Option[Unit] = {
+    val f = table(edge.i * ENTRIES + 3)
+    if (f == 0)
+      None
+    else
+      Some(())
+      // Some(ftable(f))
+  }
+
+  def setFaceInfo(edge: HalfEdgeIndex, info: Option[Unit]): Unit = {
+    info match {
+      case None => table(edge.i * ENTRIES + 3) = 0
+      case Some(attr) => {
+        table(edge.i * ENTRIES + 3) = 1
+        // table(edge * ENTRIES + 3) = faceCount
+        // ftable(faceCount) = attr
+        // faceCount += 1
+        // if (faceCount > flimit) { fresize() }
+      }
+    }
+  }
+
+  // def getFaceInfo(edge: HalfEdge[V, F]): Option[F] = edge.face
+  // def setFaceInfo(edge: HalfEdge[V, F], info: Option[F]): Unit = { edge.face = info }
+
+  private def resize() {
+    // It's important that size always be a power of 2. We grow our
+    // hash table by x4 until it starts getting big, at which point we
+    // only grow by x2.
+    val factor = if (size < 10000) 4 else 2
+
+    val nextSize = size * factor
+    val nextTable = Array.ofDim[Int](nextSize * ENTRIES)
+
+    println(s"RESIZE $size TO $nextSize")
+
+    // Given the underlying array implementation we can only store so
+    // many unique values. given that 1<<30
+    if (nextSize > MAXSIZE) sys.error("edge table has exceeded max capacity")
+
+    var i = 0
+    while (i < idx) {
+      nextTable(i) = table(i)
+      i += 1
+    }
+
+    size = nextSize
+    table = nextTable
+    limit = (size * FACTOR).toInt
+  }
+
+  // private def fresize() {
+  //   // It's important that size always be a power of 2. We grow our
+  //   // hash table by x4 until it starts getting big, at which point we
+  //   // only grow by x2.
+  //   val factor = if (fsize < 10000) 4 else 2
+
+  //   val nextSize = fsize * factor
+  //   val nextTable = Array.ofDim[F](nextSize * ENTRIES)
+
+  //   println(s"RESIZE $fsize TO $nextSize")
+
+  //   // Given the underlying array implementation we can only store so
+  //   // many unique values. given that 1<<30
+  //   if (nextSize > MAXSIZE) sys.error("face table has exceeded max capacity")
+
+  //   var i = 0
+  //   while (i < fidx) {
+  //     nextTable(i) = ftable(i)
+  //     i += 1
+  //   }
+
+  //   fsize = nextSize
+  //   ftable = nextTable
+  //   flimit = (fsize * FACTOR).toInt
+  // }
+
+  // Debug methods
+
+  def showBoundingLoop(base: HalfEdgeIndex): Unit = {
+    var e = base
+    var l: List[HalfEdgeIndex] = Nil
+
+    while (!l.contains(e)) {
+      l = l :+ e
+      print(s"|${getSrc(e)} -> ${getDest(e)}| ")
+      e = getNext(e)
+    }
+    println("")
+  }
+}

--- a/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeMesh.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeMesh.scala
@@ -1,0 +1,7 @@
+package geotrellis.vector.mesh
+
+trait HalfEdgeMesh[E <: HalfEdge, V, F] {
+  val boundary: Option[E]
+  val edgeIncidentToVertex: Map[V, E]
+  val facets: FacetMap[E, F]
+}

--- a/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeNavigation.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeNavigation.scala
@@ -1,0 +1,112 @@
+package geotrellis.vector.mesh
+
+trait HalfEdgeNavigation[HE, V, F] {
+  def getDest(edge: HE): V
+  def setDest(edge: HE, dest: V): Unit
+
+  def getSrc(edge: HE): V = getDest(getFlip(edge))
+  def setSrc(edge: HE, src: V): Unit = setDest(getFlip(edge), src)
+
+  def getPrev(edge: HE): HE = {
+    var e = getNext(getFlip(edge))
+    while (getNext(getFlip(e)) != edge) {
+      e = getNext(getFlip(e))
+    }
+    getFlip(e)
+  }
+ 
+  def getNext(edge: HE): HE
+  def setNext(edge: HE, next: HE): Unit
+
+  def getFlip(edge: HE): HE
+  def setFlip(edge: HE, flip: HE): Unit
+
+  def rotCWSrc(edge: HE): HE = getNext(getFlip(edge))
+  def rotCCWSrc(edge: HE): HE = getFlip(getPrev(edge))
+  def rotCWDest(edge: HE): HE = getFlip(getNext(edge))
+  def rotCCWDest(edge: HE): HE = getPrev(getFlip(edge))
+
+  def getFaceInfo(edge: HE): Option[F]
+  def setFaceInfo(edge: HE, info: Option[F]): Unit
+
+  def createHalfEdge(v: V): HE
+  def createHalfEdge(v: V, flip: HE, next: HE): HE = {
+    val e = createHalfEdge(v)
+    setFlip(e, flip)
+    setNext(e, next)
+    e
+  }
+
+  def createHalfEdges(v1: V, v2: V): HE = {
+    val to = createHalfEdge(v2)
+    val from = createHalfEdge(v1)
+
+    setNext(to, from)
+    setNext(from, to)
+
+    setFlip(from, to)
+    setFlip(to, from)
+
+    to
+  }
+
+  def createHalfEdges(v1:V, v2: V, v3: V): HE = {
+    val inner1 = createHalfEdge(v1)
+    val inner2 = createHalfEdge(v2)
+    val inner3 = createHalfEdge(v3)
+
+    val outer1 = createHalfEdge(v1)
+    val outer2 = createHalfEdge(v2)
+    val outer3 = createHalfEdge(v3)
+
+    setNext(inner1, inner2)
+    setNext(inner2, inner3)
+    setNext(inner3, inner1)
+
+    setFlip(inner1, outer3)
+    setFlip(inner2, outer1)
+    setFlip(inner3, outer2)
+
+    setNext(outer1, outer3)
+    setNext(outer3, outer2)
+    setNext(outer2, outer1)
+
+    setFlip(outer1, inner2)
+    setFlip(outer2, inner3)
+    setFlip(outer3, inner1)
+
+    outer1
+  }
+
+  def createHalfEdges(vs: Seq[V]): HE = {
+    val inner = vs.map(createHalfEdge(_))
+    val outer = vs.map(createHalfEdge(_))
+
+    def mkloop[T](l: Seq[HE], fst: HE): Unit = {
+      l match {
+        case Nil => ()
+        case List(x) => setNext(x, fst)
+        case x1 :: x2 :: xs => 
+          setNext(x1, x2)
+          mkloop(x2 :: xs, fst)
+      }
+    }
+    mkloop(inner, inner.head)
+    mkloop(outer.reverse, outer.reverse.head)
+
+    inner.zip(outer.last +: outer).foreach{ case (e1, e2) =>
+      setFlip(e1, e2)
+      setFlip(e2, e1)
+    }
+
+    outer.head
+  }
+
+
+  def join(e1: HE, e2: HE): Unit = {
+    setNext(getPrev(getFlip(e1)), getNext(getFlip(e2)))
+    setNext(getPrev(getFlip(e2)), getNext(getFlip(e1)))
+    setFlip(e1, e2)
+    setFlip(e2, e1)
+  }
+}

--- a/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeRef.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeRef.scala
@@ -1,0 +1,124 @@
+package geotrellis.vector.mesh
+
+import geotrellis.vector.{Line, Point, Polygon}
+
+class HalfEdgeRef[V,F](var vert: V, var flip: HalfEdgeRef[V,F], var next: HalfEdgeRef[V,F], var face: Option[F]) 
+  extends HalfEdge
+{
+  def getDest(edge: HalfEdgeRef[V, F]): V = edge.vert
+  def setDest(edge: HalfEdgeRef[V, F], dest: V): Unit = { edge.vert = dest }
+
+  def getNext(edge: HalfEdgeRef[V, F]) = edge.next
+  def setNext(edge: HalfEdgeRef[V, F], newNext: HalfEdgeRef[V, F]) = { edge.next = newNext }
+
+  def getFlip(edge: HalfEdgeRef[V, F]): HalfEdgeRef[V, F] = edge.flip
+  def setFlip(edge: HalfEdgeRef[V, F], flip: HalfEdgeRef[V, F]): Unit = { edge.flip = flip }
+
+  def getFaceInfo(edge: HalfEdgeRef[V, F]): Option[F] = edge.face
+  def setFaceInfo(edge: HalfEdgeRef[V, F], info: Option[F]): Unit = { edge.face = info }
+
+  def join(that: HalfEdgeRef[V,F]) = {
+    if (vert != that.flip.vert || flip.vert != that.vert) {
+      throw new IllegalArgumentException(s"Cannot join facets by edges (${flip.vert},${vert}) and (${that.vert},${that.flip.vert})")
+    }
+
+    next.flip.next = that.flip.next
+    that.next.flip.next = flip.next
+    flip = that
+    that.flip = this
+  }
+
+  def neighbors(): List[V] = {
+    def loop(e: HalfEdgeRef[V,F]): List[V] = {
+      if (e == this) {
+        List(e.flip.vert)
+      } else {
+        e.flip.vert :: loop(e.next.flip)
+      }
+    }
+    loop(this.flip.next)
+  }
+
+  def prev() = {
+    var e = flip.next
+    while (e.flip.next != this) {
+      e = e.flip.next
+    }
+    e.flip
+  }
+
+  def src() = flip.vert
+
+  def rotCWSrc() = flip.next
+
+  def rotCCWSrc() = prev.flip
+
+  def rotCWDest() = next.flip
+
+  def rotCCWDest() = flip.prev
+
+  override def toString() = { s"[${src} -> ${vert}]" }
+}
+
+object HalfEdgeRef {
+  def foreachWithIndex[T](s: Seq[T])(f: (T,Int) => Unit) = {
+    var i = 0
+    while (i < s.length) {
+      f(s(i), i)
+      i += 1
+    }
+  }
+
+  def apply[V,F](v1: V, v2: V) = {
+    val e1 = new HalfEdgeRef[V,F](v1, null, null, None)
+    val e2 = new HalfEdgeRef[V,F](v2, e1, e1, None)
+    e1.flip = e2
+    e1.next = e2
+    e2
+  }
+
+  def apply[V,F](verts: Seq[V], f: F) = {
+    val n = verts.length
+    val inner = verts.map { v => new HalfEdgeRef[V,F](v, null, null, Some(f)) }
+    val outer = verts.map { v => new HalfEdgeRef[V,F](v, null, null, None) }
+
+    foreachWithIndex(inner){
+      (e,i) => {
+        e.next = inner((i+1) % n)
+        e.flip = outer((i-1+n) % n)
+      }
+    }
+    foreachWithIndex(outer){
+      (e,i) => {
+        e.next = outer((i-1+n) % n)
+        e.flip = inner((i+1) % n)
+      }
+    }
+
+    outer(0)
+  }
+
+  def showBoundingLoop[V,F](base: HalfEdgeRef[V,F]): Unit = {
+    var e = base
+    var l: List[HalfEdgeRef[V,F]] = Nil
+
+    while (!l.contains(e)) {
+      l = l :+ e
+      print(s"$e ")
+      e = e.next
+    }
+    println("")
+  }
+
+  def toPolygon[V,T](base: HalfEdgeRef[V,T])(implicit trans: V => Point): Polygon = {
+    var e = base
+    var pts: List[Point] = Nil
+
+    do {
+      pts = pts :+ trans(e.vert)
+      e = e.next
+    } while (e != base)
+
+    Polygon(Line(pts).closed)
+  }
+}

--- a/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeRefNavigation.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeRefNavigation.scala
@@ -1,0 +1,25 @@
+package geotrellis.vector.mesh
+
+class HalfEdgeRefNavigation[V, F] extends HalfEdgeNavigation[HalfEdgeRef[V, F], V, F] {
+
+  type HE = HalfEdgeRef[V, F]
+
+  def getDest(edge: HE): V = edge.vert
+  def setDest(edge: HE, dest: V): Unit = edge.vert = dest
+
+  def getNext(edge: HE): HE = edge.next
+  def setNext(edge: HE, next: HE): Unit = edge.next = next
+
+  def getFlip(edge: HE): HE = edge.flip
+  def setFlip(edge: HE, flip: HE): Unit = edge.flip = flip
+
+  def getFaceInfo(edge: HE): Option[F] = edge.face
+  def setFaceInfo(edge: HE, info: Option[F]): Unit = edge.face = info
+
+  def createHalfEdge(v: V): HE = new HalfEdgeRef(v, null, null, None)
+  override def createHalfEdge(v: V, flip: HE, next: HE): HE = new HalfEdgeRef(v, flip, next, None)
+}
+
+object HalfEdgeRefNavigation {
+  def apply[V, F]() = new HalfEdgeRefNavigation
+}

--- a/vector/src/main/scala/geotrellis/vector/mesh/Point3D.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/Point3D.scala
@@ -1,0 +1,21 @@
+package geotrellis.vector.mesh
+
+import geotrellis.vector.{Extent, Point}
+
+case class Point3D(x: Double, y: Double, z: Double = 0.0) {
+  def normalized(e: Extent): Point3D =
+    Point3D(
+      (x - e.xmin) / e.width,
+      (y - e.ymin) / e.height,
+      z
+    )
+
+  def distance2D(other: Point3D): Double = {
+    val dx = other.x - x
+    val dy = other.y - y
+    math.sqrt(dx*dx + dy*dy)
+  }
+
+  def toPoint: Point =
+    Point(x, y)
+}

--- a/vector/src/main/scala/geotrellis/vector/mesh/PointSet.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/PointSet.scala
@@ -1,0 +1,9 @@
+package geotrellis.vector.mesh
+
+trait PointSet[V] {
+  def length: Int
+  def getX(i: V): Double
+  def getY(i: V): Double
+  def getZ(i: V): Double
+  def getPoint(i: V): Point3D
+}


### PR DESCRIPTION
This PR aims to reinstate a previous incarnation of the Delaunay triangulator that was mothballed due to issues of correctness to provide an alternative to the JTS-backed triangulator.  This version uses a half-edge mesh structure and a divide-and-conquer approach to deliver speedy execution, while robust numerical predicates are provided to fix earlier correctness issues.

The significant parts of this implementation are a new HalfEdge structure, the triangulation logic, and the tools to distribute triangulation tasks via Spark.  The HalfEdge structure needed to be rewritten to accommodate a fast, table-based implementation that would be easily Kryo serialized, and a more general HalfEdge representation that could be used in the merge step of a Spark implementation.  The triangulation logic needed to be properly broken out to allow for the best reuse of complicated and hard-to-debug code.  The Spark implementation relies on spatially partitioning the input set, performing a standard triangulation at each step, extracting a bounding mesh (only taking the triangles that can be affected by point additions outside of the corresponding spatial region), shipping those bounding meshes to neighboring nodes, and creating stitched patches that describe the interstices between the patchwork of individual triangulations.

- [x] New HalfEdge structures
- [ ] Base triangulator
- [ ] Spark triangulation

Signed-off-by: Justin Polchlopek <jpolchlopek@azavea.com>