### PR TITLE
Remove missing credentials warning during compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,9 @@ lazy val commonSettings = Seq(
     }
   },
 
-  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
+  credentials ++= List(Path.userHome / ".ivy2" / ".credentials")
+    .filter(_.asFile.canRead)
+    .map(Credentials(_)),
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.3" cross CrossVersion.binary),
   addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),


### PR DESCRIPTION
Do not add Credentials SBT Setting if file doesn't exist.
Removes the `[warn] Credentials file /Users/eugene/.ivy2/.credentials does not exist` during `compile`