### PR TITLE
Get absolute path for attributePath

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
@@ -34,8 +34,12 @@ import scala.util.matching.Regex
 class HadoopAttributeStore(val rootPath: Path, val hadoopConfiguration: Configuration) extends BlobLayerAttributeStore {
   import HadoopAttributeStore._
 
-  val attributePath = new Path(rootPath, "_attributes")
-  val fs = attributePath.getFileSystem(hadoopConfiguration)
+  val (fs, attributePath) = {
+    val ap = new Path(rootPath, "_attributes")
+    val fs = ap.getFileSystem(hadoopConfiguration)
+    // Get the absolute path to attributes
+    (fs, fs.getFileStatus(ap).getPath)
+  }
 
   // Create directory if it doesn't exist
   if(!fs.exists(attributePath)) {

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
@@ -18,17 +18,14 @@ package geotrellis.spark.io.hadoop
 
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.index.KeyIndex
-import org.apache.avro.Schema
 
 import spray.json._
 import DefaultJsonProtocol._
 import org.apache.hadoop.fs.Path
 import org.apache.spark._
-import java.io.PrintWriter
-
 import org.apache.hadoop.conf.Configuration
 
+import java.io.PrintWriter
 import scala.util.matching.Regex
 
 class HadoopAttributeStore(val rootPath: Path, val hadoopConfiguration: Configuration) extends BlobLayerAttributeStore {
@@ -37,13 +34,12 @@ class HadoopAttributeStore(val rootPath: Path, val hadoopConfiguration: Configur
   val (fs, attributePath) = {
     val ap = new Path(rootPath, "_attributes")
     val fs = ap.getFileSystem(hadoopConfiguration)
+
+    // Create directory if it doesn't exist
+    if(!fs.exists(ap)) fs.mkdirs(ap)
+
     // Get the absolute path to attributes
     (fs, fs.getFileStatus(ap).getPath)
-  }
-
-  // Create directory if it doesn't exist
-  if(!fs.exists(attributePath)) {
-    fs.mkdirs(attributePath)
   }
 
   def attributePath(layerId: LayerId, attributeName: String): Path = {


### PR DESCRIPTION
Fixes #2113 

What was happening is, because the attributePath was being stored as a local path, the `attributePath` method returned the relative path as well; when being compared to listed paths in `layerExists`, it would always fail the match. This didn't surface itself beforehand because we would always use absolute paths with HadoopLayer types; this prevents a problem if a user decides to user a relative path when the default filesystem is local.

This was a bit tough to capture in a unit test, but I did test this manually against geotrellis-landsat-tutorial.