### PR TITLE
A dash of API sugar to simplify summoning of implicit codec.

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/avro/AvroRecordCodec.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/AvroRecordCodec.scala
@@ -37,3 +37,7 @@ abstract class AvroRecordCodec[T: ClassTag] extends AvroCodec[T, GenericRecord] 
     implicitly[ClassTag[T]].unapply(other).isDefined
   }
 }
+
+object AvroRecordCodec {
+  def apply[T: AvroRecordCodec]: AvroRecordCodec[T] = implicitly
+}


### PR DESCRIPTION
Allows `AvroRecordCodec[Tile]` instead of `implicitly[AvroRecordCodec[Tile]]`, a pattern used a lot in the avro2spark PoC.