### PR TITLE
Fixed issue with BigTiff vs non-BigTiff offset value packing

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -103,5 +103,11 @@ class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
 
       assertEqual(actual.tile, expected.tile)
     }
+
+    it("should read a previously problematic big tiff") {
+      val tags = TiffTagsReader.read(geoTiffPath("bigtiff-marcuswr.tif"))
+      val e = tags.extent
+      e should be (Extent(-105.06398320198056, 40.743636546229, -105.05724549293515, 40.751667086819424))
+    }
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
@@ -20,6 +20,7 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.compression._
 import geotrellis.raster.io.geotiff.tags._
+import geotrellis.raster.io.geotiff.util._
 import geotrellis.vector.Extent
 import geotrellis.proj4.CRS
 import geotrellis.util.{ByteReader, Filesystem}
@@ -285,11 +286,11 @@ object GeoTiffReader {
       val tiffTags =
         if (tiffIdNumber == 42) {
           val smallStart = byteReader.getInt
-          TiffTagsReader.read(byteReader, smallStart)
+          TiffTagsReader.read(byteReader, smallStart.toLong)(IntTiffTagOffsetSize)
         } else {
           byteReader.position(8)
           val bigStart = byteReader.getLong
-          TiffTagsReader.read(byteReader, bigStart)
+          TiffTagsReader.read(byteReader, bigStart)(LongTiffTagOffsetSize)
         }
 
       val hasPixelInterleave = tiffTags.hasPixelInterleave

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteReaderExtensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteReaderExtensions.scala
@@ -17,7 +17,7 @@
 package geotrellis.raster.io.geotiff.util
 
 import geotrellis.util.ByteReader
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 
 import spire.syntax.cfor._
 
@@ -51,11 +51,11 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getByteArray(offset: Long, length: Long): Array[Short] = {
+    final def getByteArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Short] = {
       val arr = Array.ofDim[Short](length.toInt)
 
-      if (length <= 4) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt)
+      if (length <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
         cfor(0)( _ < length, _ + 1) { i =>
           arr(i) = ub2s(bb.get)
         }
@@ -73,11 +73,11 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getShortArray(offset: Long, length: Long): Array[Int] = {
+    final def getShortArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Int] = {
       val arr = Array.ofDim[Int](length.toInt)
 
-      if (length <= 2) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt)
+      if (length * 2 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
         cfor(0)(_ < length, _ + 1) { i =>
           arr(i) = us2i(bb.getShort)
         }
@@ -96,12 +96,14 @@ trait ByteReaderExtensions {
     }
 
     /** Get these as Longs, since they are unsigned and we might want to deal with values greater than Int.MaxValue */
-    final def getIntArray(offset: Long, length: Long): Array[Long] = {
+    final def getIntArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Long] = {
       val arr = Array.ofDim[Long](length.toInt)
 
-      if (length == 1) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt)
-        arr(0) = ui2l(bb.getInt)
+      if (length * 4 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = ui2l(bb.getInt)
+        }
       } else {
         val oldPos = byteReader.position
 
@@ -116,12 +118,14 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getLongArray(offset: Long, length: Long): Array[Long] = {
+    final def getLongArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Long] = {
       val arr = Array.ofDim[Long](length.toInt)
 
-      if (length <= 8) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putLong(0, offset)
-        arr(0) = bb.getLong
+      if (length * 8 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = bb.getLong
+        }
       } else {
         val oldPos = byteReader.position
 
@@ -136,11 +140,11 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getString(offset: Long, length: Long): String = {
+    final def getString(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): String = {
       val sb = new StringBuilder
-      if (length <= 4) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt)
-        cfor(0)( _ < length, _ + 1) { i =>
+      if (length <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
+        cfor(0)(_ < length, _ + 1) { i =>
           sb.append(bb.get.toChar)
         }
       } else {
@@ -157,27 +161,34 @@ trait ByteReaderExtensions {
       sb.toString
     }
 
-    final def getFractionalArray(offset: Long, length: Long): Array[(Long, Long)] = {
+    final def getFractionalArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[(Long, Long)] = {
       val arr = Array.ofDim[(Long, Long)](length.toInt)
 
-      val oldPos = byteReader.position
-      byteReader.position(offset)
+      if (length * 8 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = (ui2l(bb.getInt), ui2l(bb.getInt))
+        }
+      } else {
+        val oldPos = byteReader.position
+        byteReader.position(offset)
 
-      cfor(0)(_ < length, _ + 1) { i =>
-        arr(i) = (ui2l(byteReader.getInt), ui2l(byteReader.getInt))
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = (ui2l(byteReader.getInt), ui2l(byteReader.getInt))
+        }
+
+        byteReader.position(oldPos)
       }
-
-      byteReader.position(oldPos)
 
       arr
     }
 
     /** NOTE: We don't support lengths greater than Int.MaxValue yet (or ever). */
-    final def getSignedByteArray(offset: Long, length: Long): Array[Byte] = {
+    final def getSignedByteArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Byte] = {
       val len = length.toInt
-      if (length <= 4) {
+      if (length <= ttos.size) {
         val arr = Array.ofDim[Byte](len)
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt)
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
         cfor(0)(_ < len, _ + 1) { i =>
           arr(i) = bb.get
         }
@@ -189,11 +200,11 @@ trait ByteReaderExtensions {
       }
     }
 
-    final def getSignedShortArray(offset: Long, length: Long): Array[Short] = {
+    final def getSignedShortArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Short] = {
       val arr = Array.ofDim[Short](length.toInt)
 
-      if (length <= 2) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt)
+      if (length * 2 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
         cfor(0)(_ < length, _ + 1) { i =>
           arr(i) = bb.getShort
         }
@@ -211,11 +222,14 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getSignedIntArray(offset: Long, length: Long): Array[Int] = {
+    final def getSignedIntArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Int] = {
       val arr = Array.ofDim[Int](1)
 
-      if (length == 1) {
-        arr(0) = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt).getInt
+      if (length * 8 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = bb.getInt
+        }
       } else {
         val oldPos = byteReader.position
         byteReader.position(offset)
@@ -230,26 +244,35 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getSignedFractionalArray(offset: Long, length: Long): Array[(Int, Int)] = {
+    final def getSignedFractionalArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[(Int, Int)] = {
       val arr = Array.ofDim[(Int, Int)](length.toInt)
 
-      val oldPos = byteReader.position
-      byteReader.position(offset)
+      if(length * 8 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = (bb.getInt, bb.getInt)
+        }
+      } else {
 
-      cfor(0)(_ < length, _ + 1) { i =>
-        arr(i) = (byteReader.getInt, byteReader.getInt)
+        val oldPos = byteReader.position
+        byteReader.position(offset)
+
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = (byteReader.getInt, byteReader.getInt)
+        }
+
+        byteReader.position(oldPos)
       }
-
-      byteReader.position(oldPos)
 
       arr
     }
 
-    final def getFloatArray(offset: Long, length: Long): Array[Float] = {
+    final def getFloatArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Float] = {
       val arr = Array.ofDim[Float](length.toInt)
 
-      if (length <= 1) {
-        val bb = ByteBuffer.allocate(4).order(byteReader.order).putInt(0, offset.toInt)
+      if (length * 4 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
+
         cfor(0)(_ < length, _ + 1) { i =>
           arr(i) = bb.getFloat
         }
@@ -266,17 +289,26 @@ trait ByteReaderExtensions {
       arr
     }
 
-    final def getDoubleArray(offset: Long, length: Long): Array[Double] = {
+    final def getDoubleArray(offset: Long, length: Long)(implicit ttos: TiffTagOffsetSize): Array[Double] = {
       val arr = Array.ofDim[Double](length.toInt)
 
-      val oldPos = byteReader.position
-      byteReader.position(offset)
+      if (length * 8 <= ttos.size) {
+        val bb = ttos.allocateByteBuffer(offset, byteReader.order)
 
-      cfor(0)(_ < length, _ + 1) { i =>
-        arr(i) = byteReader.getDouble
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = bb.getDouble
+        }
+      } else {
+
+        val oldPos = byteReader.position
+        byteReader.position(offset)
+
+        cfor(0)(_ < length, _ + 1) { i =>
+          arr(i) = byteReader.getDouble
+        }
+
+        byteReader.position(oldPos)
       }
-
-      byteReader.position(oldPos)
 
       arr
     }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/util/TiffTagOffsetSize.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/util/TiffTagOffsetSize.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.io.geotiff.util
+
+import java.nio.{ByteBuffer, ByteOrder}
+
+import spire.syntax.cfor._
+
+abstract sealed class TiffTagOffsetSize {
+  /** Size, in bytes, of the offset portion of a GeoTiff tag.
+    * This is the maximum size of a value that can be contained
+    * in the offset portion of the GeoTiff tag.
+    * For regular TIFFs, the offsets are stored in 4-byte wide integers.
+    * For BigTiffs, they are stored as 8-byte wide integers (longs), and so
+    * the offsets can hold more space for packing direct values.
+    */
+  def size: Int
+
+  /** Returns a byte buffer of the appropriate size ("size" bytes long)
+    * that contains the bytes in the given offset value
+    */
+  def allocateByteBuffer(offset: Long, order: ByteOrder): ByteBuffer
+}
+
+/** Represents the offset size for tiff tags of a regular TIFF file (non-BigTiff) */
+case object IntTiffTagOffsetSize extends TiffTagOffsetSize {
+  val size = 4
+  def allocateByteBuffer(offset: Long, order: ByteOrder) =
+    ByteBuffer.allocate(size).order(order).putInt(0, offset.toInt)
+}
+
+/** Represents the offset size for tiff tags of a BigTiff */
+case object LongTiffTagOffsetSize extends TiffTagOffsetSize {
+  val size = 8
+  def allocateByteBuffer(offset: Long, order: ByteOrder) =
+    ByteBuffer.allocate(size).order(order).putLong(0, offset)
+}


### PR DESCRIPTION
Fixes #2241 

The TIFF Spec has a condition that is an optimization, but has caused a lot of issues.

A TIFF-tag is structured like `[code, type, length, offset]`. The `code` determines what tag it is, the `type` is the datatype such as Byte or Double, the `length` is the number of elements in the array of values, and the `offset` is the offset in the file where the values live.

If the value of the data is a small size, the value can be packed into the space that stores the offset. In this way, the tiff tag reads as `[code, type, length, value]` instead. This only happens if the byte size of `type`, multiplied by the `length` of the data, is less than the byte size of the `offset` value. In the regular TIFF case, the offset is a 4-byte wide `Int`, so any value that can be stored in 4 or less bytes is stored in the offset field, instead of some other location in the file which is pointed to by the value in the `offset` field.

For BigTiff, the offset field is an 8-byte wide `Long` value. We accounted for this when we first implemented bigtiffs. However, we didn't account for the changes in the packing mechanism: now if the value of the tag is less than or equal to 8 bytes, that value can be packed into the offset field of the tiff tag. The problem with not catching this packing is that, if you don't know the offset actually refers to a packed value, then you read that value as an offset into the file. For many cases this will be a very large number that will point to some huge offset in the file that doesn't actually exist; this is where the strange errors around BigTiff tag reading were coming from.

This PR fixes this. The architecture of how we were utilizing implicit classes to add method extensions to ByteReader for reading arrays is clever but a bit unmalleable (I might have designed it, or at least didn't change it in the past, so that's on me). The type class I introduced was the least invasive way to implement this that I could think of; perhaps not perfect but it gets the job done. It changes technically `public` API, but in reality the API is internal enough that I can't imagine the change effecting any users (though I will note the API change in the CHANGELOG)