### PR TITLE
Avro Schema Creation for ProjectedExtent and TemporalProjectedExtent

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ExtentCodec.scala
@@ -16,8 +16,6 @@
 
 package geotrellis.spark.io.avro.codecs
 
-import geotrellis.proj4.CRS
-import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.vector._
 
@@ -26,7 +24,7 @@ import org.apache.avro.generic._
 
 // --- //
 
-trait ExtentCodecs {
+trait ExtentCodec {
   implicit def extentCodec = new AvroRecordCodec[Extent] {
     def schema: Schema = SchemaBuilder
       .record("Extent").namespace("geotrellis.spark")
@@ -53,55 +51,5 @@ trait ExtentCodecs {
       )
     }
   }
-
-  implicit def projectedExtentCodec = new AvroRecordCodec[ProjectedExtent] {
-    def schema: Schema = SchemaBuilder
-      .record("ProjectedExtent").namespace("geotrellis.spark")
-      .fields()
-      .name("extent").`type`(extentCodec.schema).noDefault()
-      .name("wkt").`type`().stringType().noDefault()
-      .endRecord()
-
-    def encode(projectedExtent: ProjectedExtent, rec: GenericRecord): Unit = {
-      rec.put("extent", projectedExtent.extent)
-      rec.put("wkt", projectedExtent.crs)
-    }
-
-    def decode(rec: GenericRecord): ProjectedExtent = {
-      val wktString = rec[String]("crs")
-      val crs = CRS.fromWKT(wktString)
-
-      val extent = extentCodec.decode(rec("extent"))
-
-      ProjectedExtent(extent, crs)
-    }
-  }
-
-  implicit def temporalProjectedExtentCodec = new AvroRecordCodec[TemporalProjectedExtent] {
-    def schema: Schema = SchemaBuilder
-      .record("TemporalProjectedExtent").namespace("geotrellis.spark")
-      .fields()
-      .name("extent").`type`(extentCodec.schema).noDefault()
-      .name("wkt").`type`().stringType().noDefault()
-      .name("instant").`type`().longType().noDefault()
-      .endRecord()
-
-    def encode(temporalProjectedExtent: TemporalProjectedExtent, rec: GenericRecord): Unit = {
-      rec.put("extent", temporalProjectedExtent.extent)
-      rec.put("wkt", temporalProjectedExtent.crs)
-      rec.put("instant", temporalProjectedExtent.instant)
-    }
-
-    def decode(rec: GenericRecord): TemporalProjectedExtent = {
-      val instant = rec[Long]("instant")
-      val wktString = rec[String]("wkt")
-      val crs = CRS.fromWKT(wktString)
-
-      val extent = extentCodec.decode(rec("extent"))
-
-      TemporalProjectedExtent(extent, crs, instant)
-    }
-  }
 }
 
-object ExtentCodecs extends ExtentCodecs

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ExtentCodec.scala
@@ -16,15 +16,17 @@
 
 package geotrellis.spark.io.avro.codecs
 
+import geotrellis.proj4.CRS
+import geotrellis.spark._
 import geotrellis.spark.io.avro._
-import geotrellis.vector.Extent
+import geotrellis.vector._
 
 import org.apache.avro._
 import org.apache.avro.generic._
 
 // --- //
 
-trait ExtentCodec {
+trait ExtentCodecs {
   implicit def extentCodec = new AvroRecordCodec[Extent] {
     def schema: Schema = SchemaBuilder
       .record("Extent").namespace("geotrellis.spark")
@@ -51,4 +53,55 @@ trait ExtentCodec {
       )
     }
   }
+
+  implicit def projectedExtentCodec = new AvroRecordCodec[ProjectedExtent] {
+    def schema: Schema = SchemaBuilder
+      .record("ProjectedExtent").namespace("geotrellis.spark")
+      .fields()
+      .name("extent").`type`(extentCodec.schema).noDefault()
+      .name("wkt").`type`().stringType().noDefault()
+      .endRecord()
+
+    def encode(projectedExtent: ProjectedExtent, rec: GenericRecord): Unit = {
+      rec.put("extent", projectedExtent.extent)
+      rec.put("wkt", projectedExtent.crs)
+    }
+
+    def decode(rec: GenericRecord): ProjectedExtent = {
+      val wktString = rec[String]("crs")
+      val crs = CRS.fromWKT(wktString)
+
+      val extent = extentCodec.decode(rec("extent"))
+
+      ProjectedExtent(extent, crs)
+    }
+  }
+
+  implicit def temporalProjectedExtentCodec = new AvroRecordCodec[TemporalProjectedExtent] {
+    def schema: Schema = SchemaBuilder
+      .record("TemporalProjectedExtent").namespace("geotrellis.spark")
+      .fields()
+      .name("extent").`type`(extentCodec.schema).noDefault()
+      .name("wkt").`type`().stringType().noDefault()
+      .name("instant").`type`().longType().noDefault()
+      .endRecord()
+
+    def encode(temporalProjectedExtent: TemporalProjectedExtent, rec: GenericRecord): Unit = {
+      rec.put("extent", temporalProjectedExtent.extent)
+      rec.put("wkt", temporalProjectedExtent.crs)
+      rec.put("instant", temporalProjectedExtent.instant)
+    }
+
+    def decode(rec: GenericRecord): TemporalProjectedExtent = {
+      val instant = rec[Long]("instant")
+      val wktString = rec[String]("wkt")
+      val crs = CRS.fromWKT(wktString)
+
+      val extent = extentCodec.decode(rec("extent"))
+
+      TemporalProjectedExtent(extent, crs, instant)
+    }
+  }
 }
+
+object ExtentCodecs extends ExtentCodecs

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ExtentCodec.scala
@@ -52,4 +52,3 @@ trait ExtentCodec {
     }
   }
 }
-

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ExtentCodec.scala
@@ -17,7 +17,7 @@
 package geotrellis.spark.io.avro.codecs
 
 import geotrellis.spark.io.avro._
-import geotrellis.vector._
+import geotrellis.vector.Extent
 
 import org.apache.avro._
 import org.apache.avro.generic._

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/Implicits.scala
@@ -25,7 +25,9 @@ trait Implicits
     extends TileCodecs
     with TileFeatureCodec
     with VectorTileCodec
-    with ExtentCodecs
+    with ExtentCodec
+    with ProjectedExtentCodec
+    with TemporalProjectedExtentCodec
     with KeyCodecs {
   implicit def tileUnionCodec = new AvroUnionCodec[Tile](
     byteArrayTileCodec,

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/Implicits.scala
@@ -25,7 +25,7 @@ trait Implicits
     extends TileCodecs
     with TileFeatureCodec
     with VectorTileCodec
-    with ExtentCodec
+    with ExtentCodecs
     with KeyCodecs {
   implicit def tileUnionCodec = new AvroUnionCodec[Tile](
     byteArrayTileCodec,

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ProjectedExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ProjectedExtentCodec.scala
@@ -1,0 +1,38 @@
+package geotrellis.spark.io.avro.codecs
+
+import geotrellis.proj4.CRS
+import geotrellis.spark._
+import geotrellis.spark.io.avro._
+import geotrellis.spark.io.avro.codecs._
+import geotrellis.spark.io.avro.codecs.Implicits._
+import geotrellis.vector._
+
+import org.apache.avro._
+import org.apache.avro.generic._
+
+// --- //
+
+trait ProjectedExtentCodec {
+  implicit def projectedExtentCodec = new AvroRecordCodec[ProjectedExtent] {
+    def schema: Schema = SchemaBuilder
+      .record("ProjectedExtent").namespace("geotrellis.spark")
+      .fields()
+      .name("extent").`type`(extentCodec.schema).noDefault()
+      .name("epsg").`type`().intType().noDefault()
+      .endRecord()
+
+    def encode(projectedExtent: ProjectedExtent, rec: GenericRecord): Unit = {
+      rec.put("extent", extentCodec.encode(projectedExtent.extent))
+      rec.put("epsg", projectedExtent.crs.epsgCode.get)
+    }
+
+    def decode(rec: GenericRecord): ProjectedExtent = {
+      val epsg = rec[Int]("epsg")
+      val crs = CRS.fromEpsgCode(epsg)
+
+      val extent = extentCodec.decode(rec[GenericRecord]("extent"))
+
+      ProjectedExtent(extent, crs)
+    }
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ProjectedExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ProjectedExtentCodec.scala
@@ -15,7 +15,7 @@ import org.apache.avro.generic._
 trait ProjectedExtentCodec {
   implicit def projectedExtentCodec = new AvroRecordCodec[ProjectedExtent] {
     def schema: Schema = SchemaBuilder
-      .record("ProjectedExtent").namespace("geotrellis.spark")
+      .record("ProjectedExtent").namespace("geotrellis.vector")
       .fields()
       .name("extent").`type`(extentCodec.schema).noDefault()
       .name("epsg").`type`().intType().noDefault()

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/TemporalProjectedExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/TemporalProjectedExtentCodec.scala
@@ -1,0 +1,41 @@
+package geotrellis.spark.io.avro.codecs
+
+import geotrellis.proj4.CRS
+import geotrellis.spark._
+import geotrellis.spark.io.avro._
+import geotrellis.spark.io.avro.codecs._
+import geotrellis.spark.io.avro.codecs.Implicits._
+import geotrellis.vector._
+
+import org.apache.avro._
+import org.apache.avro.generic._
+
+
+trait TemporalProjectedExtentCodec {
+  implicit def temporalProjectedExtentCodec = new AvroRecordCodec[TemporalProjectedExtent] {
+    def schema: Schema = SchemaBuilder
+      .record("TemporalProjectedExtent").namespace("geotrellis.spark")
+      .fields()
+      .name("extent").`type`(extentCodec.schema).noDefault()
+      .name("epsg").`type`().intType().noDefault()
+      .name("instant").`type`().longType().noDefault()
+      .endRecord()
+
+    def encode(temporalProjectedExtent: TemporalProjectedExtent, rec: GenericRecord): Unit = {
+      rec.put("extent", extentCodec.encode(temporalProjectedExtent.extent))
+      rec.put("epsg", temporalProjectedExtent.crs.epsgCode.get)
+      rec.put("instant", temporalProjectedExtent.instant)
+    }
+
+    def decode(rec: GenericRecord): TemporalProjectedExtent = {
+      val instant = rec[Long]("instant")
+      val epsg = rec[Int]("epsg")
+      val crs = CRS.fromEpsgCode(epsg)
+
+      val extent = extentCodec.decode(rec[GenericRecord]("extent"))
+
+      TemporalProjectedExtent(extent, crs, instant)
+    }
+  }
+}
+

--- a/spark/src/test/scala/geotrellis/spark/io/avro/ExtentCodecsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/avro/ExtentCodecsSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.io.avro
+
+import geotrellis.spark.io.avro.codecs._
+import org.scalatest._
+import geotrellis.proj4._
+import geotrellis.vector._
+import geotrellis.spark._
+import geotrellis.spark.io.avro.AvroTools._
+
+class ExtentCodecsSpec extends FunSpec with Matchers with AvroTools  {
+  describe("ExtentCodecs") {
+    it("encodes Extent"){
+      roundTrip(Extent(0, 1, 2, 3))
+    }
+    it("encodes ProjectedExtent") {
+      roundTrip(ProjectedExtent(Extent(0, 1, 2, 3), CRS.fromEpsgCode(4324)))
+    }
+    it("encodes TemporalProjectedExtent"){
+      roundTrip(TemporalProjectedExtent(Extent(0, 1, 2, 3), CRS.fromEpsgCode(4324), 1.toLong))
+    }
+  }
+}


### PR DESCRIPTION
This PR adds two new codecs that can be encode/decoded in GeoTrellis: `ProjectedExtent` and `TemporalProjectedExtent`. The main reason for adding these two codecs is to allow for backend support between GeoTrellis and GeoPySpark.