### PR TITLE
[WIP] Local add on Datasets

### DIFF
--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -8,5 +8,6 @@
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project s3-test" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project s3-testkit" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project spark-etl" compile  || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project spark-sql" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project slick" test || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project vectortile" test || { exit 1; }

--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,7 @@ lazy val root = Project("geotrellis", file(".")).
     proj4,
     spark,
     sparkEtl,
+    sparkSql,
     s3,
     accumulo,
     cassandra,
@@ -175,6 +176,10 @@ lazy val hbase = Project("hbase", file("hbase")).
 
 lazy val sparkEtl = Project(id = "spark-etl", base = file("spark-etl")).
   dependsOn(spark, s3, accumulo, cassandra, hbase).
+  settings(commonSettings: _*)
+
+lazy val sparkSql = Project("spark-sql", file("spark-sql")).
+  dependsOn(sparkTestkit % "test->test", spark % "provided;test->test").
   settings(commonSettings: _*)
 
 lazy val geotools = Project("geotools", file("geotools")).

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,6 +57,7 @@ object Dependencies {
   val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.8.2a"
 
   val sparkCore     = "org.apache.spark" %% "spark-core" % Version.spark
+  val sparkSql      = "org.apache.spark" %% "spark-sql" % Version.spark
   val hadoopClient  = "org.apache.hadoop" % "hadoop-client" % Version.hadoop
 
   val avro          = "org.apache.avro" % "avro" % "1.8.1"

--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -17,6 +17,7 @@ HOSTALIASES=/tmp/hostaliases ./sbt -J-Xmx2G "project geowave" test || { exit 1; 
 ./sbt -J-Xmx2G "project slick" test:compile || { exit 1; }
 ./sbt -J-Xmx2G "project spark" test  || { exit 1; }
 ./sbt -J-Xmx2G "project spark-etl" compile  || { exit 1; }
+./sbt -J-Xmx2G "project spark-sql" compile  || { exit 1; }
 ./sbt -J-Xmx2G "project spark-testkit" compile || { exit 1; }
 ./sbt -J-Xmx2G "project util" compile || { exit 1; }
 ./sbt -J-Xmx2G "project vector-test" test || { exit 1; }

--- a/scripts/cleanall.sh
+++ b/scripts/cleanall.sh
@@ -13,6 +13,7 @@
 ./sbt -J-Xmx2G "project shapefile" clean || { exit 1; }
 ./sbt -J-Xmx2G "project slick" clean || { exit 1; }
 ./sbt -J-Xmx2G "project spark" clean  || { exit 1; }
+./sbt -J-Xmx2G "project spark-sql" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project util" clean || { exit 1; }
 ./sbt -J-Xmx2G "project vector-test" clean || { exit 1; }
 ./sbt -J-Xmx2G "project vectortile" clean || { exit 1; }
@@ -35,6 +36,7 @@ rm -r shapefile/target
 rm -r slick/target
 rm -r spark-testkit/target
 rm -r spark/target
+rm -r spark-sql/target
 rm -r util/target
 rm -r vector-test/target
 rm -r vector-testkit/target

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -13,6 +13,7 @@
 ./sbt "project vectortile" publish-local && \
 ./sbt "project slick" publish-local && \
 ./sbt "project spark" publish-local && \
+./sbt "project spark-sql" publish-local && \
 ./sbt "project spark-testkit" publish-local && \
 ./sbt "project shapefile" publish-local && \
 ./sbt "project spark-etl" publish-local && \

--- a/scripts/publish-m2.sh
+++ b/scripts/publish-m2.sh
@@ -15,6 +15,7 @@
       "project shapefile" +publish-m2 \
       "project slick" +publish-m2 \
       "project spark" +publish-m2 \
+      "project spark-sql" +publish-m2 \
       "project spark-etl" +publish-m2 \
       "project spark-testkit" +publish-m2 \
       "project util" +publish-m2 \

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -17,6 +17,7 @@
       "project hbase" publish \
       "project shapefile" publish \
       "project spark" publish \
+      "project spark-sql" +publish-m2 \
       "project spark-testkit" publish \
       "project util" publish \
       "project vector" publish \

--- a/spark-sql/build.sbt
+++ b/spark-sql/build.sbt
@@ -1,0 +1,17 @@
+import Dependencies._
+
+name := "geotrellis-spark-sql"
+libraryDependencies ++= Seq(
+  sparkSql,
+  scalatest % "test"
+)
+
+initialCommands in console :=
+  """
+  import geotrellis.raster._
+  import geotrellis.vector._
+  import geotrellis.proj4._
+  import geotrellis.spark._
+  import geotrellis.spark.util._
+  import geotrellis.spark.tiling._
+  """

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/KryoEncoderImplicits.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/KryoEncoderImplicits.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql
+
+import org.apache.spark.sql.{Encoder, Encoders}
+
+import scala.reflect.{ClassTag, classTag}
+
+object KryoEncoderImplicits extends KryoEncoderImplicits
+
+/**
+  * Kryo required for typed Datasets support, probably we would find other workarounds
+  */
+trait KryoEncoderImplicits {
+  implicit def single[A: ClassTag] = Encoders.kryo[A](classTag[A])
+
+  implicit def tuple2[A1: Encoder, A2: Encoder]: Encoder[(A1, A2)] =
+    Encoders.tuple[A1, A2](implicitly[Encoder[A1]], implicitly[Encoder[A2]])
+
+  implicit def tuple3[A1: Encoder, A2: Encoder, A3: Encoder]: Encoder[(A1, A2, A3)] =
+    Encoders.tuple[A1, A2, A3](implicitly[Encoder[A1]], implicitly[Encoder[A2]], implicitly[Encoder[A3]])
+
+  implicit def tuple4[A1: Encoder, A2: Encoder, A3: Encoder, A4: Encoder]: Encoder[(A1, A2, A3, A4)] =
+    Encoders.tuple[A1, A2, A3, A4](implicitly[Encoder[A1]], implicitly[Encoder[A2]], implicitly[Encoder[A3]], implicitly[Encoder[A4]])
+
+  implicit def tuple5[A1: Encoder, A2: Encoder, A3: Encoder, A4: Encoder, A5: Encoder]: Encoder[(A1, A2, A3, A4, A5)] =
+    Encoders.tuple[A1, A2, A3, A4, A5](implicitly[Encoder[A1]], implicitly[Encoder[A2]], implicitly[Encoder[A3]], implicitly[Encoder[A4]], implicitly[Encoder[A5]])
+}

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/DatasetCombineMethods.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/DatasetCombineMethods.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql.mapalgebra
+
+import geotrellis.spark.sql.KryoEncoderImplicits
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.sql.Dataset
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+// strong restriction on K type, to have possibilty to join by key
+abstract class DatasetCombineMethods[K <: Product: TypeTag: ClassTag, V: ClassTag] extends MethodExtensions[Dataset[(K, V)]] with KryoEncoderImplicits {
+  val ss = self.sparkSession
+  import ss.implicits._
+
+  // Tried to use this join, but that's impossible due to wrong compared binary blobs of type K
+  def combineValues[R: ClassTag](other: Dataset[(K, V)])(f: (V, V) => R): Dataset[(K, R)] =
+    self.join(other, "_1").as[(K, V, V)].map { case (key, tile1, tile2) => key -> f(tile1, tile2) }
+
+  /**
+    * Instead of the function above can be used this, that may allow us to remove constrain on K
+    * to be a subtype of Product
+    *
+    * def combineValues[R: ClassTag](other: Dataset[(K, V)])(f: (V, V) => R): Dataset[(K, R)] =
+    *   self.rdd.combineValues(other.rdd)(f).toDS()
+    */
+
+  def combineValues[R: ClassTag](others: Traversable[Dataset[(K, V)]])(f: Iterable[V] => R): Dataset[(K, R)] =
+    (self :: others.toList).reduce(_ union _).groupByKey({ case (k, _) => k }).mapGroups({ case (k, v) => k -> f(v.map(_._2).toIterable)})
+
+  /**
+    * def combineValues[R: ClassTag](others: Traversable[Dataset[(K, V)]])(f: Iterable[V] => R): Dataset[(K, R)] =
+    * (self :: others.toList).reduce(_ union _).rdd.groupByKey().toDS().mapValues(f)
+    */
+
+  def mapValues[U: ClassTag](f: V => U): Dataset[(K, U)] = self.map { case (k, v) => k -> f(v) }
+}

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/Implicits.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/Implicits.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql.mapalgebra
+
+import geotrellis.spark.sql.KryoEncoderImplicits
+import geotrellis.util.MethodExtensions
+
+import org.apache.spark.sql.Dataset
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+object Implicits extends Implicits
+
+trait Implicits {
+  implicit class withDatasetCombineMethods[K <: Product: TypeTag: ClassTag, V: ClassTag](val self: Dataset[(K, V)])
+    extends DatasetCombineMethods[K, V]
+
+  implicit class withDatasetMapValuesTupleMethods[K <: Product: TypeTag: ClassTag, V: ClassTag](val self: Dataset[(K, (V, V))]) extends MethodExtensions[Dataset[(K, (V, V))]] with KryoEncoderImplicits {
+    def combineValues[R: ClassTag](f: (V, V) => R): Dataset[(K, R)] =
+      self.mapValues { case (v1, v2) => f(v1, v2) }
+  }
+
+  implicit class withDatasetMapValuesOptionMethods[K <: Product: TypeTag: ClassTag, V: ClassTag](val self: Dataset[(K, (V, Option[V]))]) extends MethodExtensions[Dataset[(K, (V, Option[V]))]] with KryoEncoderImplicits {
+    def updateValues(f: (V, V) => V): Dataset[(K, V)] =
+      self.mapValues { case (v1, ov2) =>
+        ov2 match {
+          case Some(v2) => f(v1, v2)
+          case None => v1
+        }
+      }
+  }
+}

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/TileDatasetMethods.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/TileDatasetMethods.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql.mapalgebra
+
+import geotrellis.raster.Tile
+import geotrellis.util.MethodExtensions
+import org.apache.spark.sql.Dataset
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+trait TileDatasetMethods[K] extends MethodExtensions[Dataset[(K, Tile)]] {
+  implicit val keyTypeTag: TypeTag[K]
+  implicit val keyClassTag: ClassTag[K]
+}
+

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/local/AddTileDatasetMethods.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/local/AddTileDatasetMethods.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql.mapalgebra.local
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.local.Add
+import geotrellis.spark.sql._
+import geotrellis.spark.sql.mapalgebra.TileDatasetMethods
+
+import org.apache.spark.sql.Dataset
+
+trait AddTileDatasetMethods[K <: Product] extends TileDatasetMethods[K] {
+  /** Add a constant Int value to each cell. */
+  def localAdd(i: Int) = self.mapValues { r => Add(r, i) }
+
+  /** Add a constant Int value to each cell. */
+  def +(i: Int) = localAdd(i)
+
+  /** Add a constant Int value to each cell. */
+  def +:(i: Int) = localAdd(i)
+
+  /** Add a constant Double value to each cell. */
+  def localAdd(d: Double) = self.mapValues { r => Add(r, d) }
+
+  /** Add a constant Double value to each cell. */
+  def +(d: Double) = localAdd(d)
+
+  /** Add a constant Double value to each cell. */
+  def +:(d: Double) = localAdd(d)
+
+  /** Add the values of each cell in each raster.  */
+  def localAdd(other: Dataset[(K, Tile)]): Dataset[(K, Tile)] = self.combineValues(other) { Add.apply }
+
+  /** Add the values of each cell in each raster. */
+  def +(other: Dataset[(K, Tile)]): Dataset[(K, Tile)] = localAdd(other)
+
+  def localAdd(others: Traversable[Dataset[(K, Tile)]]): Dataset[(K, Tile)] = self.combineValues(others) { Add.apply }
+
+  def +(others: Traversable[Dataset[(K, Tile)]]): Dataset[(K, Tile)] = localAdd(others)
+}

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/local/Implicits.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/local/Implicits.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql.mapalgebra.local
+
+import geotrellis.raster._
+import geotrellis.spark._
+import org.apache.spark.sql.Dataset
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+object Implicits extends Implicits
+
+trait Implicits {
+  implicit class withLocalTileDatasetMethods[K <: Product](val self: Dataset[(K, Tile)])
+    (implicit val keyClassTag: ClassTag[K], val keyTypeTag: TypeTag[K]) extends LocalTileDatasetMethods[K]
+
+  implicit class withLocalTileDatasetSeqMethods[K <: Product](val self: Traversable[Dataset[(K, Tile)]])
+    (implicit val keyClassTag: ClassTag[K], val keyTypeTag: TypeTag[K]) extends LocalTileDatasetSeqMethods[K]
+}

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/local/LocalTileDatasetMethods.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/local/LocalTileDatasetMethods.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql.mapalgebra.local
+
+trait LocalTileDatasetMethods[K <: Product] extends AddTileDatasetMethods[K]

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/local/LocalTileDatasetSeqMethods.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/mapalgebra/local/LocalTileDatasetSeqMethods.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql.mapalgebra.local
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.local._
+import geotrellis.spark.sql._
+import geotrellis.util.MethodExtensions
+import org.apache.spark.sql.Dataset
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+abstract class LocalTileDatasetSeqMethods[K <: Product: TypeTag: ClassTag] extends MethodExtensions[Traversable[Dataset[(K, Tile)]]] {
+
+  private def r(f: Traversable[Tile] => (Tile)): Dataset[(K, Tile)] =
+    self match {
+      case Seq() => sys.error("raster rdd operations can't be applied to empty seq!")
+      case Seq(ds) => ds
+      case _ => self.head.combineValues(self.tail)(f)
+    }
+
+  def localAdd: Dataset[(K, Tile)] = r ({ Add.apply })
+
+  /** Gives the count of unique values at each location in a set of Tiles.*/
+  def localVariety: Dataset[(K, Tile)] = r ({ Variety.apply })
+
+  /** Takes the mean of the values of each cell in the set of rasters. */
+  def localMean: Dataset[(K, Tile)] = r ({ Mean.apply })
+
+  def localMin: Dataset[(K, Tile)] = r ({ Min.apply })
+
+  def localMinN(n: Int): Dataset[(K, Tile)] = r ({ MinN(n, _) })
+
+  def localMax: Dataset[(K, Tile)] = r ({ Max.apply })
+
+  def localMaxN(n: Int): Dataset[(K, Tile)] = r ({ MaxN(n, _) })
+
+  def localMinority(n: Int = 0) = r ({ Minority(n, _) })
+
+  def localMajority(n: Int = 0) = r ({ Majority(n, _) })
+}

--- a/spark-sql/src/main/scala/geotrellis/spark/sql/package.scala
+++ b/spark-sql/src/main/scala/geotrellis/spark/sql/package.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark
+
+package object sql extends mapalgebra.local.Implicits with mapalgebra.Implicits

--- a/spark-sql/src/test/scala/geotrellis/spark/sql/SqlTestEnvironment.scala
+++ b/spark-sql/src/test/scala/geotrellis/spark/sql/SqlTestEnvironment.scala
@@ -1,0 +1,14 @@
+package geotrellis.spark.sql
+
+import geotrellis.spark.TestEnvironment
+import org.apache.spark.sql.SparkSession
+import org.scalatest.Suite
+
+trait SqlTestEnvironment extends TestEnvironment with KryoEncoderImplicits { self: Suite =>
+  lazy val ssc: SparkSession =
+    SparkSession
+      .builder()
+      .master(_sc.master) // to be sure that spark context was initiated
+      .appName("Test SQL Context")
+      .getOrCreate()
+}

--- a/spark-sql/src/test/scala/geotrellis/spark/sql/mapalgebra/local/AddSpec.scala
+++ b/spark-sql/src/test/scala/geotrellis/spark/sql/mapalgebra/local/AddSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.sql.mapalgebra.local
+
+import geotrellis.spark._
+import geotrellis.spark.sql._
+import geotrellis.spark.testfiles._
+import org.scalatest.FunSpec
+
+class AddSpec extends FunSpec with SqlTestEnvironment with TestFiles {
+
+  describe("Add Operation on Datasets") {
+    import ssc.implicits._
+
+    val ones = AllOnesTestFile
+    val onesST = AllOnesSpaceTime
+
+    val onesDS = AllOnesTestFile.toDS()
+    val onesSTDS = AllOnesSpaceTime.toDS()
+
+    it("should add a constant to a raster") {
+      val twos = (onesDS + 1).rdd
+
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(ones, twos)
+    }
+
+    it("should add a constant to a spacetime raster") {
+      val twos = (onesSTDS + 1).rdd
+
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(onesST, twos)
+    }
+
+    it("should add a raster to a constant") {
+      val twos = (1 +: onesDS).rdd
+
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(ones, twos)
+    }
+
+    it("should add a spacetime raster to a constant") {
+      val twos = (1 +: onesSTDS).rdd
+
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(onesST, twos)
+    }
+
+    it("should add multiple rasters") {
+      val threes = ((onesDS + onesDS).rdd.toDS() + onesDS).rdd // Datasets serialization issues(?)
+
+      rasterShouldBe(threes, (3, 3))
+      rastersShouldHaveSameIdsAndTileCount(ones, threes)
+    }
+
+    it("should add multiple spacetime rasters") {
+      val twos = (onesSTDS + onesSTDS).rdd
+
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(onesST, twos)
+    }
+
+    it("should add multiple rasters as a seq") {
+      val threes = (onesDS + Array(onesDS, onesDS)).rdd
+
+      rasterShouldBe(threes, (3, 3))
+      rastersShouldHaveSameIdsAndTileCount(ones, threes)
+    }
+
+    it("should add multiple spacetime rasters as a seq") {
+      val twos = (onesSTDS + Array(onesSTDS)).rdd
+
+      rasterShouldBe(twos, (2, 2))
+      rastersShouldHaveSameIdsAndTileCount(onesST, twos)
+    }
+  }
+}


### PR DESCRIPTION
Replaces https://github.com/locationtech/geotrellis/pull/1675

- [x] Local Add implementation (still arguably)
- [x] Tests coverage
- [x] Test on Landsat EMR demo and compare results
- [x] Join by SpatialKey ([issue / feature](https://travis-ci.org/geotrellis/geotrellis/builds/169236176))

This implementations requires Kryo usage, and `DatasetCombineMethods` are still in development progress and can be modified.

Small RDD vs Dataset comparison:
### RDD vs Dataset, SpaceTime key
``` scala
// self localadd, count operation
(ds + ds).count()
(rdd + rdd).count()
```
- RDD / Dataset
- objects number: 9
- iteration: 1
- time: 8,578 ms / 28,700 ms
- RDD / Dataset
- objects number: 9
- iteration: 10
- time: 438 ms / 1,492 ms
- RDD / Dataset
- objects number: 655
- iteration: 1
- time: 32,663 ms / 52,722 ms
- RDD
- objects number: 655
- iteration: 10
- time: 26,319 ms / 31,112 ms

Signed-off-by: Grigory Pomadchin <gr.pomadchin@gmail.com>