### PR TITLE
Compute cellsize from tifftags

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -57,6 +57,9 @@ case class TiffTags(
   nonStandardizedTags: NonStandardizedTags = NonStandardizedTags()
 ) {
 
+  def cellSize =
+    CellSize(this.extent.width / this.cols, this.extent.height / this.rows)
+
   def compression =
     (this
       &|-> TiffTags._basicTags


### PR DESCRIPTION
The data is available for computing `CellSize` from data available on tiff tags. This PR adds such a method. Are there any other methods which might be handy on a `TiffTags` instance?