### PR TITLE
Allow MapKeyTransform to deal with points north and west of extent

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -92,7 +92,7 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
     val trow =
       ((extent.ymax - y) / extent.height) * layoutRows
 
-    (tcol.toInt, trow.toInt)
+    (tcol.floor.toInt, trow.floor.toInt)
   }
 
   def apply[K: SpatialComponent](key: K): Extent = {

--- a/spark/src/test/scala/geotrellis/spark/tiling/MapKeyTransformSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/tiling/MapKeyTransformSpec.scala
@@ -84,5 +84,12 @@ class MapKeyTransformSpec extends FunSpec with Matchers {
       assert(mp(Extent(0,0,0,0)) === GridBounds(0, 2, 0, 2))
       assert(mp(Extent(0,0,2,0)) === GridBounds(0, 2, 1, 2))
     }
+
+    it("should properly handle points north or west of the extent bounds") {
+      val mp = MapKeyTransform(Extent(0.0, 0.0, 1.0, 1.0), 2, 2)
+      assert(mp(Point(0.0, 1.0)) == SpatialKey(0, 0))
+      assert(mp(Point(-0.1, 1.0)) == SpatialKey(-1, 0))
+      assert(mp(Point(0.0, 1.1)) == SpatialKey(0, -1))
+    }
   }
 }


### PR DESCRIPTION
Previously, `MapKeyTransform(Extent(0, 0, 1, 1), 2, 2).apply(-0.1,1.0)` erroneously yielded `SpatialKey(0, 0)`.  The relevant code has been fixed, and the above now correctly produces `SpatialKey(-1, 0)`.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>