### PR TITLE
Fixed logic in decompose function

### DIFF
--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReader.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReader.scala
@@ -47,13 +47,21 @@ class AccumuloLayerReader(val attributeStore: AttributeStore)(implicit sc: Spark
     }
 
     val queryKeyBounds = tileQuery(metadata)
+    val layerBounds = metadata.getComponent[Bounds[K]]
 
-    val decompose = (bounds: KeyBounds[K]) => {
-      if(queryKeyBounds.size == 1 && queryKeyBounds.head == bounds) Seq(new AccumuloRange())
-      else keyIndex.indexRanges(bounds).map { case (min, max) =>
-        new AccumuloRange(new Text(AccumuloKeyEncoder.long2Bytes(min)), new Text(AccumuloKeyEncoder.long2Bytes(max)))
+    val decompose: KeyBounds[K] => Seq[AccumuloRange] =
+      if(queryKeyBounds.size == 1 && queryKeyBounds.head.contains(layerBounds)) {
+        // This query is asking for all the keys of the layer;
+        // avoid a heavy set of accumulo ranges by not setting any at all,
+        // which equates to a full request.
+        { _ => Seq(new AccumuloRange()) }
+      } else {
+        (bounds: KeyBounds[K]) => {
+          keyIndex.indexRanges(bounds).map { case (min, max) =>
+            new AccumuloRange(new Text(AccumuloKeyEncoder.long2Bytes(min)), new Text(AccumuloKeyEncoder.long2Bytes(max)))
+          }
+        }
       }
-    }
 
     val rdd = AccumuloRDDReader.read[K, V](header.tileTable, columnFamily(id), queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
     new ContextRDD(rdd, metadata)


### PR DESCRIPTION
Fixes #2218

Slightly different than the fix suggested in the issue; in that this checks to see that the query bounds covers the layer bounds, instead of checking to see if it's equivalent to the key index bounds.