### PR TITLE
HadoopGeoTiffRDD and S3GeoTiffRDD add overloads to use file names in keys

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffRDD.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffRDD.scala
@@ -37,8 +37,6 @@ import java.nio.ByteBuffer
  * The S3GeoTiffRDD object allows for the creation of whole or windowed RDD[(K, V)]s from files on S3.
  */
 object S3GeoTiffRDD {
-  implicit def stringToUri(str: String): URI = new URI(str)
-
   final val GEOTIFF_TIME_TAG_DEFAULT = "TIFFTAG_DATETIME"
   final val GEOTIFF_TIME_FORMAT_DEFAULT = "yyyy:MM:dd HH:mm:ss"
 
@@ -124,7 +122,7 @@ object S3GeoTiffRDD {
         ).mapPartitions(
           _.map { case (key, bytes) =>
             val (k, v) = rr.readFully(ByteBuffer.wrap(bytes), options)
-            keyTransform(key, k) -> v
+            keyTransform(new URI(key), k) -> v
           },
           preservesPartitioning = true
         )
@@ -175,7 +173,7 @@ object S3GeoTiffRDD {
 
       val (k, v) = rr.readWindow(reader, pixelWindow, options)
 
-      keyTransform(objectRequest.getKey, k) -> v
+      keyTransform(new URI(objectRequest.getKey), k) -> v
     }
   }
 

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffRDD.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffRDD.scala
@@ -94,10 +94,10 @@ object S3GeoTiffRDD {
     *
     * @param bucket   Name of the bucket on S3 where the files are kept.
     * @param prefix   Prefix of all of the keys on S3 that are to be read in.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param uriToKey function to transform input key basing on the URI information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def apply[I, K, V](bucket: String, prefix: String, keyTransform: (URI, I) => K, options: Options)
+  def apply[I, K, V](bucket: String, prefix: String, uriToKey: (URI, I) => K, options: Options)
     (implicit sc: SparkContext, rr: RasterReader[Options, (I, V)]): RDD[(K, V)] = {
 
     val conf = configuration(bucket, prefix, options)
@@ -112,7 +112,7 @@ object S3GeoTiffRDD {
             classOf[TiffTags]
           ).mapValues { tiffTags => (tiffTags.cols, tiffTags.rows) }
 
-        apply[I, K, V](objectRequestsToDimensions, keyTransform, options)
+        apply[I, K, V](objectRequestsToDimensions, uriToKey, options)
       case None =>
         sc.newAPIHadoopRDD(
           conf,
@@ -122,7 +122,7 @@ object S3GeoTiffRDD {
         ).mapPartitions(
           _.map { case (key, bytes) =>
             val (k, v) = rr.readFully(ByteBuffer.wrap(bytes), options)
-            keyTransform(new URI(key), k) -> v
+            uriToKey(new URI(key), k) -> v
           },
           preservesPartitioning = true
         )
@@ -144,10 +144,10 @@ object S3GeoTiffRDD {
     * Creates a RDD[(K, V)] whose K and V depends on the type of the GeoTiff that is going to be read in.
     *
     * @param objectRequestsToDimensions A RDD of GetObjectRequest of a given GeoTiff and its cols and rows as a (Int, Int).
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param uriToKey function to transform input key basing on the URI information.
     * @param options An instance of [[Options]] that contains any user defined or default settings.
     */
-  def apply[I, K, V](objectRequestsToDimensions: RDD[(GetObjectRequest, (Int, Int))], keyTransform: (URI, I) => K, options: Options)
+  def apply[I, K, V](objectRequestsToDimensions: RDD[(GetObjectRequest, (Int, Int))], uriToKey: (URI, I) => K, options: Options)
     (implicit rr: RasterReader[Options, (I, V)]): RDD[(K, V)] = {
 
     val windows =
@@ -173,7 +173,7 @@ object S3GeoTiffRDD {
 
       val (k, v) = rr.readWindow(reader, pixelWindow, options)
 
-      keyTransform(new URI(objectRequest.getKey), k) -> v
+      uriToKey(new URI(s"s3://${objectRequest.getBucketName}/${objectRequest.getKey}"), k) -> v
     }
   }
 
@@ -183,10 +183,10 @@ object S3GeoTiffRDD {
     *
     * @param bucket Name of the bucket on S3 where the files are kept.
     * @param prefix Prefix of all of the keys on S3 that are to be read in.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param uriToKey function to transform input key basing on the URI information.
     */
-  def singleband[I, K](bucket: String, prefix: String, keyTransform: (URI, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, Tile)]): RDD[(K, Tile)] =
-    apply[I, K, Tile](bucket, prefix, keyTransform, options)
+  def singleband[I, K](bucket: String, prefix: String, uriToKey: (URI, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, Tile)]): RDD[(K, Tile)] =
+    apply[I, K, Tile](bucket, prefix, uriToKey, options)
 
   /**
     * Creates RDD that will read all GeoTiffs in the given bucket and prefix as singleband GeoTiffs.
@@ -204,10 +204,10 @@ object S3GeoTiffRDD {
     *
     * @param bucket Name of the bucket on S3 where the files are kept.
     * @param prefix Prefix of all of the keys on S3 that are to be read in.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param uriToKey function to transform input key basing on the URI information.
     */
-  def multiband[I, K](bucket: String, prefix: String, keyTransform: (URI, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, MultibandTile)]): RDD[(K, MultibandTile)] =
-    apply[I, K, MultibandTile](bucket, prefix, keyTransform, options)
+  def multiband[I, K](bucket: String, prefix: String, uriToKey: (URI, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, MultibandTile)]): RDD[(K, MultibandTile)] =
+    apply[I, K, MultibandTile](bucket, prefix, uriToKey, options)
 
   /**
     * Creates RDD that will read all GeoTiffs in the given bucket and prefix as multiband GeoTiffs.
@@ -246,11 +246,11 @@ object S3GeoTiffRDD {
     *
     * @param bucket   Name of the bucket on S3 where the files are kept.
     * @param prefix   Prefix of all of the keys on S3 that are to be read in.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param uriToKey function to transform input key basing on the URI information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def spatial(bucket: String, prefix: String, keyTransform: (URI, ProjectedExtent) => ProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] =
-    singleband[ProjectedExtent, ProjectedExtent](bucket, prefix, keyTransform, options)
+  def spatial(bucket: String, prefix: String, uriToKey: (URI, ProjectedExtent) => ProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] =
+    singleband[ProjectedExtent, ProjectedExtent](bucket, prefix, uriToKey, options)
 
   /**
     * Creates RDD that will read all GeoTiffs in the given bucket and prefix as multiband tiles.
@@ -277,11 +277,11 @@ object S3GeoTiffRDD {
     *
     * @param bucket   Name of the bucket on S3 where the files are kept.
     * @param prefix   Prefix of all of the keys on S3 that are to be read in.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param uriToKey function to transform input key basing on the URI information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def spatialMultiband(bucket: String, prefix: String, keyTransform: (URI, ProjectedExtent) => ProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
-    multiband[ProjectedExtent, ProjectedExtent](bucket, prefix, keyTransform, options)
+  def spatialMultiband(bucket: String, prefix: String, uriToKey: (URI, ProjectedExtent) => ProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
+    multiband[ProjectedExtent, ProjectedExtent](bucket, prefix, uriToKey, options)
 
   /**
     * Creates RDD that will read all GeoTiffs in the given bucket and prefix as singleband tiles.
@@ -310,11 +310,11 @@ object S3GeoTiffRDD {
     *
     * @param bucket   Name of the bucket on S3 where the files are kept.
     * @param prefix   Prefix of all of the keys on S3 that are to be read in.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param uriToKey function to transform input key basing on the URI information.
     * @param options  Options for the reading process. Including the timestamp tiff tag and its pattern.
     */
-  def temporal(bucket: String, prefix: String, keyTransform: (URI, TemporalProjectedExtent) => TemporalProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, Tile)] =
-    singleband[TemporalProjectedExtent, TemporalProjectedExtent](bucket, prefix, keyTransform, options)
+  def temporal(bucket: String, prefix: String, uriToKey: (URI, TemporalProjectedExtent) => TemporalProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, Tile)] =
+    singleband[TemporalProjectedExtent, TemporalProjectedExtent](bucket, prefix, uriToKey, options)
 
   /**
     * Creates RDD that will read all GeoTiffs in the given bucket and prefix as multiband tiles.
@@ -343,9 +343,9 @@ object S3GeoTiffRDD {
     *
     * @param bucket   Name of the bucket on S3 where the files are kept.
     * @param prefix   Prefix of all of the keys on S3 that are to be read in.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param uriToKey function to transform input key basing on the URI information.
     * @param options  Options for the reading process. Including the timestamp tiff tag and its pattern.
     */
-  def temporalMultiband(bucket: String, prefix: String, keyTransform: (URI, TemporalProjectedExtent) => TemporalProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, MultibandTile)] =
-    multiband[TemporalProjectedExtent, TemporalProjectedExtent](bucket, prefix, keyTransform, options)
+  def temporalMultiband(bucket: String, prefix: String, uriToKey: (URI, TemporalProjectedExtent) => TemporalProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, MultibandTile)] =
+    multiband[TemporalProjectedExtent, TemporalProjectedExtent](bucket, prefix, uriToKey, options)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDD.scala
@@ -84,10 +84,10 @@ object HadoopGeoTiffRDD {
     * Creates a RDD[(K, V)] whose K and V depends on the type of the GeoTiff that is going to be read in.
     *
     * @param path     Hdfs GeoTiff path.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param pathToKey function to transform input key basing on the Path information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def apply[I, K, V](path: Path, keyTransform: (URI, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, V)]): RDD[(K, V)] = {
+  def apply[I, K, V](path: Path, pathToKey: (Path, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, V)]): RDD[(K, V)] = {
     val conf = configuration(path, options)
     options.maxTileSize match {
       case Some(tileSize) =>
@@ -99,7 +99,7 @@ object HadoopGeoTiffRDD {
             classOf[TiffTags]
           ).mapValues { tiffTags => (tiffTags.cols, tiffTags.rows) }
 
-        apply[I, K, V](pathsAndDimensions, keyTransform, options)
+        apply[I, K, V](pathsAndDimensions, pathToKey, options)
       case None =>
         sc.newAPIHadoopRDD(
           conf,
@@ -109,7 +109,7 @@ object HadoopGeoTiffRDD {
         ).mapPartitions(
           _.map { case (p, bytes) =>
             val (k, v) = rr.readFully(ByteBuffer.wrap(bytes), options)
-            keyTransform(p.toUri, k) -> v
+            pathToKey(p, k) -> v
           },
           preservesPartitioning = true
         )
@@ -123,16 +123,16 @@ object HadoopGeoTiffRDD {
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
   def apply[K, V](path: Path, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (K, V)]): RDD[(K, V)] =
-    apply[K, K, V](path, (_: URI, key: K) => key, options)
+    apply[K, K, V](path, (_: Path, key: K) => key, options)
 
   /**
     * Creates a RDD[(K, V)] whose K and V depends on the type of the GeoTiff that is going to be read in.
     *
     * @param pathsToDimensions  RDD keyed by GeoTiff path with (cols, rows) tuple as value.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param pathToKey function to transform input key basing on the Path information.
     * @param options            An instance of [[Options]] that contains any user defined or default settings.
     */
-  def apply[I, K, V](pathsToDimensions: RDD[(Path, (Int, Int))], keyTransform: (URI, I) => K, options: Options)
+  def apply[I, K, V](pathsToDimensions: RDD[(Path, (Int, Int))], pathToKey: (Path, I) => K, options: Options)
                     (implicit rr: RasterReader[Options, (I, V)]): RDD[(K, V)] = {
 
     val conf = new SerializableConfiguration(pathsToDimensions.sparkContext.hadoopConfiguration)
@@ -159,7 +159,7 @@ object HadoopGeoTiffRDD {
       }
 
       val (k, v) = rr.readWindow(reader, pixelWindow, options)
-      keyTransform(path.toUri, k) -> v
+      pathToKey(path, k) -> v
     }
   }
 
@@ -168,11 +168,11 @@ object HadoopGeoTiffRDD {
     * It assumes that the provided files are [[SinglebandGeoTiff]]s.
     *
     * @param path     Hadoop path to recursively search for GeoTiffs.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param pathToKey function to transform input key basing on the Path information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def singleband[I, K](path: Path, keyTransform: (URI, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, Tile)]): RDD[(K, Tile)] =
-    apply[I, K, Tile](path, keyTransform, options)
+  def singleband[I, K](path: Path, pathToKey: (Path, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, Tile)]): RDD[(K, Tile)] =
+    apply[I, K, Tile](path, pathToKey, options)
 
   /**
     * Creates RDDs with the [(K, V)] values where V is a [[Tile]].
@@ -189,12 +189,12 @@ object HadoopGeoTiffRDD {
     * It assumes that the provided files are [[MultibandGeoTiff]]s.
     *
     * @param path     Hadoop path to recursively search for GeoTiffs.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param pathToKey function to transform input key basing on the Path information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
 
-  def multiband[I, K](path: Path, keyTransform: (URI, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, MultibandTile)]): RDD[(K, MultibandTile)] =
-    apply[I, K, MultibandTile](path, keyTransform, options)
+  def multiband[I, K](path: Path, pathToKey: (Path, I) => K, options: Options)(implicit sc: SparkContext, rr: RasterReader[Options, (I, MultibandTile)]): RDD[(K, MultibandTile)] =
+    apply[I, K, MultibandTile](path, pathToKey, options)
 
   /**
     * Creates RDDs with the [(K, V)] values where V is a [[MultibandTile]].
@@ -230,11 +230,11 @@ object HadoopGeoTiffRDD {
     * It assumes that the provided files are [[SinglebandGeoTiff]]s.
     *
     * @param path     Hadoop path to recursively search for GeoTiffs.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param pathToKey function to transform input key basing on the Path information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def spatial(path: Path, keyTransform: (URI, ProjectedExtent) => ProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] =
-    singleband[ProjectedExtent, ProjectedExtent](path, keyTransform, options)
+  def spatial(path: Path, pathToKey: (Path, ProjectedExtent) => ProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] =
+    singleband[ProjectedExtent, ProjectedExtent](path, pathToKey, options)
 
   /**
     * Creates RDDs with the [(K, V)] values being [[ProjectedExtent]] and [[MultibandTile]], respectively.
@@ -260,11 +260,11 @@ object HadoopGeoTiffRDD {
     * It assumes that the provided files are [[MultibandGeoTiff]]s.
     *
     * @param path     Hadoop path to recursively search for GeoTiffs.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param pathToKey function to transform input key basing on the Path information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def spatialMultiband(path: Path, keyTransform: (URI, ProjectedExtent) => ProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
-    multiband[ProjectedExtent, ProjectedExtent](path, keyTransform, options)
+  def spatialMultiband(path: Path, pathToKey: (Path, ProjectedExtent) => ProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(ProjectedExtent, MultibandTile)] =
+    multiband[ProjectedExtent, ProjectedExtent](path, pathToKey, options)
 
   /**
     * Creates RDDs with the [(K, V)] values being [[TemporalProjectedExtent]] and [[Tile]], respectively.
@@ -290,11 +290,11 @@ object HadoopGeoTiffRDD {
     * It assumes that the provided files are [[SinglebandGeoTiff]]s.
     *
     * @param path     Hadoop path to recursively search for GeoTiffs.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param pathToKey function to transform input key basing on the Path information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def temporal(path: Path, keyTransform: (URI, TemporalProjectedExtent) => TemporalProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, Tile)] =
-    singleband[TemporalProjectedExtent, TemporalProjectedExtent](path, keyTransform, options)
+  def temporal(path: Path, pathToKey: (Path, TemporalProjectedExtent) => TemporalProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, Tile)] =
+    singleband[TemporalProjectedExtent, TemporalProjectedExtent](path, pathToKey, options)
 
   /**
     * Creates RDDs with the [(K, V)] values being [[TemporalProjectedExtent]] and [[MultibandTile]], respectively.
@@ -320,9 +320,9 @@ object HadoopGeoTiffRDD {
     * It assumes that the provided files are [[MultibandGeoTiff]]s.
     *
     * @param path     Hadoop path to recursively search for GeoTiffs.
-    * @param keyTransform function to transform input key basing on the URI information.
+    * @param pathToKey function to transform input key basing on the Path information.
     * @param options  An instance of [[Options]] that contains any user defined or default settings.
     */
-  def temporalMultiband(path: Path, keyTransform: (URI, TemporalProjectedExtent) => TemporalProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, MultibandTile)] =
-    multiband[TemporalProjectedExtent, TemporalProjectedExtent](path, keyTransform, options)
+  def temporalMultiband(path: Path, pathToKey: (Path, TemporalProjectedExtent) => TemporalProjectedExtent, options: Options)(implicit sc: SparkContext): RDD[(TemporalProjectedExtent, MultibandTile)] =
+    multiband[TemporalProjectedExtent, TemporalProjectedExtent](path, pathToKey, options)
 }

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDDSpec.scala
@@ -135,8 +135,8 @@ class HadoopGeoTiffRDDSpec
       val actual =
         HadoopGeoTiffRDD.singleband[ProjectedExtent, TemporalProjectedExtent](
           path = tilesDir,
-          keyTransform = (uri: URI, key: ProjectedExtent) => {
-            val n = pattern.findAllIn(uri.getPath.split("/").last)
+          pathToKey = (p: Path, key: ProjectedExtent) => {
+            val n = pattern.findAllIn(p.toUri.getPath.split("/").last)
             n.next()
             val gr = n.group(1)
             val zdt = LocalDateTime.of(gr.substring(0, 4).toInt, gr.substring(4, 6).toInt, 1, 0, 0, 0).atZone(ZoneId.of("UTC"))


### PR DESCRIPTION
Fixes #1958 without a significant API changes. This PR introduces a `keyTransform: (URI, I) => K` function to have ability to read necessary metadata from files paths, and to modify `Input key`.

- [x] Tests