### PR TITLE
S3AttributeStore now handles ending slashes in prefix.

### DIFF
--- a/s3-test/src/test/scala/geotrellis/spark/io/s3/S3AttributeStoreSpec.scala
+++ b/s3-test/src/test/scala/geotrellis/spark/io/s3/S3AttributeStoreSpec.scala
@@ -27,4 +27,13 @@ class S3AttributeStoreSpec extends AttributeStoreSpec {
   lazy val attributeStore = new S3AttributeStore(bucket, prefix) {
     override val s3Client = new MockS3Client()
   }
+
+  it("should handle prefix with ending slash") {
+    val bucket = "test-bucket"
+    val prefix = "some/key/"
+    val as = new S3AttributeStore(bucket, prefix) { override val s3Client = new MockS3Client() }
+
+    import S3AttributeStore.SEP
+    as.attributePath(LayerId("testLayer", 0), "metadata") should be (s"some/key/_attributes/metadata${SEP}testLayer${SEP}0.json")
+  }
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
@@ -33,7 +33,7 @@ import java.io.ByteArrayInputStream
  * Stores and retrieves layer attributes in an S3 bucket in JSON format
  *
  * @param bucket    S3 bucket to use for attribute store
- * @param prefix  path in the bucket for given LayerId, not ending in "/"
+ * @param prefix    path in the bucket for given LayerId
  */
 class S3AttributeStore(val bucket: String, val prefix: String) extends BlobLayerAttributeStore {
   val s3Client: S3Client = S3Client.DEFAULT
@@ -45,7 +45,11 @@ class S3AttributeStore(val bucket: String, val prefix: String) extends BlobLayer
    * It could be remedied by some kind of time-out cache for both read/write in this class.
    */
 
-  def path(parts: String*) = parts.filter(_.nonEmpty).mkString("/")
+  def path(parts: String*) =
+    parts
+      .filter(_.nonEmpty)
+      .map { s => if(s.endsWith("/")) s.dropRight(1) else s }
+      .mkString("/")
 
   def attributePath(id: LayerId, attributeName: String): String =
     path(prefix, "_attributes", s"${attributeName}${SEP}${id.name}${SEP}${id.zoom}.json")


### PR DESCRIPTION
Signed-off-by: lossyrob <rdemanuele@gmail.com>