### PR TITLE
Make attributeStore accessible through ValueReader

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/ValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/ValueReader.scala
@@ -28,6 +28,7 @@ import java.util.ServiceLoader
  * This interface abstracts over various construction requirements for
  * constructing a storage back-end specific reader. */
 trait ValueReader[ID] {
+  val attributeStore: AttributeStore
 
   /** Produce a key value reader for a specific layer, prefetching layer metadata once at construction time */
   def reader[K: AvroRecordCodec: JsonFormat: ClassTag, V: AvroRecordCodec](layerId: ID): Reader[K, V]


### PR DESCRIPTION
Following the change to the SPI-based ValueReader URI construction method, it became clear that the attributeStore kept by each ValueReader implementation should be made accessible through the ValueReader interface, as we are now no longer sure what type of ValueReader we've constructed.  This PR makes that change to the interface.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>