### PR TITLE
Documentation for KeyBounds

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
+++ b/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
@@ -21,45 +21,79 @@ import geotrellis.util._
 
 import org.apache.spark.rdd.RDD
 
+/** Represents a region of discrete space, bounding it by minimum and maximum points.
+ * The bounds maybe [[EmptyBounds]] as result of intersection operation.
+ *
+ * The dimensionality of region is implied by the dimensionality of type parameter A.
+ * [[Boundable]] typeclass is required to manipulate instance of A.
+ *
+ * Conceptually this ADT is similar `Option[KeyBounds[A]]` but adds methods convenient
+ * for testing and forming region intersection, union and mutation.
+ *
+ * @tparam A Type of keys, or points in descrete space
+ */
 sealed trait Bounds[+A] extends Product with Serializable {
+  /** Returns true if this is [[EmptyBounds]] */
   def isEmpty: Boolean
 
+  /** Returns false if this is [[EmptyBounds]] */
   def nonEmpty: Boolean = ! isEmpty
 
+  /** Expand bounds to include the key or keep unchanged if it is already included */
   def include[B >: A](key: B)(implicit b: Boundable[B]): KeyBounds[B]
 
+  /** Test if the key is included in bounds */
   def includes[B >: A](key: B)(implicit b: Boundable[B]): Boolean
 
+  /** Combine two regions by creating a region that covers both regions fully */
   def combine[B >: A](other: Bounds[B])(implicit b: Boundable[B]): Bounds[B]
 
+  /** Test if other bounds are fully contained by this bounds.
+   * [[EmptyBounds]] contain no other bounds but are contained by all non-empty bounds.
+   */
   def contains[B >: A](other: Bounds[B])(implicit b: Boundable[B]): Boolean
 
+  /** Returns the intersection, if any, between two bounds */
   def intersect[B >: A](other: Bounds[B])(implicit b: Boundable[B]): Bounds[B]
 
+  /** Test if two bounds for intersection */
   def intersects[B >: A](other: KeyBounds[B])(implicit b: Boundable[B]): Boolean =
     intersect(other).nonEmpty
 
+  /** Returns non-empty bounds or throws [[NoSuchElementException]] */
   def get: KeyBounds[A]
 
+  /** Returns non-empty bounds or the default value */
   def getOrElse[B >: A](default: => KeyBounds[B]): KeyBounds[B] =
     if (isEmpty) default else this.get
 
-  @inline
-  final def map[B](f: KeyBounds[A] => KeyBounds[B]): Bounds[B] =
-    if (isEmpty)
-      EmptyBounds
-    else {
-      f(get)
-    }
+  /** Returns the result of applying f to this [[Bounds]] minKey and maxKey if this it is nonempty.
+   * The minKey and maxKey are given as instance of [[KeyBounds]] instead of a tuple.
+   * If this [[Bounds]] is [[EmptyBounds]] it is returned unchanged.
+   */
+ @inline
+ final def map[B](f: KeyBounds[A] => KeyBounds[B]): Bounds[B] =
+   if (isEmpty)
+     EmptyBounds
+   else {
+     f(get)
+   }
 
-  @inline
-  final def flatMap[B](f: KeyBounds[A] => Bounds[B]): Bounds[B] =
-    if (isEmpty)
-      EmptyBounds
-    else {
-      f(get)
-    }
+  /** Returns the result of applying f to this [[Bounds]] minKey and maxKey if this it is nonempty.
+   * The minKey and maxKeys are given as instance of [[KeyBounds]] instead of a tuple.
+   * If this [[Bounds]] is [[EmptyBounds]] it is returned unchanged.
+   */
+ @inline
+ final def flatMap[B](f: KeyBounds[A] => Bounds[B]): Bounds[B] =
+   if (isEmpty)
+     EmptyBounds
+   else {
+     f(get)
+   }
 
+  /** Updates the spatial region of bounds to match that of the argument,
+   *  leaving other dimensions, if any, unchanged.
+   */
   def setSpatialBounds[B >: A](other: KeyBounds[SpatialKey])(implicit ev: SpatialComponent[B]): Bounds[B]
 
   def toOption: Option[KeyBounds[A]]
@@ -80,6 +114,9 @@ object Bounds {
     }
 }
 
+/** Represents empty region of space.
+ * Empty region contains no possible key.
+ */
 case object EmptyBounds extends Bounds[Nothing] {
   def isEmpty = true
 
@@ -106,6 +143,13 @@ case object EmptyBounds extends Bounds[Nothing] {
   def toOption = None
 }
 
+/** Represents non-empty region of descrete space.
+ * Any key which is greater than or equal to minKey and less then or equal to maxKey
+ * in each individual dimension is part of the region described by these [[Bounds]].
+ *
+ * @param minKey Minimum key of the region, inclusive.
+ * @param maxKey Maximum key of the region, inclusive.
+ */
 case class KeyBounds[+K](
   minKey: K,
   maxKey: K


### PR DESCRIPTION
Resolves: https://github.com/locationtech/geotrellis/issues/2160

@metasim This should provide enough context to discuss validity further. Looking through the code it looks like the usage from `map` and `flatMap` is gone, so there may be a discussion if they have a useful shape at all. 

The original reasoning was that `Bounds` captures the idea of optionality where our version of `None`, which is `EmptyBounds` can still be used as valid arguments for `include`, `combine` and `intersect` removing the need to do these case checks at call sites since they all follow the same pattern.

Given that `map` and `flatMap` should expose the contents of `Some` case, which is really a tuple of `minKey` and `maxKey` providing them as `KeyBounds` instead of `Tuple2` is more descriptive and allows for manipulations which are not possible with `.map(f: A => B): Bounds[B]`. Because in the latter case you can't discriminate on min vs max key.