### PR TITLE
Fixed problematic polygons in Voronoi diagram generation

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
@@ -170,23 +170,6 @@ object VoronoiDiagram {
     } else {
       clippedCorners += clippedCorners.head
       val poly = Polygon(clippedCorners.map(Point.jtsCoord2Point(_)))
-      // if (!poly.isValid) {
-      //   import het._
-
-      //   println("Invalid polygon generated:")
-      //   println(s"\t$poly")
-      //   println(s"\t$cell")
-
-      //   val coords = collection.mutable.ListBuffer.empty[Coordinate]
-      //   var e = incidentEdge
-      //   do {
-      //     coords += verts(getDest(e))
-      //     coords += verts(getSrc(e))
-      //     e = rotCCWDest(e)
-      //   } while (e != incidentEdge)
-
-      //   println(s"${Line(coords.map{Point.jtsCoord2Point(_)})}")
-      // }
       Some(poly)
     }
   }

--- a/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
@@ -2,7 +2,6 @@ package geotrellis.vector.voronoi
 
 import com.vividsolutions.jts.geom.Coordinate
 import org.apache.commons.math3.linear._
-import geotrellis.util.Constants.{FLOAT_EPSILON => EPSILON}
 import geotrellis.vector._
 import geotrellis.vector.mesh.HalfEdgeTable
 import geotrellis.vector.triangulation._
@@ -48,6 +47,8 @@ object VoronoiDiagram {
   case class BoundedRay(base: Coordinate, dir: V2) extends CellBound
   case class Ray(base: Coordinate, dir: V2) extends CellBound
   case class ReverseRay(base: Coordinate, dir: V2) extends CellBound
+
+  private final val EPSILON = 1e-10
 
   private def cellBoundsNew(het: HalfEdgeTable, verts: Int => Coordinate, extent: Extent)(incidentEdge: Int): Seq[CellBound] = {
     import het._


### PR DESCRIPTION
Voronoi cells are constructed by creating a boundary representation in terms of half planes which are then used to clip the extent polygon.  We were previously including half planes for degenerate cell boundaries which were introducing duplicate vertices to the clipped polygons that were causing problems for the rasterizer and negatively affecting EuclideanDistanceTile.  

This PR adjusts numerical tolerances to make sure that degenerate edges are not included.  We use a more conservative value for the tolerance that may interpret valid edges as degenerate.  This might result in losing some edges, but the failure mode will be to have corners where the desired result should have been a very slightly truncated corner.  A mild problem that should only appear very rarely.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>