### PR TITLE
Fix writing multiband GeoTiff with compression

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -19,6 +19,7 @@ package geotrellis.raster.io.geotiff.writer
 import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff._
+import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.raster.io.geotiff.tags.codes.ColorSpace
 import geotrellis.raster.render.{ColorRamps, IndexedColorMap}
 import geotrellis.raster.testkit._
@@ -145,6 +146,32 @@ class GeoTiffWriterSpec extends FunSpec
       GeoTiffWriter.write(geoTiff, path)
 
       addToPurge(path)
+
+      val gt = MultibandGeoTiff(path)
+
+      gt.extent should equal (geoTiff.extent)
+      gt.crs should equal (geoTiff.crs)
+      gt.tile.bandCount should equal (geoTiff.tile.bandCount)
+      for(i <- 0 until gt.tile.bandCount) {
+        val actualBand = gt.tile.band(i)
+        val expectedBand = geoTiff.tile.band(i)
+
+        assertEqual(actualBand, expectedBand)
+      }
+    }
+
+    it ("should read write multibandraster with compression correctly") {
+      val geoTiff = {
+        val gt = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
+        MultibandGeoTiff(gt.raster, gt.crs, options = GeoTiffOptions(compression.DeflateCompression))
+      }
+
+      GeoTiffWriter.write(geoTiff, path)
+
+      addToPurge(path)
+
+      val tags = TiffTags(path)
+      tags.compression should be (geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZLibCoded)
 
       val gt = MultibandGeoTiff(path)
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
@@ -37,7 +37,7 @@ case class MultibandGeoTiff(
   def imageData: GeoTiffImageData =
     tile match {
       case gtt: GeoTiffMultibandTile => gtt
-      case _ => GeoTiffMultibandTile(tile)
+      case _ => tile.toGeoTiffTile(options)
     }
 
   def crop(subExtent: Extent): MultibandGeoTiff = {
@@ -133,4 +133,32 @@ object MultibandGeoTiff {
     tags: Tags
   ): MultibandGeoTiff =
     apply(tile, extent, crs, tags, GeoTiffOptions.DEFAULT)
+
+  def apply(
+    tile: MultibandTile,
+    extent: Extent,
+    crs: CRS,
+    options: GeoTiffOptions
+  ): MultibandGeoTiff =
+    apply(tile, extent, crs, Tags.empty, options)
+
+  def apply(
+    raster: Raster[MultibandTile],
+    crs: CRS
+  ): MultibandGeoTiff =
+    apply(raster.tile, raster.extent, crs, Tags.empty)
+
+  def apply(
+    raster: Raster[MultibandTile],
+    crs: CRS,
+    tags: Tags
+  ): MultibandGeoTiff =
+    apply(raster.tile, raster.extent, crs, tags, GeoTiffOptions.DEFAULT)
+
+  def apply(
+    raster: Raster[MultibandTile],
+    crs: CRS,
+    options: GeoTiffOptions
+  ): MultibandGeoTiff =
+    apply(raster.tile, raster.extent, crs, Tags.empty, options)
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/package.scala
@@ -36,4 +36,18 @@ package object geotiff {
     def toGeoTiffTile(layout: StorageMethod): GeoTiffTile =
       GeoTiffTile(tile, GeoTiffOptions(layout))
   }
+
+  implicit class GeoTiffMultibandTileMethods(val tile: MultibandTile) extends AnyRef {
+    def toGeoTiffTile(): GeoTiffMultibandTile =
+      GeoTiffMultibandTile(tile)
+
+    def toGeoTiffTile(options: GeoTiffOptions): GeoTiffMultibandTile =
+      GeoTiffMultibandTile(tile, options)
+
+    def toGeoTiffTile(compression: Compression): GeoTiffMultibandTile =
+      GeoTiffMultibandTile(tile, GeoTiffOptions(compression))
+
+    def toGeoTiffTile(layout: StorageMethod): GeoTiffMultibandTile =
+      GeoTiffMultibandTile(tile, GeoTiffOptions(layout))
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -21,6 +21,7 @@ import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.tags.codes._
 import geotrellis.raster.io.geotiff.reader._
 import geotrellis.raster.io.geotiff.util._
+import geotrellis.util.ByteReader
 import CommonPublicValues._
 import ModelTypes._
 import ProjectionTypesMap.UserDefinedProjectionType
@@ -40,6 +41,14 @@ import monocle.syntax.apply._
 import monocle.macros.Lenses
 
 import spire.syntax.cfor._
+
+object TiffTags {
+  def apply(path: String): TiffTags =
+    TiffTagsReader.read(path)
+
+  def apply(byteReader: ByteReader): TiffTags =
+    TiffTagsReader.read(byteReader)
+}
 
 @Lenses("_")
 case class TiffTags(


### PR DESCRIPTION
Ass reported by @stevekuo on Gitter:

> I'm seeing GeoTiffOptions(DeflateCompression) being correctly observed with SinglebandGeoTiff, but ignored with MultibandGeoTiff.
> Roughly my code is

```scala
val geotiff = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions(DeflateCompression))
// OR
val geotiff = MultibandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions(DeflateCompression))

val geotiffArray = GeoTiffWriter.write(geotiff)
val stream = new ByteArrayInputStream(geotiffArray)
```

> I then write out to a file. Using gdalinfo, the single band is COMPRESSION=DEFLATE, where as the multi band is not compressed.

This fixes the oversight that was causing the GeoTiff to be written as uncompressed.