### PR TITLE
Expose `isEmpty` for Geometries

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/Geometry.scala
+++ b/vector/src/main/scala/geotrellis/vector/Geometry.scala
@@ -34,6 +34,18 @@ trait Geometry {
   def isValid: Boolean =
     jtsGeom.isValid
 
+  /** Is this Geometry empty? This is faster than checking manually like:
+    * {{{
+    * val mp: MultiPoint = ...
+    * val ps: Array[Point] = mp.points  // `.points` is a lazy val with processing overhead
+    *
+    * ps.isEmpty  // possible, but mp.isEmpty is faster
+    * }}}
+    * It would be similar for [[MultiLine]] or [[MultiPolygon]].
+    */
+  def isEmpty: Boolean =
+    jtsGeom.isEmpty
+
   /** Calculate the distance to another Geometry */
   def distance(other: Geometry): Double =
     jtsGeom.distance(other.jtsGeom)


### PR DESCRIPTION
Patchy patch!

Calling down to JTS's `isEmpty` is faster than doing, say:

```scala
val mp: MultiPoint = ...

mp.points.isEmpty
```