### PR TITLE
Fix 2166

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/CellTypeSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/CellTypeSpec.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.raster
 
+import geotrellis.raster.io.geotiff.writer.TiffTagFieldValue
 import org.scalatest._
 
 class CellTypeSpec extends FunSpec with Matchers with Inspectors {
@@ -153,6 +154,8 @@ class CellTypeSpec extends FunSpec with Matchers with Inspectors {
                 case WideIntNoData(wnd) ⇒ assert(wnd === nd)
                 case WideDoubleNoData(wnd) ⇒ assert(wnd === nd)
               }
+
+              assert(TiffTagFieldValue.createNoDataString(ct) === Some(nd.toString))
             }
           }
         }

--- a/raster-test/src/test/scala/geotrellis/raster/CellTypeSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/CellTypeSpec.scala
@@ -18,7 +18,23 @@ package geotrellis.raster
 
 import org.scalatest._
 
-class CellTypeSpec extends FunSpec with Matchers {
+class CellTypeSpec extends FunSpec with Matchers with Inspectors {
+  def roundTrip(ct: CellType) {
+    withClue("fromName"){
+      // Updated behavior.
+      val str = ct.name
+      val ctp = CellType.fromName(str)
+      ctp should be (ct)
+    }
+    withClue("fromString"){
+      // Tests backward compatibility.
+      val str = ct.toString
+      //noinspection ScalaDeprecation
+      val ctp = CellType.fromString(str)
+      ctp should be (ct)
+    }
+  }
+
   describe("CellType") {
     it("should union cells correctly under various circumstance") {
       ShortCellType.union(IntCellType) should be (IntCellType)
@@ -35,20 +51,7 @@ class CellTypeSpec extends FunSpec with Matchers {
       IntCellType.intersect(FloatCellType) should be (IntCellType)
       FloatCellType.intersect(IntCellType) should be (IntCellType)
     }
-    def roundTrip(ct: CellType) {
-      {
-        // Updated behavior.
-        val str = ct.name
-        val ctp = CellType.fromName(str)
-        ctp should be (ct)
-      }
-      {
-        // Tests backward compatibility.
-        val str = ct.toString
-        val ctp = CellType.fromString(str)
-        ctp should be (ct)
-      }
-    }
+
 
     it("should serialize float64ud123") {
       roundTrip(DoubleUserDefinedNoDataCellType(123))
@@ -128,4 +131,115 @@ class CellTypeSpec extends FunSpec with Matchers {
     }
 
   }
+
+  describe("CellType Bounds checking") {
+
+    //    it("should serialize uint8ud with various ND values") {
+    //
+    //      val ndVals = Seq(0, 1, Byte.MaxValue/2, Byte.MaxValue - 1, Byte.MaxValue, Byte.MaxValue * 2)
+    //      forEvery(ndVals) { nd ⇒
+    //        roundTrip(UByteUserDefinedNoDataCellType(nd.toByte))
+    //      }
+    //    }
+    //
+    //    it("should serialize int8ud with various ND values") {
+    //
+    //      val ndVals = Seq(0, 1, 127, 128, 255)
+    //      forEvery(ndVals) { nd ⇒
+    //        roundTrip(ByteUserDefinedNoDataCellType(nd.toByte))
+    //      }
+    //    }
+
+
+
+    implicit val doubleAsIntegral = scala.math.Numeric.DoubleAsIfIntegral
+    implicit val floatAsIntegral = scala.math.Numeric.FloatAsIfIntegral
+
+
+    it("should handle encoding no data types across valid bounds") {
+      forEvery(CellDef.all) { cellDef ⇒
+        val cd = cellDef.asInstanceOf[CellDef[AnyVal]]
+        forEvery(cd.testPoints) { nd ⇒
+          val ct = cd(nd)
+          assert(cd.toCode(nd) === ct.name)
+          roundTrip(ct)
+        }
+      }
+    }
+
+    abstract class RangeAlgebra[T: Integral] {
+      protected val alg = implicitly[Integral[T]]
+      import alg._
+      val one = alg.one
+      val twice =  one + one
+      val half = one / twice
+    }
+
+    case class TestRange[Encoding: Integral](min: Encoding, max: Encoding) extends RangeAlgebra[Encoding]{
+      import alg._
+      def width = max - min
+      def middle = width * half
+    }
+
+    abstract class CellDef[T: Integral] extends RangeAlgebra[T] {
+      import alg._
+      type Encoding = T
+      val rng: TestRange[Encoding]
+      val baseCode: String
+      def apply(noData: Encoding): CellType with UserDefinedNoData[_]
+      def toCode(noData: Encoding): String = {
+        s"${baseCode}ud${noData}"
+      }
+      def testPoints = Seq(
+        rng.min, rng.min + one, rng.middle - one, rng.middle, rng.middle + one, rng.max - one, rng.max
+      )
+      override def toString = getClass.getSimpleName
+    }
+    object CellDef {
+      val all = Seq(UByteDef, ByteDef, UShortDef, ShortDef, IntDef, FloatDef, DoubleDef)
+    }
+
+    object UByteDef extends CellDef[Short] {
+      val baseCode = "uint8"
+      def apply(noData: Short) = UByteUserDefinedNoDataCellType(noData.toByte)
+      val rng = TestRange(0.toShort, (Byte.MaxValue * 2).toShort)
+    }
+
+    object ByteDef extends CellDef[Byte] {
+      val baseCode = "int8"
+      def apply(noData: Byte) = ByteUserDefinedNoDataCellType(noData.toByte)
+      val rng = TestRange(Byte.MinValue, Byte.MaxValue)
+    }
+
+    object UShortDef extends CellDef[Int] {
+      val baseCode = "uint16"
+      def apply(noData: Int) = UShortUserDefinedNoDataCellType(noData.toShort)
+      val rng = TestRange(0, Short.MaxValue * 2)
+    }
+
+    object ShortDef extends CellDef[Short] {
+      val baseCode = "int16"
+      def apply(noData: Short) = ShortUserDefinedNoDataCellType(noData)
+      val rng = TestRange(Short.MinValue, Short.MaxValue)
+    }
+
+    object IntDef extends CellDef[Int] {
+      val baseCode = "int32"
+      def apply(noData: Int) = IntUserDefinedNoDataCellType(noData)
+      val rng = TestRange(Int.MinValue, Int.MaxValue)
+    }
+
+    object FloatDef extends CellDef[Float] {
+      val baseCode = "float32"
+      def apply(noData: Float) = FloatUserDefinedNoDataCellType(noData)
+      val rng = TestRange(Float.MinValue, Float.MaxValue)
+    }
+
+    object DoubleDef extends CellDef[Double] {
+      val baseCode = "float64"
+      def apply(noData: Double) = DoubleUserDefinedNoDataCellType(noData)
+      val rng = TestRange(Double.MinValue, Double.MaxValue)
+    }
+  }
+
 }

--- a/raster/src/main/scala/geotrellis/raster/CellType.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellType.scala
@@ -351,7 +351,7 @@ case object UByteConstantNoDataCellType
     extends UByteCells with ConstantNoData
 case class UByteUserDefinedNoDataCellType(noDataValue: Byte)
     extends UByteCells with UserDefinedNoData[Byte] {
-  override def widenedNoData(implicit ev: Numeric[Byte]) = WideIntNoData(noDataValue & 0xFF)
+  override def widenedNoData(implicit ev: Numeric[Byte]) = WideIntNoData(noDataValue)
 }
 
 case object ShortCellType
@@ -367,7 +367,7 @@ case object UShortConstantNoDataCellType
     extends UShortCells with ConstantNoData
 case class UShortUserDefinedNoDataCellType(noDataValue: Short)
     extends UShortCells with UserDefinedNoData[Short] {
-  override def widenedNoData(implicit ev: Numeric[Short]) = WideIntNoData(noDataValue & 0xFFFF)
+  override def widenedNoData(implicit ev: Numeric[Short]) = WideIntNoData(noDataValue)
 }
 
 case object IntCellType

--- a/raster/src/main/scala/geotrellis/raster/CellType.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellType.scala
@@ -321,7 +321,13 @@ sealed trait NoNoData extends NoDataHandling { cellType: CellType => }
   * The [[UserDefinedNoData]] type, derived from [[NoDataHandling]].
   */
 sealed trait UserDefinedNoData[@specialized(Byte, Short, Int, Float, Double) T] extends NoDataHandling { cellType: CellType =>
+  /** The no data value as represented in the JVM in the underlying cell. If unsigned types are involved then
+   * this value may be an overflow representation, and  `widenedNoData` should be used.*/
   val noDataValue: T
+
+  def widenedNoData(implicit ev: Numeric[T]): WidenedNoData =
+    if (cellType.isFloatingPoint) WideDoubleNoData(ev.toDouble(noDataValue))
+    else WideIntNoData(ev.toInt(noDataValue))
 }
 
 /**
@@ -344,7 +350,9 @@ case object UByteCellType
 case object UByteConstantNoDataCellType
     extends UByteCells with ConstantNoData
 case class UByteUserDefinedNoDataCellType(noDataValue: Byte)
-    extends UByteCells with UserDefinedNoData[Byte]
+    extends UByteCells with UserDefinedNoData[Byte] {
+  override def widenedNoData(implicit ev: Numeric[Byte]) = WideIntNoData(noDataValue & 0xFF)
+}
 
 case object ShortCellType
     extends ShortCells with NoNoData
@@ -358,7 +366,9 @@ case object UShortCellType
 case object UShortConstantNoDataCellType
     extends UShortCells with ConstantNoData
 case class UShortUserDefinedNoDataCellType(noDataValue: Short)
-    extends UShortCells with UserDefinedNoData[Short]
+    extends UShortCells with UserDefinedNoData[Short] {
+  override def widenedNoData(implicit ev: Numeric[Short]) = WideIntNoData(noDataValue & 0xFFFF)
+}
 
 case object IntCellType
     extends IntCells with NoNoData
@@ -381,9 +391,8 @@ case object DoubleConstantNoDataCellType
 case class DoubleUserDefinedNoDataCellType(noDataValue: Double)
     extends DoubleCells with UserDefinedNoData[Double]
 
-
-// No NoData
 object CellType {
+  import CellTypeEncoding._
 
   /**
    * Translate a string representing a cell type into a [[CellType]].
@@ -400,65 +409,37 @@ object CellType {
    * @param name A string representing a cell type, as reported by [[DataType.name]] e.g. "uint32"
    * @return The CellType corresponding to `name`
    */
-  def fromName(name: String): CellType = name match {
-    case "bool" | "boolraw" => BitCellType // No NoData values
-    case "int8raw" => ByteCellType
-    case "uint8raw" => UByteCellType
-    case "int16raw" => ShortCellType
-    case "uint16raw" => UShortCellType
-    case "float32raw" => FloatCellType
-    case "float64raw" => DoubleCellType
-    case "int8" => ByteConstantNoDataCellType // Constant NoData values
-    case "uint8" => UByteConstantNoDataCellType
-    case "int16" => ShortConstantNoDataCellType
-    case "uint16" => UShortConstantNoDataCellType
-    case "int32" => IntConstantNoDataCellType
-    case "int32raw" => IntCellType
-    case "float32" => FloatConstantNoDataCellType
-    case "float64" => DoubleConstantNoDataCellType
-    case ct if ct.startsWith("int8ud") =>
-      val ndVal = new Regex("\\d+$").findFirstIn(ct).getOrElse {
+  def fromName(name: String): CellType = {
+    name match {
+      case bool() | boolraw() => BitCellType // No NoData values
+      case int8raw() => ByteCellType
+      case uint8raw() => UByteCellType
+      case int16raw() => ShortCellType
+      case uint16raw() => UShortCellType
+      case float32raw() => FloatCellType
+      case float64raw() => DoubleCellType
+      case int8() => ByteConstantNoDataCellType // Constant NoData values
+      case uint8() => UByteConstantNoDataCellType
+      case int16() => ShortConstantNoDataCellType
+      case uint16() => UShortConstantNoDataCellType
+      case int32() => IntConstantNoDataCellType
+      case int32raw() => IntCellType
+      case float32() => FloatConstantNoDataCellType
+      case float64() => DoubleConstantNoDataCellType
+      case int8ud(nd) => ByteUserDefinedNoDataCellType(nd.asInt.toByte)
+      case uint8ud(nd) => UByteUserDefinedNoDataCellType(nd.asInt.toByte)
+      case int16ud(nd) => ShortUserDefinedNoDataCellType(nd.asInt.toShort)
+      case uint16ud(nd) => UShortUserDefinedNoDataCellType(nd.asInt.toShort)
+      case int32ud(nd) => IntUserDefinedNoDataCellType(nd.asInt)
+      case float32ud(nd) =>
+        if (nd.asDouble.isNaN) FloatConstantNoDataCellType
+        else FloatUserDefinedNoDataCellType(nd.asDouble.toFloat)
+      case float64ud(nd) =>
+        if (nd.asDouble.isNaN) DoubleConstantNoDataCellType
+        else DoubleUserDefinedNoDataCellType(nd.asDouble)
+      case _ =>
         throw new IllegalArgumentException(s"Cell type $name is not supported")
-      }
-      ByteUserDefinedNoDataCellType(ndVal.toByte)
-    case ct if ct.startsWith("uint8ud") =>
-      val ndVal = new Regex("\\d+$").findFirstIn(ct).getOrElse {
-        throw new IllegalArgumentException(s"Cell type $name is not supported")
-      }
-      UByteUserDefinedNoDataCellType(ndVal.toByte)
-    case ct if ct.startsWith("int16ud") =>
-      val ndVal = new Regex("\\d+$").findFirstIn(ct).getOrElse {
-        throw new IllegalArgumentException(s"Cell type $name is not supported")
-      }
-      ShortUserDefinedNoDataCellType(ndVal.toShort)
-    case ct if ct.startsWith("uint16ud") =>
-      val ndVal = new Regex("\\d+$").findFirstIn(ct).getOrElse {
-        throw new IllegalArgumentException(s"Cell type $name is not supported")
-      }
-      UShortUserDefinedNoDataCellType(ndVal.toShort)
-    case ct if ct.startsWith("int32ud") =>
-      val ndVal = new Regex("\\d+$").findFirstIn(ct).getOrElse {
-        throw new IllegalArgumentException(s"Cell type $name is not supported")
-      }
-      IntUserDefinedNoDataCellType(ndVal.toInt)
-    case ct if ct.startsWith("float32ud") =>
-      try {
-        val ndVal = ct.stripPrefix("float32ud").toDouble.toFloat
-        if (ndVal.isNaN) FloatConstantNoDataCellType
-        else FloatUserDefinedNoDataCellType(ndVal)
-      } catch {
-        case _: NumberFormatException => throw new IllegalArgumentException(s"Cell type $name is not supported")
-      }
-    case ct if ct.startsWith("float64ud") =>
-      try {
-        val ndVal = ct.stripPrefix("float64ud").toDouble
-        if (ndVal.isNaN) DoubleConstantNoDataCellType
-        else DoubleUserDefinedNoDataCellType(ndVal)
-      } catch {
-        case _: NumberFormatException => throw new IllegalArgumentException(s"Cell type $name is not supported")
-      }
-    case str =>
-      throw new IllegalArgumentException(s"Cell type $name is not supported")
+    }
   }
 
   /**
@@ -468,32 +449,33 @@ object CellType {
    * @return String representation
    */
   def toName(cellType: CellType): String = {
-    def forUserDefined[T <: AnyVal](base: CellType, value: T) = base.name + "ud" + value.toString
 
-    cellType match {
-      case BitCellType => "bool"
-      case ByteCellType => "int8raw"
-      case UByteCellType => "uint8raw"
-      case ShortCellType => "int16raw"
-      case UShortCellType => "uint16raw"
-      case IntCellType => "int32raw"
-      case FloatCellType => "float32raw"
-      case DoubleCellType => "float64raw"
-      case ByteConstantNoDataCellType => "int8"
-      case UByteConstantNoDataCellType => "uint8"
-      case ShortConstantNoDataCellType => "int16"
-      case UShortConstantNoDataCellType => "uint16"
-      case IntConstantNoDataCellType => "int32"
-      case FloatConstantNoDataCellType => "float32"
-      case DoubleConstantNoDataCellType => "float64"
-      case ByteUserDefinedNoDataCellType(nd) => forUserDefined(ByteConstantNoDataCellType, nd)
-      case UByteUserDefinedNoDataCellType(nd) => forUserDefined(UByteConstantNoDataCellType, nd)
-      case ShortUserDefinedNoDataCellType(nd) => forUserDefined(ShortConstantNoDataCellType, nd)
-      case UShortUserDefinedNoDataCellType(nd) => forUserDefined(UShortConstantNoDataCellType, nd)
-      case IntUserDefinedNoDataCellType(nd) => forUserDefined(IntConstantNoDataCellType, nd)
-      case FloatUserDefinedNoDataCellType(nd) => forUserDefined(FloatConstantNoDataCellType, nd)
-      case DoubleUserDefinedNoDataCellType(nd) => forUserDefined(DoubleConstantNoDataCellType, nd)
+    val encoding = cellType match {
+      case BitCellType => bool
+      case ByteCellType => int8raw
+      case UByteCellType => uint8raw
+      case ShortCellType => int16raw
+      case UShortCellType => uint16raw
+      case IntCellType => int32raw
+      case FloatCellType => float32raw
+      case DoubleCellType => float64raw
+      case ByteConstantNoDataCellType => int8
+      case UByteConstantNoDataCellType => uint8
+      case ShortConstantNoDataCellType => int16
+      case UShortConstantNoDataCellType => uint16
+      case IntConstantNoDataCellType => int32
+      case FloatConstantNoDataCellType => float32
+      case DoubleConstantNoDataCellType => float64
+      case ct: ByteUserDefinedNoDataCellType => int8ud(ct.widenedNoData.asInt)
+      case ct: UByteUserDefinedNoDataCellType => uint8ud(ct.widenedNoData.asInt)
+      case ct: ShortUserDefinedNoDataCellType => int16ud(ct.widenedNoData.asInt)
+      case ct: UShortUserDefinedNoDataCellType => uint16ud(ct.widenedNoData.asInt)
+      case ct: IntUserDefinedNoDataCellType => int32ud(ct.widenedNoData.asInt)
+      case ct: FloatUserDefinedNoDataCellType => float32ud(ct.widenedNoData.asDouble)
+      case ct: DoubleUserDefinedNoDataCellType => float64ud(ct.widenedNoData.asDouble)
     }
+
+    encoding.name
   }
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/CellTypeEncoding.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellTypeEncoding.scala
@@ -99,6 +99,7 @@ sealed trait WidenedNoData {
 /** NoData value stored as an Int. */
 case class WideIntNoData(asInt: Int) extends WidenedNoData {
   def asDouble = asInt.toDouble
+  override def toString = asInt.toString
 }
 object WideIntNoData {
   def apply(thinned: Byte) = new WideIntNoData(thinned & 0xFF)
@@ -108,6 +109,7 @@ object WideIntNoData {
 /** NoData stored as a Double */
 case class WideDoubleNoData(asDouble: Double) extends WidenedNoData {
   def asInt = asDouble.toInt
+  override def toString = asDouble.toString
 }
 
 

--- a/raster/src/main/scala/geotrellis/raster/CellTypeEncoding.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellTypeEncoding.scala
@@ -76,7 +76,7 @@ sealed trait UserDefinedNoDataEncoding extends CellTypeEncoding { self ⇒
       val number = text.replace(name, "")
 
       if(isFloatingPoint) Try(number.toDouble).map(WideDoubleNoData).toOption
-      else Try(number.toInt).map(WideIntNoData).toOption
+      else Try(number.toInt).map(WideIntNoData.apply).toOption
     }
     else None
   }
@@ -99,6 +99,10 @@ sealed trait WidenedNoData {
 /** NoData value stored as an Int. */
 case class WideIntNoData(asInt: Int) extends WidenedNoData {
   def asDouble = asInt.toDouble
+}
+object WideIntNoData {
+  def apply(thinned: Byte) = new WideIntNoData(thinned & 0xFF)
+  def apply(thinned: Short) = new WideIntNoData(thinned & 0xFFFF)
 }
 
 /** NoData stored as a Double */

--- a/raster/src/main/scala/geotrellis/raster/CellTypeEncoding.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellTypeEncoding.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Astraea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geotrellis.raster
+
+import scala.util.Try
+
+/**
+ * Enumeration of tokens used to represent the different types of cell encodings and their
+ * associated no-data values in GeoTrellis. Used primarily for serialization to/from String, and
+ * pattern-matching operations.
+ */
+object CellTypeEncoding {
+  case object bool extends FixedNoDataEncoding
+  case object boolraw extends FixedNoDataEncoding
+  case object int8raw extends FixedNoDataEncoding
+  case object uint8raw extends FixedNoDataEncoding
+  case object int16raw extends FixedNoDataEncoding
+  case object uint16raw extends FixedNoDataEncoding
+  case object int32raw extends FixedNoDataEncoding
+  case object float32raw extends FixedNoDataEncoding
+  case object float64raw extends FixedNoDataEncoding
+  case object int8 extends FixedNoDataEncoding
+  case object uint8 extends FixedNoDataEncoding
+  case object int16 extends FixedNoDataEncoding
+  case object uint16 extends FixedNoDataEncoding
+  case object int32 extends FixedNoDataEncoding
+  case object float32 extends FixedNoDataEncoding
+  case object float64 extends FixedNoDataEncoding
+  case object int8ud extends UserDefinedNoDataEncoding
+  case object uint8ud extends UserDefinedNoDataEncoding
+  case object int16ud extends UserDefinedNoDataEncoding
+  case object uint16ud extends UserDefinedNoDataEncoding
+  case object int32ud extends UserDefinedNoDataEncoding
+  case object float32ud extends UserDefinedNoDataEncoding {
+    override val isFloatingPoint = true
+  }
+  object float64ud extends UserDefinedNoDataEncoding {
+    override val isFloatingPoint = true
+  }
+}
+
+/** Root trait for CellType encoding definitions. */
+sealed trait CellTypeEncoding {
+  def name = getClass.getName.split('$').last
+}
+
+/** Base trait for encoding CellTypes with fixed or no NoData values. */
+sealed trait FixedNoDataEncoding extends CellTypeEncoding {
+  def unapplySeq(text: String): Option[Seq[_]] = {
+    if(text == name) Some(Seq.empty) else None
+  }
+}
+
+/** Base trait for encoding CellTypes with user defined NoData values. */
+sealed trait UserDefinedNoDataEncoding extends CellTypeEncoding { self ⇒
+  val isFloatingPoint = false
+
+  /** Create a cell encoding for a specific noData value. */
+  def apply[T](noData: T) = SpecifiedUserDefinedNoDataEncoding(self, noData)
+
+  def unapply(text: String): Option[WidenedNoData] = {
+    if (text.startsWith(name)) {
+      val number = text.replace(name, "")
+
+      if(isFloatingPoint) Try(number.toDouble).map(WideDoubleNoData).toOption
+      else Try(number.toInt).map(WideIntNoData).toOption
+    }
+    else None
+  }
+}
+
+/** On-demand cell type encoding for specific user defined no data values. */
+case class SpecifiedUserDefinedNoDataEncoding[N](
+  base: UserDefinedNoDataEncoding, noData: N) extends UserDefinedNoDataEncoding {
+  override def name = base.name + noData
+  override def apply[T](noData: T) = SpecifiedUserDefinedNoDataEncoding(base, noData)
+}
+
+/** Container for NoData value using wider word size than declared to handled
+ * unsigned number rollover.
+ */
+sealed trait WidenedNoData {
+  def asInt: Int
+  def asDouble: Double
+}
+/** NoData value stored as an Int. */
+case class WideIntNoData(asInt: Int) extends WidenedNoData {
+  def asDouble = asInt.toDouble
+}
+
+/** NoData stored as a Double */
+case class WideDoubleNoData(asDouble: Double) extends WidenedNoData {
+  def asInt = asDouble.toInt
+}
+
+

--- a/raster/src/main/scala/geotrellis/raster/UserDefinedNoDataConversions.scala
+++ b/raster/src/main/scala/geotrellis/raster/UserDefinedNoDataConversions.scala
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package geotrellis.raster
-
-import scala.math.ScalaNumericAnyConversions
-
 
 trait UserDefinedByteNoDataConversions {
   val userDefinedByteNoDataValue: Byte

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -57,20 +57,21 @@ object TiffTagFieldValue {
 
   def createNoDataString(cellType: CellType): Option[String] =
     cellType match {
-      case BitCellType | ByteCellType | UByteCellType | ShortCellType | UShortCellType | IntCellType | FloatCellType | DoubleCellType => None
+      case BitCellType | ByteCellType | UByteCellType | ShortCellType | UShortCellType | IntCellType |
+           FloatCellType | DoubleCellType => None
       case ByteConstantNoDataCellType => Some(byteNODATA.toString)
-      case ByteUserDefinedNoDataCellType(nd) => Some(nd.toString)
       case UByteConstantNoDataCellType => Some(ubyteNODATA.toString)
-      case UByteUserDefinedNoDataCellType(nd) => Some(nd.toString)
       case ShortConstantNoDataCellType => Some(shortNODATA.toString)
-      case ShortUserDefinedNoDataCellType(nd) => Some(nd.toString)
       case UShortConstantNoDataCellType => Some(ushortNODATA.toString)
-      case UShortUserDefinedNoDataCellType(nd) => Some(nd.toString)
       case IntConstantNoDataCellType => Some(NODATA.toString)
-      case IntUserDefinedNoDataCellType(nd) => Some(nd.toString)
       case FloatConstantNoDataCellType | DoubleConstantNoDataCellType => Some("nan")
-      case FloatUserDefinedNoDataCellType(nd) => Some(nd.toDouble.toString) // Convert to a double, since there can be some weirdness with float toString.
-      case DoubleUserDefinedNoDataCellType(nd) => Some(nd.toString)
+      case ct: ByteUserDefinedNoDataCellType => Some(ct.widenedNoData.toString)
+      case ct: UByteUserDefinedNoDataCellType => Some(ct.widenedNoData.toString)
+      case ct: ShortUserDefinedNoDataCellType => Some(ct.widenedNoData.toString)
+      case ct: UShortUserDefinedNoDataCellType => Some(ct.widenedNoData.toString)
+      case ct: IntUserDefinedNoDataCellType => Some(ct.widenedNoData.toString)
+      case ct: FloatUserDefinedNoDataCellType => Some(ct.widenedNoData.toString)
+      case ct: DoubleUserDefinedNoDataCellType => Some(ct.widenedNoData.toString)
     }
 
   def collect(geoTiff: GeoTiffData): (Array[TiffTagFieldValue], Array[Int] => TiffTagFieldValue) = {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -26,7 +26,6 @@ import spire.syntax.cfor._
 
 import scala.collection.mutable
 import java.nio.ByteOrder
-import java.util.IllegalFormatException
 
 case class TiffTagFieldValue(
   tag: Int,

--- a/raster/src/main/scala/geotrellis/raster/io/json/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/json/Implicits.scala
@@ -29,11 +29,11 @@ trait Implicits extends HistogramJsonFormats {
 
   implicit object CellTypeFormat extends RootJsonFormat[CellType] {
     def write(cellType: CellType) =
-      JsString(cellType.toString)
+      JsString(cellType.name)
 
     def read(value: JsValue): CellType =
       value match {
-        case JsString(name) => CellType.fromString(name)
+        case JsString(name) => CellType.fromName(name)
         case _ =>
           throw new DeserializationException("CellType must be a string")
       }


### PR DESCRIPTION
Refactoring of code responsible for translating to/from CellType definitions
and string representations, particularly for JSON serialization. Addresses issues
outlined in #2166, where specific NoData values that are negative, or ones
for unsigned CellTypes that overflow JVM native encodings (e.g. uint8ud255).
As a part of the refactoring, expanded the tests around edge cases associated
with numeric bounds. The only public API change is the addition of the
method `UserDefinedNoData.widenedNoData`.