### PR TITLE
Repartition in ETL when re-tiling increases layer resolution

### DIFF
--- a/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
@@ -144,35 +144,65 @@ case class Etl(conf: EtlConf, @transient modules: Seq[TypedModule] = Etl.default
     val targetCellType = output.cellType
     val destCrs = output.getCrs.get
 
-    def adjustCellType(md: TileLayerMetadata[K]) =
-      md.copy(cellType = targetCellType.getOrElse(md.cellType))
+    /** Tile layers form some resolution and adjust partition count based on resolution difference */
+    def resizingTileRDD(
+      rdd: RDD[(I, V)],
+      floatMD: TileLayerMetadata[K],
+      targetLayout: LayoutDefinition
+    ): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] = {
+      // rekey metadata to targetLayout
+      val newSpatialBounds = KeyBounds(targetLayout.mapTransform(floatMD.extent))
+      val tiledMD = floatMD.copy(
+        bounds = floatMD.bounds.setSpatialBounds(newSpatialBounds))
+
+      // > 1 means we're upsampling during tiling process
+      val resolutionRatio = (floatMD.layout.cellSize.resolution / targetLayout.cellSize.resolution)
+      val tilerOptions = Tiler.Options(
+        resampleMethod = method,
+        partitioner = new HashPartitioner(
+          partitions = (math.pow(2, (resolutionRatio - 1) * 2) * rdd.partitions.length).toInt))
+
+      val tiledRDD = rdd.tileToLayout[K](tiledMD, tilerOptions)
+      ContextRDD(tiledRDD, tiledMD)
+    }
 
     output.reprojectMethod match {
       case PerTileReproject =>
         val reprojected = rdd.reproject(destCrs)
-        val (zoom: Int, md: TileLayerMetadata[K]) = scheme match {
-          case Left(layoutScheme) => output.maxZoom match {
-            case Some(zoom) =>  reprojected.collectMetadata(destCrs, output.tileSize, zoom)
-            case _ => reprojected.collectMetadata(layoutScheme)
-          }
-          case Right(layoutDefinition) => reprojected.collectMetadata(layoutDefinition)
+        val floatMD = { // collecting floating metadata allows detecting upsampling
+          val (_, md) = reprojected.collectMetadata(FloatingLayoutScheme(output.tileSize))
+          md.copy(cellType = targetCellType.getOrElse(md.cellType))
         }
-        val amd = adjustCellType(md)
-        val tilerOptions = Tiler.Options(resampleMethod = method, partitioner = new HashPartitioner(rdd.partitions.length))
-        zoom -> ContextRDD(reprojected.tileToLayout[K](amd, tilerOptions), amd)
+
+        scheme match {
+          case Left(scheme: ZoomedLayoutScheme) if output.maxZoom.isDefined=>
+            val LayoutLevel(zoom, layoutDefinition) = scheme.levelForZoom(output.maxZoom.get)
+            zoom -> resizingTileRDD(reprojected, floatMD, layoutDefinition)
+
+          case Left(scheme) => // True for both FloatinglayoutScheme and ZoomedlayoutScheme
+            val LayoutLevel(zoom, layoutDefinition) = scheme.levelFor(floatMD.extent, floatMD.cellSize)
+            zoom -> resizingTileRDD(reprojected, floatMD, layoutDefinition)
+
+          case Right(layoutDefinition) =>
+            0 -> resizingTileRDD(reprojected, floatMD, layoutDefinition)
+        }
 
       case BufferedReproject =>
-        val (_, md) = output.maxZoom match {
-          case Some(zoom) => rdd.collectMetadata(destCrs, output.tileSize, zoom)
-          case _ => rdd.collectMetadata(FloatingLayoutScheme(output.tileSize))
+        // Buffered reproject requires that tiles are already in some layout so we can find the neighbors
+        val md = { // collecting floating metadata allows detecting upsampling
+          val (_, md) = rdd.collectMetadata(FloatingLayoutScheme(output.tileSize))
+          md.copy(cellType = targetCellType.getOrElse(md.cellType))
         }
-        val amd = adjustCellType(md)
-        // Keep the same number of partitions after tiling.
-        val tilerOptions = Tiler.Options(resampleMethod = method, partitioner = new HashPartitioner(rdd.partitions.length))
-        val tiled = ContextRDD(rdd.tileToLayout[K](amd, tilerOptions), amd)
+        val tiled = ContextRDD(rdd.tileToLayout[K](md, method), md)
+
         scheme match {
+          case Left(layoutScheme: ZoomedLayoutScheme) if output.maxZoom.isDefined =>
+            val LayoutLevel(_, layoutDefinition) = layoutScheme.levelForZoom(output.maxZoom.get)
+            tiled.reproject(destCrs, layoutDefinition, method)
+
           case Left(layoutScheme) =>
             tiled.reproject(destCrs, layoutScheme, method)
+
           case Right(layoutDefinition) =>
             tiled.reproject(destCrs, layoutDefinition, method)
         }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
@@ -197,8 +197,8 @@ case class Etl(conf: EtlConf, @transient modules: Seq[TypedModule] = Etl.default
 
         scheme match {
           case Left(layoutScheme: ZoomedLayoutScheme) if output.maxZoom.isDefined =>
-            val LayoutLevel(_, layoutDefinition) = layoutScheme.levelForZoom(output.maxZoom.get)
-            tiled.reproject(destCrs, layoutDefinition, method)
+            val LayoutLevel(zoom, layoutDefinition) = layoutScheme.levelForZoom(output.maxZoom.get)
+            zoom -> tiled.reproject(destCrs, layoutDefinition, method)._2
 
           case Left(layoutScheme) =>
             tiled.reproject(destCrs, layoutScheme, method)

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/Output.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/Output.scala
@@ -44,6 +44,10 @@ case class Output(
   breaks: Option[String] = None,
   maxZoom: Option[Int] = None
 ) extends Serializable {
+
+  require(maxZoom.isEmpty || layoutScheme == Some("zoomed"),
+    "maxZoom can only be used with 'zoomed' layoutScheme")
+
   def getCrs = crs.map(CRS.fromName)
 
   def getLayoutScheme: LayoutScheme = (layoutScheme, getCrs, resolutionThreshold) match {

--- a/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
+++ b/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
@@ -61,6 +61,8 @@ sealed trait Bounds[+A] extends Product with Serializable {
     }
 
   def setSpatialBounds[B >: A](other: KeyBounds[SpatialKey])(implicit ev: SpatialComponent[B]): Bounds[B]
+
+  def toOption: Option[KeyBounds[A]]
 }
 
 object Bounds {
@@ -100,6 +102,8 @@ case object EmptyBounds extends Bounds[Nothing] {
 
   def setSpatialBounds[B](other: KeyBounds[SpatialKey])(implicit ev: SpatialComponent[B]): Bounds[B] =
     this
+
+  def toOption = None
 }
 
 case class KeyBounds[+K](
@@ -155,6 +159,8 @@ case class KeyBounds[+K](
 
   def setSpatialBounds[B >: K](gb: GridBounds)(implicit ev: SpatialComponent[B]): KeyBounds[B] =
     setSpatialBounds[B](KeyBounds(SpatialKey(gb.colMin, gb.rowMin), SpatialKey(gb.colMax, gb.rowMax)))
+
+  def toOption: Option[KeyBounds[K]] = Some(this)
 }
 
 object KeyBounds {

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -16,19 +16,20 @@
 
 package geotrellis.spark.tiling
 
-import geotrellis.vector.Extent
 import geotrellis.raster._
 import geotrellis.raster.merge._
 import geotrellis.raster.prototype._
 import geotrellis.raster.resample._
 import geotrellis.spark._
+import geotrellis.util.LazyLogging
 
-import org.apache.spark._
 import org.apache.spark.rdd._
 
 import scala.reflect.ClassTag
 
 object CutTiles {
+  @transient private lazy val logger = LazyLogging(this)
+
   def apply[
     K1: (? => TilerKeyMethods[K1, K2]),
     K2: SpatialComponent: ClassTag,
@@ -39,6 +40,7 @@ object CutTiles {
     layoutDefinition: LayoutDefinition,
     resampleMethod: ResampleMethod = NearestNeighbor
   ): RDD[(K2, V)] = {
+    logger.debug(s"CutTiles($rdd, $cellType, $resampleMethod)")
     val mapTransform = layoutDefinition.mapTransform
     val (tileCols, tileRows) = layoutDefinition.tileLayout.tileDimensions
 
@@ -46,11 +48,12 @@ object CutTiles {
       .flatMap { tup =>
         val (inKey, tile) = tup
         val extent = inKey.extent
-
+        logger.debug(s"Cutting $inKey of ${tile.dimensions} cells covering $extent")
         mapTransform(extent)
-          .coords
+          .coords.toIterator
           .map  { spatialComponent =>
             val outKey = inKey.translate(spatialComponent)
+            logger.debug(s"Merge $inKey into $outKey of (${tileCols}, ${tileRows}) cells")
             val newTile = tile.prototype(cellType, tileCols, tileRows)
             (outKey, newTile.merge(mapTransform(outKey), extent, tile, resampleMethod))
           }

--- a/util/src/main/scala/geotrellis/util/LazyLogging.scala
+++ b/util/src/main/scala/geotrellis/util/LazyLogging.scala
@@ -26,8 +26,7 @@ import org.slf4j.LoggerFactory
   */
 
 trait LazyLogging {
-  @transient protected lazy val logger: Logger =
-    Logger(LoggerFactory.getLogger(getClass.getName))
+  @transient protected lazy val logger: Logger = LazyLogging(this)
 }
 
 object LazyLogging {

--- a/util/src/main/scala/geotrellis/util/LazyLogging.scala
+++ b/util/src/main/scala/geotrellis/util/LazyLogging.scala
@@ -29,3 +29,9 @@ trait LazyLogging {
   @transient protected lazy val logger: Logger =
     Logger(LoggerFactory.getLogger(getClass.getName))
 }
+
+object LazyLogging {
+  private[geotrellis]
+  def apply(source: Any): Logger =
+    Logger(LoggerFactory.getLogger(source.getClass.getName))
+}


### PR DESCRIPTION
During ETL process there are two ways in which the job specification can cause increase in resolution:

- When `maxZoom` parameter forces a higher than necessary level using `ZoomedLayoutScheme`
- When `LayoutDefinition` is provided that has higher resolution than source imagery

This is possible both in per-tile reprojected and buffered reproject methods.

If the increase in resolution is significant it will dramatically increase the size of the partitions, which were originally mapped to source imagery. Past certain point the partitions become too large to be processed.

For per-tile reproject this PR handles the logic in `geotrellis.spark.etl.Etl` class by inspecting the difference in resolutions of pre-tiled metadata and post-tiled metadata.

However in buffered reproject the check must happen during after the reprojection took place. The resolutions in different CRS are not comparable so we must check the tiles covered by the `KeyBounds`, assuming that the tiles themselves remain mostly constant in size.

### Incidental Fixes
- Render module was not callable due to incorrect name specification
- Logging added to CutTiles for when a single resample may OOM
- `Etl` must return `maxZoom` as zoom level when its specified

Resolves: https://github.com/locationtech/geotrellis/issues/2129