### PR TITLE
Fix usage of IntCachedColorMap in Indexed PNG encoding

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/render/ColorMapSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/render/ColorMapSpec.scala
@@ -113,6 +113,40 @@ class ColorMapSpec extends FunSpec with Matchers
       }
     }
 
+    it("should correctly map values to colors using IntCacheColorMap") {
+      val limits = Array(25,50,80,100)
+      val colors = Array(100,110,120,130)
+
+      val colorMap1 = ColorMap(limits, colors)
+      val arr = (0 until 90 by 5).toArray
+      val r = createTile(arr)
+      val h = r.histogram
+      val colorMap = colorMap1.withNoDataColor(0).withBoundaryType(LessThanOrEqualTo).asInstanceOf[IntColorMap].cache(h)
+
+      val color: IndexedPngEncoding =
+        PngColorEncoding(colorMap.colors, colorMap.options.noDataColor, colorMap.options.fallbackColor) match {
+          case i @ IndexedPngEncoding(_, _) => i
+          case _ =>
+            withClue(s"Color should be Indexed") { sys.error("") }
+        }
+
+      // check that PNG will correctly convert raster to their color index values
+      val pngMap = color.convertColorMap(colorMap)
+      for ( (c, i) <- colorMap.colors.zipWithIndex) {
+        pngMap.map(c) should be (i)
+      }
+
+      // check that we can convert all raster values we have seen in our histogram
+      withClue(s"Cached colors: ${colorMap.colors.toList}") {
+        for (x <- arr) {
+          if (x <= 25) colorMap.map(x) should be(100)
+          else if (x <= 50) colorMap.map(x) should be(110)
+            // tile does not have any values past 75, since we didn't see them, we don't expect to color them
+          else if (x > 75) colorMap.options.noDataColor
+        }
+      }
+    }
+
     it("should correctly map redundant values to colors") {
       val limits = Array(25,42,60)
       val colors = Array(10,20,30)

--- a/raster-test/src/test/scala/geotrellis/raster/render/ColorMapSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/render/ColorMapSpec.scala
@@ -117,11 +117,13 @@ class ColorMapSpec extends FunSpec with Matchers
       val limits = Array(25,50,80,100)
       val colors = Array(100,110,120,130)
 
-      val colorMap1 = ColorMap(limits, colors)
+      val colorRamp: ColorRamp = colors
+      val breaksToColors: Map[Int, Int] = (limits zip colorRamp.stops(limits.size).colors).toMap
+      val colorMap1 = new IntColorMap(breaksToColors, ColorMap.Options(noDataColor =  0, classBoundaryType = LessThanOrEqualTo))
       val arr = (0 until 90 by 5).toArray
       val r = createTile(arr)
       val h = r.histogram
-      val colorMap = colorMap1.withNoDataColor(0).withBoundaryType(LessThanOrEqualTo).asInstanceOf[IntColorMap].cache(h)
+      val colorMap = colorMap1.cache(h)
 
       val color: IndexedPngEncoding =
         PngColorEncoding(colorMap.colors, colorMap.options.noDataColor, colorMap.options.fallbackColor) match {

--- a/raster-test/src/test/scala/geotrellis/raster/render/ColorMapSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/render/ColorMapSpec.scala
@@ -132,8 +132,10 @@ class ColorMapSpec extends FunSpec with Matchers
 
       // check that PNG will correctly convert raster to their color index values
       val pngMap = color.convertColorMap(colorMap)
-      for ( (c, i) <- colorMap.colors.zipWithIndex) {
-        pngMap.map(c) should be (i)
+      h.foreachValue { z =>
+        val color = colorMap.map(z)
+        val colorIndex = colorMap.colors.indexOf(color)
+        pngMap.map(z) should be(colorIndex)
       }
 
       // check that we can convert all raster values we have seen in our histogram

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
@@ -256,6 +256,8 @@ class IntColorMap(breaksToColors: Map[Int, Int], val options: Options = Options.
   * In order for this class to work correctly the histogram acts as a map from values to their colors
   * and must contain a value for each pixel value that we expect to encounter.
   *
+  * The performance benefit is `eC` lookup cost instead of `Log` provided by [[IntColorMap]]
+  *
   * @param colors All color values that can be encountered
   * @param h      Histogram where counts of values have been replaced cached RGBA color
   */

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
@@ -265,10 +265,6 @@ class IntCachedColorMap(val colors: Vector[Int], h: Histogram[Int], val options:
     extends ColorMap {
   val noDataColor = options.noDataColor
 
-  h.foreachValue{ z =>
-    println(s"Cache map: $z -> ${h.itemCount(z)}")
-  }
-
   def map(z: Int): Int = { if(isNoData(z)) noDataColor else h.itemCount(z).toInt }
 
   def mapDouble(z: Double): Int = map(d2i(z))
@@ -282,6 +278,7 @@ class IntCachedColorMap(val colors: Vector[Int], h: Histogram[Int], val options:
   def mapColorsToIndex(): ColorMap = {
     val colorIndexMap = colors.zipWithIndex.toMap
     val ch = h.mutable
+
     h.foreachValue(z => ch.setItem(z, colorIndexMap(h.itemCount(z).toInt)))
     new IntCachedColorMap((0 to colors.length).toVector, ch, options)
   }

--- a/raster/src/main/scala/geotrellis/raster/render/png/PngColorEncoding.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/png/PngColorEncoding.scala
@@ -18,6 +18,7 @@ package geotrellis.raster.render.png
 
 import geotrellis.raster.render._
 
+/** Captures the conversion strategies from RGBA color space to PNG pixels. */
 sealed abstract class PngColorEncoding(val n: Byte, val depth: Int) {
  def convertColorMap(colorMap: ColorMap): ColorMap
 }


### PR DESCRIPTION
`IntCachedColorMap` implementation was not covered by unit tests and turned out to be incorrect.
This PR adds unit tests for its usage and changes the behavior to something that works.

It looks like this class fell through some cracks in the refactors. In reality it leans on implementation of `FastMapHistogram` to convert pixels directly to colors, which uses a hash table lookup.

In effect we get `eC` color encoding instead of `Log` which is provided by `IntColorMap`