### PR TITLE
DeflateCompression is Now Serializable

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compression.scala
@@ -16,6 +16,6 @@
 
 package geotrellis.raster.io.geotiff.compression
 
-trait Compression {
+trait Compression extends Serializable {
   def createCompressor(segmentCount: Int): Compressor
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/DeflateCompression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/DeflateCompression.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable
 import spire.syntax.cfor._
 
 object DeflateCompression extends Compression {
-  def createCompressor(segmentCount: Int): Compressor = 
+  def createCompressor(segmentCount: Int): Compressor =
     new Compressor {
       private val segmentSizes = Array.ofDim[Int](segmentCount)
       def compress(segment: Array[Byte], segmentIndex: Int): Array[Byte] = {


### PR DESCRIPTION
This PR makes `DeflateCompression` serializable. This is needed as trying to use this form of compression in GeoPySpark fails.

```
Caused by: java.io.NotSerializableException: geotrellis.raster.io.geotiff.compression.DeflateCompression$
E                   Serialization stack:
E                   	- object not serializable (class: geotrellis.raster.io.geotiff.compression.DeflateCompression$, value: geotrellis.raster.io.geotiff.compression.DeflateCompression$@5a2b1895)
E                   	- field (class: geotrellis.raster.io.geotiff.GeoTiffOptions, name: compression, type: interface geotrellis.raster.io.geotiff.compression.Compression)
E                   	- object (class geotrellis.raster.io.geotiff.GeoTiffOptions, GeoTiffOptions(Tiled(256,256),geotrellis.raster.io.geotiff.compression.DeflateCompression$@5a2b1895,0,None))
E                   	- field (class: geopyspark.geotrellis.ProjectedRasterRDD$$anonfun$7, name: geotiffOptions$1, type: class geotrellis.raster.io.geotiff.GeoTiffOptions)
E                   	- object (class geopyspark.geotrellis.ProjectedRasterRDD$$anonfun$7, <function1>)
E                   	at org.apache.spark.serializer.SerializationDebugger$.improveException(SerializationDebugger.scala:40)
E                   	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:46)
E                   	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:100)
E                   	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:295)
E                   	... 22 more
```
