### PR TITLE
Added Intersction by Line and MultiLine capability to LayerFilters

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
@@ -21,7 +21,7 @@ import geotrellis.raster.{GridBounds, RasterExtent, PixelIsArea}
 import geotrellis.raster.rasterize.Rasterizer.Options
 import geotrellis.spark._
 import geotrellis.spark.tiling._
-import geotrellis.vector.{Extent, Point, MultiPolygon, Polygon}
+import geotrellis.vector._
 import geotrellis.util._
 
 import scala.annotation.implicitNotFound
@@ -179,6 +179,55 @@ object Intersects {
     new LayerFilter[K, Intersects.type, Polygon, M] {
       def apply(metadata: M, kb: KeyBounds[K], polygon: Polygon) =
         forMultiPolygon[K, M].apply(metadata, kb, MultiPolygon(polygon))
+    }
+
+  /** Define Intersects filter for MultiLine */
+  implicit def forMultiLine[K: SpatialComponent: Boundable, M: GetComponent[?, LayoutDefinition]] =
+    new LayerFilter[K, Intersects.type, MultiLine, M] {
+      def apply(metadata: M, kb: KeyBounds[K], multiLine: MultiLine) = {
+        val mapTransform = metadata.getComponent[LayoutDefinition].mapTransform
+        val extent = multiLine.envelope
+        val keyext = mapTransform(kb.minKey)
+        val bounds: GridBounds = mapTransform(extent)
+        val options = Options(includePartial=true, sampleType=PixelIsArea)
+
+        val boundsExtent: Extent = mapTransform(bounds)
+        val rasterExtent = RasterExtent(boundsExtent, bounds.width, bounds.height)
+
+        /*
+         * Use the Rasterizer to construct  a list of tiles which meet
+         * the  query polygon.   That list  of tiles  is stored  as an
+         * array of  tuples which  is then  mapped-over to  produce an
+         * array of KeyBounds.
+         */
+        val tiles = new ConcurrentHashMap[(Int,Int), Unit]
+        val fn = new Callback {
+          def apply(col : Int, row : Int): Unit = {
+            val tile : (Int, Int) = (bounds.colMin + col, bounds.rowMin + row)
+            tiles.put(tile, Unit)
+          }
+        }
+
+        multiLine.foreach(rasterExtent, options)(fn)
+        tiles.keys.asScala
+          .map({ tile =>
+            val qb = KeyBounds(
+              kb.minKey setComponent SpatialKey(tile._1, tile._2),
+              kb.maxKey setComponent SpatialKey(tile._1, tile._2))
+            qb intersect kb match {
+              case kb: KeyBounds[K] => List(kb)
+              case EmptyBounds => Nil
+            }
+          })
+          .reduce({ (x,y) => x ++ y })
+      }
+    }
+
+  /** Define Intersects filter for Polygon */
+  implicit def forLine[K: SpatialComponent: Boundable, M: GetComponent[?, LayoutDefinition]] =
+    new LayerFilter[K, Intersects.type, Line, M] {
+      def apply(metadata: M, kb: KeyBounds[K], line: Line) =
+        forMultiLine[K, M].apply(metadata, kb, MultiLine(line))
     }
 }
 

--- a/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
@@ -160,6 +160,35 @@ class LayerQuerySpec extends FunSpec
       // test specifically for previously missing key
       actual should contain (SpatialKey(272, 79))
     }
+
+    it("should query perimeter of huc10 polygon") {
+      val wkt = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/wkt/huc10-conestoga.wkt")).getLines.mkString
+      val huc10 = WKT.read(wkt).asInstanceOf[MultiPolygon]
+      val ml = MultiLine(huc10.polygons.flatMap { p =>
+        p.exterior +: p.holes.toList
+      })
+      val huc10LayerMetadata = TileLayerMetadata(
+        crs = ConusAlbers,
+        cellType = FloatCellType,
+        layout = LayoutDefinition(Extent(-2493045.0, 177285.0, 2345355.0, 3310725.0),TileLayout(1315,1204,512,512)),
+        extent = Extent(-2493045.0, 177285.0, 2345355.0, 3310725.0),
+        bounds = KeyBounds(SpatialKey(0,0),SpatialKey(1314,1204))
+      )
+      val mapTransform = huc10LayerMetadata.mapTransform
+      val query = new LayerQuery[SpatialKey, TileLayerMetadata[SpatialKey]]
+        .where(Intersects(ml))
+      val actual: Seq[SpatialKey] = query(huc10LayerMetadata).flatMap(spatialKeyBoundsKeys)
+      val expected =  {
+        val bounds = huc10LayerMetadata.bounds.get.toGridBounds
+        for {
+          (x, y) <- bounds.coords
+          //
+          if ml.intersects(mapTransform(SpatialKey(x, y)))
+        } yield SpatialKey(x, y)
+      }
+
+      (expected.toList diff actual) should be ('empty)
+    }
   }
 
   describe("LayerQuery KeyBounds generation") {


### PR DESCRIPTION
This PR adds the ability to query a GeoTrellis layer by Line and MultiLine, much like we can already query by Polygon and MultiPolygon.

For instance,

```scala
val poly: Polygon = ???
val rdd = 
    layerReader
       .query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](Layer("name", zoom))
       .where(Intersects(poly))
       .result
```

will give you all tiles that intersect with the polygon, where as now

```scala
val poly: Polygon = ???
val rdd = 
    layerReader
       .query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](Layer("name", zoom))
       .where(Intersects(poly.exterior))
       .result
```

will give you all tiles that intersect just the exterior of the polygon.
