### PR TITLE
Deps update and cleanup

### DIFF
--- a/.travis/hbase-install.sh
+++ b/.travis/hbase-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-if [ ! -f $HOME/downloads/hbase-1.2.4-bin.tar.gz ]; then sudo wget -O $HOME/downloads/hbase-1.2.4-bin.tar.gz http://www-eu.apache.org/dist/hbase/1.2.4/hbase-1.2.4-bin.tar.gz; fi
-sudo mv $HOME/downloads/hbase-1.2.4-bin.tar.gz hbase-1.2.4-bin.tar.gz && tar xzf hbase-1.2.4-bin.tar.gz
-sudo rm -f hbase-1.2.4/conf/hbase-site.xml && sudo mv .travis/hbase/hbase-site.xml hbase-1.2.4/conf
-sudo hbase-1.2.4/bin/start-hbase.sh
+if [ ! -f $HOME/downloads/hbase-1.3.0-bin.tar.gz ]; then sudo wget -O $HOME/downloads/hbase-1.3.0-bin.tar.gz http://www-eu.apache.org/dist/hbase/1.3.0/hbase-1.3.0-bin.tar.gz; fi
+sudo mv $HOME/downloads/hbase-1.3.0-bin.tar.gz hbase-1.3.0-bin.tar.gz && tar xzf hbase-1.3.0-bin.tar.gz
+sudo rm -f hbase-1.3.0/conf/hbase-site.xml && sudo mv .travis/hbase/hbase-site.xml hbase-1.3.0/conf
+sudo hbase-1.3.0/bin/start-hbase.sh

--- a/build.sbt
+++ b/build.sbt
@@ -25,10 +25,10 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
 
-  publishTo <<= version { (v: String) =>
+  publishTo := {
     val sonatype = "https://oss.sonatype.org/"
     val locationtech = "https://repo.locationtech.org/content/repositories"
-    if (v.trim.endsWith("SNAPSHOT")) {
+    if (isSnapshot.value) {
       // Publish snapshots to LocationTech
       Some("LocationTech Snapshot Repository" at s"${locationtech}/geotrellis-snapshots")
     } else {

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import Dependencies._
-import UnidocKeys._
 import sbt.Keys._
 import de.heikoseeberger.sbtheader.license.Apache2_0
 
@@ -92,6 +91,7 @@ lazy val root = Project("geotrellis", file(".")).
     vectortile
   ).
   settings(commonSettings: _*).
+  enablePlugins(ScalaUnidocPlugin).
   settings(
     scalacOptions in (ScalaUnidoc, unidoc) += "-Ymacro-expand:none",
     initialCommands in console :=
@@ -101,9 +101,8 @@ lazy val root = Project("geotrellis", file(".")).
       import geotrellis.proj4._
       import geotrellis.spark._
       """
-  )
-  .settings(unidocSettings: _*)
-  .settings(unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(geowave))
+  ).
+  settings(unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(geowave))
 
 lazy val macros = Project("macros", file("macros")).
   settings(commonSettings: _*)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"    % Version.monocle
   val monocleMacro  = "com.github.julien-truffaut" %% "monocle-macro"   % Version.monocle
 
-  val openCSV       = "com.opencsv" % "opencsv" % "3.8"
+  val openCSV       = "com.opencsv" % "opencsv" % "3.9"
 
   val akkaKernel    = "com.typesafe.akka" %% "akka-kernel"  % Version.akka
   val akkaRemote    = "com.typesafe.akka" %% "akka-remote"  % Version.akka
@@ -39,20 +39,12 @@ object Dependencies {
 
   val apacheMath    = "org.apache.commons" % "commons-math3" % "3.6.1"
 
-  val jettyWebapp   = "org.eclipse.jetty" % "jetty-webapp" % "9.4.0.M1"
-  val jerseyBundle  = "com.sun.jersey"    % "jersey-bundle" % "1.19.2"
-  val slf4jApi      = "org.slf4j"         % "slf4j-api" % "1.7.22"
-  val asm           = "asm"               % "asm"       % "3.3.1"
-
   val slick         = "com.typesafe.slick" %% "slick"      % "3.1.1"
   val postgresql    = "postgresql"         % "postgresql"  % "9.1-901.jdbc4"
 
-  val caliper       = ("com.google.code.caliper" % "caliper" % "1.0-SNAPSHOT"
-    from "http://plastic-idolatry.com/jars/caliper-1.0-SNAPSHOT.jar")
+  val chronoscala   = "jp.ne.opt" %% "chronoscala" % "0.1.2"
 
-  val chronoscala   = "jp.ne.opt" %% "chronoscala" % "0.1.0"
-
-  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.70"
+  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.92"
 
   val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,30 +17,22 @@
 import sbt._
 
 object Dependencies {
-  val typesafeConfig = "com.typesafe"        % "config"           % "1.3.1"
+  val typesafeConfig = "com.typesafe"       %  "config"          % "1.3.1"
   val logging       = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
   val scalatest     = "org.scalatest"       %%  "scalatest"      % "3.0.1"
   val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.13.4"
   val jts           = "com.vividsolutions"  %  "jts-core"        % "1.14.0"
 
-  val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"    % Version.monocle
-  val monocleMacro  = "com.github.julien-truffaut" %% "monocle-macro"   % Version.monocle
+  val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"  % Version.monocle
+  val monocleMacro  = "com.github.julien-truffaut" %% "monocle-macro" % Version.monocle
 
   val openCSV       = "com.opencsv" % "opencsv" % "3.9"
 
-  val akkaKernel    = "com.typesafe.akka" %% "akka-kernel"  % Version.akka
-  val akkaRemote    = "com.typesafe.akka" %% "akka-remote"  % Version.akka
-  val akkaActor     = "com.typesafe.akka" %% "akka-actor"   % Version.akka
-  val akkaCluster   = "com.typesafe.akka" %% "akka-cluster" % Version.akka
-
   val spire         = "org.spire-math" %% "spire" % "0.13.0"
 
-  val sprayJson     = "io.spray"        %% "spray-json"    % Version.sprayJson
+  val sprayJson     = "io.spray" %% "spray-json" % Version.sprayJson
 
   val apacheMath    = "org.apache.commons" % "commons-math3" % "3.6.1"
-
-  val slick         = "com.typesafe.slick" %% "slick"      % "3.1.1"
-  val postgresql    = "postgresql"         % "postgresql"  % "9.1-901.jdbc4"
 
   val chronoscala   = "jp.ne.opt" %% "chronoscala" % "0.1.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
 
   val avro          = "org.apache.avro" % "avro" % "1.8.1"
 
-  val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.14.4"
+  val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.14.6"
 
   val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
 }

--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -21,6 +21,6 @@ object Environment {
     Properties.envOrElse(environmentVariable, default)
 
   lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.7.3")
-  lazy val sparkVersion   = either("SPARK_VERSION", "2.0.2")
+  lazy val sparkVersion   = either("SPARK_VERSION", "2.1.0")
   lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -19,13 +19,12 @@ object Version {
   val scala       = "2.11.8"
   val geotools    = "16.1"
   val akka        = "2.4.16"
-  val spray       = "1.3.3"
-  val sprayJson   = "1.3.2"
-  val monocle     = "1.4.0-M1"
+  val sprayJson   = "1.3.3"
+  val monocle     = "1.4.0"
   val accumulo    = "1.7.2"
-  val cassandra   = "3.1.2"
+  val cassandra   = "3.1.4"
   val hbase       = "1.2.4"
-  val geomesa     = "1.2.7.2"
+  val geomesa     = "1.2.7.3"
   lazy val hadoop = Environment.hadoopVersion
   lazy val spark  = Environment.sparkVersion
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -23,7 +23,7 @@ object Version {
   val monocle     = "1.4.0"
   val accumulo    = "1.7.2"
   val cassandra   = "3.1.4"
-  val hbase       = "1.2.4"
+  val hbase       = "1.3.0"
   val geomesa     = "1.2.7.3"
   lazy val hadoop = Environment.hadoopVersion
   lazy val spark  = Environment.sparkVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-dirty-money" % "0.1.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers ++= Seq(
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
@@ -13,6 +13,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-dirty-money" % "0.1.0")
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.7.0")

--- a/slick/build.sbt
+++ b/slick/build.sbt
@@ -4,5 +4,4 @@ name := "geotrellis-slick"
 libraryDependencies := Seq(
   slickPG,
   postgresql,
-  slf4jApi,
   scalatest % "test")

--- a/slick/build.sbt
+++ b/slick/build.sbt
@@ -3,5 +3,5 @@ import Dependencies._
 name := "geotrellis-slick"
 libraryDependencies := Seq(
   slickPG,
-  postgresql,
-  scalatest % "test")
+  scalatest % "test"
+)

--- a/vector-test/build.sbt
+++ b/vector-test/build.sbt
@@ -2,6 +2,5 @@ import Dependencies._
 
 name := "geotrellis-vector-test"
 libraryDependencies ++= Seq(
-  akkaActor   % "test",
   scalatest   % "test",
   scalacheck  % "test")


### PR DESCRIPTION
Includes #2018 and #2019. 
Doesn't include scalapb update (as it has some api changes, that may be siginficant).
Doesn't include geowave updates (as it can be sensitive to deps).
Doesn't include Accumulo update (as it includes API changes).
Fixes https://github.com/locationtech/geotrellis/issues/2014

```
[info] No dependency updates found for geotrellis-proj4
[info] No dependency updates found for geotrellis
[info] No dependency updates found for geotrellis-vector
[info] Found 1 dependency update for geotrellis-vectortile
[info]   com.trueaccord.scalapb:scalapb-runtime : 0.5.46 -> 0.5.47
[info] No dependency updates found for geotrellis-slick
[info] No dependency updates found for geotrellis-vector-test
[info] No dependency updates found for geotrellis-raster
[info] No dependency updates found for geotrellis-raster-test
[info] Found 1 dependency update for geotrellis-spark
[info]   org.scalaz.stream:scalaz-stream : 0.8.6a -> 0.8.6
[info] No dependency updates found for geotrellis-cassandra
[info] No dependency updates found for geotrellis-s3
[info] No dependency updates found for geotrellis-geotools
[info] No dependency updates found for geotrellis-hbase
[info] Found 1 dependency update for geotrellis-accumulo
[info]   org.apache.accumulo:accumulo-core : 1.7.2 -> 1.8.0
[info] No dependency updates found for geotrellis-geomesa
[info] No dependency updates found for geotrellis-spark-etl
[info] Found 3 dependency updates for geotrellis-geowave
[info]   com.esotericsoftware:kryo-shaded  : 3.0.3          -> 4.0.0
[info]   de.javakaffee:kryo-serializers    : 0.38  -> 0.41          
[info]   org.apache.accumulo:accumulo-core : 1.7.2 -> 1.8.0 
```
