### PR TITLE
Use getDouble instead of get in DoubleHistogramSummary

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/DoubleHistogramSummary.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/DoubleHistogramSummary.scala
@@ -27,7 +27,7 @@ object DoubleHistogramSummary extends TilePolygonalSummaryHandler[Histogram[Doub
     val rasterExtent = raster.rasterExtent
     val histogram = StreamingHistogram()
     Rasterizer.foreachCellByGeometry(polygon, rasterExtent) { (col: Int, row: Int) =>
-      val z = tile.get(col, row)
+      val z = tile.getDouble(col, row)
       if (isData(z)) histogram.countItem(z, 1)
     }
     histogram


### PR DESCRIPTION
Fixes polygonal summarization of double-valued tiles