### PR TITLE
[BACKPORT 1.1] CellSize values should not be truncated to integer when parsing from Json.

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/json/CellSizeJsonSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/json/CellSizeJsonSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Astraea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.io.json
+
+import geotrellis.raster.CellSize
+import geotrellis.raster.io._
+import org.scalatest.{Assertions, FunSpec}
+import spray.json._
+
+class CellSizeJsonSpec extends FunSpec with Assertions {
+
+  describe("CellSize should not be truncated when reading") {
+    val json =
+      """
+        |{
+        |   "cellSize": {
+        |     "width": 463.3127165274989,
+        |     "height": 463.3127165274989
+        |   }
+        |}
+      """.stripMargin
+    json.parseJson match {
+      case JsObject(fields) => {
+        val cs = fields.get("cellSize").map(_.convertTo[CellSize])
+        assert(cs.isDefined)
+        assert(Math.abs(cs.get.height - 463.3127165274989) < .000000001)
+        assert(Math.abs(cs.get.width - 463.3127165274989) < .000000001)
+      }
+      case _ => fail("Could not parse cellSize")
+    }
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/io/json/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/json/Implicits.scala
@@ -46,7 +46,7 @@ trait Implicits extends HistogramJsonFormats {
     )
     def read(value: JsValue): CellSize =
       value.asJsObject.getFields("width", "height") match {
-        case Seq(JsNumber(width), JsNumber(height)) => CellSize(width.toInt, height.toInt)
+        case Seq(JsNumber(width), JsNumber(height)) => CellSize(width.toDouble, height.toDouble)
         case _ =>
           throw new DeserializationException("BackendType must be a valid object.")
       }


### PR DESCRIPTION
#2174 