### PR TITLE
getSignedByteArray BugFix

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteReaderExtensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/util/ByteReaderExtensions.scala
@@ -194,8 +194,10 @@ trait ByteReaderExtensions {
         }
         arr
       } else {
+        val oldPosition = byteReader.position
         byteReader.position(offset)
         val arr = byteReader.getBytes(len)
+        byteReader.position(oldPosition)
         arr
       }
     }


### PR DESCRIPTION
This PR makes it so that `getSignedByteArray` does not reset to its old position after reading.

Resolves #2268 