### PR TITLE
LazySegmentBytes fix: always read bytes at the offset

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -525,6 +525,15 @@ class GeoTiffReaderSpec extends FunSpec
 
       gt3.tags.headTags.get(Tags.TIFFTAG_DATETIME) should be (Some("1988:02:18 13:59:59"))
     }
+
+    it("must read tiny tiles") {
+      val extent = Extent(0,0,100,100)
+      val expected = IntArrayTile(Array(145), 1, 1)
+      GeoTiff(expected, extent, LatLng).write(path)
+      addToPurge(path)
+      val actual = SinglebandGeoTiff(path).tile
+      assertEqual(actual, expected)
+    }
   }
 
   describe("handling special CRS cases") {


### PR DESCRIPTION
Fixes #1959

The problem here was that we were using the same ByteReader extension method that we use for TiffTag reading to read the segment bytes. The TiffTag bytes have a property that if the length is less than 4 bytes, the value is stored inside the offset field. This property does not apply to segment bytes, so I refactored LazySegmentBytes so that it uses it's own straightforward byte reading code. ArraySegmentBytes delegates to LazySegmentBytes, so this fixes both streaming and non-streaming cases.