### PR TITLE
Removed pgp plugin.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,6 @@ resolvers ++= Seq(
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")
-
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")


### PR DESCRIPTION
The PGP plugin works better as a globally installed plugin, and if you have the proper 1.0 version installed, you get SBT errors about the conflicting versions of plugins. This removes it, with the thought that if you are publishing signed JARs of GeoTrellis, you should have `sbt-plugin` installed globally.