### PR TITLE
StorageMethod is Now Serializable

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/StorageMethod.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/StorageMethod.scala
@@ -18,7 +18,7 @@ package geotrellis.raster.io.geotiff
 
 import geotrellis.raster._
 
-abstract sealed class StorageMethod
+abstract sealed class StorageMethod extends Serializable
 
 case class Tiled(blockCols: Int = 256, blockRows: Int = 256) extends StorageMethod
 


### PR DESCRIPTION
This PR makes it so that `StorageMethod` and its sub-classes now extend `Serializable`. This is needed as not having it be serializable causes errors when trying to create `MultibandGeoTiff`s in GeoPySpark.

Error output:

```
E                   Caused by: java.io.NotSerializableException: geotrellis.raster.io.geotiff.Striped
E                   Serialization stack:
E                   	- object not serializable (class: geotrellis.raster.io.geotiff.Striped, value: geotrellis.raster.io.geotiff.Striped@3049fd69)
E                   	- field (class: geotrellis.raster.io.geotiff.GeoTiffOptions, name: storageMethod, type: class geotrellis.raster.io.geotiff.StorageMethod)
E                   	- object (class geotrellis.raster.io.geotiff.GeoTiffOptions, GeoTiffOptions(geotrellis.raster.io.geotiff.Striped@3049fd69,geotrellis.raster.io.geotiff.compression.NoCompression$@15be4bd1,1,None))
E                   	- field (class: geopyspark.geotrellis.ProjectedRasterRDD$$anonfun$8, name: geotiffOptions$1, type: class geotrellis.raster.io.geotiff.GeoTiffOptions)
E                   	- object (class geopyspark.geotrellis.ProjectedRasterRDD$$anonfun$8, <function1>)
E                   	- field (class: geopyspark.geotrellis.ProjectedRasterRDD$$anonfun$9, name: f$1, type: interface scala.Function1)
E                   	- object (class geopyspark.geotrellis.ProjectedRasterRDD$$anonfun$9, <function1>)
E                   	at org.apache.spark.serializer.SerializationDebugger$.improveException(SerializationDebugger.scala:40)
E                   	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:46)
E                   	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:100)
E                   	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:295)
```