### PR TITLE
Relax safeguards on delete methods

### DIFF
--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStore.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStore.scala
@@ -70,7 +70,6 @@ class AccumuloAttributeStore(val connector: Connector, val attributeTable: Strin
   }
 
   private def delete(layerId: LayerId, attributeName: Option[String]): Unit = {
-    if(!layerExists(layerId)) throw new LayerNotFoundError(layerId)
     val numThreads = 1
     val config = new BatchWriterConfig()
     config.setMaxWriteThreads(numThreads)

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerDeleter.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerDeleter.scala
@@ -18,32 +18,35 @@ package geotrellis.spark.io.accumulo
 
 import geotrellis.spark.LayerId
 import geotrellis.spark.io._
+import geotrellis.util.LazyLogging
+
 import org.apache.accumulo.core.client.{BatchWriterConfig, Connector}
 import org.apache.accumulo.core.security.Authorizations
-import spray.json.JsonFormat
 import org.apache.accumulo.core.data.{Range => AccumuloRange}
+import spray.json.JsonFormat
 import spray.json.DefaultJsonProtocol._
+
 import scala.collection.JavaConversions._
 
-class AccumuloLayerDeleter(val attributeStore: AttributeStore, connector: Connector) extends LayerDeleter[LayerId] {
+class AccumuloLayerDeleter(val attributeStore: AttributeStore, connector: Connector) extends LazyLogging with LayerDeleter[LayerId] {
 
   def delete(id: LayerId): Unit = {
-    if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
-    val header = try {
-      attributeStore.readHeader[AccumuloLayerHeader](id)
+    try {
+      val header = attributeStore.readHeader[AccumuloLayerHeader](id)
+      val numThreads = 1
+      val config = new BatchWriterConfig()
+      config.setMaxWriteThreads(numThreads)
+      val deleter = connector.createBatchDeleter(header.tileTable, new Authorizations(), numThreads, config)
+      deleter.fetchColumnFamily(columnFamily(id))
+      deleter.setRanges(new AccumuloRange() :: Nil)
+      deleter.delete()
     } catch {
-      case e: AttributeNotFoundError => throw new LayerDeleteError(id).initCause(e)
+      case e: AttributeNotFoundError =>
+        logger.info(s"Metadata for $id was not found. Any associated layer data (if any) will require manual deletion")
+        throw new LayerDeleteError(id).initCause(e)
+    } finally {
+      attributeStore.delete(id)
     }
-
-    val numThreads = 1
-    val config = new BatchWriterConfig()
-    config.setMaxWriteThreads(numThreads)
-    val deleter = connector.createBatchDeleter(header.tileTable, new Authorizations(), numThreads, config)
-    deleter.fetchColumnFamily(columnFamily(id))
-    deleter.setRanges(new AccumuloRange() :: Nil)
-    deleter.delete()
-
-    attributeStore.delete(id)
   }
 }
 

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraAttributeStore.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraAttributeStore.scala
@@ -73,8 +73,6 @@ class CassandraAttributeStore(val instance: CassandraInstance, val attributeKeys
   }
 
   private def delete(layerId: LayerId, attributeName: Option[String]): Unit = instance.withSessionDo { session =>
-    if (!layerExists(layerId)) throw new LayerNotFoundError(layerId)
-
     val query =
       attributeName match {
         case Some(name) =>

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerDeleter.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerDeleter.scala
@@ -18,47 +18,48 @@ package geotrellis.spark.io.cassandra
 
 import geotrellis.spark.LayerId
 import geotrellis.spark.io._
+import geotrellis.util.LazyLogging
 
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.querybuilder.QueryBuilder.{eq => eqs}
 
 import scala.collection.JavaConversions._
 
-class CassandraLayerDeleter(val attributeStore: AttributeStore, instance: CassandraInstance) extends LayerDeleter[LayerId] {
+class CassandraLayerDeleter(val attributeStore: AttributeStore, instance: CassandraInstance) extends LazyLogging with LayerDeleter[LayerId] {
 
   def delete(id: LayerId): Unit = {
-    if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
-    val header = try {
-      attributeStore.readHeader[CassandraLayerHeader](id)
-    } catch {
-      case e: AttributeNotFoundError => throw new LayerDeleteError(id).initCause(e)
-    }
+    try {
+      val header = attributeStore.readHeader[CassandraLayerHeader](id)
+      instance.withSessionDo { session =>
+        val squery = QueryBuilder.select("key")
+          .from(header.keyspace, header.tileTable).allowFiltering()
+          .where(eqs("name", id.name))
+          .and(eqs("zoom", id.zoom))
 
-    instance.withSessionDo { session =>
-      val squery = QueryBuilder.select("key")
-        .from(header.keyspace, header.tileTable).allowFiltering()
-        .where(eqs("name", id.name))
-        .and(eqs("zoom", id.zoom))
+        val dquery = QueryBuilder.delete()
+          .from(header.keyspace, header.tileTable)
+          .where(eqs("key", QueryBuilder.bindMarker()))
+          .and(eqs("name", id.name))
+          .and(eqs("zoom", id.zoom))
 
-      val dquery = QueryBuilder.delete()
-        .from(header.keyspace, header.tileTable)
-        .where(eqs("key", QueryBuilder.bindMarker()))
-        .and(eqs("name", id.name))
-        .and(eqs("zoom", id.zoom))
+        val statement = session.prepare(dquery)
 
-      val statement = session.prepare(dquery)
-
-      session.execute(squery).all().map { entry =>
-        session.execute(statement.bind(entry.getLong("key").asInstanceOf[java.lang.Long]))
+        session.execute(squery).all().map { entry =>
+          session.execute(statement.bind(entry.getLong("key").asInstanceOf[java.lang.Long]))
+        }
       }
+    } catch {
+      case e: AttributeNotFoundError =>
+        logger.info(s"Metadata for $id was not found. Any associated layer data (if any) will require manual deletion")
+        throw new LayerDeleteError(id).initCause(e)
+    } finally {
+      attributeStore.delete(id)
     }
-
-    attributeStore.delete(id)
   }
 }
 
 object CassandraLayerDeleter {
-  def apply(attributeStore: AttributeStore, instance: CassandraInstance): CassandraLayerDeleter =
+  def apply(attributeStore: CassandraAttributeStore, instance: CassandraInstance): CassandraLayerDeleter =
     new CassandraLayerDeleter(attributeStore, instance)
 
   def apply(attributeStore: CassandraAttributeStore): CassandraLayerDeleter =

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseAttributeStore.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseAttributeStore.scala
@@ -73,16 +73,16 @@ class HBaseAttributeStore(val instance: HBaseInstance, val attributeTable: Strin
 
   private def delete(layerId: LayerId, attributeName: Option[String]): Unit =
     instance.withTableConnectionDo(attributeTableName) { table =>
-      if (!layerExists(layerId)) throw new LayerNotFoundError(layerId)
-
       val delete = new Delete(layerIdString(layerId))
       attributeName.foreach(delete.addFamily(_))
       table.delete(delete)
-      attributeName.foreach(table.getTableDescriptor.removeFamily(_))
 
       attributeName match {
-        case Some(attribute) => clearCache(layerId, attribute)
-        case None => clearCache(layerId)
+        case Some(attribute) =>
+          table.getTableDescriptor.removeFamily(attribute)
+          clearCache(layerId, attribute)
+        case None =>
+          clearCache(layerId)
       }
     }
 

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerDeleter.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerDeleter.scala
@@ -18,42 +18,45 @@ package geotrellis.spark.io.hbase
 
 import geotrellis.spark.LayerId
 import geotrellis.spark.io._
+import geotrellis.util.LazyLogging
+
 import org.apache.hadoop.hbase.client._
 import org.apache.hadoop.hbase.filter.PrefixFilter
 import com.typesafe.config.ConfigFactory
 
 import scala.collection.JavaConversions._
 
-class HBaseLayerDeleter(val attributeStore: AttributeStore, instance: HBaseInstance) extends LayerDeleter[LayerId] {
+class HBaseLayerDeleter(val attributeStore: AttributeStore, instance: HBaseInstance) extends LazyLogging with LayerDeleter[LayerId] {
 
   def delete(id: LayerId): Unit = {
-    if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
-    val header = try {
-      attributeStore.readHeader[HBaseLayerHeader](id)
+    try{
+      val header = attributeStore.readHeader[HBaseLayerHeader](id)
+
+      // Deletion list should be mutable
+      val list = new java.util.ArrayList[Delete]()
+      val scan = new Scan()
+      scan.addFamily(HBaseRDDWriter.tilesCF)
+      scan.setFilter(new PrefixFilter(HBaseRDDWriter.layerIdString(id)))
+
+      instance.withTableConnectionDo(header.tileTable) { table =>
+        val scanner = table.getScanner(scan)
+        try {
+          scanner.iterator().foreach { kv =>
+            val delete = new Delete(kv.getRow)
+            delete.addFamily(HBaseRDDWriter.tilesCF)
+            list.add(delete)
+          }
+        } finally scanner.close()
+
+        table.delete(list)
+      }
     } catch {
-      case e: AttributeNotFoundError => throw new LayerDeleteError(id).initCause(e)
+      case e: AttributeNotFoundError =>
+        logger.info(s"Metadata for $id was not found. Any associated layer data (if any) will require manual deletion")
+        throw new LayerDeleteError(id).initCause(e)
+    } finally {
+      attributeStore.delete(id)
     }
-
-    // Deletion list should be mutable
-    val list = new java.util.ArrayList[Delete]()
-    val scan = new Scan()
-    scan.addFamily(HBaseRDDWriter.tilesCF)
-    scan.setFilter(new PrefixFilter(HBaseRDDWriter.layerIdString(id)))
-
-    instance.withTableConnectionDo(header.tileTable) { table =>
-      val scanner = table.getScanner(scan)
-      try {
-        scanner.iterator().foreach { kv =>
-          val delete = new Delete(kv.getRow)
-          delete.addFamily(HBaseRDDWriter.tilesCF)
-          list.add(delete)
-        }
-      } finally scanner.close()
-
-      table.delete(list)
-    }
-
-    attributeStore.delete(id)
   }
 }
 

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
@@ -87,7 +87,6 @@ class FileAttributeStore(val catalogPath: String) extends BlobLayerAttributeStor
     val layerFiles =
       attributeDirectory
         .listFiles(new WildcardFileFilter(s"${layerId.name}${SEP}${layerId.zoom}${SEP}*.json"): FileFilter)
-    if(layerFiles.isEmpty) throw new LayerNotFoundError(layerId)
     layerFiles.find(f => f.getAbsolutePath.endsWith(s"${SEP}${attributeName}.json")) match {
       case Some(f) => f.delete()
       case _ =>
@@ -99,7 +98,6 @@ class FileAttributeStore(val catalogPath: String) extends BlobLayerAttributeStor
     val layerFiles =
       attributeDirectory
         .listFiles(new WildcardFileFilter(s"${layerId.name}${SEP}${layerId.zoom}${SEP}*.json"): FileFilter)
-    if(layerFiles.isEmpty) throw new LayerNotFoundError(layerId)
     layerFiles.foreach { f => f.delete() }
     clearCache(layerId)
   }

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerDeleter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerDeleter.scala
@@ -20,6 +20,7 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.AttributeStore.Fields
 import geotrellis.spark.io.index._
+import geotrellis.util.LazyLogging
 
 import spray.json.JsonFormat
 import org.apache.avro.Schema
@@ -27,36 +28,27 @@ import org.apache.avro.Schema
 import scala.reflect.ClassTag
 import java.io.File
 
-object FileLayerDeleter {
-  def apply(attributeStore: FileAttributeStore): LayerDeleter[LayerId] =
-    new LayerDeleter[LayerId] {
-      def delete(layerId: LayerId): Unit = {
-        // Read the metadata file out.
-        val header =
-          try {
-            attributeStore.readHeader[FileLayerHeader](layerId)
-          } catch {
-            case e: AttributeNotFoundError =>
-              throw new LayerNotFoundError(layerId).initCause(e)
-          }
-
-        // Delete the attributes
-        for((_, file) <- attributeStore.attributeFiles(layerId)) {
-          file.delete()
-        }
-
-        // Delete the elements
-        val sourceLayerPath = new File(attributeStore.catalogPath, header.path)
-        if(sourceLayerPath.exists()) {
-          sourceLayerPath
-            .listFiles()
-            .foreach(_.delete())
-
-          sourceLayerPath.delete
-        }
+class FileLayerDeleter(val attributeStore: FileAttributeStore) extends LazyLogging with LayerDeleter[LayerId] {
+  def delete(id: LayerId): Unit =
+    try {
+      val header = attributeStore.readHeader[FileLayerHeader](id)
+      val sourceLayerPath = new File(attributeStore.catalogPath, header.path)
+      sourceLayerPath.delete
+    } catch {
+      case e: AttributeNotFoundError =>
+        logger.info(s"Metadata for $id was not found. Any associated layer data (if any) will require manual deletion")
+        throw new LayerDeleteError(id).initCause(e)
+    } finally {
+      for((_, file) <- attributeStore.attributeFiles(id)) {
+        file.delete()
       }
     }
+}
 
-  def apply(catalogPath: String): LayerDeleter[LayerId] =
+object FileLayerDeleter {
+  def apply(attributeStore: FileAttributeStore): FileLayerDeleter =
+    new FileLayerDeleter(attributeStore)
+
+  def apply(catalogPath: String): FileLayerDeleter =
     apply(FileAttributeStore(catalogPath))
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
@@ -48,7 +48,6 @@ class HadoopAttributeStore(val rootPath: Path, val hadoopConfiguration: Configur
   }
 
   private def delete(layerId: LayerId, path: Path): Unit = {
-    if(!layerExists(layerId)) throw new LayerNotFoundError(layerId)
     HdfsUtils
       .listFiles(new Path(attributePath, path), hadoopConfiguration)
       .foreach(fs.delete(_, false))

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerDeleter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerDeleter.scala
@@ -19,6 +19,7 @@ package geotrellis.spark.io.hadoop
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.AttributeStore.Fields
+import geotrellis.util.LazyLogging
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -26,19 +27,18 @@ import org.apache.spark._
 import spray.json.JsonFormat
 import spray.json.DefaultJsonProtocol._
 
-class HadoopLayerDeleter(val attributeStore: AttributeStore, conf: Configuration) extends LayerDeleter[LayerId] {
+class HadoopLayerDeleter(val attributeStore: AttributeStore, conf: Configuration) extends LazyLogging with LayerDeleter[LayerId] {
   def delete(id: LayerId): Unit = {
-    if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
-    val header =
-      try {
-      attributeStore.readHeader[HadoopLayerHeader](id)
-      } catch {
-        case e: AttributeNotFoundError => throw new LayerDeleteError(id).initCause(e)
-      }
-
-    HdfsUtils.deletePath(header.path, conf)
-    attributeStore.delete(id)
-    attributeStore.clearCache()
+    try {
+      val header = attributeStore.readHeader[HadoopLayerHeader](id)
+      HdfsUtils.deletePath(header.path, conf)
+    } catch {
+      case e: AttributeNotFoundError =>
+        logger.info(s"Metadata for $id was not found. Any associated layer data (if any) will require manual deletion")
+        throw new LayerDeleteError(id).initCause(e)
+    } finally {
+      attributeStore.delete(id)
+    }
   }
 }
 

--- a/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
@@ -104,8 +104,8 @@ abstract class PersistenceSpec[
         }
       }
 
-      it("should not delete layer before write") {
-        intercept[LayerNotFoundError] {
+      it("should throw a layer deletion error if metadata required for deleting a layer's tiles is not found") {
+        intercept[LayerDeleteError] {
           deleter.delete(layerId)
         }
       }


### PR DESCRIPTION
Prior to this change, `delete` methods threw in any case where the reference to a layer happened to be faulty. This is based on metadata which, though always present in case of tile data (and necessary for its deletion), might not be present. Lacking this metadata, we should log information about the failure and delete any `_attribute` data we can.