### PR TITLE
Fix errors in StitchedDelaunay when used with BoundaryDelaunay extracts

### DIFF
--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunay.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunay.scala
@@ -470,11 +470,11 @@ object BoundaryDelaunay {
         ne = halfEdgeTable.getNext(ne)
       } while (e != dt.boundary)
 
-      writeWKT("bounds.wkt")
+      //writeWKT("bounds.wkt")
       //isMeshValid(triangles, halfEdgeTable)
 
       fillInnerLoop
-      writeWKT("filled.wkt")
+      //writeWKT("filled.wkt")
 
       // // Add fans of boundary edges
       // do {

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunay.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunay.scala
@@ -1,6 +1,6 @@
 package geotrellis.pointcloud.spark.triangulation
 
-import geotrellis.vector.{Extent, Line, MultiPolygon, Point, Polygon}
+import geotrellis.vector.{Extent, Line, MultiPolygon, Point, Polygon, RobustPredicates}
 import geotrellis.vector.triangulation._
 
 import com.vividsolutions.jts.algorithm.distance.{DistanceToPoint, PointPairDistance}
@@ -47,12 +47,53 @@ object BoundaryDelaunay {
 
     val triangles = new TriangleMap(halfEdgeTable)
 
+    def writeWKT(wktFile: String) = {
+      val indexToCoord = { i: Int => Point.jtsCoord2Point(dt.pointSet.getCoordinate(i)) }
+      val mp = geotrellis.vector.MultiPolygon(triangles.getTriangles.keys.map{ case (i,j,k) => Polygon(indexToCoord(i), indexToCoord(j), indexToCoord(k), indexToCoord(i)) })
+      val wktString = geotrellis.vector.io.wkt.WKT.write(mp)
+      new java.io.PrintWriter(wktFile) { write(wktString); close }
+    }
+
+    def navigateThis(e0: Int) = {
+      halfEdgeTable.navigate(e0, verts.apply(_), Map[Char, (String, Int => Int)](
+        'x' -> (("export current loop to loop.wkt", { einit =>
+          import halfEdgeTable._
+          var e = einit
+          val pts = collection.mutable.ListBuffer[Coordinate](verts(getSrc(e)))
+          do {
+            pts += verts(getDest(e))
+            e = getNext(e)
+          } while (e != einit)
+          val loop = Polygon(pts.map(Point.jtsCoord2Point(_)))
+          new java.io.PrintWriter("loop.wkt") { write(geotrellis.vector.io.wkt.WKT.write(loop)); close }
+          einit
+        })),
+        'c' -> (("print the center of the current triangle's circumscribing circle", { e =>
+          val predicates = new TriangulationPredicates(DelaunayPointSet(verts.toMap), halfEdgeTable)
+          import predicates._
+          import halfEdgeTable._
+          val (_, center) = circleCenter(getDest(e), getDest(getNext(e)), getDest(getNext(getNext(e))))
+          println(s"Circle center: $center")
+          e
+        })),
+        't' -> (("export triangles to triangles.wkt", { e => 
+          val polys = collection.mutable.ListBuffer.empty[Polygon]
+          val trans = { i : Int => Point.jtsCoord2Point(verts(i)) }
+          triangles.triangleVertices.foreach { case (i, j, k) => {
+            polys += Polygon(trans(i), trans(j), trans(k), trans(i))
+          }}
+          val mp = MultiPolygon(polys)
+          new java.io.PrintWriter("triangles.wkt"){ write(geotrellis.vector.io.wkt.WKT.write(mp)); close }
+          e
+        }))
+      ))
+    }
+
     def circumcircleLeavesExtent(extent: Extent)(tri: HalfEdge): Boolean = {
       import dt.halfEdgeTable._
       import dt.predicates._
 
-      val center = circleCenter(getDest(tri), getDest(getNext(tri)), getDest(getNext(getNext(tri))))
-      val radius = center.distance(new Coordinate(dt.pointSet.getX(getDest(tri)), dt.pointSet.getY(getDest(tri))))
+      val (radius, center) = circleCenter(getDest(tri), getDest(getNext(tri)), getDest(getNext(getNext(tri))))
       val ppd = new PointPairDistance
 
       DistanceToPoint.computeDistance(extent.toPolygon.jtsGeom, center, ppd)
@@ -233,17 +274,17 @@ object BoundaryDelaunay {
               halfEdgeTable.join(opp, tri)
               innerEdges -= halfEdgeTable.getSrc(tri) -> halfEdgeTable.getDest(tri)
               innerEdges -= halfEdgeTable.getDest(tri) -> halfEdgeTable.getSrc(tri)
-              // r.joinTriangles(opp, tri)
-              // println(s"    JOIN FOUND TRIANGLE")
-              // r.showBoundingLoop(r.getFlip(r.getNext(tri)))
-              // r.showBoundingLoop(r.getFlip(r.getNext(opp)))
+            // r.joinTriangles(opp, tri)
+            // println(s"    JOIN FOUND TRIANGLE")
+            // r.showBoundingLoop(r.getFlip(r.getNext(tri)))
+            // r.showBoundingLoop(r.getFlip(r.getNext(opp)))
             case None =>
               // We haven't been here yet, so create a triangle to mirror the one referred to by e, and link opp to it.
               // (If that triangle belongs in the boundary, otherwise, mark opp as part of the inner ring for later)
               //println("     --- DID NOT FIND TRIANGLE")
 
-        //      val tri = copyConvertTriangle(e)
-        //      halfEdgeTable.join(opp, tri)
+              //      val tri = copyConvertTriangle(e)
+              //      halfEdgeTable.join(opp, tri)
 
               if (circumcircleLeavesExtent(boundingExtent)(e)) {
                 //println("         Triangle circle leaves extent")
@@ -353,9 +394,7 @@ object BoundaryDelaunay {
           e = rotCWDest(e)
           pairedE = halfEdgeTable.rotCWDest(pairedE)
           j += 1
-        } while (continue && j < 20)
-        if (j == 20)
-          println("Premature termination")
+        } while (continue)
       }}
 
     }
@@ -383,17 +422,27 @@ object BoundaryDelaunay {
       val newBound: ResultEdge = copyConvertBoundingLoop()
       var e = dt.boundary
       var ne = newBound
+      navigateThis(ne)
+
       val boundingTris = collection.mutable.Set.empty[Int]
       do {
         // println(s"in CCBT $e")
+        assert(getDest(e) == halfEdgeTable.getDest(ne) && getSrc(e) == halfEdgeTable.getSrc(ne))
+        if (circumcircleLeavesExtent(boundingExtent)(getFlip(e))) {
+          val f = getFlip(e)
+          println(s"Triangle ${(getSrc(f), getDest(f), getDest(getNext(f)), getDest(getNext(getNext(f))))} has circumcircle outside extent")
+        }
         recursiveAddTris(getFlip(e), ne)
+        navigateThis(ne)
         e = getNext(e)
         ne = halfEdgeTable.getNext(ne)
       } while (e != dt.boundary)
 
+      writeWKT("bounds.wkt")
       //isMeshValid(triangles, halfEdgeTable)
 
       fillInnerLoop
+      writeWKT("filled.wkt")
 
       // // Add fans of boundary edges
       // do {
@@ -438,13 +487,6 @@ object BoundaryDelaunay {
         copyConvertBoundingTris
 
     BoundaryDelaunay(DelaunayPointSet(verts.toMap), halfEdgeTable, triangles, boundary, /*innerEdges.head._2._2,*/ isLinear)  }
-
-  // def writeWKT(wktFile: String) = {
-  //   val indexToCoord = { i: Int => Point.jtsCoord2Point(dt.pointSet.getCoordinate(i)) }
-  //   val mp = geotrellis.vector.MultiPolygon(triangles.getTriangles.keys.map{ case (i,j,k) => Polygon(indexToCoord(i), indexToCoord(j), indexToCoord(k), indexToCoord(i)) })
-  //   val wktString = geotrellis.vector.io.wkt.WKT.write(mp)
-  //   new java.io.PrintWriter(wktFile) { write(wktString); close }
-  // }
 
 }
 

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunay.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunay.scala
@@ -94,10 +94,12 @@ object BoundaryDelaunay {
       import dt.predicates._
 
       val (radius, center, valid) = circleCenter(getDest(tri), getDest(getNext(tri)), getDest(getNext(getNext(tri))))
-      val ppd = new PointPairDistance
 
-      DistanceToPoint.computeDistance(extent.toPolygon.jtsGeom, center, ppd)
-      !valid || ppd.getDistance < radius
+      !valid || {
+        val ppd = new PointPairDistance
+        DistanceToPoint.computeDistance(extent.toPolygon.jtsGeom, center, ppd)
+        ppd.getDistance < radius
+      }
     }
 
     def inclusionTest(extent: Extent, thresh: Double)(tri: HalfEdge): Boolean = {

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/CoordinatePredicates.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/CoordinatePredicates.scala
@@ -92,7 +92,7 @@ object CoordinatePredicates {
     ShewchuksDeterminant.incircle(a.x, a.y, b.x, b.y, c.x, c.y, d.x, d.y) > EPSILON
   }
 
-  def circleCenter[V](ai: V, bi: V, ci: V)(implicit trans: V => Coordinate): (Double, Coordinate) = {
+  def circleCenter[V](ai: V, bi: V, ci: V)(implicit trans: V => Coordinate): (Double, Coordinate, Boolean) = {
     val a = trans(ai)
     val b = trans(bi)
     val c = trans(ci)

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunay.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunay.scala
@@ -93,7 +93,29 @@ object StitchedDelaunay {
       .map{row => row.reduce{ (l, r) => {
         val (left, isLeftLinear) = l
         val (right, isRightLinear) = r
-        stitcher.merge(left, isLeftLinear, right, isRightLinear, overlayTris, debug)
+        val result = stitcher.merge(left, isLeftLinear, right, isRightLinear, overlayTris, debug)
+        allEdges.navigate(result._1, pointMap, Map(
+          't' -> ("export triangles to triangles.wkt", { e0 =>
+            val mp = MultiPolygon(overlayTris.triangleVertices.map{ case (i,j,k) => {
+              Polygon(pointMap(i), pointMap(j), pointMap(k), pointMap(i))
+            }})
+            new java.io.PrintWriter("triangles.wkt") { write(WKT.write(mp)); close }
+            e0
+          }),
+          'x' -> ("export current loop to poly.wkt", { e0 =>
+            import allEdges._
+            var e = e0
+            val pts = collection.mutable.ListBuffer[Coordinate](pointMap(getSrc(e)))
+            do {
+              pts += pointMap(getDest(e))
+              e = getNext(e)
+            } while (e != e0)
+            val mp = Polygon(pts.map(Point.jtsCoord2Point(_)))
+            new java.io.PrintWriter("poly.wkt") { write(WKT.write(mp)); close }
+            e0
+          })
+        ))
+        result
       }}}
       .reduce{ (l, r) => {
         val (left, isLeftLinear) = l
@@ -127,7 +149,9 @@ object StitchedDelaunay {
       .map{row => row.reduce{ (l, r) => {
         val (left, isLeftLinear) = l
         val (right, isRightLinear) = r
-        stitcher.merge(left, isLeftLinear, right, isRightLinear, overlayTris, debug)
+        val result = stitcher.merge(left, isLeftLinear, right, isRightLinear, overlayTris, debug)
+        //allEdges.navigate(result._1, pointMap, Map.empty)
+        result
       }}}
       .reduce{ (l, r) => {
         val (left, isLeftLinear) = l

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunay.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunay.scala
@@ -94,27 +94,27 @@ object StitchedDelaunay {
         val (left, isLeftLinear) = l
         val (right, isRightLinear) = r
         val result = stitcher.merge(left, isLeftLinear, right, isRightLinear, overlayTris, debug)
-        allEdges.navigate(result._1, pointMap, Map(
-          't' -> ("export triangles to triangles.wkt", { e0 =>
-            val mp = MultiPolygon(overlayTris.triangleVertices.map{ case (i,j,k) => {
-              Polygon(pointMap(i), pointMap(j), pointMap(k), pointMap(i))
-            }})
-            new java.io.PrintWriter("triangles.wkt") { write(WKT.write(mp)); close }
-            e0
-          }),
-          'x' -> ("export current loop to poly.wkt", { e0 =>
-            import allEdges._
-            var e = e0
-            val pts = collection.mutable.ListBuffer[Coordinate](pointMap(getSrc(e)))
-            do {
-              pts += pointMap(getDest(e))
-              e = getNext(e)
-            } while (e != e0)
-            val mp = Polygon(pts.map(Point.jtsCoord2Point(_)))
-            new java.io.PrintWriter("poly.wkt") { write(WKT.write(mp)); close }
-            e0
-          })
-        ))
+        // allEdges.navigate(result._1, pointMap, Map(
+        //   't' -> ("export triangles to triangles.wkt", { e0 =>
+        //     val mp = MultiPolygon(overlayTris.triangleVertices.map{ case (i,j,k) => {
+        //       Polygon(pointMap(i), pointMap(j), pointMap(k), pointMap(i))
+        //     }})
+        //     new java.io.PrintWriter("triangles.wkt") { write(WKT.write(mp)); close }
+        //     e0
+        //   }),
+        //   'x' -> ("export current loop to poly.wkt", { e0 =>
+        //     import allEdges._
+        //     var e = e0
+        //     val pts = collection.mutable.ListBuffer[Coordinate](pointMap(getSrc(e)))
+        //     do {
+        //       pts += pointMap(getDest(e))
+        //       e = getNext(e)
+        //     } while (e != e0)
+        //     val mp = Polygon(pts.map(Point.jtsCoord2Point(_)))
+        //     new java.io.PrintWriter("poly.wkt") { write(WKT.write(mp)); close }
+        //     e0
+        //   })
+        // ))
         result
       }}}
       .reduce{ (l, r) => {

--- a/pointcloud/src/test/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunaySpec.scala
+++ b/pointcloud/src/test/scala/geotrellis/pointcloud/spark/triangulation/BoundaryDelaunaySpec.scala
@@ -45,12 +45,11 @@ class BoundaryDelaunaySpec extends FunSpec with Matchers {
         import dt.pointSet._
         import dt.predicates._
 
-        val center = circleCenter(getDest(tri), getDest(getNext(tri)), getDest(getNext(getNext(tri))))
-        val radius = center.distance(getCoordinate(getDest(tri)))
+        val (radius, center, valid) = circleCenter(getDest(tri), getDest(getNext(tri)), getDest(getNext(getNext(tri))))
         val ppd = new PointPairDistance
 
         DistanceToPoint.computeDistance(ex.toPolygon.jtsGeom, center, ppd)
-        ppd.getDistance < radius
+        !valid || ppd.getDistance < radius
       }
 
       dt.triangleMap.getTriangles.toSeq.forall{ case (idx, tri) => {
@@ -70,7 +69,7 @@ class BoundaryDelaunaySpec extends FunSpec with Matchers {
 
       // implicit val trans = { i: Int => pts(i) }
       import bdt.halfEdgeTable._
-      val predicates = new Predicates(bdt.pointSet, bdt.halfEdgeTable)
+      val predicates = new TriangulationPredicates(bdt.pointSet, bdt.halfEdgeTable)
       import predicates._
 
       var validCW = true

--- a/pointcloud/src/test/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunaySpec.scala
+++ b/pointcloud/src/test/scala/geotrellis/pointcloud/spark/triangulation/StitchedDelaunaySpec.scala
@@ -104,7 +104,7 @@ class StitchedDelaunaySpec extends FunSpec with Matchers {
         val b = stitch.indexToCoord(bi)
         val c = stitch.indexToCoord(ci)
         points.forall{ pt => {
-          val result = !Predicates.inCircle(a, b, c, pt)
+          val result = !RobustPredicates.inCircle(a, b, c, pt)
           // if (!result) {
           //   println(s"plot([${pt.x}], [${pt.y}], 'k*', [${a.x}, ${b.x}, ${c.x}, ${a.x}], [${a.y}, ${b.y}, ${c.y}, ${a.y}], 'r-', [${a.x}], [${a.y}], 'b*', [${b.x}], [${b.y}], 'g*')")
           // }
@@ -159,7 +159,7 @@ class StitchedDelaunaySpec extends FunSpec with Matchers {
         val b = stitch.indexToCoord(bi)
         val c = stitch.indexToCoord(ci)
         points.forall{ pt => {
-          val result = !Predicates.inCircle(a, b, c, pt)
+          val result = !RobustPredicates.inCircle(a, b, c, pt)
           result
         }}
       }} should be (true)

--- a/vector-test/src/test/scala/spec/geotrellis/vector/triangulation/DelaunayTriangulationSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/triangulation/DelaunayTriangulationSpec.scala
@@ -121,7 +121,7 @@ class DelaunayTriangulationSpec extends FunSpec with Matchers {
 
       (dt.triangleMap.getTriangles.forall{ case ((ai,bi,ci),_) =>
         val otherPts = (0 until numpts).filter{ i: Int => i != ai && i != bi && i != ci }
-        otherPts.forall{ i => ! RobustPredicates.inCircle(ai, bi, ci, i) }
+        otherPts.forall{ i => ! dt.predicates.inCircle(ai, bi, ci, i) }
       }) should be (true)
     }
 

--- a/vector-test/src/test/scala/spec/geotrellis/vector/triangulation/DelaunayTriangulationSpec.scala
+++ b/vector-test/src/test/scala/spec/geotrellis/vector/triangulation/DelaunayTriangulationSpec.scala
@@ -121,7 +121,7 @@ class DelaunayTriangulationSpec extends FunSpec with Matchers {
 
       (dt.triangleMap.getTriangles.forall{ case ((ai,bi,ci),_) =>
         val otherPts = (0 until numpts).filter{ i: Int => i != ai && i != bi && i != ci }
-        otherPts.forall{ i => ! Predicates.inCircle(ai, bi, ci, i) }
+        otherPts.forall{ i => ! RobustPredicates.inCircle(ai, bi, ci, i) }
       }) should be (true)
     }
 

--- a/vector/src/main/java/geotrellis/vector/ShewchuksDeterminant.java
+++ b/vector/src/main/java/geotrellis/vector/ShewchuksDeterminant.java
@@ -10,7 +10,7 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  */
 
-package geotrellis.vector.triangulation;
+package geotrellis.vector;
 
 // This file is a modified port that is in JTS of SHewchuk's predicates.
 // Below are the original comments by the JTS developer.

--- a/vector/src/main/scala/geotrellis/vector/RobustPredicates.scala
+++ b/vector/src/main/scala/geotrellis/vector/RobustPredicates.scala
@@ -1,0 +1,91 @@
+package geotrellis.vector
+
+import com.vividsolutions.jts.geom.Coordinate
+import org.apache.commons.math3.linear._
+
+import geotrellis.util.Constants.{DOUBLE_EPSILON => EPSILON}
+
+
+object RobustPredicates {
+
+  def det2 (a11: Double, a12: Double,
+            a21: Double, a22: Double): Double = {
+    a11 * a22 - a12 * a21
+  }
+
+  def det3 (a11: Double, a12: Double, a13: Double,
+            a21: Double, a22: Double, a23: Double,
+            a31: Double, a32: Double, a33: Double): Double = {
+    val m = MatrixUtils.createRealMatrix(Array(Array(a11, a12, a13),
+                                               Array(a21, a22, a23),
+                                               Array(a31, a32, a33)))
+    (new LUDecomposition(m)).getDeterminant
+  }
+
+  def isCollinear(
+    ax: Double, ay: Double,
+    bx: Double, by: Double,
+    cx: Double, cy: Double
+  ): Boolean = {
+    math.abs(ShewchuksDeterminant.orient2d(ax, ay, bx, by, cx, cy)) < EPSILON
+  }
+
+  def isCollinear(a: Coordinate, b: Coordinate, c: Coordinate): Boolean = {
+    isCollinear(a.x, a.y, b.x, b.y, c.x, c.y)
+  }
+
+  def isCCW(
+    ax: Double, ay: Double,
+    bx: Double, by: Double,
+    cx: Double, cy: Double
+  ): Boolean = {
+    ShewchuksDeterminant.orient2d(ax, ay, bx, by, cx, cy) > EPSILON
+  }
+
+  def isCCW(a: Coordinate, b: Coordinate, c: Coordinate): Boolean =
+    isCCW(a.x, a.y, b.x, b.y, c.x, c.y)
+
+  def inCircle(
+    ax: Double, ay: Double,
+    bx: Double, by: Double,
+    cx: Double, cy: Double,
+    dx: Double, dy: Double
+  ): Boolean = {
+    ShewchuksDeterminant.incircle(ax, ay, bx, by, cx, cy, dx, dy) > EPSILON
+  }
+
+  def inCircle(a: Coordinate, b: Coordinate, c: Coordinate, d: Coordinate): Boolean =
+    inCircle(a.x, a.y, b.x, b.y, c.x, c.y, d.x, d.y)
+
+  def circleCenter(ax: Double, ay: Double, bx: Double, by: Double, cx: Double, cy: Double): (Double, Coordinate) = {
+    // val d = 2.0 * det3(ax, ay, 1.0,
+    //                    bx, by, 1.0,
+    //                    cx, cy, 1.0)
+    // val h = det3(ax * ax + ay * ay, ay, 1.0,
+    //              bx * bx + by * by, by, 1.0,
+    //              cx * cx + cy * cy, cy, 1.0) / d
+    // val k = det3(ax, ax * ax + ay * ay, 1.0,
+    //              bx, bx * bx + by * by, 1.0,
+    //              cx, cx * cx + cy * cy, 1.0) / d
+
+    val dbx = bx - ax
+    val dby = by - ay
+    val dcx = cx - ax
+    val dcy = cy - ay
+
+    val lenΔb2 = dbx * dbx + dby * dby
+    val lenΔc2 = dcx * dcx + dcy * dcy
+
+    val d = 2.0 * det2(dbx, dby,
+                       dcx, dcy)
+    val h = ax - det2(dby, lenΔb2,
+                      dcy, lenΔc2) / d
+    val k = ay - det2(dbx, lenΔb2,
+                      dcx, lenΔc2) / d
+
+    val r = math.sqrt(lenΔb2 * lenΔc2 * ((bx - cx) * (bx - cx) + (by - cy) * (by - cy))) / d
+
+    (r, new Coordinate(h,k))
+  }
+
+}

--- a/vector/src/main/scala/geotrellis/vector/RobustPredicates.scala
+++ b/vector/src/main/scala/geotrellis/vector/RobustPredicates.scala
@@ -57,7 +57,7 @@ object RobustPredicates {
   def inCircle(a: Coordinate, b: Coordinate, c: Coordinate, d: Coordinate): Boolean =
     inCircle(a.x, a.y, b.x, b.y, c.x, c.y, d.x, d.y)
 
-  def circleCenter(ax: Double, ay: Double, bx: Double, by: Double, cx: Double, cy: Double): (Double, Coordinate) = {
+  def circleCenter(ax: Double, ay: Double, bx: Double, by: Double, cx: Double, cy: Double): (Double, Coordinate, Boolean) = {
     // val d = 2.0 * det3(ax, ay, 1.0,
     //                    bx, by, 1.0,
     //                    cx, cy, 1.0)
@@ -80,12 +80,12 @@ object RobustPredicates {
                        dcx, dcy)
     val h = ax - det2(dby, lenΔb2,
                       dcy, lenΔc2) / d
-    val k = ay - det2(dbx, lenΔb2,
+    val k = ay + det2(dbx, lenΔb2,
                       dcx, lenΔc2) / d
 
     val r = math.sqrt(lenΔb2 * lenΔc2 * ((bx - cx) * (bx - cx) + (by - cy) * (by - cy))) / d
 
-    (r, new Coordinate(h,k))
+    (r, new Coordinate(h,k), d > 2e-8)
   }
 
 }

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayStitcher.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayStitcher.scala
@@ -3,10 +3,10 @@ package geotrellis.vector.triangulation
 import com.vividsolutions.jts.geom.Coordinate
 import geotrellis.vector.{Line, MultiLine, Point}
 
-import Predicates.{LEFTOF, RIGHTOF, ON}
+import TriangulationPredicates.{LEFTOF, RIGHTOF, ON}
 
 final class DelaunayStitcher(pointSet: DelaunayPointSet, halfEdgeTable: HalfEdgeTable) {
-  val predicates = new Predicates(pointSet, halfEdgeTable)
+  val predicates = new TriangulationPredicates(pointSet, halfEdgeTable)
   import predicates._
   import pointSet._
   import halfEdgeTable._

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulation.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulation.scala
@@ -41,7 +41,7 @@ case class DelaunayTriangulation(pointSet: DelaunayPointSet, halfEdgeTable: Half
    */
   val triangleMap = new TriangleMap(halfEdgeTable)
 
-  val predicates = new Predicates(pointSet, halfEdgeTable)
+  val predicates = new TriangulationPredicates(pointSet, halfEdgeTable)
   import halfEdgeTable._
   import predicates._
 

--- a/vector/src/main/scala/geotrellis/vector/triangulation/TriangulationPredicates.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/TriangulationPredicates.scala
@@ -136,7 +136,7 @@ final class TriangulationPredicates(pointSet: DelaunayPointSet, halfEdgeTable: H
     RobustPredicates.inCircle(ax, ay, bx, by, cx, cy, dx, dy)
   }
 
-  def circleCenter(ai: Int, bi: Int, ci: Int): (Double, Coordinate) = {
+  def circleCenter(ai: Int, bi: Int, ci: Int): (Double, Coordinate, Boolean) = {
     val ax = getX(ai)
     val ay = getY(ai)
     val bx = getX(bi)

--- a/vector/src/main/scala/geotrellis/vector/triangulation/TriangulationPredicates.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/TriangulationPredicates.scala
@@ -3,69 +3,21 @@ package geotrellis.vector.triangulation
 import com.vividsolutions.jts.geom.Coordinate
 import org.apache.commons.math3.linear._
 
+import geotrellis.vector.ShewchuksDeterminant
+import geotrellis.vector.RobustPredicates
 import geotrellis.util.Constants.{DOUBLE_EPSILON => EPSILON}
 
-object Predicates {
+object TriangulationPredicates {
   final val LEFTOF = -1
   final val RIGHTOF = 1
   final val ON = 0
-
-  def det3 (a11: Double, a12: Double, a13: Double,
-            a21: Double, a22: Double, a23: Double,
-            a31: Double, a32: Double, a33: Double): Double = {
-    val m = MatrixUtils.createRealMatrix(Array(Array(a11, a12, a13),
-                                               Array(a21, a22, a23),
-                                               Array(a31, a32, a33)))
-    (new LUDecomposition(m)).getDeterminant
-  }
-
-  def isCollinear(a: Coordinate, b: Coordinate, c: Coordinate): Boolean = {
-    isCollinear(a.x, a.y, b.x, b.y, c.x, c.y)
-  }
-
-  def isCollinear(
-    ax: Double, ay: Double,
-    bx: Double, by: Double,
-    cx: Double, cy: Double
-  ): Boolean = {
-    math.abs(ShewchuksDeterminant.orient2d(ax, ay, bx, by, cx, cy)) < EPSILON
-  }
-
-  def isCCW(
-    ax: Double, ay: Double,
-    bx: Double, by: Double,
-    cx: Double, cy: Double
-  ): Boolean = {
-    // det [ a.x-c.x  a.y-c.y ]
-    //     [ b.x-c.x  b.y-c.y ] > 0
-    ShewchuksDeterminant.orient2d(ax, ay, bx, by, cx, cy) > EPSILON
-  }
-
-  def isCCW(a: Coordinate, b: Coordinate, c: Coordinate): Boolean =
-    isCCW(a.x, a.y, b.x, b.y, c.x, c.y)
-
-  def inCircle(
-    ax: Double, ay: Double,
-    bx: Double, by: Double,
-    cx: Double, cy: Double,
-    dx: Double, dy: Double
-  ): Boolean = {
-    // det3(a.x - d.x, a.y - d.y, pow(a.x - d.x, 2) + pow(a.y - d.y, 2),
-    //      b.x - d.x, b.y - d.y, pow(b.x - d.x, 2) + pow(b.y - d.y, 2),
-    //      c.x - d.x, c.y - d.y, pow(c.x - d.x, 2) + pow(c.y - d.y, 2)) > EPSILON
-    ShewchuksDeterminant.incircle(ax, ay, bx, by, cx, cy, dx, dy) > EPSILON
-  }
-
-  def inCircle(a: Coordinate, b: Coordinate, c: Coordinate, d: Coordinate): Boolean =
-    inCircle(a.x, a.y, b.x, b.y, c.x, c.y, d.x, d.y)
-
-
 }
 
-final class Predicates(pointSet: DelaunayPointSet, halfEdgeTable: HalfEdgeTable) {
+final class TriangulationPredicates(pointSet: DelaunayPointSet, halfEdgeTable: HalfEdgeTable) {
   import pointSet._
   import halfEdgeTable._
-  import Predicates._
+  import TriangulationPredicates._
+  import RobustPredicates._
 
   def isCollinear(a: Int, b: Int, c: Int): Boolean =
     math.abs(
@@ -142,7 +94,7 @@ final class Predicates(pointSet: DelaunayPointSet, halfEdgeTable: HalfEdgeTable)
     val by = getY(b)
     val cx = getX(c)
     val cy = getY(c)
-    Predicates.isCCW(ax, ay, bx, by, cx, cy)
+    RobustPredicates.isCCW(ax, ay, bx, by, cx, cy)
   }
 
   def isRightOf(e: Int, p: Int) = {
@@ -154,7 +106,7 @@ final class Predicates(pointSet: DelaunayPointSet, halfEdgeTable: HalfEdgeTable)
     val c = getSrc(e)
     val cx = getX(c)
     val cy = getY(c)
-    Predicates.isCCW(px, py, bx, by, cx, cy)
+    RobustPredicates.isCCW(px, py, bx, by, cx, cy)
   }
 
   // def isLeftOf(e: Int, p: Coordinate)(implicit trans: Int => Coordinate, het: HalfEdgeTable) =
@@ -169,7 +121,7 @@ final class Predicates(pointSet: DelaunayPointSet, halfEdgeTable: HalfEdgeTable)
     val c = getDest(e)
     val cx = getX(c)
     val cy = getY(c)
-    Predicates.isCCW(px, py, bx, by, cx, cy)
+    RobustPredicates.isCCW(px, py, bx, by, cx, cy)
   }
 
   def inCircle(ai: Int, bi: Int, ci: Int, di: Int): Boolean = {
@@ -181,41 +133,17 @@ final class Predicates(pointSet: DelaunayPointSet, halfEdgeTable: HalfEdgeTable)
     val cy = getY(ci)
     val dx = getX(di)
     val dy = getY(di)
-    Predicates.inCircle(ax, ay, bx, by, cx, cy, dx, dy)
+    RobustPredicates.inCircle(ax, ay, bx, by, cx, cy, dx, dy)
   }
 
-  // def circleCenter(a: Coordinate, b: Coordinate, c: Coordinate): Coordinate = {
-  //   val d = 2.0 * det3(a.x, a.y, 1.0,
-  //                      b.x, b.y, 1.0,
-  //                      c.x, c.y, 1.0)
-  //   val h = det3(a.x * a.x + a.y * a.y, a.y, 1.0,
-  //                b.x * b.x + b.y * b.y, b.y, 1.0,
-  //                c.x * c.x + c.y * c.y, c.y, 1.0) / d
-  //   val k = det3(a.x, a.x * a.x + a.y * a.y, 1.0,
-  //                b.x, b.x * b.x + b.y * b.y, 1.0,
-  //                c.x, c.x * c.x + c.y * c.y, 1.0) / d
-  //   new Coordinate(h,k)
-  // }
-
-  def circleCenter(ai: Int, bi: Int, ci: Int): Coordinate = {
+  def circleCenter(ai: Int, bi: Int, ci: Int): (Double, Coordinate) = {
     val ax = getX(ai)
     val ay = getY(ai)
     val bx = getX(bi)
     val by = getY(bi)
     val cx = getX(ci)
     val cy = getY(ci)
-
-    val d = 2.0 * det3(ax, ay, 1.0,
-                       bx, by, 1.0,
-                       cx, cy, 1.0)
-    val h = det3(ax * ax + ay * ay, ay, 1.0,
-                 bx * bx + by * by, by, 1.0,
-                 cx * cx + cy * cy, cy, 1.0) / d
-    val k = det3(ax, ax * ax + ay * ay, 1.0,
-                 bx, bx * bx + by * by, 1.0,
-                 cx, cx * cx + cy * cy, 1.0) / d
-
-    new Coordinate(h,k)
+    RobustPredicates.circleCenter(ax, ay, bx, by, cx, cy)
   }
 
   def isDelaunayEdge(e: Int): Boolean = {


### PR DESCRIPTION
In order to enable distributed Delaunay triangulations, we opted to allow triangulations defined over non-overlapping extents to be "stitched" together.  This requires, for each extent, the eight neighboring triangulations to be made available to the process.  Given that triangulations are actually rather heavy in terms of memory consumption, this can lead to large volumes of shuffle traffic in practice.  For example, when dealing with 3GB of pointcloud input (.LAS files), the stitch observes on the order of a terabyte of shuffle reads/writes.

This is unnecessary.  During the stitch, only a thin layer of triangles around the boundary are actually used.  We have had an implementation of the stitching algorithm using BoundaryDelaunay objects in the codebase for some time; however, the implementation of this boundary-stitching algorithm has been plagued with problems.  This PR aims to put this issue to bed.

BoundaryDelaunay construction has been affected by numerical problems which prevented correct extraction of the relevant triangles---notably involving very thin triangles on the boundary failing to be recognized as a part of the set of extracted triangles.  This patch is predominantly numerical in nature, with the main contribution being a reimplementation of the circleCenter function in the geotrellis.vector.RobustPredicates object.  I've also loosened the definition of the triangles that can be included in the boundary construction to hopefully skirt around numerically ill-conditioned cases.