### PR TITLE
Dependencies update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val commonSettings = Seq(
 
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
 
-  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.3" cross CrossVersion.binary),
+  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary),
   addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
 
   pomExtra := (

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ import sbt._
 object Dependencies {
   val typesafeConfig = "com.typesafe"       %  "config"          % "1.3.1"
   val logging       = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
-  val scalatest     = "org.scalatest"       %%  "scalatest"      % "3.0.1"
-  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.13.4"
+  val scalatest     = "org.scalatest"       %%  "scalatest"      % "3.0.3"
+  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.13.5"
   val jts           = "com.vividsolutions"  %  "jts-core"        % "1.14.0"
 
   val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"  % Version.monocle
@@ -34,20 +34,20 @@ object Dependencies {
 
   val apacheMath    = "org.apache.commons" % "commons-math3" % "3.6.1"
 
-  val chronoscala   = "jp.ne.opt" %% "chronoscala" % "0.1.2"
+  val chronoscala   = "jp.ne.opt" %% "chronoscala" % "0.1.3"
 
-  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.92"
+  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.143"
 
   val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a"
 
   val sparkCore     = "org.apache.spark" %% "spark-core" % Version.spark
   val hadoopClient  = "org.apache.hadoop" % "hadoop-client" % Version.hadoop
 
-  val avro          = "org.apache.avro" % "avro" % "1.8.1"
+  val avro          = "org.apache.avro" % "avro" % "1.8.2"
 
-  val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.14.6"
+  val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.15.0"
 
-  val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
+  val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
 
   val jsonSchemaValidator = "com.networknt" % "json-schema-validator" % "0.1.7"
 }

--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -20,7 +20,7 @@ object Environment {
   def either(environmentVariable: String, default: String): String =
     Properties.envOrElse(environmentVariable, default)
 
-  lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.7.3")
-  lazy val sparkVersion   = either("SPARK_VERSION", "2.1.0")
+  lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.8.0")
+  lazy val sparkVersion   = either("SPARK_VERSION", "2.1.1")
   lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -17,13 +17,13 @@
 object Version {
   val geotrellis  = "1.2.0" + Environment.versionSuffix
   val scala       = "2.11.11"
-  val geotools    = "16.1"
+  val geotools    = "17.1"
   val sprayJson   = "1.3.3"
   val monocle     = "1.4.0"
-  val accumulo    = "1.7.2"
-  val cassandra   = "3.1.4"
-  val hbase       = "1.3.0"
-  val geomesa     = "1.2.7.3"
+  val accumulo    = "1.7.3"
+  val cassandra   = "3.2.0"
+  val hbase       = "1.3.1"
+  val geomesa     = "1.2.8"
   lazy val hadoop = Environment.hadoopVersion
   lazy val spark  = Environment.sparkVersion
 }

--- a/vectortile/build.sbt
+++ b/vectortile/build.sbt
@@ -4,5 +4,5 @@ name := "geotrellis-vectortile"
 
 libraryDependencies ++= Seq(
   scalatest % "test",
-  "com.trueaccord.scalapb" %% "scalapb-runtime" % "0.6.0-pre1"
+  "com.trueaccord.scalapb" %% "scalapb-runtime" % "0.6.0-pre4"
 )


### PR DESCRIPTION
Updates HBase DB for tests.
It's a security fix, old version [is not available](http://www-eu.apache.org/dist/hbase/1.3.0/hbase-1.3.0-bin.tar.gz) any more.

Full deps update logs: 

 - [x] 1.3.0 => 1.3.1 [CQ 13663](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13663)
 - [x] scalatest 3.0.1 => 3.0.3 [CQ 13686](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13686)
 - [x] scalacheck 1.13.4 => 1.13.5 [CQ 13687](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13687)
 - [x] chronoscala 0.1.2 => 0.1.3 [CQ 13688](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13688)
 - [x] aws-java-sdk-s3 1.11.92 => 1.11.143 [CQ 13711](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13711)
 - [x] avro 1.8.1 => 1.8.2 [CQ 13712](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13712)
 - [x] slick-pg 0.14.6 => 0.15.0 [CQ 1373](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13713)
 - [x] scala-parser-combinators 1.0.5 => 1.0.6 [CQ 13714](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13714)
 - [x] Hadoop 2.7.3 => 2.8.0 (provided)
 - [x] Spark 2.1.0 => 2.1.1 (provided)
 - [x] GeoTools 16.1 => 17.1 [CQ 13715](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13715)
 - [x] Accumulo 1.7.2 => 1.7.3 [CQ 13720](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13720)
 - [x] Cassandra 3.1.4 => 3.2.0 [CQ 13721](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13721)
 - [x] GeoMesa 1.2.7.3 => 1.2.8 (locationtech project)
 - [x] scalapb-runtime 0.6.0-pre1 => 0.6.0-pre4 [CQ 13426](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13426)

GeoWave requires update up to 0.9.4, but this update involves API changes and was omitted in this PR.