### PR TITLE
Fixed issue with S3 URI not having a key prefix

### DIFF
--- a/s3-test/src/test/scala/geotrellis/spark/io/s3/S3LayerProviderSpec.scala
+++ b/s3-test/src/test/scala/geotrellis/spark/io/s3/S3LayerProviderSpec.scala
@@ -27,6 +27,13 @@ class S3LayerProviderSpec extends FunSpec with TestEnvironment {
     assert(store.isInstanceOf[S3AttributeStore])
   }
 
+  it("construct S3AttributeStore from URI with no prefix"){
+    val store = AttributeStore(new java.net.URI("s3://fake-bucket"))
+    assert(store.isInstanceOf[S3AttributeStore])
+    assert(store.asInstanceOf[S3AttributeStore].prefix != null)
+  }
+
+
   it("construct S3LayerReader from URI") {
     val reader = LayerReader(uri)
     assert(reader.isInstanceOf[S3LayerReader])

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerProvider.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerProvider.scala
@@ -33,7 +33,12 @@ class S3LayerProvider extends AttributeStoreProvider
 
   def attributeStore(uri: URI): AttributeStore = {
     val s3Uri = new AmazonS3URI(uri)
-    new S3AttributeStore(bucket = s3Uri.getBucket, prefix = s3Uri.getKey)
+    val prefix =
+      Option(s3Uri.getKey) match {
+        case Some(s) => s
+        case None => ""
+      }
+    new S3AttributeStore(bucket = s3Uri.getBucket, prefix = prefix)
   }
 
   def layerReader(uri: URI, store: AttributeStore, sc: SparkContext): FilteringLayerReader[LayerId] = {


### PR DESCRIPTION
This was causing null errors when trying to read from a catalog like `s3://some-catalog-bucket`