### PR TITLE
Move to a different Json Schema validator

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,4 +48,6 @@ object Dependencies {
   val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.14.6"
 
   val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
+
+  val jsonSchemaValidator = "com.networknt" % "json-schema-validator" % "0.1.7"
 }

--- a/spark-etl/build.sbt
+++ b/spark-etl/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 name := "geotrellis-spark-etl"
 libraryDependencies ++= Seq(
-  "com.github.fge" % "json-schema-validator" % "2.2.6",
+  jsonSchemaValidator,
   sparkCore % "provided",
   scalatest % "test")
 

--- a/spark-etl/src/main/resources/input-schema.json
+++ b/spark-etl/src/main/resources/input-schema.json
@@ -1,71 +1,74 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
-  "properties": {
-    "format": {
-      "type": "string"
-    },
-    "name": {
-      "type": "string"
-    },
-    "cache": {
-      "type": "string"
-    },
-    "crs": {
-      "type": "string"
-    },
-    "noData": {
-      "type": "integer"
-    },
-    "maxTileSize": {
-      "type": "integer"
-    },
-    "numPartitions": {
-      "type": "integer"
-    },
-    "clip": {
-      "type": "object",
-      "properties": {
-        "xmin": {
-          "type": "number"
-        },
-        "ymin": {
-          "type": "number"
-        },
-        "xmax": {
-          "type": "number"
-        },
-        "ymax": {
-          "type": "number"
-        }
+  "items": {
+    "type": "object",
+    "properties": {
+      "format": {
+        "type": "string"
       },
-      "required": [
-        "xmin",
-        "ymin",
-        "xmax",
-        "ymax"
-      ]
-    },
-    "backend": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        }
+      "name": {
+        "type": "string"
       },
-      "required": [
-        "type",
-        "path"
-      ]
-    }
+      "cache": {
+        "type": "string"
+      },
+      "crs": {
+        "type": "string"
+      },
+      "noData": {
+        "type": "integer"
+      },
+      "maxTileSize": {
+        "type": "integer"
+      },
+      "numPartitions": {
+        "type": "integer"
+      },
+      "clip": {
+        "type": "object",
+        "properties": {
+          "xmin": {
+            "type": "number"
+          },
+          "ymin": {
+            "type": "number"
+          },
+          "xmax": {
+            "type": "number"
+          },
+          "ymax": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "xmin",
+          "ymin",
+          "xmax",
+          "ymax"
+        ]
+      },
+      "backend": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "path"
+        ]
+      }
+    },
+    "required": [
+      "format",
+      "name",
+      "backend"
+    ]
   },
-  "required": [
-    "format",
-    "name",
-    "backend"
-  ],
   "additionalProperties": false
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/ConfigParse.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/ConfigParse.scala
@@ -16,7 +16,9 @@
 
 package geotrellis.spark.etl.config
 
-import com.github.fge.jsonschema.main.JsonSchemaFactory
+import com.networknt.schema.JsonSchemaFactory
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
@@ -25,7 +27,7 @@ trait ConfigParse {
   val help: String
   val requiredFields: Set[Symbol]
 
-  val schemaFactory = JsonSchemaFactory.byDefault()
+  val schemaFactory = new JsonSchemaFactory()
 
   def getJson(filePath: String, conf: Configuration): String = {
     val path = new Path(filePath)
@@ -34,6 +36,8 @@ trait ConfigParse {
     val json = scala.io.Source.fromInputStream(is).getLines.mkString(" ")
     is.close(); fs.close(); json
   }
+
+  def jsonNodeFromString(content: String): JsonNode = new ObjectMapper().readTree(content)
 
   def nextOption(map: Map[Symbol, String], list: Seq[String]): Map[Symbol, String]
 


### PR DESCRIPTION
A lightweight https://github.com/networknt/json-schema-validator is used instead of https://github.com/java-json-tools/json-schema-validator.

Were applied some changes into the input schema definition (it was incorrect). 
Some changes into printing validation error messages were added (logger used, error messages are red)

A source with tests for different json schema validators in different languages:
https://github.com/json-schema-org/JSON-Schema-Test-Suite