### PR TITLE
Fix issue with S3LayerDeleter deleting files outside of layer

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerDeleter.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerDeleter.scala
@@ -31,7 +31,7 @@ class S3LayerDeleter(val attributeStore: AttributeStore) extends LazyLogging wit
     try {
       val header = attributeStore.readHeader[S3LayerHeader](id)
       val bucket = header.bucket
-      val prefix = header.key
+      val prefix = header.key + "/"
       val s3Client = getS3Client()
 
       s3Client.deleteListing(bucket, s3Client.listObjects(bucket, prefix))


### PR DESCRIPTION
S3LayerDeleter can incorrectly delete keys since it is based on a wildcard pattern.

For example:
If you have multiple keys like 
```
1/files
10/files
```

and you delete an entry with the key `1` then it will also delete `10/files` Appending the extra `/` will perform the task as expected