### PR TITLE
Fixed geotiff reading for tie point and PixelIsPoint

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -561,3 +561,17 @@ class PackBitsGeoTiffReaderSpec extends FunSpec
     }
   }
 }
+
+class TiePointsTests extends FunSuite
+     with RasterMatchers
+     with GeoTiffTestUtils {
+
+   test("Reads correct extent for tie points and PixelIsPoint") {
+     val actual = SinglebandGeoTiff.compressed(geoTiffPath("tie-points.tif")).extent
+     // The expected Extent is read in from gdalinfo
+     val expected = Extent( 0.5000000,   0.5000000,
+                           10.5000000,  10.5000000)
+
+     actual should be (expected)
+   }
+ }


### PR DESCRIPTION
Fixes #1574

When dealing with GeoTiffs that use ModelTiepointTag and ModelPixelScaleTag to define their coordinate transform, one must take into account whether the raster is considered `PixelIsPoint`. If this is the case, the tie point references the center of the cell, and the extent needs to be adjusted.

This approach is taken by GDAL, see here: https://github.com/OSGeo/gdal/blob/7480b720aa74c87d63d1fbf563373dc7c24fa191/gdal/frmts/gtiff/gt_wkt_srs.cpp#L2722