### PR TITLE
Resolved Path java serialization issue in HadoopGeoTiffRDD

### DIFF
--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDDSpec.scala
@@ -135,8 +135,8 @@ class HadoopGeoTiffRDDSpec
       val actual =
         HadoopGeoTiffRDD.singleband[ProjectedExtent, TemporalProjectedExtent](
           path = tilesDir,
-          pathToKey = (p: Path, key: ProjectedExtent) => {
-            val n = pattern.findAllIn(p.toUri.getPath.split("/").last)
+          uriToKey = (u: URI, key: ProjectedExtent) => {
+            val n = pattern.findAllIn(u.getPath.split("/").last)
             n.next()
             val gr = n.group(1)
             val zdt = LocalDateTime.of(gr.substring(0, 4).toInt, gr.substring(4, 6).toInt, 1, 0, 0, 0).atZone(ZoneId.of("UTC"))


### PR DESCRIPTION
Currently, `HadoopGeoTiffRDD` has an issue where setting both `maxTileSize` and `numPartitions` causes the reading to fail. This is due to a serialization problem where the default serializer cannot serialize/deserialize `org.apache.hadoop.fs.Path`. To fix this problem, the `Path`s were converted to `URI`s during the transformation of the input key.

This resolves #2103 