### PR TITLE
Removed inefficient LayerFilter check

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
@@ -34,6 +34,8 @@ trait LayerFilter[K, F, T, M] {
     * @param metadata  M of the layer being filtered
     * @param kb        KeyBounds within the layer, possibly already reduce for max
     * @param param     Parameter to the filter, contains information to restrict kb
+    *
+    * @note            The KeyBounds returned must be non-overlapping.
     */
   def apply(metadata: M, kb: KeyBounds[K], param: T): Seq[KeyBounds[K]]
 
@@ -50,13 +52,7 @@ trait LayerFilter[K, F, T, M] {
         case Or(v1, v2) => flatten(metadata, kb, v1) ++ flatten(metadata,kb, v2)
       }
 
-    val keyBounds = flatten(metadata, kb, ast)
-    keyBounds.combinations(2).foreach { case Seq(a, b) =>
-      if (a intersects b)
-        sys.error(s"Query expression produced intersecting bounds, only non-intersecting regions are supported. ($a, $b)")
-    }
-
-    keyBounds.toList
+    flatten(metadata, kb, ast).toList
   }
 }
 

--- a/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
@@ -57,15 +57,6 @@ class LayerQuerySpec extends FunSpec
       info(outKeyBounds.toString)
     }
 
-    it("should throw on intersecting regions") {
-      val query = new LayerQuery[SpatialKey, TileLayerMetadata[SpatialKey]]
-        .where(Intersects(GridBounds(2, 2, 2, 2)) or Intersects(GridBounds(2, 2, 2, 2)))
-
-      intercept[RuntimeException] {
-        query(md)
-      }
-    }
-
   }
 
   describe("LayerFilter Polygon Intersection") {


### PR DESCRIPTION
The non-overlapping check took upwards of 2 minutes in a case where I was querying a zoom 12 512x512 GlobalLayout for the state of Nevada. This is a nice thing to ensure, but not at that price. Make a note in the scaladocs for the implementor's responsibility to ensure non-overlapping KeyBounds.