### PR TITLE
Fix issue with duplicate tiles being read for File and Cassandra backends

### DIFF
--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraRDDReader.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraRDDReader.scala
@@ -73,7 +73,7 @@ object CassandraRDDReader {
           val statement = session.prepare(query)
 
           val result = partition map { seq =>
-            LayerReader.njoin[K, V](ranges.iterator, threads) { index: Long =>
+            LayerReader.njoin[K, V](seq.iterator, threads) { index: Long =>
               val row = session.execute(statement.bind(index.asInstanceOf[java.lang.Long]))
               if (row.nonEmpty) {
                 val bytes = row.one().getBytes("value").array()

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
@@ -70,8 +70,8 @@ trait S3RDDReader {
       .mapPartitions { partition: Iterator[Seq[(Long, Long)]] =>
         val s3client = _getS3Client()
         val writerSchema = kwWriterSchema.value.getOrElse(_recordCodec.schema)
-        partition flatMap { ranges =>
-          LayerReader.njoin[K, V](ranges.toIterator, threads){ index: Long =>
+        partition flatMap { seq =>
+          LayerReader.njoin[K, V](seq.toIterator, threads){ index: Long =>
             try {
               val bytes = IOUtils.toByteArray(s3client.getObject(bucket, keyPath(index)).getObjectContent)
               val recs = AvroEncoder.fromBinary(writerSchema, bytes)(_recordCodec)

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/TestEnvironment.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/TestEnvironment.scala
@@ -69,6 +69,7 @@ trait TestEnvironment extends BeforeAndAfterAll
     conf
       .setMaster("local")
       .setAppName("Test Context")
+      .set("spark.default.parallelism", "4")
 
     // Shortcut out of using Kryo serialization if we want to test against
     // java serialization.

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileRDDReader.scala
@@ -58,7 +58,7 @@ object FileRDDReader {
     sc.parallelize(bins, bins.size)
       .mapPartitions { partition: Iterator[Seq[(Long, Long)]] =>
         partition flatMap { seq =>
-          LayerReader.njoin[K, V](ranges.toIterator, threads) { index: Long =>
+          LayerReader.njoin[K, V](seq.toIterator, threads) { index: Long =>
             val path = keyPath(index)
             if (new File(path).exists) {
               val bytes: Array[Byte] = Filesystem.slurp(path)


### PR DESCRIPTION
This nasty bug was caused by some unfortunate variable naming and a bad merge; tiles were being read in for these to backends per-partition. Our unit tests had only 1 partition per RDD so it was never caught.

Fixes #2140