### PR TITLE
GeoWave Update

### DIFF
--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Removing until the geowave API we need solidifies
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project geowave" compile test:compile || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project cassandra" test  || { exit 1; }
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project vector-test" test || { exit 1; }

--- a/publish/publish-to-sonatype.sh
+++ b/publish/publish-to-sonatype.sh
@@ -12,6 +12,7 @@
     && ./sbt "project hbase" publish-signed \
     && ./sbt "project spark-etl" publish-signed \
     && ./sbt "project geomesa" publish-signed \
+    && ./sbt "project geowave" publish-signed \
     && ./sbt "project geotools" publish-signed \
     && ./sbt "project shapefile" publish-signed \
     && ./sbt "project slick" publish-signed \

--- a/scripts/geowaveTestDB.sh
+++ b/scripts/geowaveTestDB.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 echo leader localhost > /tmp/hostaliases
-docker pull jamesmcclain/geowave:8760ce2
+docker pull jamesmcclain/geowave:e62deaf
 docker network create --driver bridge geowave
 docker run -td --restart=always --net=geowave \
        -p 50095:5009 -p 21810:2181 -p 9997:9997 -p 9999:9999 \
        --hostname leader --name leader \
-       jamesmcclain/geowave:c127c16
+       jamesmcclain/geowave:e62deaf


### PR DESCRIPTION
This contains GeoWave-related updates.

Tests pass locally:
```
Script started on Tue 04 Apr 2017 01:14:52 PM EDT
[1m[3m%[23m[1m[0m                                                                                                                                                                                                                                              
 

[0m[23m[24m[Jsrc/geotrellis% [K[?1h=HHOSTALIASES=/tmp/hostaliases ./sbt -J-Xmx2G "project geowave" test[?1l>

[0m[[0minfo[0m] [0mLoading project definition from /home/likewise-open/AZVA-INT/jmcclain/local/src/geotrellis/project[0m
[0m[[0minfo[0m] [0mResolving key references (15816 settings) ...[0m
[0m[[0minfo[0m] [0mSet current project to geotrellis (in build file:/home/likewise-open/AZVA-INT/jmcclain/local/src/geotrellis/)[0m
[0m[[0minfo[0m] [0mSet current project to geotrellis-geowave (in build file:/home/likewise-open/AZVA-INT/jmcclain/local/src/geotrellis/)[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
[0m[[33mwarn[0m] [0mCredentials file /home/likewise-open/AZVA-INT/jmcclain/.ivy2/.credentials does not exist[0m
13:15:10 NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
13:15:12 Utils: Your hostname, beijing resolves to a loopback address: 127.0.1.1; using 172.26.100.4 instead (on interface eth0)
13:15:12 Utils: Set SPARK_LOCAL_IP if you need to bind to another address
13:15:13 log: Logging initialized @18875ms
13:15:15 ClientConfiguration: Found no client.conf in default paths. Using default client configuration values.
13:15:15 ZooKeeper: Client environment:zookeeper.version=3.4.6-1569965, built on 02/20/2014 09:09 GMT
13:15:15 ZooKeeper: Client environment:host.name=beijing.internal.azavea.com
13:15:15 ZooKeeper: Client environment:java.version=1.8.0_111
13:15:15 ZooKeeper: Client environment:java.vendor=Oracle Corporation
13:15:15 ZooKeeper: Client environment:java.home=/usr/lib/jvm/java-8-openjdk-amd64/jre
13:15:15 ZooKeeper: Client environment:java.class.path=/home/likewise-open/AZVA-INT/jmcclain/.sbt/launchers/0.13.13/sbt-launch.jar
13:15:15 ZooKeeper: Client environment:java.library.path=/home/likewise-open/AZVA-INT/jmcclain/local/xfce-4.12/lib:/home/likewise-open/AZVA-INT/jmcclain/local/PDAL/lib:/home/likewise-open/AZVA-INT/jmcclain/local/lxde/lib:/home/likewise-open/AZVA-INT/jmcclain/local/nodejs-0.10.26/lib:/home/likewise-open/AZVA-INT/jmcclain/local/git-2.5.0/lib:/home/likewise-open/AZVA-INT/jmcclain/local/emacs-24.4.90/lib:/usr/java/packages/lib/amd64:/usr/lib/x86_64-linux-gnu/jni:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/jni:/lib:/usr/lib
13:15:15 ZooKeeper: Client environment:java.io.tmpdir=/tmp
13:15:15 ZooKeeper: Client environment:java.compiler=<NA>
13:15:15 ZooKeeper: Client environment:os.name=Linux
13:15:15 ZooKeeper: Client environment:os.arch=amd64
13:15:15 ZooKeeper: Client environment:os.version=3.16.0-77-generic
13:15:15 ZooKeeper: Client environment:user.name=AZVA-INT\jmcclain
13:15:15 ZooKeeper: Client environment:user.home=/home/likewise-open/AZVA-INT/jmcclain
13:15:15 ZooKeeper: Client environment:user.dir=/home/likewise-open/AZVA-INT/jmcclain/local/src/geotrellis
13:15:15 ZooKeeper: Initiating client connection, connectString=localhost:21810 sessionTimeout=30000 watcher=org.apache.accumulo.fate.zookeeper.ZooSession$ZooWatcher@29c377d4
13:15:15 ClientCnxn: Opening socket connection to server localhost/127.0.0.1:21810. Will not attempt to authenticate using SASL (unknown error)
13:15:15 ClientCnxn: Socket connection established to localhost/127.0.0.1:21810, initiating session
13:15:15 ClientCnxn: Session establishment complete on server localhost/127.0.0.1:21810, sessionid = 0x15b39ed8964000a, negotiated timeout = 30000
13:15:16 platform: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.
13:15:16 platform: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.
13:15:16 platform: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.
13:15:16 platform: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.
13:15:16 platform: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.
13:15:16 ENGINE: dataFileCache open start
13:15:16 platform: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.
13:15:16 platform: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.
13:15:16 platform: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.
13:15:16 platform: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.
13:15:16 platform: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.
13:15:16 FeatureDataUtils: Generating patched classloader
13:15:18 TIOStreamTransport: Error closing output stream.
java.io.IOException: The stream is closed
	at org.apache.hadoop.net.SocketOutputStream.write(SocketOutputStream.java:118)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
	at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
	at org.apache.thrift.transport.TIOStreamTransport.close(TIOStreamTransport.java:110)
	at org.apache.thrift.transport.TFramedTransport.close(TFramedTransport.java:89)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool$CachedTTransport.close(ThriftTransportPool.java:309)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool.returnTransport(ThriftTransportPool.java:571)
	at org.apache.accumulo.core.rpc.ThriftUtil.returnClient(ThriftUtil.java:151)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator.doLookup(TabletServerBatchReaderIterator.java:686)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator$QueryTask.run(TabletServerBatchReaderIterator.java:349)
	at org.apache.htrace.wrappers.TraceRunnable.run(TraceRunnable.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.accumulo.fate.util.LoggingRunnable.run(LoggingRunnable.java:35)
	at java.lang.Thread.run(Thread.java:745)
[0m[[0minfo[0m] [0m[32mGeoWaveFeatureRDDReaderSpec:[0m[0m
[0m[[0minfo[0m] [0m[32mGeoTrellis read/write with GeoWave[0m[0m
[0m[[0minfo[0m] [0m[32m- Should roundtrip geowave records in accumulo[0m[0m
13:15:18 GeowaveAttributeStore: GeoWave support is experimental
13:15:18 ClientConfiguration: Found no client.conf in default paths. Using default client configuration values.
13:15:18 ZooKeeper: Initiating client connection, connectString=leader:21810 sessionTimeout=30000 watcher=org.apache.accumulo.fate.zookeeper.ZooSession$ZooWatcher@406f30f8
13:15:18 ClientCnxn: Opening socket connection to server ip6-localhost/0:0:0:0:0:0:0:1:21810. Will not attempt to authenticate using SASL (unknown error)
13:15:18 ClientCnxn: Socket connection established to ip6-localhost/0:0:0:0:0:0:0:1:21810, initiating session
13:15:18 ClientCnxn: Session establishment complete on server ip6-localhost/0:0:0:0:0:0:0:1:21810, sessionid = 0x15b39ed8964000b, negotiated timeout = 30000
13:15:18 ClientConfiguration: Found no client.conf in default paths. Using default client configuration values.
13:15:19 AbstractAccumuloPersistence: Unable to find objects, table 'GEOWAVE_METADATA' does not exist
org.apache.accumulo.core.client.TableNotFoundException: Table TEST_GEOWAVE_METADATA does not exist
	at org.apache.accumulo.core.client.impl.Tables._getTableId(Tables.java:117)
	at org.apache.accumulo.core.client.impl.Tables.getTableId(Tables.java:102)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.getTableId(ConnectorImpl.java:81)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.createBatchScanner(ConnectorImpl.java:96)
	at mil.nga.giat.geowave.datastore.accumulo.BasicAccumuloOperations.createBatchScanner(BasicAccumuloOperations.java:599)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getScanner(AbstractAccumuloPersistence.java:287)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getFullScanner(AbstractAccumuloPersistence.java:276)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getObjects(AbstractAccumuloPersistence.java:242)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore.getAdapters(AccumuloAdapterStore.java:59)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore$.adapters(GeowaveAttributeStore.scala:102)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.adapters(GeowaveAttributeStore.scala:205)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.gwLayerExists(GeowaveAttributeStore.scala:238)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.layerExists(GeowaveAttributeStore.scala:256)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$2.apply(AttributeStoreSpec.scala:45)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$2.apply(AttributeStoreSpec.scala:44)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSpecLike$$anon$1.apply(FunSpecLike.scala:454)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.FunSpec.withFixture(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$class.invokeWithFixture$1(FunSpecLike.scala:451)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.FunSpecLike$class.runTest(FunSpecLike.scala:464)
	at org.scalatest.FunSpec.runTest(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.FunSpecLike$class.runTests(FunSpecLike.scala:497)
	at org.scalatest.FunSpec.runTests(FunSpec.scala:1630)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at org.scalatest.FunSpec.org$scalatest$FunSpecLike$$super$run(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.FunSpecLike$class.run(FunSpecLike.scala:501)
	at geotrellis.spark.io.AttributeStoreSpec.org$scalatest$BeforeAndAfterAll$$super$run(AttributeStoreSpec.scala:30)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at geotrellis.spark.io.AttributeStoreSpec.run(AttributeStoreSpec.scala:30)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
	at sbt.TestRunner.runTest$1(TestFramework.scala:76)
	at sbt.TestRunner.run(TestFramework.scala:85)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFunction.apply(TestFramework.scala:207)
	at sbt.Tests$.sbt$Tests$$processRunnable$1(Tests.scala:239)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
13:15:19 AbstractAccumuloPersistence: Unable to find objects, table 'GEOWAVE_METADATA' does not exist
org.apache.accumulo.core.client.TableNotFoundException: Table TEST_GEOWAVE_METADATA does not exist
	at org.apache.accumulo.core.client.impl.Tables._getTableId(Tables.java:117)
	at org.apache.accumulo.core.client.impl.Tables.getTableId(Tables.java:102)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.getTableId(ConnectorImpl.java:81)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.createBatchScanner(ConnectorImpl.java:96)
	at mil.nga.giat.geowave.datastore.accumulo.BasicAccumuloOperations.createBatchScanner(BasicAccumuloOperations.java:599)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getScanner(AbstractAccumuloPersistence.java:287)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getFullScanner(AbstractAccumuloPersistence.java:276)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getObjects(AbstractAccumuloPersistence.java:242)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore.getAdapters(AccumuloAdapterStore.java:59)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore$.adapters(GeowaveAttributeStore.scala:102)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.adapters(GeowaveAttributeStore.scala:205)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.gwLayerExists(GeowaveAttributeStore.scala:238)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.layerExists(GeowaveAttributeStore.scala:256)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$2.apply(AttributeStoreSpec.scala:46)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$2.apply(AttributeStoreSpec.scala:44)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSpecLike$$anon$1.apply(FunSpecLike.scala:454)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.FunSpec.withFixture(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$class.invokeWithFixture$1(FunSpecLike.scala:451)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.FunSpecLike$class.runTest(FunSpecLike.scala:464)
	at org.scalatest.FunSpec.runTest(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.FunSpecLike$class.runTests(FunSpecLike.scala:497)
	at org.scalatest.FunSpec.runTests(FunSpec.scala:1630)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at org.scalatest.FunSpec.org$scalatest$FunSpecLike$$super$run(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.FunSpecLike$class.run(FunSpecLike.scala:501)
	at geotrellis.spark.io.AttributeStoreSpec.org$scalatest$BeforeAndAfterAll$$super$run(AttributeStoreSpec.scala:30)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at geotrellis.spark.io.AttributeStoreSpec.run(AttributeStoreSpec.scala:30)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
	at sbt.TestRunner.runTest$1(TestFramework.scala:76)
	at sbt.TestRunner.run(TestFramework.scala:85)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFunction.apply(TestFramework.scala:207)
	at sbt.Tests$.sbt$Tests$$processRunnable$1(Tests.scala:239)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
13:15:19 AbstractAccumuloPersistence: Unable to find objects, table 'GEOWAVE_METADATA' does not exist
org.apache.accumulo.core.client.TableNotFoundException: Table TEST_GEOWAVE_METADATA does not exist
	at org.apache.accumulo.core.client.impl.Tables._getTableId(Tables.java:117)
	at org.apache.accumulo.core.client.impl.Tables.getTableId(Tables.java:102)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.getTableId(ConnectorImpl.java:81)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.createBatchScanner(ConnectorImpl.java:96)
	at mil.nga.giat.geowave.datastore.accumulo.BasicAccumuloOperations.createBatchScanner(BasicAccumuloOperations.java:599)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getScanner(AbstractAccumuloPersistence.java:287)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getFullScanner(AbstractAccumuloPersistence.java:276)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getObjects(AbstractAccumuloPersistence.java:242)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore.getAdapters(AccumuloAdapterStore.java:59)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore$.adapters(GeowaveAttributeStore.scala:102)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.adapters(GeowaveAttributeStore.scala:205)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.gwLayerExists(GeowaveAttributeStore.scala:238)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.layerExists(GeowaveAttributeStore.scala:256)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$2.apply(AttributeStoreSpec.scala:47)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$2.apply(AttributeStoreSpec.scala:44)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSpecLike$$anon$1.apply(FunSpecLike.scala:454)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.FunSpec.withFixture(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$class.invokeWithFixture$1(FunSpecLike.scala:451)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.FunSpecLike$class.runTest(FunSpecLike.scala:464)
	at org.scalatest.FunSpec.runTest(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.FunSpecLike$class.runTests(FunSpecLike.scala:497)
	at org.scalatest.FunSpec.runTests(FunSpec.scala:1630)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at org.scalatest.FunSpec.org$scalatest$FunSpecLike$$super$run(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.FunSpecLike$class.run(FunSpecLike.scala:501)
	at geotrellis.spark.io.AttributeStoreSpec.org$scalatest$BeforeAndAfterAll$$super$run(AttributeStoreSpec.scala:30)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at geotrellis.spark.io.AttributeStoreSpec.run(AttributeStoreSpec.scala:30)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
	at sbt.TestRunner.runTest$1(TestFramework.scala:76)
	at sbt.TestRunner.run(TestFramework.scala:85)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFunction.apply(TestFramework.scala:207)
	at sbt.Tests$.sbt$Tests$$processRunnable$1(Tests.scala:239)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
13:15:19 AbstractAccumuloPersistence: Unable to find objects, table 'GEOWAVE_METADATA' does not exist
org.apache.accumulo.core.client.TableNotFoundException: Table TEST_GEOWAVE_METADATA does not exist
	at org.apache.accumulo.core.client.impl.Tables._getTableId(Tables.java:117)
	at org.apache.accumulo.core.client.impl.Tables.getTableId(Tables.java:102)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.getTableId(ConnectorImpl.java:81)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.createBatchScanner(ConnectorImpl.java:96)
	at mil.nga.giat.geowave.datastore.accumulo.BasicAccumuloOperations.createBatchScanner(BasicAccumuloOperations.java:599)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getScanner(AbstractAccumuloPersistence.java:287)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getFullScanner(AbstractAccumuloPersistence.java:276)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getObjects(AbstractAccumuloPersistence.java:242)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore.getAdapters(AccumuloAdapterStore.java:59)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore$.adapters(GeowaveAttributeStore.scala:102)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.adapters(GeowaveAttributeStore.scala:205)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.gwLayerIds(GeowaveAttributeStore.scala:264)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.layerIds(GeowaveAttributeStore.scala:285)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$3.apply(AttributeStoreSpec.scala:51)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$3.apply(AttributeStoreSpec.scala:51)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSpecLike$$anon$1.apply(FunSpecLike.scala:454)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.FunSpec.withFixture(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$class.invokeWithFixture$1(FunSpecLike.scala:451)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.FunSpecLike$class.runTest(FunSpecLike.scala:464)
	at org.scalatest.FunSpec.runTest(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.FunSpecLike$class.runTests(FunSpecLike.scala:497)
	at org.scalatest.FunSpec.runTests(FunSpec.scala:1630)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at org.scalatest.FunSpec.org$scalatest$FunSpecLike$$super$run(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.FunSpecLike$class.run(FunSpecLike.scala:501)
	at geotrellis.spark.io.AttributeStoreSpec.org$scalatest$BeforeAndAfterAll$$super$run(AttributeStoreSpec.scala:30)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at geotrellis.spark.io.AttributeStoreSpec.run(AttributeStoreSpec.scala:30)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
	at sbt.TestRunner.runTest$1(TestFramework.scala:76)
	at sbt.TestRunner.run(TestFramework.scala:85)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFunction.apply(TestFramework.scala:207)
	at sbt.Tests$.sbt$Tests$$processRunnable$1(Tests.scala:239)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
13:15:19 AbstractAccumuloPersistence: Unable to find objects, table 'GEOWAVE_METADATA' does not exist
org.apache.accumulo.core.client.TableNotFoundException: Table TEST_GEOWAVE_METADATA does not exist
	at org.apache.accumulo.core.client.impl.Tables._getTableId(Tables.java:117)
	at org.apache.accumulo.core.client.impl.Tables.getTableId(Tables.java:102)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.getTableId(ConnectorImpl.java:81)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.createBatchScanner(ConnectorImpl.java:96)
	at mil.nga.giat.geowave.datastore.accumulo.BasicAccumuloOperations.createBatchScanner(BasicAccumuloOperations.java:599)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getScanner(AbstractAccumuloPersistence.java:287)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getFullScanner(AbstractAccumuloPersistence.java:276)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getObjects(AbstractAccumuloPersistence.java:242)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore.getAdapters(AccumuloAdapterStore.java:59)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore$.adapters(GeowaveAttributeStore.scala:102)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.adapters(GeowaveAttributeStore.scala:205)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.gwLayerIds(GeowaveAttributeStore.scala:264)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.layerIds(GeowaveAttributeStore.scala:285)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$4.apply(AttributeStoreSpec.scala:56)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$4.apply(AttributeStoreSpec.scala:54)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSpecLike$$anon$1.apply(FunSpecLike.scala:454)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.FunSpec.withFixture(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$class.invokeWithFixture$1(FunSpecLike.scala:451)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.FunSpecLike$class.runTest(FunSpecLike.scala:464)
	at org.scalatest.FunSpec.runTest(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.FunSpecLike$class.runTests(FunSpecLike.scala:497)
	at org.scalatest.FunSpec.runTests(FunSpec.scala:1630)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at org.scalatest.FunSpec.org$scalatest$FunSpecLike$$super$run(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.FunSpecLike$class.run(FunSpecLike.scala:501)
	at geotrellis.spark.io.AttributeStoreSpec.org$scalatest$BeforeAndAfterAll$$super$run(AttributeStoreSpec.scala:30)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at geotrellis.spark.io.AttributeStoreSpec.run(AttributeStoreSpec.scala:30)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
	at sbt.TestRunner.runTest$1(TestFramework.scala:76)
	at sbt.TestRunner.run(TestFramework.scala:85)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFunction.apply(TestFramework.scala:207)
	at sbt.Tests$.sbt$Tests$$processRunnable$1(Tests.scala:239)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
13:15:19 AbstractAccumuloPersistence: Unable to find objects, table 'GEOWAVE_METADATA' does not exist
org.apache.accumulo.core.client.TableNotFoundException: Table TEST_GEOWAVE_METADATA does not exist
	at org.apache.accumulo.core.client.impl.Tables._getTableId(Tables.java:117)
	at org.apache.accumulo.core.client.impl.Tables.getTableId(Tables.java:102)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.getTableId(ConnectorImpl.java:81)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.createBatchScanner(ConnectorImpl.java:96)
	at mil.nga.giat.geowave.datastore.accumulo.BasicAccumuloOperations.createBatchScanner(BasicAccumuloOperations.java:599)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getScanner(AbstractAccumuloPersistence.java:287)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getFullScanner(AbstractAccumuloPersistence.java:276)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getObjects(AbstractAccumuloPersistence.java:242)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore.getAdapters(AccumuloAdapterStore.java:59)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore$.adapters(GeowaveAttributeStore.scala:102)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.adapters(GeowaveAttributeStore.scala:205)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.gwLayerIds(GeowaveAttributeStore.scala:264)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.layerIds(GeowaveAttributeStore.scala:285)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$4.apply(AttributeStoreSpec.scala:60)
	at geotrellis.spark.io.AttributeStoreSpec$$anonfun$4.apply(AttributeStoreSpec.scala:54)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSpecLike$$anon$1.apply(FunSpecLike.scala:454)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.FunSpec.withFixture(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$class.invokeWithFixture$1(FunSpecLike.scala:451)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.FunSpecLike$class.runTest(FunSpecLike.scala:464)
	at org.scalatest.FunSpec.runTest(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.FunSpecLike$class.runTests(FunSpecLike.scala:497)
	at org.scalatest.FunSpec.runTests(FunSpec.scala:1630)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at org.scalatest.FunSpec.org$scalatest$FunSpecLike$$super$run(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.FunSpecLike$class.run(FunSpecLike.scala:501)
	at geotrellis.spark.io.AttributeStoreSpec.org$scalatest$BeforeAndAfterAll$$super$run(AttributeStoreSpec.scala:30)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at geotrellis.spark.io.AttributeStoreSpec.run(AttributeStoreSpec.scala:30)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
	at sbt.TestRunner.runTest$1(TestFramework.scala:76)
	at sbt.TestRunner.run(TestFramework.scala:85)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFunction.apply(TestFramework.scala:207)
	at sbt.Tests$.sbt$Tests$$processRunnable$1(Tests.scala:239)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
13:15:19 AbstractAccumuloPersistence: Unable to find objects, table 'GEOWAVE_METADATA' does not exist
org.apache.accumulo.core.client.TableNotFoundException: Table TEST_GEOWAVE_METADATA does not exist
	at org.apache.accumulo.core.client.impl.Tables._getTableId(Tables.java:117)
	at org.apache.accumulo.core.client.impl.Tables.getTableId(Tables.java:102)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.getTableId(ConnectorImpl.java:81)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.createBatchScanner(ConnectorImpl.java:96)
	at mil.nga.giat.geowave.datastore.accumulo.BasicAccumuloOperations.createBatchScanner(BasicAccumuloOperations.java:599)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getScanner(AbstractAccumuloPersistence.java:287)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getFullScanner(AbstractAccumuloPersistence.java:276)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getObjects(AbstractAccumuloPersistence.java:242)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore.getAdapters(AccumuloAdapterStore.java:59)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore$.adapters(GeowaveAttributeStore.scala:102)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.adapters(GeowaveAttributeStore.scala:205)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.gwLayerIds(GeowaveAttributeStore.scala:264)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.layerIds(GeowaveAttributeStore.scala:285)
	at geotrellis.spark.io.geowave.GeowaveAttributeStoreSpec.geotrellis$spark$io$geowave$GeowaveAttributeStoreSpec$$clear(GeowaveAttributeStoreSpec.scala:27)
	at geotrellis.spark.io.geowave.GeowaveAttributeStoreSpec$$anonfun$1.apply$mcV$sp(GeowaveAttributeStoreSpec.scala:39)
	at geotrellis.spark.io.geowave.GeowaveAttributeStoreSpec$$anonfun$1.apply(GeowaveAttributeStoreSpec.scala:39)
	at geotrellis.spark.io.geowave.GeowaveAttributeStoreSpec$$anonfun$1.apply(GeowaveAttributeStoreSpec.scala:39)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSpecLike$$anon$1.apply(FunSpecLike.scala:454)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.FunSpec.withFixture(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$class.invokeWithFixture$1(FunSpecLike.scala:451)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.FunSpecLike$class.runTest(FunSpecLike.scala:464)
	at org.scalatest.FunSpec.runTest(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.FunSpecLike$class.runTests(FunSpecLike.scala:497)
	at org.scalatest.FunSpec.runTests(FunSpec.scala:1630)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at org.scalatest.FunSpec.org$scalatest$FunSpecLike$$super$run(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.FunSpecLike$class.run(FunSpecLike.scala:501)
	at geotrellis.spark.io.AttributeStoreSpec.org$scalatest$BeforeAndAfterAll$$super$run(AttributeStoreSpec.scala:30)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at geotrellis.spark.io.AttributeStoreSpec.run(AttributeStoreSpec.scala:30)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
	at sbt.TestRunner.runTest$1(TestFramework.scala:76)
	at sbt.TestRunner.run(TestFramework.scala:85)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFunction.apply(TestFramework.scala:207)
	at sbt.Tests$.sbt$Tests$$processRunnable$1(Tests.scala:239)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
[0m[[0minfo[0m] [0m[32mGeowaveAttributeStoreSpec:[0m[0m
[0m[[0minfo[0m] [0m[32m- should write to an attribute store[0m[0m
[0m[[0minfo[0m] [0m[32m- should know that these new IDs exist[0m[0m
[0m[[0minfo[0m] [0m[32m- should read layer ids[0m[0m
[0m[[0minfo[0m] [0m[32m- should clear out the attribute store[0m[0m
[0m[[0minfo[0m] [0m[32m- should save and pull out a histogram[0m[0m
[0m[[0minfo[0m] [0m[32m- should save and load a random RootJsonReadable object[0m[0m
[0m[[0minfo[0m] [0m[32m- should clean up after itself[0m[0m
13:15:19 GeowaveAttributeStore: GeoWave support is experimental
13:15:19 ClientConfiguration: Found no client.conf in default paths. Using default client configuration values.
13:15:19 GeowaveLayerReader: GeoWave support is experimental
13:15:20 GeowaveLayerWriter: GeoWave support is experimental
13:15:20 AbstractAccumuloPersistence: Unable to find objects, table 'GEOWAVE_METADATA' does not exist
org.apache.accumulo.core.client.TableNotFoundException: Table TEST_GEOWAVE_METADATA does not exist
	at org.apache.accumulo.core.client.impl.Tables._getTableId(Tables.java:117)
	at org.apache.accumulo.core.client.impl.Tables.getTableId(Tables.java:102)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.getTableId(ConnectorImpl.java:81)
	at org.apache.accumulo.core.client.impl.ConnectorImpl.createBatchScanner(ConnectorImpl.java:96)
	at mil.nga.giat.geowave.datastore.accumulo.BasicAccumuloOperations.createBatchScanner(BasicAccumuloOperations.java:599)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getScanner(AbstractAccumuloPersistence.java:287)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getFullScanner(AbstractAccumuloPersistence.java:276)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.getObjects(AbstractAccumuloPersistence.java:242)
	at mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore.getAdapters(AccumuloAdapterStore.java:59)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore$.adapters(GeowaveAttributeStore.scala:102)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.adapters(GeowaveAttributeStore.scala:205)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.gwLayerExists(GeowaveAttributeStore.scala:238)
	at geotrellis.spark.io.geowave.GeowaveAttributeStore.layerExists(GeowaveAttributeStore.scala:256)
	at geotrellis.spark.io.geowave.GeowaveLayerReader.read(GeowaveLayerReader.scala:213)
	at geotrellis.spark.io.geowave.GeowaveLayerReader.read(GeowaveLayerReader.scala:277)
	at geotrellis.spark.io.geowave.GeowaveSpatialSpec$$anonfun$3$$anonfun$apply$1.apply(GeowaveSpatialSpec.scala:85)
	at geotrellis.spark.io.geowave.GeowaveSpatialSpec$$anonfun$3$$anonfun$apply$1.apply(GeowaveSpatialSpec.scala:85)
	at org.scalatest.Assertions$class.intercept(Assertions.scala:805)
	at org.scalatest.FunSpec.intercept(FunSpec.scala:1630)
	at geotrellis.spark.io.geowave.GeowaveSpatialSpec$$anonfun$3.apply(GeowaveSpatialSpec.scala:84)
	at geotrellis.spark.io.geowave.GeowaveSpatialSpec$$anonfun$3.apply(GeowaveSpatialSpec.scala:84)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FunSpecLike$$anon$1.apply(FunSpecLike.scala:454)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.FunSpec.withFixture(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$class.invokeWithFixture$1(FunSpecLike.scala:451)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.FunSpecLike$$anonfun$runTest$1.apply(FunSpecLike.scala:464)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
	at org.scalatest.FunSpecLike$class.runTest(FunSpecLike.scala:464)
	at org.scalatest.FunSpec.runTest(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.FunSpecLike$$anonfun$runTests$1.apply(FunSpecLike.scala:497)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
	at org.scalatest.FunSpecLike$class.runTests(FunSpecLike.scala:497)
	at org.scalatest.FunSpec.runTests(FunSpec.scala:1630)
	at org.scalatest.Suite$class.run(Suite.scala:1147)
	at org.scalatest.FunSpec.org$scalatest$FunSpecLike$$super$run(FunSpec.scala:1630)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.FunSpecLike$$anonfun$run$1.apply(FunSpecLike.scala:501)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
	at org.scalatest.FunSpecLike$class.run(FunSpecLike.scala:501)
	at geotrellis.spark.io.geowave.GeowaveSpatialSpec.org$scalatest$BeforeAndAfterAll$$super$run(GeowaveSpatialSpec.scala:37)
	at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:213)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:210)
	at geotrellis.spark.io.geowave.GeowaveSpatialSpec.run(GeowaveSpatialSpec.scala:37)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
	at sbt.TestRunner.runTest$1(TestFramework.scala:76)
	at sbt.TestRunner.run(TestFramework.scala:85)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
	at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
	at sbt.TestFunction.apply(TestFramework.scala:207)
	at sbt.Tests$.sbt$Tests$$processRunnable$1(Tests.scala:239)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.Tests$$anonfun$makeSerial$1.apply(Tests.scala:245)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:237)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
13:15:20 gdalframework: Failed to load the GDAL native libs. This is not a problem unless you need to use the GDAL plugins: they won't be enabled.
java.lang.UnsatisfiedLinkError: no gdaljni in java.library.path
13:15:20 platform: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.
13:15:20 platform: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.
13:15:20 platform: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.
13:15:20 platform: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.
13:15:20 platform: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.
13:15:24 image: Warp/affine reduction enabled: true
13:15:26 TIOStreamTransport: Error closing output stream.
java.io.IOException: The stream is closed
	at org.apache.hadoop.net.SocketOutputStream.write(SocketOutputStream.java:118)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
	at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
	at org.apache.thrift.transport.TIOStreamTransport.close(TIOStreamTransport.java:110)
	at org.apache.thrift.transport.TFramedTransport.close(TFramedTransport.java:89)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool$CachedTTransport.close(ThriftTransportPool.java:309)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool.returnTransport(ThriftTransportPool.java:571)
	at org.apache.accumulo.core.rpc.ThriftUtil.returnClient(ThriftUtil.java:151)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator.doLookup(TabletServerBatchReaderIterator.java:686)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator$QueryTask.run(TabletServerBatchReaderIterator.java:349)
	at org.apache.htrace.wrappers.TraceRunnable.run(TraceRunnable.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.accumulo.fate.util.LoggingRunnable.run(LoggingRunnable.java:35)
	at java.lang.Thread.run(Thread.java:745)
13:15:26 TIOStreamTransport: Error closing output stream.
java.io.IOException: The stream is closed
	at org.apache.hadoop.net.SocketOutputStream.write(SocketOutputStream.java:118)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
	at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
	at org.apache.thrift.transport.TIOStreamTransport.close(TIOStreamTransport.java:110)
	at org.apache.thrift.transport.TFramedTransport.close(TFramedTransport.java:89)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool$CachedTTransport.close(ThriftTransportPool.java:309)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool.returnTransport(ThriftTransportPool.java:571)
	at org.apache.accumulo.core.rpc.ThriftUtil.returnClient(ThriftUtil.java:151)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator.doLookup(TabletServerBatchReaderIterator.java:686)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator$QueryTask.run(TabletServerBatchReaderIterator.java:349)
	at org.apache.htrace.wrappers.TraceRunnable.run(TraceRunnable.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.accumulo.fate.util.LoggingRunnable.run(LoggingRunnable.java:35)
	at java.lang.Thread.run(Thread.java:745)
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:26 AccumuloSplitsProvider: Query split outside of range
13:15:27 TIOStreamTransport: Error closing output stream.
java.io.IOException: The stream is closed
	at org.apache.hadoop.net.SocketOutputStream.write(SocketOutputStream.java:118)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
	at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
	at org.apache.thrift.transport.TIOStreamTransport.close(TIOStreamTransport.java:110)
	at org.apache.thrift.transport.TFramedTransport.close(TFramedTransport.java:89)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool$CachedTTransport.close(ThriftTransportPool.java:309)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool.returnTransport(ThriftTransportPool.java:571)
	at org.apache.accumulo.core.rpc.ThriftUtil.returnClient(ThriftUtil.java:151)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator.doLookup(TabletServerBatchReaderIterator.java:686)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator$QueryTask.run(TabletServerBatchReaderIterator.java:349)
	at org.apache.htrace.wrappers.TraceRunnable.run(TraceRunnable.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.accumulo.fate.util.LoggingRunnable.run(LoggingRunnable.java:35)
	at java.lang.Thread.run(Thread.java:745)
13:15:27 TIOStreamTransport: Error closing output stream.
java.io.IOException: The stream is closed
	at org.apache.hadoop.net.SocketOutputStream.write(SocketOutputStream.java:118)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
	at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
	at org.apache.thrift.transport.TIOStreamTransport.close(TIOStreamTransport.java:110)
	at org.apache.thrift.transport.TFramedTransport.close(TFramedTransport.java:89)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool$CachedTTransport.close(ThriftTransportPool.java:309)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool.returnTransport(ThriftTransportPool.java:571)
	at org.apache.accumulo.core.rpc.ThriftUtil.returnClient(ThriftUtil.java:151)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator.doLookup(TabletServerBatchReaderIterator.java:686)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator$QueryTask.run(TabletServerBatchReaderIterator.java:349)
	at org.apache.htrace.wrappers.TraceRunnable.run(TraceRunnable.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.accumulo.fate.util.LoggingRunnable.run(LoggingRunnable.java:35)
	at java.lang.Thread.run(Thread.java:745)
13:15:27 TIOStreamTransport: Error closing output stream.
java.io.IOException: The stream is closed
	at org.apache.hadoop.net.SocketOutputStream.write(SocketOutputStream.java:118)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
	at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
	at org.apache.thrift.transport.TIOStreamTransport.close(TIOStreamTransport.java:110)
	at org.apache.thrift.transport.TFramedTransport.close(TFramedTransport.java:89)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool$CachedTTransport.close(ThriftTransportPool.java:309)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool.returnTransport(ThriftTransportPool.java:571)
	at org.apache.accumulo.core.rpc.ThriftUtil.returnClient(ThriftUtil.java:151)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator.doLookup(TabletServerBatchReaderIterator.java:686)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator$QueryTask.run(TabletServerBatchReaderIterator.java:349)
	at org.apache.htrace.wrappers.TraceRunnable.run(TraceRunnable.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.accumulo.fate.util.LoggingRunnable.run(LoggingRunnable.java:35)
	at java.lang.Thread.run(Thread.java:745)
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 AccumuloSplitsProvider: Query split outside of range
13:15:27 ThriftTransportPool: Server leader:9997 (120000) had 20 failures in a short time period, will not complain anymore
13:15:27 GeowaveLayerWriter: GeoWave has its own notion of levels/tiering, so 11 in Layer(name = "Sample Elevation 2", zoom = 11) will be ignored
13:15:27 GeowaveLayerWriter: It is highly recommended that you specify a bit precision when writing into GeoWave
13:15:29 GeowaveLayerWriter$: partition size = 3
13:15:29 ClientConfiguration: Found no client.conf in default paths. Using default client configuration values.
13:15:29 GeowaveLayerWriter$: partition size = 3
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 AccumuloSplitsProvider: Query split outside of range
13:15:48 TIOStreamTransport: Error closing output stream.
java.io.IOException: The stream is closed
	at org.apache.hadoop.net.SocketOutputStream.write(SocketOutputStream.java:118)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
	at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
	at org.apache.thrift.transport.TIOStreamTransport.close(TIOStreamTransport.java:110)
	at org.apache.thrift.transport.TFramedTransport.close(TFramedTransport.java:89)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool$CachedTTransport.close(ThriftTransportPool.java:309)
	at org.apache.accumulo.core.client.impl.ThriftTransportPool.returnTransport(ThriftTransportPool.java:571)
	at org.apache.accumulo.core.rpc.ThriftUtil.returnClient(ThriftUtil.java:151)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator.doLookup(TabletServerBatchReaderIterator.java:686)
	at org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator$QueryTask.run(TabletServerBatchReaderIterator.java:349)
	at org.apache.htrace.wrappers.TraceRunnable.run(TraceRunnable.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.accumulo.fate.util.LoggingRunnable.run(LoggingRunnable.java:35)
	at java.lang.Thread.run(Thread.java:745)
[0m[[0minfo[0m] [0m[32mGeowaveSpatialSpec:[0m[0m
[0m[[0minfo[0m] [0m[32m- should not find layer before write[0m[0m
[0m[[0minfo[0m] [0m[32m- should read an existing layer[0m[0m
[0m[[0minfo[0m] [0m[32m- should write a layer[0m[0m
[0m[[0minfo[0m] [0m[32m- should read a layer back[0m[0m
[0m[[0minfo[0m] [0m[32m- should clean up after itself[0m[0m
[0m[[0minfo[0m] [0m[36mRun completed in 39 seconds, 816 milliseconds.[0m[0m
[0m[[0minfo[0m] [0m[36mTotal number of tests run: 13[0m[0m
[0m[[0minfo[0m] [0m[36mSuites: completed 3, aborted 0[0m[0m
[0m[[0minfo[0m] [0m[36mTests: succeeded 13, failed 0, canceled 0, ignored 0, pending 0[0m[0m
[0m[[0minfo[0m] [0m[32mAll tests passed.[0m[0m
[0m[[32msuccess[0m] [0mTotal time: 44 s, completed Apr 4, 2017 1:15:50 PM[0m
[1m[3m%[23m[1m[0m                                                                                                                                                                                                                                              
 

[0m[23m[24m[Jsrc/geotrellis% [K[?1h=eexit[?1l>


Script done on Tue 04 Apr 2017 01:15:55 PM EDT
```
