### PR TITLE
Remove redundant elements in construction of Voronoi from linear triangulations

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
@@ -71,7 +71,7 @@ object VoronoiDiagram {
       if (abs(norm dot vplus) < EPSILON) {
         if (abs(norm dot vminus) < EPSILON) {
           // Linear triangulation; corresponding cell edge is an infinite line
-          l ++= Seq(ReverseRay(x.toCoord, norm * (-1)), Ray(x.toCoord, norm))
+          l ++= Seq(/*ReverseRay(x.toCoord, norm * (-1)), */Ray(x.toCoord, norm))
         } else {
           // On boundary; next "face center" is point at infinity
           l += Ray((x + norm * aminus).toCoord, norm)


### PR DESCRIPTION
Voronoi cells are represented by a collection of line segments and rays.  When constructing Voronoi diagrams from linear triangulations, each edge in the triangulaton can be conceived of as generating a pair of opposite and opposing rays emanating from the midpoint of the triangulation edge.  However, when generating a Polygon from a Voronoi cell, the process is to clip a seed region to the boundaries of the Voronoi cell.  The opposite and opposing rays represent the same clipping constraint, which can in practice lead to broken output Polygons. Here we simplify the cell construction process to only include one of the two bounding rays.  This resolves the observed bug in clipping.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>