### PR TITLE
AvroSerialization Now Uses Proj4Strings in the Encoding/Decoding of ProjectedExtents and TemproalProjectedExtents

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ProjectedExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/ProjectedExtentCodec.scala
@@ -7,6 +7,9 @@ import geotrellis.spark.io.avro.codecs._
 import geotrellis.spark.io.avro.codecs.Implicits._
 import geotrellis.vector._
 
+import java.nio.charset.Charset
+import java.nio.ByteBuffer
+
 import org.apache.avro._
 import org.apache.avro.generic._
 
@@ -18,17 +21,17 @@ trait ProjectedExtentCodec {
       .record("ProjectedExtent").namespace("geotrellis.vector")
       .fields()
       .name("extent").`type`(extentCodec.schema).noDefault()
-      .name("epsg").`type`().intType().noDefault()
+      .name("proj4").`type`().stringType().noDefault()
       .endRecord()
 
     def encode(projectedExtent: ProjectedExtent, rec: GenericRecord): Unit = {
       rec.put("extent", extentCodec.encode(projectedExtent.extent))
-      rec.put("epsg", projectedExtent.crs.epsgCode.get)
+      rec.put("proj4", projectedExtent.crs.toProj4String)
     }
 
     def decode(rec: GenericRecord): ProjectedExtent = {
-      val epsg = rec[Int]("epsg")
-      val crs = CRS.fromEpsgCode(epsg)
+      val proj4 = rec.get("proj4").toString()
+      val crs = CRS.fromString(proj4)
 
       val extent = extentCodec.decode(rec[GenericRecord]("extent"))
 

--- a/spark/src/main/scala/geotrellis/spark/io/avro/codecs/TemporalProjectedExtentCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/codecs/TemporalProjectedExtentCodec.scala
@@ -17,20 +17,21 @@ trait TemporalProjectedExtentCodec {
       .record("TemporalProjectedExtent").namespace("geotrellis.spark")
       .fields()
       .name("extent").`type`(extentCodec.schema).noDefault()
-      .name("epsg").`type`().intType().noDefault()
+      .name("proj4").`type`().stringType().noDefault()
       .name("instant").`type`().longType().noDefault()
       .endRecord()
 
     def encode(temporalProjectedExtent: TemporalProjectedExtent, rec: GenericRecord): Unit = {
       rec.put("extent", extentCodec.encode(temporalProjectedExtent.extent))
-      rec.put("epsg", temporalProjectedExtent.crs.epsgCode.get)
+      rec.put("proj4", temporalProjectedExtent.crs.toProj4String)
       rec.put("instant", temporalProjectedExtent.instant)
     }
 
     def decode(rec: GenericRecord): TemporalProjectedExtent = {
       val instant = rec[Long]("instant")
-      val epsg = rec[Int]("epsg")
-      val crs = CRS.fromEpsgCode(epsg)
+
+      val proj4 = rec.get("proj4").toString()
+      val crs = CRS.fromString(proj4)
 
       val extent = extentCodec.decode(rec[GenericRecord]("extent"))
 
@@ -38,4 +39,3 @@ trait TemporalProjectedExtentCodec {
     }
   }
 }
-

--- a/spark/src/test/scala/geotrellis/spark/io/avro/ExtentCodecsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/avro/ExtentCodecsSpec.scala
@@ -25,14 +25,15 @@ import geotrellis.spark.io.avro.AvroTools._
 
 class ExtentCodecsSpec extends FunSpec with Matchers with AvroTools  {
   describe("ExtentCodecs") {
+    val crs = CRS.fromEpsgCode(4324)
     it("encodes Extent"){
       roundTrip(Extent(0, 1, 2, 3))
     }
     it("encodes ProjectedExtent") {
-      roundTrip(ProjectedExtent(Extent(0, 1, 2, 3), CRS.fromEpsgCode(4324)))
+      roundTrip(ProjectedExtent(Extent(0, 1, 2, 3), crs))
     }
     it("encodes TemporalProjectedExtent"){
-      roundTrip(TemporalProjectedExtent(Extent(0, 1, 2, 3), CRS.fromEpsgCode(4324), 1.toLong))
+      roundTrip(TemporalProjectedExtent(Extent(0, 1, 2, 3), crs, 1.toLong))
     }
   }
 }


### PR DESCRIPTION
This PR fixes a previously merged in change, #1971 , so that the `Proj4String` of `ProjectedExtent` and `TemproalProjectedExtent` will be encoded/decoded instead of their EPSG code.