### PR TITLE
Tile columns cannot be zero when rounding

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -41,8 +41,8 @@ class GridExtent(val extent: Extent, val cellwidth: Double, val cellheight: Doub
     *       types.
     */
   def toRasterExtent(): RasterExtent = {
-    val targetCols = 1L.max(math.round(extent.width / cellwidth).toLong)
-    val targetRows = 1L.max(math.round(extent.height / cellheight).toLong)
+    val targetCols = math.max(1L, math.round(extent.width / cellwidth).toLong)
+    val targetRows = math.max(1L, math.round(extent.height / cellheight).toLong)
     if(targetCols > Int.MaxValue) {
       throw new GeoAttrsError(s"Cannot convert GridExtent into a RasterExtent: number of columns exceeds maximum integer value ($targetCols > ${Int.MaxValue})")
     }

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -41,8 +41,8 @@ class GridExtent(val extent: Extent, val cellwidth: Double, val cellheight: Doub
     *       types.
     */
   def toRasterExtent(): RasterExtent = {
-    val targetCols = math.round(extent.width / cellwidth).toLong
-    val targetRows = math.round(extent.height / cellheight).toLong
+    val targetCols = 1L.max(math.round(extent.width / cellwidth).toLong)
+    val targetRows = 1L.max(math.round(extent.height / cellheight).toLong)
     if(targetCols > Int.MaxValue) {
       throw new GeoAttrsError(s"Cannot convert GridExtent into a RasterExtent: number of columns exceeds maximum integer value ($targetCols > ${Int.MaxValue})")
     }


### PR DESCRIPTION
These round to zero values cause zero column tiles in a LatLng to WebMercator reproject.  I could not figure out the root cause.  It looked to me like reasonable values were used, and that rounding was the issue.  An alternative fix might be to clip the data to the maximum extent of WebMercator in the projection.