### PR TITLE
Dependencies update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val commonSettings = Seq(
 
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
 
-  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.0" cross CrossVersion.binary),
+  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.3" cross CrossVersion.binary),
   addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
 
   pomExtra := (

--- a/geowave/build.sbt
+++ b/geowave/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   hadoopClient % "provided"
     excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
       ExclusionRule(organization = "javax.servlet")),
-  "org.geoserver" % "gs-wms" % "2.10.0"
+  "org.geoserver" % "gs-wms" % "2.10.1"
     excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
       ExclusionRule(organization = "javax.servlet")),
   "org.geotools" % "gt-coverage" % Version.geotools % "provided"
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
   "org.geotools" % "gt-referencing" % Version.geotools % "provided"
     excludeAll(ExclusionRule(organization = "org.mortbay.jetty"),
       ExclusionRule(organization = "javax.servlet")),
-  "com.jsuereth" %% "scala-arm" % "1.4",
+  "com.jsuereth" %% "scala-arm" % "2.0",
   "de.javakaffee" % "kryo-serializers" % "0.38" exclude("com.esotericsoftware", "kryo"),
   "com.esotericsoftware" % "kryo-shaded" % "3.0.3",
   sparkCore % "provided",

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 name := "geotrellis-macros"
 
-sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genMacro)
+sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.genMacro).taskValue
 
 libraryDependencies ++= Seq(
   "org.spire-math" %% "spire-macros" % "0.11.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   val akkaActor     = "com.typesafe.akka" %% "akka-actor"   % Version.akka
   val akkaCluster   = "com.typesafe.akka" %% "akka-cluster" % Version.akka
 
-  val spire         = "org.spire-math" %% "spire" % "0.11.0"
+  val spire         = "org.spire-math" %% "spire" % "0.13.0"
 
   val sprayJson     = "io.spray"        %% "spray-json"    % Version.sprayJson
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ import sbt._
 object Dependencies {
   val typesafeConfig = "com.typesafe"        % "config"           % "1.3.1"
   val logging       = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
-  val scalatest     = "org.scalatest"       %%  "scalatest"      % "3.0.0"
-  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.13.2"
+  val scalatest     = "org.scalatest"       %%  "scalatest"      % "3.0.1"
+  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.13.4"
   val jts           = "com.vividsolutions"  %  "jts-core"        % "1.14.0"
 
   val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"    % Version.monocle
@@ -41,7 +41,7 @@ object Dependencies {
 
   val jettyWebapp   = "org.eclipse.jetty" % "jetty-webapp" % "9.4.0.M1"
   val jerseyBundle  = "com.sun.jersey"    % "jersey-bundle" % "1.19.2"
-  val slf4jApi      = "org.slf4j"         % "slf4j-api" % "1.7.21"
+  val slf4jApi      = "org.slf4j"         % "slf4j-api" % "1.7.22"
   val asm           = "asm"               % "asm"       % "3.3.1"
 
   val slick         = "com.typesafe.slick" %% "slick"      % "3.1.1"
@@ -50,18 +50,18 @@ object Dependencies {
   val caliper       = ("com.google.code.caliper" % "caliper" % "1.0-SNAPSHOT"
     from "http://plastic-idolatry.com/jars/caliper-1.0-SNAPSHOT.jar")
 
-  val chronoscala   = "jp.ne.opt" %% "chronoscala" % "0.0.4"
+  val chronoscala   = "jp.ne.opt" %% "chronoscala" % "0.1.0"
 
-  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.37"
+  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.70"
 
-  val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.8.2a"
+  val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a"
 
   val sparkCore     = "org.apache.spark" %% "spark-core" % Version.spark
   val hadoopClient  = "org.apache.hadoop" % "hadoop-client" % Version.hadoop
 
   val avro          = "org.apache.avro" % "avro" % "1.8.1"
 
-  val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.14.3"
+  val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.14.4"
 
-  val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
+  val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
 }

--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -21,6 +21,6 @@ object Environment {
     Properties.envOrElse(environmentVariable, default)
 
   lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.7.3")
-  lazy val sparkVersion   = either("SPARK_VERSION", "2.0.1")
+  lazy val sparkVersion   = either("SPARK_VERSION", "2.0.2")
   lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -17,15 +17,15 @@
 object Version {
   val geotrellis  = "1.0.0" + Environment.versionSuffix
   val scala       = "2.11.8"
-  val geotools    = "16.0"
-  val akka        = "2.4.10"
+  val geotools    = "16.1"
+  val akka        = "2.4.16"
   val spray       = "1.3.3"
   val sprayJson   = "1.3.2"
-  val monocle     = "1.2.2"
+  val monocle     = "1.4.0-M1"
   val accumulo    = "1.7.2"
-  val cassandra   = "3.1.0"
+  val cassandra   = "3.1.2"
   val hbase       = "1.2.4"
-  val geomesa     = "1.2.7"
+  val geomesa     = "1.2.7.2"
   lazy val hadoop = Environment.hadoopVersion
   lazy val spark  = Environment.sparkVersion
 }

--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies := {
     // if scala 2.11+ is used, add dependency on scala-xml module
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.5"
+        "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
       )
     case _ =>
       libraryDependencies.value
@@ -26,7 +26,7 @@ libraryDependencies := {
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 scalacOptions ++= Seq("-optimize", "-language:experimental.macros")
-sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genRaster)
+sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.genRaster).taskValue
 
 initialCommands in console :=
   """

--- a/vectortile/build.sbt
+++ b/vectortile/build.sbt
@@ -4,5 +4,5 @@ name := "geotrellis-vectortile"
 
 libraryDependencies ++= Seq(
   scalatest % "test",
-  "com.trueaccord.scalapb" %% "scalapb-runtime" % "0.5.32"
+  "com.trueaccord.scalapb" %% "scalapb-runtime" % "0.5.46"
 )


### PR DESCRIPTION
Everything is updated up to latest version, except Accumulo, as Accumulo update can break compatibility with old Accumulo versions. And didn't touch `kryo` in the geowave project, as it may cause serialization issues.

```
geotrellis > dependencyUpdates
[info] No dependency updates found for geotrellis-vector
[info] No dependency updates found for geotrellis-raster
[info] No dependency updates found for geotrellis-vectortile
[info] Found 1 dependency update for geotrellis-spark
[info]   org.scalaz.stream:scalaz-stream : 0.8.6a -> 0.8.6
[info] No dependency updates found for geotrellis-geotools
[info] No dependency updates found for geotrellis-spark-etl
[info] No dependency updates found for geotrellis-raster-test
[info] No dependency updates found for geotrellis-s3
[info] No dependency updates found for geotrellis-slick
[info] No dependency updates found for geotrellis
[info] No dependency updates found for geotrellis-cassandra
[info] Found 1 dependency update for geotrellis-accumulo
[info]   org.apache.accumulo:accumulo-core : 1.7.2 -> 1.8.0
[info] No dependency updates found for geotrellis-hbase
[info] No dependency updates found for geotrellis-vector-test
[info] No dependency updates found for geotrellis-proj4
[info] Found 3 dependency updates for geotrellis-geowave
[info]   com.esotericsoftware:kryo-shaded  : 3.0.3          -> 4.0.0
[info]   de.javakaffee:kryo-serializers    : 0.38  -> 0.41          
[info]   org.apache.accumulo:accumulo-core : 1.7.2 -> 1.8.0         
[info] No dependency updates found for geotrellis-geomesa
```

Signed-off-by: Grigory Pomadchin <gr.pomadchin@gmail.com>