### PR TITLE
Fixup StitchedDelaunay rasterizer

### DIFF
--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunay.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunay.scala
@@ -90,12 +90,10 @@ case class StitchedDelaunay(
 
   def rasterize(re: RasterExtent, cellType: CellType = DoubleConstantNoDataCellType)(center: DelaunayTriangulation) = {
     DelaunayRasterizer
-      .rasterizeTriangles
-        (re, cellType)
-        (fillTriangles.getTriangles, 
-         DelaunayRasterizer.rasterizeDelaunayTriangulation
-           (re, cellType)
-           (center, ArrayTile.empty(cellType, re.cols, re.rows))
-        )(indexToCoord, edges)
+      .rasterizeTriangles(re, cellType)(fillTriangles.getTriangles, 
+         DelaunayRasterizer.rasterizeDelaunayTriangulation(re, cellType)(
+           center, ArrayTile.empty(cellType, re.cols, re.rows)
+         )
+       )(indexToCoord, edges)
   }
 }

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunay.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunay.scala
@@ -88,8 +88,14 @@ case class StitchedDelaunay(
                            ) {
   def triangles(): Seq[(Int, Int, Int)] = fillTriangles.getTriangles.keys.toSeq
 
-  def rasterize(re: RasterExtent, cellType: CellType = DoubleConstantNoDataCellType)(center: DelaunayTriangulation, tile: MutableArrayTile = ArrayTile.empty(cellType, re.cols, re.rows)) = {
-    DelaunayRasterizer.rasterizeDelaunayTriangulation(re, cellType)(center, tile)
-    DelaunayRasterizer.rasterizeTriangles(re, cellType)(fillTriangles.getTriangles, tile)(indexToCoord, edges)
+  def rasterize(re: RasterExtent, cellType: CellType = DoubleConstantNoDataCellType)(center: DelaunayTriangulation) = {
+    DelaunayRasterizer
+      .rasterizeTriangles
+        (re, cellType)
+        (fillTriangles.getTriangles, 
+         DelaunayRasterizer.rasterizeDelaunayTriangulation
+           (re, cellType)
+           (center, ArrayTile.empty(cellType, re.cols, re.rows))
+        )(indexToCoord, edges)
   }
 }

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/TinToDem.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/TinToDem.scala
@@ -139,9 +139,7 @@ object TinToDem {
               layoutDefinition.tileRows
             )
 
-          //val tile = ArrayTile.empty(options.cellType, re.rows, re.cols)
           val tile = stitched.rasterize(re, options.cellType)(triangulation)
-          //val tile = DelaunayRasterizer.rasterizeDelaunayTriangulation(re, options.cellType)(triangulation)
 
           (key, tile)
         }

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/TinToDem.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/TinToDem.scala
@@ -138,7 +138,10 @@ object TinToDem {
               layoutDefinition.tileCols,
               layoutDefinition.tileRows
             )
+
+          //val tile = ArrayTile.empty(options.cellType, re.rows, re.cols)
           val tile = stitched.rasterize(re, options.cellType)(triangulation)
+          //val tile = DelaunayRasterizer.rasterizeDelaunayTriangulation(re, options.cellType)(triangulation)
 
           (key, tile)
         }

--- a/raster/src/main/scala/geotrellis/raster/triangulation/DelaunayRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/triangulation/DelaunayRasterizer.scala
@@ -77,7 +77,7 @@ object DelaunayRasterizer {
     tile
   }
 
-  def rasterizeDelaunayTriangulation(re: RasterExtent, cellType: CellType = DoubleConstantNoDataCellType)(dt: DelaunayTriangulation, tile: MutableArrayTile = ArrayTile.empty(cellType, re.rows, re.cols)) = {
+  def rasterizeDelaunayTriangulation(re: RasterExtent, cellType: CellType = DoubleConstantNoDataCellType)(dt: DelaunayTriangulation, tile: MutableArrayTile = ArrayTile.empty(cellType, re.cols, re.rows)) = {
     implicit val trans = dt.verts.getCoordinate(_)
     implicit val nav = dt.navigator
     rasterizeTriangles(re, cellType)(dt.triangles.getTriangles)

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayStitcher.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayStitcher.scala
@@ -41,8 +41,8 @@ object DelaunayStitcher {
     import het._
     import Predicates._
 
-    var left = left0
-    var right = right0
+    var left = advanceIfNotCorner(left0)
+    var right = advanceIfNotCorner(right0)
 
     // if (isLeftLinear && isRightLinear) {
     //   // In the linear case, in the event of a linear result, we want to make 


### PR DESCRIPTION
There was an error in StitchedDelauay.rasterize() that resulted in only stitch triangles being displayed.  This is now fixed.