### PR TITLE
Extend Delaunay/Voronoi/EuclideanDistance interfaces to work with other types

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTile.scala
@@ -58,4 +58,20 @@ object EuclideanDistanceTile {
     tile
   }
 
+  def apply(pts: Array[(Double, Double)], rasterExtent: RasterExtent): Tile = {
+    val vor = VoronoiDiagram(pts.map{ case (x, y) => new Coordinate(x, y) }, rasterExtent.extent)
+    val tile = DoubleArrayTile.empty(rasterExtent.cols, rasterExtent.rows)
+
+    vor.voronoiCellsWithPoints.foreach(rasterizeDistanceCell(rasterExtent, tile))
+    tile
+  }
+
+  def apply(pts: Array[(Double, Double, Double)], rasterExtent: RasterExtent): Tile = {
+    val vor = VoronoiDiagram(pts.map{ case (x, y, z) => new Coordinate(x, y, z) }, rasterExtent.extent)
+    val tile = DoubleArrayTile.empty(rasterExtent.cols, rasterExtent.rows)
+
+    vor.voronoiCellsWithPoints.foreach(rasterizeDistanceCell(rasterExtent, tile))
+    tile
+  }
+
 }

--- a/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTile.scala
@@ -42,14 +42,6 @@ object EuclideanDistanceTile {
     PolygonRasterizer.foreachCellByPolygon(buffered, rasterExtent)(fillFn(rasterExtent, tile, Point.jtsCoord2Point(coord)))
   }
 
-  def apply(pts: Array[Point], rasterExtent: RasterExtent): Tile = {
-    val vor = VoronoiDiagram(pts.map{ pt => new Coordinate(pt.x, pt.y) }, rasterExtent.extent)
-    val tile = DoubleArrayTile.empty(rasterExtent.cols, rasterExtent.rows)
-
-    vor.voronoiCellsWithPoints.foreach(rasterizeDistanceCell(rasterExtent, tile))
-    tile
-  }
-
   def apply(pts: Array[Coordinate], rasterExtent: RasterExtent): Tile = {
     val vor = VoronoiDiagram(pts, rasterExtent.extent)
     val tile = DoubleArrayTile.empty(rasterExtent.cols, rasterExtent.rows)
@@ -58,20 +50,16 @@ object EuclideanDistanceTile {
     tile
   }
 
-  def apply(pts: Array[(Double, Double)], rasterExtent: RasterExtent): Tile = {
-    val vor = VoronoiDiagram(pts.map{ case (x, y) => new Coordinate(x, y) }, rasterExtent.extent)
-    val tile = DoubleArrayTile.empty(rasterExtent.cols, rasterExtent.rows)
+  def apply(pts: Array[Point], rasterExtent: RasterExtent): Tile = {
+    apply(pts.map{ pt => new Coordinate(pt.x, pt.y) }, rasterExtent)
+  }
 
-    vor.voronoiCellsWithPoints.foreach(rasterizeDistanceCell(rasterExtent, tile))
-    tile
+  def apply(pts: Array[(Double, Double)], rasterExtent: RasterExtent): Tile = {
+    apply(pts.map{ case (x, y) => new Coordinate(x, y) }, rasterExtent)
   }
 
   def apply(pts: Array[(Double, Double, Double)], rasterExtent: RasterExtent): Tile = {
-    val vor = VoronoiDiagram(pts.map{ case (x, y, z) => new Coordinate(x, y, z) }, rasterExtent.extent)
-    val tile = DoubleArrayTile.empty(rasterExtent.cols, rasterExtent.rows)
-
-    vor.voronoiCellsWithPoints.foreach(rasterizeDistanceCell(rasterExtent, tile))
-    tile
+    apply(pts.map{ case (x, y, z) => new Coordinate(x, y, z) }, rasterExtent)
   }
 
 }

--- a/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTileMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTileMethods.scala
@@ -40,22 +40,6 @@ trait EuclideanDistanceTileCoordinateMethods extends MethodExtensions[Traversabl
   def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.toArray, rasterExtent) }
 }
 
-trait EuclideanDistanceTilePairArrayMethods extends MethodExtensions[Array[(Double, Double)]] {
-  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self, rasterExtent) }
-}
-
-trait EuclideanDistanceTilePairMethods extends MethodExtensions[Traversable[(Double, Double)]] {
-  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.toArray, rasterExtent) }
-}
-
-trait EuclideanDistanceTileTripleArrayMethods extends MethodExtensions[Array[(Double, Double, Double)]] {
-  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self, rasterExtent) }
-}
-
-trait EuclideanDistanceTileTripleMethods extends MethodExtensions[Traversable[(Double, Double, Double)]] {
-  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.toArray, rasterExtent) }
-}
-
 trait EuclideanDistanceTileMultiPointMethods extends MethodExtensions[MultiPoint] {
   def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.points.map{_.jtsGeom.getCoordinate}, rasterExtent) }
 }

--- a/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTileMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTileMethods.scala
@@ -20,7 +20,7 @@ import com.vividsolutions.jts.geom.Coordinate
 
 import geotrellis.raster.{RasterExtent, Tile}
 import geotrellis.util.MethodExtensions
-import geotrellis.vector.Point
+import geotrellis.vector.{MultiPoint, Point}
 
 trait EuclideanDistanceTileArrayMethods extends MethodExtensions[Array[Point]] {
   @deprecated("call euclideanDistanceTile() on Array[Coordinate] instead", "1.2")
@@ -54,4 +54,8 @@ trait EuclideanDistanceTileTripleArrayMethods extends MethodExtensions[Array[(Do
 
 trait EuclideanDistanceTileTripleMethods extends MethodExtensions[Traversable[(Double, Double, Double)]] {
   def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.toArray, rasterExtent) }
+}
+
+trait EuclideanDistanceTileMultiPointMethods extends MethodExtensions[MultiPoint] {
+  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.points.map{_.jtsGeom.getCoordinate}, rasterExtent) }
 }

--- a/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTileMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/distance/EuclideanDistanceTileMethods.scala
@@ -39,3 +39,19 @@ trait EuclideanDistanceTileCoordinateArrayMethods extends MethodExtensions[Array
 trait EuclideanDistanceTileCoordinateMethods extends MethodExtensions[Traversable[Coordinate]] {
   def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.toArray, rasterExtent) }
 }
+
+trait EuclideanDistanceTilePairArrayMethods extends MethodExtensions[Array[(Double, Double)]] {
+  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self, rasterExtent) }
+}
+
+trait EuclideanDistanceTilePairMethods extends MethodExtensions[Traversable[(Double, Double)]] {
+  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.toArray, rasterExtent) }
+}
+
+trait EuclideanDistanceTileTripleArrayMethods extends MethodExtensions[Array[(Double, Double, Double)]] {
+  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self, rasterExtent) }
+}
+
+trait EuclideanDistanceTileTripleMethods extends MethodExtensions[Traversable[(Double, Double, Double)]] {
+  def euclideanDistanceTile(rasterExtent: RasterExtent): Tile = { EuclideanDistanceTile(self.toArray, rasterExtent) }
+}

--- a/raster/src/main/scala/geotrellis/raster/distance/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/distance/Implicits.scala
@@ -22,11 +22,21 @@ import geotrellis.vector.Point
 object Implicits extends Implicits
 
 trait Implicits {
+  implicit class withEuclideanDistanceTileCoordinateMethods(val self: Traversable[Coordinate]) extends EuclideanDistanceTileCoordinateMethods
+
+  implicit class withEuclideanDistanceTileArrayCoordinateMethods(val self: Array[Coordinate]) extends EuclideanDistanceTileCoordinateArrayMethods
+
+  implicit class withEuclideanDistanceTilePairMethods(val self: Traversable[(Double, Double)]) extends EuclideanDistanceTilePairMethods
+
+  implicit class withEuclideanDistanceTilePairArrayMethods(val self: Array[(Double, Double)]) extends EuclideanDistanceTilePairArrayMethods
+
+  implicit class withEuclideanDistanceTileTripleMethods(val self: Traversable[(Double, Double, Double)]) extends EuclideanDistanceTileTripleMethods
+
+  implicit class withEuclideanDistanceTileTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends EuclideanDistanceTileTripleArrayMethods
+
+  // The following will be edited to use the new Euclidean distance classes upon deleting the JTS-derived versions
   implicit class withEuclideanDistanceTileMethods(val self: Traversable[Point]) extends EuclideanDistanceTileMethods
 
   implicit class withEuclideanDistanceTileArrayMethods(val self: Array[Point]) extends EuclideanDistanceTileArrayMethods
 
-  implicit class withEuclideanDistanceTileCoordinateMethods(val self: Traversable[Coordinate]) extends EuclideanDistanceTileCoordinateMethods
-
-  implicit class withEuclideanDistanceTileArrayCoordinateMethods(val self: Array[Coordinate]) extends EuclideanDistanceTileCoordinateArrayMethods
 }

--- a/raster/src/main/scala/geotrellis/raster/distance/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/distance/Implicits.scala
@@ -17,7 +17,7 @@
 package geotrellis.raster.distance
 
 import com.vividsolutions.jts.geom.Coordinate
-import geotrellis.vector.Point
+import geotrellis.vector.{MultiPoint, Point}
 
 object Implicits extends Implicits
 
@@ -33,6 +33,8 @@ trait Implicits {
   implicit class withEuclideanDistanceTileTripleMethods(val self: Traversable[(Double, Double, Double)]) extends EuclideanDistanceTileTripleMethods
 
   implicit class withEuclideanDistanceTileTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends EuclideanDistanceTileTripleArrayMethods
+
+  implicit class withEuclideanDistanceTileMultiPointMethods(val self: MultiPoint) extends EuclideanDistanceTileMultiPointMethods
 
   // The following will be edited to use the new Euclidean distance classes upon deleting the JTS-derived versions
   implicit class withEuclideanDistanceTileMethods(val self: Traversable[Point]) extends EuclideanDistanceTileMethods

--- a/raster/src/main/scala/geotrellis/raster/distance/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/distance/Implicits.scala
@@ -26,14 +26,6 @@ trait Implicits {
 
   implicit class withEuclideanDistanceTileArrayCoordinateMethods(val self: Array[Coordinate]) extends EuclideanDistanceTileCoordinateArrayMethods
 
-  implicit class withEuclideanDistanceTilePairMethods(val self: Traversable[(Double, Double)]) extends EuclideanDistanceTilePairMethods
-
-  implicit class withEuclideanDistanceTilePairArrayMethods(val self: Array[(Double, Double)]) extends EuclideanDistanceTilePairArrayMethods
-
-  implicit class withEuclideanDistanceTileTripleMethods(val self: Traversable[(Double, Double, Double)]) extends EuclideanDistanceTileTripleMethods
-
-  implicit class withEuclideanDistanceTileTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends EuclideanDistanceTileTripleArrayMethods
-
   implicit class withEuclideanDistanceTileMultiPointMethods(val self: MultiPoint) extends EuclideanDistanceTileMultiPointMethods
 
   // The following will be edited to use the new Euclidean distance classes upon deleting the JTS-derived versions

--- a/spark/src/main/scala/geotrellis/spark/distance/EuclideanDistanceRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/distance/EuclideanDistanceRDDMethods.scala
@@ -12,3 +12,17 @@ import geotrellis.vector.{Extent, Point}
 trait EuclideanDistanceRDDMethods extends MethodExtensions[RDD[(SpatialKey, Array[Coordinate])]] {
   def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] = { EuclideanDistance(self, layout) }
 }
+
+trait EuclideanDistancePointRDDMethods extends MethodExtensions[RDD[(SpatialKey, Array[Point])]] {
+  def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] = { EuclideanDistance(self.mapValues(_.map(_.jtsGeom.getCoordinate)), layout) }
+}
+
+trait EuclideanDistancePairRDDMethods extends MethodExtensions[RDD[(SpatialKey, Array[(Double, Double)])]] {
+  def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] =
+    EuclideanDistance(self.mapValues(_.map{ case (x, y) => new Coordinate(x, y) }), layout) 
+}
+
+trait EuclideanDistanceTripleRDDMethods extends MethodExtensions[RDD[(SpatialKey, Array[(Double, Double, Double)])]] {
+  def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] =
+    EuclideanDistance(self.mapValues(_.map{ case (x, y, z) => new Coordinate(x, y, z) }), layout) 
+}

--- a/spark/src/main/scala/geotrellis/spark/distance/EuclideanDistanceRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/distance/EuclideanDistanceRDDMethods.scala
@@ -7,7 +7,7 @@ import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.util.MethodExtensions
-import geotrellis.vector.{Extent, Point}
+import geotrellis.vector.{Extent, MultiPoint, Point}
 
 trait EuclideanDistanceRDDMethods extends MethodExtensions[RDD[(SpatialKey, Array[Coordinate])]] {
   def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] = { EuclideanDistance(self, layout) }
@@ -25,4 +25,9 @@ trait EuclideanDistancePairRDDMethods extends MethodExtensions[RDD[(SpatialKey, 
 trait EuclideanDistanceTripleRDDMethods extends MethodExtensions[RDD[(SpatialKey, Array[(Double, Double, Double)])]] {
   def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] =
     EuclideanDistance(self.mapValues(_.map{ case (x, y, z) => new Coordinate(x, y, z) }), layout) 
+}
+
+trait EuclideanDistanceMultiPointRDDMethods extends MethodExtensions[RDD[(SpatialKey, MultiPoint)]] {
+  def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] =
+    EuclideanDistance(self.mapValues(_.points.map(_.jtsGeom.getCoordinate)), layout) 
 }

--- a/spark/src/main/scala/geotrellis/spark/distance/EuclideanDistanceRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/distance/EuclideanDistanceRDDMethods.scala
@@ -17,16 +17,6 @@ trait EuclideanDistancePointRDDMethods extends MethodExtensions[RDD[(SpatialKey,
   def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] = { EuclideanDistance(self.mapValues(_.map(_.jtsGeom.getCoordinate)), layout) }
 }
 
-trait EuclideanDistancePairRDDMethods extends MethodExtensions[RDD[(SpatialKey, Array[(Double, Double)])]] {
-  def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] =
-    EuclideanDistance(self.mapValues(_.map{ case (x, y) => new Coordinate(x, y) }), layout) 
-}
-
-trait EuclideanDistanceTripleRDDMethods extends MethodExtensions[RDD[(SpatialKey, Array[(Double, Double, Double)])]] {
-  def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] =
-    EuclideanDistance(self.mapValues(_.map{ case (x, y, z) => new Coordinate(x, y, z) }), layout) 
-}
-
 trait EuclideanDistanceMultiPointRDDMethods extends MethodExtensions[RDD[(SpatialKey, MultiPoint)]] {
   def euclideanDistance(layout: LayoutDefinition): RDD[(SpatialKey, Tile)] =
     EuclideanDistance(self.mapValues(_.points.map(_.jtsGeom.getCoordinate)), layout) 

--- a/spark/src/main/scala/geotrellis/spark/distance/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/distance/Implicits.scala
@@ -13,9 +13,5 @@ trait Implicits {
 
   implicit class withEuclideanDistancePointRDDMethods(val self: RDD[(SpatialKey, Array[Point])]) extends EuclideanDistancePointRDDMethods
 
-  implicit class withEuclideanDistancePairRDDMethods(val self: RDD[(SpatialKey, Array[(Double, Double)])]) extends EuclideanDistancePairRDDMethods
-
-  implicit class withEuclideanDistanceTripleRDDMethods(val self: RDD[(SpatialKey, Array[(Double, Double, Double)])]) extends EuclideanDistanceTripleRDDMethods
-
   implicit class withEuclideanDistanceMultiPointRDDMethods(val self: RDD[(SpatialKey, MultiPoint)]) extends EuclideanDistanceMultiPointRDDMethods
 }

--- a/spark/src/main/scala/geotrellis/spark/distance/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/distance/Implicits.scala
@@ -4,9 +4,16 @@ import com.vividsolutions.jts.geom.Coordinate
 import org.apache.spark.rdd.RDD
 
 import geotrellis.spark._
+import geotrellis.vector.Point
 
 object Implicits extends Implicits
 
 trait Implicits {
   implicit class withEuclideanDistanceRDDMethods(val self: RDD[(SpatialKey, Array[Coordinate])]) extends EuclideanDistanceRDDMethods
+
+  implicit class withEuclideanDistancePointRDDMethods(val self: RDD[(SpatialKey, Array[Point])]) extends EuclideanDistancePointRDDMethods
+
+  implicit class withEuclideanDistancePairRDDMethods(val self: RDD[(SpatialKey, Array[(Double, Double)])]) extends EuclideanDistancePairRDDMethods
+
+  implicit class withEuclideanDistanceTripleRDDMethods(val self: RDD[(SpatialKey, Array[(Double, Double, Double)])]) extends EuclideanDistanceTripleRDDMethods
 }

--- a/spark/src/main/scala/geotrellis/spark/distance/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/distance/Implicits.scala
@@ -4,7 +4,7 @@ import com.vividsolutions.jts.geom.Coordinate
 import org.apache.spark.rdd.RDD
 
 import geotrellis.spark._
-import geotrellis.vector.Point
+import geotrellis.vector.{MultiPoint, Point}
 
 object Implicits extends Implicits
 
@@ -16,4 +16,6 @@ trait Implicits {
   implicit class withEuclideanDistancePairRDDMethods(val self: RDD[(SpatialKey, Array[(Double, Double)])]) extends EuclideanDistancePairRDDMethods
 
   implicit class withEuclideanDistanceTripleRDDMethods(val self: RDD[(SpatialKey, Array[(Double, Double, Double)])]) extends EuclideanDistanceTripleRDDMethods
+
+  implicit class withEuclideanDistanceMultiPointRDDMethods(val self: RDD[(SpatialKey, MultiPoint)]) extends EuclideanDistanceMultiPointRDDMethods
 }

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulationMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulationMethods.scala
@@ -29,22 +29,6 @@ trait DelaunayTriangulationArrayMethods extends MethodExtensions[Array[Coordinat
   def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self) }
 }
 
-trait DelaunayTriangulationPairMethods extends MethodExtensions[Traversable[(Double, Double)]] {
-  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y) => new Coordinate(x, y) }.toArray) }
-}
-
-trait DelaunayTriangulationPairArrayMethods extends MethodExtensions[Array[(Double, Double)]] {
-  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y) => new Coordinate(x, y) }) }
-}
-
-trait DelaunayTriangulationTripleMethods extends MethodExtensions[Traversable[(Double, Double, Double)]] {
-  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y, z) => new Coordinate(x, y, z) }.toArray) }
-}
-
-trait DelaunayTriangulationTripleArrayMethods extends MethodExtensions[Array[(Double, Double, Double)]] {
-  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y, z) => new Coordinate(x, y, z) }) }
-}
-
 trait DelaunayTriangulationMultiPointMethods extends MethodExtensions[MultiPoint] {
   def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.points.map(_.jtsGeom.getCoordinate)) }
 }

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulationMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulationMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.vector.triangulation
 import com.vividsolutions.jts.geom.Coordinate
 
 import geotrellis.util.MethodExtensions
+import geotrellis.vector.MultiPoint
 
 trait DelaunayTriangulationMethods extends MethodExtensions[Traversable[Coordinate]] {
   def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.toArray) }
@@ -42,4 +43,8 @@ trait DelaunayTriangulationTripleMethods extends MethodExtensions[Traversable[(D
 
 trait DelaunayTriangulationTripleArrayMethods extends MethodExtensions[Array[(Double, Double, Double)]] {
   def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y, z) => new Coordinate(x, y, z) }) }
+}
+
+trait DelaunayTriangulationMultiPointMethods extends MethodExtensions[MultiPoint] {
+  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.points.map(_.jtsGeom.getCoordinate)) }
 }

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulationMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulationMethods.scala
@@ -27,3 +27,19 @@ trait DelaunayTriangulationMethods extends MethodExtensions[Traversable[Coordina
 trait DelaunayTriangulationArrayMethods extends MethodExtensions[Array[Coordinate]] {
   def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self) }
 }
+
+trait DelaunayTriangulationPairMethods extends MethodExtensions[Traversable[(Double, Double)]] {
+  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y) => new Coordinate(x, y) }.toArray) }
+}
+
+trait DelaunayTriangulationPairArrayMethods extends MethodExtensions[Array[(Double, Double)]] {
+  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y) => new Coordinate(x, y) }) }
+}
+
+trait DelaunayTriangulationTripleMethods extends MethodExtensions[Traversable[(Double, Double, Double)]] {
+  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y, z) => new Coordinate(x, y, z) }.toArray) }
+}
+
+trait DelaunayTriangulationTripleArrayMethods extends MethodExtensions[Array[(Double, Double, Double)]] {
+  def delaunayTriangulation(): DelaunayTriangulation = { DelaunayTriangulation(self.map{ case (x, y, z) => new Coordinate(x, y, z) }) }
+}

--- a/vector/src/main/scala/geotrellis/vector/triangulation/Implicits.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/Implicits.scala
@@ -18,6 +18,8 @@ package geotrellis.vector.triangulation
 
 import com.vividsolutions.jts.geom.Coordinate
 
+import geotrellis.vector.MultiPoint
+
 object Implicits extends Implicits
 
 trait Implicits {
@@ -32,4 +34,6 @@ trait Implicits {
   implicit class withDelaunayTriangulationTripleMethods(val self: Traversable[(Double, Double, Double)]) extends DelaunayTriangulationTripleMethods
 
   implicit class withDelaunayTriangulationTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends DelaunayTriangulationTripleArrayMethods
+
+  implicit class withDelaunayTriangulationMultiPointMethods(val self: MultiPoint) extends DelaunayTriangulationMultiPointMethods
 }

--- a/vector/src/main/scala/geotrellis/vector/triangulation/Implicits.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/Implicits.scala
@@ -27,13 +27,5 @@ trait Implicits {
 
   implicit class withDelaunayTriangulationArrayMethods(val self: Array[Coordinate]) extends DelaunayTriangulationArrayMethods
 
-  implicit class withDelaunayTriangulationPairMethods(val self: Traversable[(Double, Double)]) extends DelaunayTriangulationPairMethods
-
-  implicit class withDelaunayTriangulationPairArrayMethods(val self: Array[(Double, Double)]) extends DelaunayTriangulationPairArrayMethods
-
-  implicit class withDelaunayTriangulationTripleMethods(val self: Traversable[(Double, Double, Double)]) extends DelaunayTriangulationTripleMethods
-
-  implicit class withDelaunayTriangulationTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends DelaunayTriangulationTripleArrayMethods
-
   implicit class withDelaunayTriangulationMultiPointMethods(val self: MultiPoint) extends DelaunayTriangulationMultiPointMethods
 }

--- a/vector/src/main/scala/geotrellis/vector/triangulation/Implicits.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/Implicits.scala
@@ -24,4 +24,12 @@ trait Implicits {
   implicit class withDelaunayTriangulationMethods(val self: Traversable[Coordinate]) extends DelaunayTriangulationMethods
 
   implicit class withDelaunayTriangulationArrayMethods(val self: Array[Coordinate]) extends DelaunayTriangulationArrayMethods
+
+  implicit class withDelaunayTriangulationPairMethods(val self: Traversable[(Double, Double)]) extends DelaunayTriangulationPairMethods
+
+  implicit class withDelaunayTriangulationPairArrayMethods(val self: Array[(Double, Double)]) extends DelaunayTriangulationPairArrayMethods
+
+  implicit class withDelaunayTriangulationTripleMethods(val self: Traversable[(Double, Double, Double)]) extends DelaunayTriangulationTripleMethods
+
+  implicit class withDelaunayTriangulationTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends DelaunayTriangulationTripleArrayMethods
 }

--- a/vector/src/main/scala/geotrellis/vector/voronoi/Implicits.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/Implicits.scala
@@ -33,4 +33,12 @@ trait Implicits {
   implicit class withFastVoronoiDiagramMethods(val self: Traversable[Coordinate]) extends FastVoronoiDiagramMethods
 
   implicit class withFastVoronoiDiagramArrayMethods(val self: Array[Coordinate]) extends FastVoronoiDiagramArrayMethods
+
+  implicit class withFastVoronoiDiagramPairMethods(val self: Traversable[(Double, Double)]) extends FastVoronoiDiagramPairMethods
+
+  implicit class withFastVoronoiDiagramPairArrayMethods(val self: Array[(Double, Double)]) extends FastVoronoiDiagramPairArrayMethods
+
+  implicit class withFastVoronoiDiagramTripleMethods(val self: Traversable[(Double, Double, Double)]) extends FastVoronoiDiagramTripleMethods
+
+  implicit class withFastVoronoiDiagramTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends FastVoronoiDiagramTripleArrayMethods
 }

--- a/vector/src/main/scala/geotrellis/vector/voronoi/Implicits.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/Implicits.scala
@@ -17,7 +17,7 @@
 package geotrellis.vector.voronoi
 
 import com.vividsolutions.jts.geom.Coordinate
-import geotrellis.vector.Point
+import geotrellis.vector.{MultiPoint, Point}
 
 object Implicits extends Implicits
 
@@ -41,4 +41,6 @@ trait Implicits {
   implicit class withFastVoronoiDiagramTripleMethods(val self: Traversable[(Double, Double, Double)]) extends FastVoronoiDiagramTripleMethods
 
   implicit class withFastVoronoiDiagramTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends FastVoronoiDiagramTripleArrayMethods
+
+  implicit class withFastVoronoiDiagramMultiPointMethods(val self: MultiPoint) extends FastVoronoiDiagramMultiPointMethods
 }

--- a/vector/src/main/scala/geotrellis/vector/voronoi/Implicits.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/Implicits.scala
@@ -34,13 +34,5 @@ trait Implicits {
 
   implicit class withFastVoronoiDiagramArrayMethods(val self: Array[Coordinate]) extends FastVoronoiDiagramArrayMethods
 
-  implicit class withFastVoronoiDiagramPairMethods(val self: Traversable[(Double, Double)]) extends FastVoronoiDiagramPairMethods
-
-  implicit class withFastVoronoiDiagramPairArrayMethods(val self: Array[(Double, Double)]) extends FastVoronoiDiagramPairArrayMethods
-
-  implicit class withFastVoronoiDiagramTripleMethods(val self: Traversable[(Double, Double, Double)]) extends FastVoronoiDiagramTripleMethods
-
-  implicit class withFastVoronoiDiagramTripleArrayMethods(val self: Array[(Double, Double, Double)]) extends FastVoronoiDiagramTripleArrayMethods
-
   implicit class withFastVoronoiDiagramMultiPointMethods(val self: MultiPoint) extends FastVoronoiDiagramMultiPointMethods
 }

--- a/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
@@ -220,7 +220,7 @@ class VoronoiDiagram(val dt: DelaunayTriangulation, val extent: Extent) {
    * corresponding polygonal regions.
    */
   def voronoiCellsWithPoints(): Seq[(Polygon, Coordinate)] = {
-    dt.halfEdgeTable.allVertices.toSeq.flatMap{ i: Int => 
+    dt.liveVertices.toSeq.flatMap{ i: Int => 
       voronoiCell(i) match { 
         case None => None
         case Some(poly) => Some(poly, dt.pointSet.getCoordinate(i)) 

--- a/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiMethods.scala
@@ -38,3 +38,19 @@ trait FastVoronoiDiagramMethods extends MethodExtensions[Traversable[Coordinate]
 trait FastVoronoiDiagramArrayMethods extends MethodExtensions[Array[Coordinate]] {
   def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self, extent) }
 }
+
+trait FastVoronoiDiagramPairMethods extends MethodExtensions[Traversable[(Double, Double)]] {
+  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y) => new Coordinate(x, y) }.toArray, extent) }
+}
+
+trait FastVoronoiDiagramPairArrayMethods extends MethodExtensions[Array[(Double, Double)]] {
+  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y) => new Coordinate(x, y) }, extent) }
+}
+
+trait FastVoronoiDiagramTripleMethods extends MethodExtensions[Traversable[(Double, Double, Double)]] {
+  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y, z) => new Coordinate(x, y, z) }.toArray, extent) }
+}
+
+trait FastVoronoiDiagramTripleArrayMethods extends MethodExtensions[Array[(Double, Double, Double)]] {
+  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y, z) => new Coordinate(x, y, z) }, extent) }
+}

--- a/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiMethods.scala
@@ -39,22 +39,6 @@ trait FastVoronoiDiagramArrayMethods extends MethodExtensions[Array[Coordinate]]
   def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self, extent) }
 }
 
-trait FastVoronoiDiagramPairMethods extends MethodExtensions[Traversable[(Double, Double)]] {
-  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y) => new Coordinate(x, y) }.toArray, extent) }
-}
-
-trait FastVoronoiDiagramPairArrayMethods extends MethodExtensions[Array[(Double, Double)]] {
-  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y) => new Coordinate(x, y) }, extent) }
-}
-
-trait FastVoronoiDiagramTripleMethods extends MethodExtensions[Traversable[(Double, Double, Double)]] {
-  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y, z) => new Coordinate(x, y, z) }.toArray, extent) }
-}
-
-trait FastVoronoiDiagramTripleArrayMethods extends MethodExtensions[Array[(Double, Double, Double)]] {
-  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y, z) => new Coordinate(x, y, z) }, extent) }
-}
-
 trait FastVoronoiDiagramMultiPointMethods extends MethodExtensions[MultiPoint] {
   def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.points.map(_.jtsGeom.getCoordinate), extent) }
 }

--- a/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiMethods.scala
@@ -18,8 +18,8 @@ package geotrellis.vector.voronoi
 
 import com.vividsolutions.jts.geom.Coordinate
 
-import geotrellis.vector.{Extent, Point}
 import geotrellis.util.MethodExtensions
+import geotrellis.vector.{Extent, MultiPoint, Point}
 
 trait VoronoiDiagramMethods extends MethodExtensions[Traversable[Point]] {
   @deprecated("call voronoiDiagram() on Traversable[Coordinate] instead", "1.2")
@@ -53,4 +53,8 @@ trait FastVoronoiDiagramTripleMethods extends MethodExtensions[Traversable[(Doub
 
 trait FastVoronoiDiagramTripleArrayMethods extends MethodExtensions[Array[(Double, Double, Double)]] {
   def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.map{ case (x, y, z) => new Coordinate(x, y, z) }, extent) }
+}
+
+trait FastVoronoiDiagramMultiPointMethods extends MethodExtensions[MultiPoint] {
+  def voronoiDiagram(extent: Extent): VoronoiDiagram = { VoronoiDiagram(self.points.map(_.jtsGeom.getCoordinate), extent) }
 }


### PR DESCRIPTION
Method extensions existed in the Delaunay interface for working with `Coordinates`.  This isn't always the most useful interface.  This PR adds other modes of interaction including `Double` pairs and triples and `MultiPoint`s.