### PR TITLE
Allow for tile dimensions to be set into PointCloudToDem

### DIFF
--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunay.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunay.scala
@@ -337,7 +337,7 @@ object BoundaryDelaunay {
           println("Premature termination")
       }}
 
-      new java.io.PrintWriter("buffer.wkt") { write(geotrellis.vector.io.wkt.WKT.write(MultiPolygon(polys))); close }
+      // new java.io.PrintWriter("buffer.wkt") { write(geotrellis.vector.io.wkt.WKT.write(MultiPolygon(polys))); close }
 
   /*
       val e0 = innerLoop._1


### PR DESCRIPTION
This allows users to put in the tile dimensions for a tile coming out of PointCloudToDem, so that if for example you require 256 x 256, you don't get a different dimension caused by the cellSize computing a different set of dimensions. Useful for ingest.