### PR TITLE
Added New Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ fast batch processing of large raster data sets.
 Please visit the **[project site](http://geotrellis.io)**
 for more information as well as some interactive demos.
 
-#### Using GeoTrellis in Other Languages
+#### GeoTrellis with Python
 
-If you are interested in GeoTrellis but are unable to work in Scala, then
-there is an alternative available,
-[GeoPySpark](http://github.com/locationtech-labs/geopyspark). GeoPySpark
-is a Python bindings library for GeoTrellis and can do many (but not
-all) of the operations present in GeoTrellis.
+GeoTrellis has Python bindings through a project called [GeoPySpark](http://github.com/locationtech-labs/geopyspark).
+GeoPySpark is a Python bindings library for GeoTrellis and can do many
+(but not all) of the operations present in GeoTrellis. GeoPySpark can
+be integrated with other tools in the Python ecosystem, such as NumPy,  
+scikit-learn, and Jupyter notebooks. Several GeoPySpark tutorials have
+been developed that leverage the visualization capability of [GeoNotebook](https://github.com/OpenGeoscience/geonotebook), 
+an open-source Jupyter extension that provides interactive map displays.
 
 ## Contact and Support
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ fast batch processing of large raster data sets.
 Please visit the **[project site](http://geotrellis.io)**
 for more information as well as some interactive demos.
 
+#### Using GeoTrellis in Other Languages
+
+If you are interested in GeoTrellis but are unable to work in Scala, then
+there is an alternative available,
+[GeoPySpark](http://github.com/locationtech-labs/geopyspark). GeoPySpark
+is a Python bindings library for GeoTrellis and can do many (but not
+all) of the operations present in GeoTrellis.
+
 ## Contact and Support
 
 You can find more information and talk to developers


### PR DESCRIPTION
This PR adds the "Using GeoTrellis in Other Languages" section to the `README`. The purpose of this new section is to inform users that an alternative to GeoTrellis, GeoPySpark, exists if they are unable to use Scala.