### PR TITLE
Added broadcasting version of EuclideanDistance

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/EuclideanDistanceExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/EuclideanDistanceExamples.scala
@@ -1,0 +1,50 @@
+package geotrellis.doc.examples.distance
+
+object EuclideanDistanceExamples {
+  def `Demonstration of shortcomings of dense EuclideanDistance operation`: Unit = {
+    import com.vividsolutions.jts.geom.Coordinate
+    import org.apache.spark.SparkContext
+    import org.apache.spark.rdd.RDD
+
+    import geotrellis.proj4._
+    import geotrellis.raster._
+    import geotrellis.raster.render._
+    import geotrellis.spark._
+    import geotrellis.spark.tiling._
+    import geotrellis.vector._
+
+    // This examples show some problems that may arise when using the distribued 
+    // Euclidean distance operations on data that does not sufficiently cover 
+    // the extent in question.  Run this test and look at the resulting schools.
+    // png; you'll notice the lower left hand corner has areas that are empty 
+    // and other areas showing discontinuous behavior because the points which 
+    // define the Euclidean distance are too far away.
+
+    val sc: SparkContext = ???
+
+    val geomWKT = scala.io.Source.fromFile("geotrellis/spark/src/test/resources/wkt/schools.wkt").getLines.mkString
+    val LayoutLevel(z, ld) = ZoomedLayoutScheme(WebMercator).levelForZoom(12)
+    val maptrans = ld.mapTransform
+
+    val geom = geotrellis.vector.io.wkt.WKT.read(geomWKT).asInstanceOf[MultiPoint]
+    val GridBounds(cmin, rmin, cmax, rmax) = maptrans(geom.envelope)
+
+    val skRDD = sc.parallelize(for (r <- rmin to rmax; c <- cmin to cmax) yield SpatialKey(c, r))
+
+    def createPoints(sk: SpatialKey): (SpatialKey, Array[Coordinate]) = {
+      val ex = maptrans(sk)
+      val coords = geom.points.filter(ex.contains(_)).map(_.jtsGeom.getCoordinate)
+      println(s"$sk has ${coords.size} points")
+      (sk, coords)
+    }
+
+    val inputRDD = skRDD.map(createPoints)
+
+    val tileRDD: RDD[(SpatialKey, Tile)] = inputRDD.euclideanDistance(ld)
+
+    val maxDistance = tileRDD.map(_._2.findMinMaxDouble).collect.foldLeft(-1.0/0.0){ (max, minMax) => scala.math.max(max, minMax._2) }
+    val cm = ColorMap((0.0 to maxDistance by (maxDistance/512)).toArray, ColorRamps.BlueToRed)
+    tileRDD.stitch().renderPng(cm).write("schools.png")
+  }
+
+}

--- a/spark/src/main/scala/geotrellis/spark/distance/EuclideanDistance.scala
+++ b/spark/src/main/scala/geotrellis/spark/distance/EuclideanDistance.scala
@@ -1,6 +1,7 @@
 package geotrellis.spark.distance
 
 import com.vividsolutions.jts.geom.Coordinate
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
 import geotrellis.raster._
@@ -92,6 +93,27 @@ object EuclideanDistance {
     }
   }
 
+  /**
+   * Computes a tiled Euclidean distance raster over a very large, dense point set.
+   *
+   * Given a very large, dense point set—on the order of 10s to 100s of millions
+   * of points or more—this apply method provides the means to relatively
+   * efficiently produce a Euclidean distance raster layer for those points.
+   * This operator assumes that there is a layout definition for the space in
+   * qustion, and that the input points have been binned according to that
+   * layout's mapTransform object.
+   *
+   * There are caveats to using this function.  The assumption is that the
+   * incoming point set is _dense_ relative to the layout.  An empty SpatialKey
+   * in isolation is not probematic.  However, large areas devoid of points
+   * which translate to many adjacent spatial keys in the grid which are empty
+   * will likely cause problems.  Additionally, tiles whose Euclidean distance
+   * values are defined by points that are not in the current tile or in one of
+   * the 8 neighboring tiles will produce incorrect values.  This is
+   * particularly true in regions outside the mass of points where the medial
+   * axis of the point set intrudes (these will be generated in large interior
+   * voids or in areas where the point set boundary has nonconvex pockets).
+   */
   def apply(rdd: RDD[(SpatialKey, Array[Coordinate])], layoutDefinition: LayoutDefinition): RDD[(SpatialKey, Tile)] = {
     val triangulations: RDD[(SpatialKey, DelaunayTriangulation)] =
       rdd
@@ -138,6 +160,46 @@ object EuclideanDistance {
         }}
       }, preservesPartitioning = true)
 
+  }
+
+}
+
+object SparseEuclideanDistance {
+
+  /**
+   * Generates a Euclidean distance tile RDD from a small collection of points.
+   *
+   * The standard EuclideanDistance object apply method is meant to build
+   * Euclidean distance tiles from a very large, dense set of points where the
+   * generation of the triangulation itself is a significant performance
+   * bottleneck (i.e., when the point set is 10s or 100s of millions strong or
+   * more).  In the event that one wishes to generate a set of Euclidean
+   * distance tiles over a large area from a small or sparse set of points which
+   * would exhibit artifacts under the assumptions employed by the dense
+   * EuclideanDistance operator, this apply method will accomplish the desired
+   * end.  Be aware, however, that if there are many points, this operation will
+   * have a lengthy runtime.
+   */
+  def apply(pts: Array[Coordinate], 
+            geomExtent: Extent, 
+            ld: LayoutDefinition, 
+            tileCols: Int,
+            tileRows: Int,
+            cellType: CellType = DoubleConstantNoDataCellType)(implicit sc: SparkContext): RDD[(SpatialKey, Tile)] = {
+    val dt = sc.broadcast(DelaunayTriangulation(pts))
+    val GridBounds(cmin, rmin, cmax, rmax) = ld.mapTransform(geomExtent)
+    val keys = sc.parallelize(for (r <- rmin to rmax; c <- cmin to cmax) yield SpatialKey(c, r))
+
+    keys.mapPartitions(_.map{ key =>
+      val ex = ld.mapTransform(key)
+      val vor = new VoronoiDiagram(dt.value, ex)
+      val re = RasterExtent(ex, tileCols, tileRows)
+      val tile = ArrayTile.empty(cellType, re.cols, re.rows)
+
+      vor.voronoiCellsWithPoints.foreach(EuclideanDistanceTile.rasterizeDistanceCell(re, tile))
+
+      (key, tile)
+    }, preservesPartitioning=true)
   }
 
 }

--- a/spark/src/test/scala/geotrellis/spark/distance/EuclideanDistanceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/distance/EuclideanDistanceSpec.scala
@@ -131,41 +131,6 @@ class EuclideanDistanceSpec extends FunSpec
       assertEqual(neighborTile, rasterTile)
     }
 
-    ignore("should work for real data tiled in WebMercator") {
-      // This is a "test" showing some problems that may arise when using the
-      // distribued Euclidean distance operations on data that does not sufficiently
-      // cover the extent in question.  Run this test and look at the resulting
-      // schools.png; you'll notice the lower left hand corner has areas that are empty
-      // and other areas showing discontinuous behavior because the points which define
-      // the Euclidean distance are too far away.
-
-      val geomWKT = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/wkt/schools.wkt")).getLines.mkString
-      val LayoutLevel(z, ld) = ZoomedLayoutScheme(WebMercator).levelForZoom(12)
-      val maptrans = ld.mapTransform
-
-      val geom = geotrellis.vector.io.wkt.WKT.read(geomWKT).asInstanceOf[MultiPoint]
-      val GridBounds(cmin, rmin, cmax, rmax) = maptrans(geom.envelope)
-
-      val skRDD = sc.parallelize(for (r <- rmin to rmax; c <- cmin to cmax) yield SpatialKey(c, r))
-
-      def createPoints(sk: SpatialKey): (SpatialKey, Array[Coordinate]) = {
-        val ex = maptrans(sk)
-        val coords = geom.points.filter(ex.contains(_)).map(_.jtsGeom.getCoordinate)
-        println(s"$sk has ${coords.size} points")
-        (sk, coords)
-      }
-
-      val inputRDD = skRDD.map(createPoints)
-
-      val tileRDD: RDD[(SpatialKey, Tile)] = inputRDD.euclideanDistance(ld)
-
-      val (_, maxDistance) = tileRDD.findMinMax
-      val cm = ColorMap((0.0 to maxDistance by (maxDistance/512)).toArray, ColorRamps.BlueToRed)
-      tileRDD.stitch().renderPng(cm).write("schools.png")
-
-      true should be (true)
-    }
-
     it("should work in a spark environment") {
       // val domain = Extent(-1.0, -0.5, 1.0, 1.0)
       val domain = Extent(0, -1.15, 1, -0.05)


### PR DESCRIPTION
The EuclideanDistance operation provided in the spark package is intended for use with very large, dense point sets (namely LiDAR point clouds).  These have the problem of being too large to triangulate as a whole.  This PR adds the SparseEuclideanDistance object, which allows ED tiles to be generated when the input point set is small and/or sparse.  This will handle regions in the tiling with contiguous regions of empty tiles without error.  An example is also included in doc-examples which demonstrates the failure mode of the dense EuclideanDistance operator.