### PR TITLE
Don't constrain GridBounds size to IntMax x IntMax

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.2.0
+-----
+
+Deprecations
+^^^^^^^^^^^^
+
+- ``GridBounds.size`` in favour of ``GridBounds.sizeLong``
+- ``GridBounds.coords`` in favour of ``GridBounds.coordsIter``
+
 1.1.0
 -----
 

--- a/raster-test/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
@@ -100,4 +100,13 @@ class GridBoundsSpec extends FunSpec with Matchers{
       GridBounds.distinct(gridBounds).map(_.size).sum should be ((101 * 101) - (25 * 25 * 2))
     }
   }
+
+  describe("GridBounds.coords") {
+    // TODO This test can be removed in 2.0
+    it("should match the output of coordsIter") {
+      val gbs = GridBounds(0, 0, 10, 10)
+
+      gbs.coordsIter.toSeq shouldBe gbs.coords.toSeq
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -17,6 +17,7 @@
 package geotrellis.raster
 
 import scala.collection.mutable
+import spire.syntax.cfor._
 
 /**
   * The companion object for the [[GridBounds]] type.
@@ -74,8 +75,13 @@ object GridBounds {
 case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
   def width = colMax - colMin + 1
   def height = rowMax - rowMin + 1
-  def size: Long = width.toLong * height.toLong
-  def isEmpty = size == 0
+
+  def size: Int = width * height
+
+  @deprecated("This will be removed in favour of `size` returning a `Long`.", "1.2")
+  def sizeLong: Long = width.toLong * width.toLong
+
+  def isEmpty = sizeLong == 0
 
   /**
     * Return true if the present [[GridBounds]] contains the position
@@ -155,12 +161,24 @@ case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
       result
     }
 
+  @deprecated("Use `coordsIter` instead.", "1.2")
+  def coords: Array[(Int, Int)] = {
+    val arr = Array.ofDim[(Int, Int)](width*height)
+    cfor(0)(_ < height, _ + 1) { row =>
+      cfor(0)(_ < width, _ + 1) { col =>
+        arr(row * width + col) =
+          (col + colMin, row + rowMin)
+      }
+    }
+    arr
+  }
+
   /**
     * Return the coordinates covered by the present [[GridBounds]].
     */
-  def coords: Stream[(Int, Int)] = for {
-    row <- Stream.range(0, height)
-    col <- Stream.range(0, width)
+  def coordsIter: Iterator[(Int, Int)] = for {
+    row <- Iterator.range(0, height)
+    col <- Iterator.range(0, width)
   } yield (row, col)
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -17,7 +17,6 @@
 package geotrellis.raster
 
 import scala.collection.mutable
-import spire.syntax.cfor._
 
 /**
   * The companion object for the [[GridBounds]] type.
@@ -75,8 +74,7 @@ object GridBounds {
 case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
   def width = colMax - colMin + 1
   def height = rowMax - rowMin + 1
-  if(width.toLong * height.toLong > Int.MaxValue) { sys.error(s"Cannot construct grid bounds of this size: $width x $height") }
-  def size = width * height
+  def size: Long = width.toLong * height.toLong
   def isEmpty = size == 0
 
   /**
@@ -160,16 +158,10 @@ case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
   /**
     * Return the coordinates covered by the present [[GridBounds]].
     */
-  def coords: Array[(Int, Int)] = {
-    val arr = Array.ofDim[(Int, Int)](width*height)
-    cfor(0)(_ < height, _ + 1) { row =>
-      cfor(0)(_ < width, _ + 1) { col =>
-        arr(row * width + col) =
-          (col + colMin, row + rowMin)
-      }
-    }
-    arr
-  }
+  def coords: Stream[(Int, Int)] = for {
+    row <- Stream.range(0, height)
+    col <- Stream.range(0, width)
+  } yield (row, col)
 
   /**
     * Return the intersection of the present [[GridBounds]] and the

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -76,9 +76,10 @@ case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
   def width = colMax - colMin + 1
   def height = rowMax - rowMin + 1
 
+  @deprecated("This will return a `Long` in 2.0. Until then, sizeLong may be more accurate.", "1.2")
   def size: Int = width * height
 
-  @deprecated("This will be removed in favour of `size` returning a `Long`.", "1.2")
+  // TODO Mark for deprecation in 3.0 when 2.0 comes out!
   def sizeLong: Long = width.toLong * width.toLong
 
   def isEmpty = sizeLong == 0

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -180,7 +180,7 @@ case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
   def coordsIter: Iterator[(Int, Int)] = for {
     row <- Iterator.range(0, height)
     col <- Iterator.range(0, width)
-  } yield (row, col)
+  } yield (col + colMin, row + rowMin)
 
   /**
     * Return the intersection of the present [[GridBounds]] and the

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/TileLayerRDDBuilders.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/TileLayerRDDBuilders.scala
@@ -251,7 +251,7 @@ trait TileLayerRDDBuilders {
         else CompositeTile.wrap(tile, tileLayout, cropped = false)
 
       tmsTiles ++=
-        tileBounds.coords.map { case (col, row) =>
+        tileBounds.coordsIter.map { case (col, row) =>
 
           val targetRasterExtent =
             RasterExtent(

--- a/spark/src/main/scala/geotrellis/spark/merge/RDDLayoutMerge.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/RDDLayoutMerge.scala
@@ -42,7 +42,7 @@ object RDDLayoutMerge {
         .flatMap { case (k: K, tile: V) =>
           val extent = thatLayout.mapTransform(k)
           thisLayout.mapTransform(extent)
-            .coords
+            .coordsIter
             .map { case (col, row) =>
               val outKey = k.setComponent(SpatialKey(col, row))
               val newTile = tile.prototype(thisLayout.tileCols, thisLayout.tileRows)

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -50,7 +50,7 @@ object CutTiles {
         val extent = inKey.extent
         logger.debug(s"Cutting $inKey of ${tile.dimensions} cells covering $extent")
         mapTransform(extent)
-          .coords.toIterator
+          .coordsIter
           .map  { spatialComponent =>
             val outKey = inKey.translate(spatialComponent)
             logger.debug(s"Merge $inKey into $outKey of (${tileCols}, ${tileRows}) cells")


### PR DESCRIPTION
### Issues

- `size` returning a `Long` instead of `Int` is likely backwards incompatible.
- I wanted to make `coords` return an `Iterator` instead of a `Stream`, but one single function (`RDDKernelDensity.pointFeatureToSpatialKey`) in GT requires the output of a `for` over `coords`
to be a `Seq`, which `Array` can be cast to and `Iterator` cannot.
- I ingested a 60k-by-60k GeoTiff after making this change, and while the ingest itself was very strange (took forever to process, was all single core, no I didn't mess up the Spark config), it did succeed. 

Closes #2265 .