### PR TITLE
MapKeyTransform method aliases

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/CellGridLayoutCollectionMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/CellGridLayoutCollectionMethods.scala
@@ -25,9 +25,10 @@ import scala.reflect.ClassTag
 abstract class CellGridLayoutCollectionMethods[K: SpatialComponent, V <: CellGrid, M: GetComponent[?, LayoutDefinition]]
     extends MethodExtensions[Seq[(K, V)] with Metadata[M]] {
   def asRasters(): Seq[(K, Raster[V])] = {
-    val mapTransform = self.metadata.getComponent[LayoutDefinition].mapTransform
+    val layout = self.metadata.getComponent[LayoutDefinition]
+
     self.map { case (key, tile) =>
-        (key, Raster(tile, mapTransform(key)))
+      (key, Raster(tile, key.getComponent[SpatialKey].toExtent(layout)))
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/CellGridLayoutCollectionMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/CellGridLayoutCollectionMethods.scala
@@ -28,7 +28,7 @@ abstract class CellGridLayoutCollectionMethods[K: SpatialComponent, V <: CellGri
     val layout = self.metadata.getComponent[LayoutDefinition]
 
     self.map { case (key, tile) =>
-      (key, Raster(tile, key.getComponent[SpatialKey].tileExtent(layout)))
+      (key, Raster(tile, key.getComponent[SpatialKey].extent(layout)))
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/CellGridLayoutCollectionMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/CellGridLayoutCollectionMethods.scala
@@ -28,7 +28,7 @@ abstract class CellGridLayoutCollectionMethods[K: SpatialComponent, V <: CellGri
     val layout = self.metadata.getComponent[LayoutDefinition]
 
     self.map { case (key, tile) =>
-      (key, Raster(tile, key.getComponent[SpatialKey].toExtent(layout)))
+      (key, Raster(tile, key.getComponent[SpatialKey].tileExtent(layout)))
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/CellGridLayoutRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/CellGridLayoutRDDMethods.scala
@@ -31,7 +31,7 @@ abstract class CellGridLayoutRDDMethods[K: SpatialComponent: ClassTag, V <: Cell
 
     self.mapPartitions({ part =>
       part.map { case (key, tile) =>
-        (key, Raster(tile, key.getComponent[SpatialKey].toExtent(layout)))
+        (key, Raster(tile, key.getComponent[SpatialKey].tileExtent(layout)))
       }
     }, true)
   }

--- a/spark/src/main/scala/geotrellis/spark/CellGridLayoutRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/CellGridLayoutRDDMethods.scala
@@ -27,10 +27,11 @@ import scala.reflect.ClassTag
 abstract class CellGridLayoutRDDMethods[K: SpatialComponent: ClassTag, V <: CellGrid, M: GetComponent[?, LayoutDefinition]]
     extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
   def asRasters(): RDD[(K, Raster[V])] = {
-    val mapTransform = self.metadata.getComponent[LayoutDefinition].mapTransform
+    val layout = self.metadata.getComponent[LayoutDefinition]
+
     self.mapPartitions({ part =>
       part.map { case (key, tile) =>
-        (key, Raster(tile, mapTransform(key)))
+        (key, Raster(tile, key.getComponent[SpatialKey].toExtent(layout)))
       }
     }, true)
   }

--- a/spark/src/main/scala/geotrellis/spark/CellGridLayoutRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/CellGridLayoutRDDMethods.scala
@@ -31,7 +31,7 @@ abstract class CellGridLayoutRDDMethods[K: SpatialComponent: ClassTag, V <: Cell
 
     self.mapPartitions({ part =>
       part.map { case (key, tile) =>
-        (key, Raster(tile, key.getComponent[SpatialKey].tileExtent(layout)))
+        (key, Raster(tile, key.getComponent[SpatialKey].extent(layout)))
       }
     }, true)
   }

--- a/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
+++ b/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
@@ -16,12 +16,17 @@
 
 package geotrellis.spark
 
+import geotrellis.spark.tiling.LayoutDefinition
+import geotrellis.vector.Extent
 import org.apache.spark.rdd.RDD
 
 /** A SpatialKey designates the spatial positioning of a layer's tile. */
 case class SpatialKey(col: Int, row: Int) extends Product2[Int, Int] {
   def _1 = col
   def _2 = row
+
+  /** Retrieve the [[Extent]] that corresponds to this key, given a layout. */
+  def toExtent(layout: LayoutDefinition): Extent = layout.mapTransform(this)
 }
 
 object SpatialKey {

--- a/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
+++ b/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
@@ -26,7 +26,7 @@ case class SpatialKey(col: Int, row: Int) extends Product2[Int, Int] {
   def _2 = row
 
   /** Retrieve the [[Extent]] that corresponds to this key, given a layout. */
-  def tileExtent(layout: LayoutDefinition): Extent = layout.mapTransform(this)
+  def extent(layout: LayoutDefinition): Extent = layout.mapTransform.keyToExtent(this)
 }
 
 object SpatialKey {

--- a/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
+++ b/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
@@ -26,7 +26,7 @@ case class SpatialKey(col: Int, row: Int) extends Product2[Int, Int] {
   def _2 = row
 
   /** Retrieve the [[Extent]] that corresponds to this key, given a layout. */
-  def toExtent(layout: LayoutDefinition): Extent = layout.mapTransform(this)
+  def tileExtent(layout: LayoutDefinition): Extent = layout.mapTransform(this)
 }
 
 object SpatialKey {

--- a/spark/src/main/scala/geotrellis/spark/crop/Crop.scala
+++ b/spark/src/main/scala/geotrellis/spark/crop/Crop.scala
@@ -42,7 +42,7 @@ object Crop {
               rdd
                 .mapPartitions({ partition =>
                   partition.flatMap({ case (key, tile) =>
-                    val srcExtent: Extent = mapTransform.tileExtent(key.getComponent[SpatialKey])
+                    val srcExtent: Extent = mapTransform.keyToExtent(key.getComponent[SpatialKey])
 
                     if (extent.contains(srcExtent)) {
                       Some((key, tile))

--- a/spark/src/main/scala/geotrellis/spark/crop/Crop.scala
+++ b/spark/src/main/scala/geotrellis/spark/crop/Crop.scala
@@ -42,7 +42,8 @@ object Crop {
               rdd
                 .mapPartitions({ partition =>
                   partition.flatMap({ case (key, tile) =>
-                    val srcExtent = mapTransform(key)
+                    val srcExtent: Extent = mapTransform(key.getComponent[SpatialKey])
+
                     if (extent.contains(srcExtent)) {
                       Some((key, tile))
                     } else if (extent.interiorIntersects(srcExtent)) {

--- a/spark/src/main/scala/geotrellis/spark/crop/Crop.scala
+++ b/spark/src/main/scala/geotrellis/spark/crop/Crop.scala
@@ -42,7 +42,7 @@ object Crop {
               rdd
                 .mapPartitions({ partition =>
                   partition.flatMap({ case (key, tile) =>
-                    val srcExtent: Extent = mapTransform(key.getComponent[SpatialKey])
+                    val srcExtent: Extent = mapTransform.tileExtent(key.getComponent[SpatialKey])
 
                     if (extent.contains(srcExtent)) {
                       Some((key, tile))

--- a/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
@@ -134,7 +134,7 @@ object Intersects {
       def apply(metadata: M, kb: KeyBounds[K], polygon: MultiPolygon) = {
         val mapTransform = metadata.getComponent[LayoutDefinition].mapTransform
         val extent: Extent = polygon.envelope
-        val keyext: Extent = mapTransform.tileExtent(kb.minKey.getComponent[SpatialKey])
+        val keyext: Extent = mapTransform.keyToExtent(kb.minKey.getComponent[SpatialKey])
         val bounds: GridBounds = mapTransform.extentToBounds(extent)
         val options = Options(includePartial=true, sampleType=PixelIsArea)
 
@@ -183,7 +183,7 @@ object Intersects {
       def apply(metadata: M, kb: KeyBounds[K], multiLine: MultiLine) = {
         val mapTransform = metadata.getComponent[LayoutDefinition].mapTransform
         val extent: Extent = multiLine.envelope
-        val keyext: Extent = mapTransform.tileExtent(kb.minKey.getComponent[SpatialKey])
+        val keyext: Extent = mapTransform.keyToExtent(kb.minKey.getComponent[SpatialKey])
         val bounds: GridBounds = mapTransform(extent)
         val options = Options(includePartial=true, sampleType=PixelIsArea)
 

--- a/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
@@ -133,8 +133,8 @@ object Intersects {
     new LayerFilter[K, Intersects.type, MultiPolygon, M] {
       def apply(metadata: M, kb: KeyBounds[K], polygon: MultiPolygon) = {
         val mapTransform = metadata.getComponent[LayoutDefinition].mapTransform
-        val extent = polygon.envelope
-        val keyext = mapTransform(kb.minKey)
+        val extent: Extent = polygon.envelope
+        val keyext: Extent = mapTransform(kb.minKey.getComponent[SpatialKey])
         val bounds: GridBounds = mapTransform(extent)
         val options = Options(includePartial=true, sampleType=PixelIsArea)
 
@@ -182,8 +182,8 @@ object Intersects {
     new LayerFilter[K, Intersects.type, MultiLine, M] {
       def apply(metadata: M, kb: KeyBounds[K], multiLine: MultiLine) = {
         val mapTransform = metadata.getComponent[LayoutDefinition].mapTransform
-        val extent = multiLine.envelope
-        val keyext = mapTransform(kb.minKey)
+        val extent: Extent = multiLine.envelope
+        val keyext: Extent = mapTransform(kb.minKey.getComponent[SpatialKey])
         val bounds: GridBounds = mapTransform(extent)
         val options = Options(includePartial=true, sampleType=PixelIsArea)
 

--- a/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
@@ -134,8 +134,8 @@ object Intersects {
       def apply(metadata: M, kb: KeyBounds[K], polygon: MultiPolygon) = {
         val mapTransform = metadata.getComponent[LayoutDefinition].mapTransform
         val extent: Extent = polygon.envelope
-        val keyext: Extent = mapTransform(kb.minKey.getComponent[SpatialKey])
-        val bounds: GridBounds = mapTransform(extent)
+        val keyext: Extent = mapTransform.tileExtent(kb.minKey.getComponent[SpatialKey])
+        val bounds: GridBounds = mapTransform.extentToBounds(extent)
         val options = Options(includePartial=true, sampleType=PixelIsArea)
 
         val boundsExtent: Extent = mapTransform(bounds)
@@ -183,7 +183,7 @@ object Intersects {
       def apply(metadata: M, kb: KeyBounds[K], multiLine: MultiLine) = {
         val mapTransform = metadata.getComponent[LayoutDefinition].mapTransform
         val extent: Extent = multiLine.envelope
-        val keyext: Extent = mapTransform(kb.minKey.getComponent[SpatialKey])
+        val keyext: Extent = mapTransform.tileExtent(kb.minKey.getComponent[SpatialKey])
         val bounds: GridBounds = mapTransform(extent)
         val options = Options(includePartial=true, sampleType=PixelIsArea)
 

--- a/spark/src/main/scala/geotrellis/spark/merge/RDDLayoutMerge.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/RDDLayoutMerge.scala
@@ -41,14 +41,14 @@ object RDDLayoutMerge {
     val cutRdd =
       right
         .flatMap { case (k: K, tile: V) =>
-          val extent: Extent = k.getComponent[SpatialKey].toExtent(thatLayout)
+          val extent: Extent = k.getComponent[SpatialKey].tileExtent(thatLayout)
 
           thisLayout.mapTransform(extent)
             .coordsIter
             .map { case (col, row) =>
               val outKey = k.setComponent(SpatialKey(col, row))
               val newTile = tile.prototype(thisLayout.tileCols, thisLayout.tileRows)
-              val merged = newTile.merge(outKey.getComponent[SpatialKey].toExtent(thisLayout), extent, tile)
+              val merged = newTile.merge(outKey.getComponent[SpatialKey].tileExtent(thisLayout), extent, tile)
               (outKey, merged)
             }
         }

--- a/spark/src/main/scala/geotrellis/spark/merge/RDDLayoutMerge.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/RDDLayoutMerge.scala
@@ -41,14 +41,14 @@ object RDDLayoutMerge {
     val cutRdd =
       right
         .flatMap { case (k: K, tile: V) =>
-          val extent: Extent = k.getComponent[SpatialKey].tileExtent(thatLayout)
+          val extent: Extent = k.getComponent[SpatialKey].extent(thatLayout)
 
           thisLayout.mapTransform(extent)
             .coordsIter
             .map { case (col, row) =>
               val outKey = k.setComponent(SpatialKey(col, row))
               val newTile = tile.prototype(thisLayout.tileCols, thisLayout.tileRows)
-              val merged = newTile.merge(outKey.getComponent[SpatialKey].tileExtent(thisLayout), extent, tile)
+              val merged = newTile.merge(outKey.getComponent[SpatialKey].extent(thisLayout), extent, tile)
               (outKey, merged)
             }
         }

--- a/spark/src/main/scala/geotrellis/spark/pyramid/Pyramid.scala
+++ b/spark/src/main/scala/geotrellis/spark/pyramid/Pyramid.scala
@@ -96,7 +96,7 @@ object Pyramid extends LazyLogging {
     val nextRdd = {
      val transformedRdd = rdd
         .map { case (key, tile) =>
-          val extent: Extent = key.getComponent[SpatialKey].tileExtent(sourceLayout)
+          val extent: Extent = key.getComponent[SpatialKey].extent(sourceLayout)
           val newSpatialKey = nextLayout.mapTransform(extent.center)
           (key.setComponent(newSpatialKey), (key, tile))
         }
@@ -104,11 +104,11 @@ object Pyramid extends LazyLogging {
         partitioner
           .fold(transformedRdd.combineByKey(createTiles, mergeTiles1, mergeTiles2))(transformedRdd.combineByKey(createTiles _, mergeTiles1 _, mergeTiles2 _, _))
           .mapPartitions ( partition => partition.map { case (newKey: K, seq: Seq[(K, V)]) =>
-            val newExtent = newKey.getComponent[SpatialKey].tileExtent(nextLayout)
+            val newExtent = newKey.getComponent[SpatialKey].extent(nextLayout)
             val newTile = seq.head._2.prototype(nextLayout.tileLayout.tileCols, nextLayout.tileLayout.tileRows)
 
             for ((oldKey, tile) <- seq) {
-              val oldExtent = oldKey.getComponent[SpatialKey].tileExtent(sourceLayout)
+              val oldExtent = oldKey.getComponent[SpatialKey].extent(sourceLayout)
               newTile.merge(newExtent, oldExtent, tile, resampleMethod)
             }
             (newKey, newTile: V)

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -87,7 +87,7 @@ object TileRDDReproject {
           val inverseTransform = Transform(destCrs, crs)
 
           partition.map { case (key, BufferedTile(tile, gridBounds)) =>
-            val innerExtent = key.getComponent[SpatialKey].tileExtent(layout)
+            val innerExtent = key.getComponent[SpatialKey].extent(layout)
             val innerRasterExtent = RasterExtent(innerExtent, gridBounds.width, gridBounds.height)
             val outerGridBounds =
               GridBounds(
@@ -208,7 +208,7 @@ object TileRDDReproject {
             val transform = Transform(crs, destCrs)
 
             partition.map { case (key, _) =>
-              val extent = key.getComponent[SpatialKey].tileExtent(layout)
+              val extent = key.getComponent[SpatialKey].extent(layout)
               val rasterExtent = RasterExtent(extent, tileLayout.tileCols, tileLayout.tileRows)
               (key, (rasterExtent, ReprojectRasterExtent(rasterExtent, transform)))
             }

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -87,7 +87,7 @@ object TileRDDReproject {
           val inverseTransform = Transform(destCrs, crs)
 
           partition.map { case (key, BufferedTile(tile, gridBounds)) =>
-            val innerExtent = key.getComponent[SpatialKey].toExtent(layout)
+            val innerExtent = key.getComponent[SpatialKey].tileExtent(layout)
             val innerRasterExtent = RasterExtent(innerExtent, gridBounds.width, gridBounds.height)
             val outerGridBounds =
               GridBounds(
@@ -208,7 +208,7 @@ object TileRDDReproject {
             val transform = Transform(crs, destCrs)
 
             partition.map { case (key, _) =>
-              val extent = key.getComponent[SpatialKey].toExtent(layout)
+              val extent = key.getComponent[SpatialKey].tileExtent(layout)
               val rasterExtent = RasterExtent(extent, tileLayout.tileCols, tileLayout.tileRows)
               (key, (rasterExtent, ReprojectRasterExtent(rasterExtent, transform)))
             }

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -28,7 +28,7 @@ import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.spark.buffer._
 import geotrellis.vector._
-import geotrellis.util.LazyLogging
+import geotrellis.util._
 
 import org.apache.spark.rdd._
 import org.apache.spark._
@@ -64,7 +64,6 @@ object TileRDDReproject {
   ): (Int, RDD[(K, V)] with Metadata[TileLayerMetadata[K]]) = {
     val crs: CRS = metadata.crs
     val layout = metadata.layout
-    val mapTransform: MapKeyTransform = layout.mapTransform
     val tileLayout: TileLayout = layout.tileLayout
 
     val rasterReprojectOptions =
@@ -88,7 +87,7 @@ object TileRDDReproject {
           val inverseTransform = Transform(destCrs, crs)
 
           partition.map { case (key, BufferedTile(tile, gridBounds)) =>
-            val innerExtent = mapTransform(key)
+            val innerExtent = key.getComponent[SpatialKey].toExtent(layout)
             val innerRasterExtent = RasterExtent(innerExtent, gridBounds.width, gridBounds.height)
             val outerGridBounds =
               GridBounds(
@@ -141,7 +140,7 @@ object TileRDDReproject {
       for {
         sourceBounds <- metadata.bounds.toOption
         targetBounds <- newMetadata.bounds.toOption
-        sizeRatio = targetBounds.toGridBounds.size.toDouble / sourceBounds.toGridBounds.size.toDouble
+        sizeRatio = targetBounds.toGridBounds.sizeLong.toDouble / sourceBounds.toGridBounds.sizeLong.toDouble
         if sizeRatio > 1.5
       } yield {
         val newPartitionCount = (bufferedTiles.partitions.length * sizeRatio).toInt
@@ -200,7 +199,7 @@ object TileRDDReproject {
       }
     } else {
       val crs = rdd.metadata.crs
-      val mapTransform = rdd.metadata.layout.mapTransform
+      val layout = rdd.metadata.layout
       val tileLayout = rdd.metadata.layout.tileLayout
 
       val rasterExtents: RDD[(K, (RasterExtent, RasterExtent))] =
@@ -209,7 +208,7 @@ object TileRDDReproject {
             val transform = Transform(crs, destCrs)
 
             partition.map { case (key, _) =>
-              val extent = mapTransform(key)
+              val extent = key.getComponent[SpatialKey].toExtent(layout)
               val rasterExtent = RasterExtent(extent, tileLayout.tileCols, tileLayout.tileRows)
               (key, (rasterExtent, ReprojectRasterExtent(rasterExtent, transform)))
             }

--- a/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
+++ b/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
@@ -90,8 +90,8 @@ object ZoomResample {
                 gbaz.map { gb =>
                   gb.coordsIter
                     .map { case (col, row) =>
-                      val sourceExtent = sourceMapTransform.tileExtent(key.getComponent[SpatialKey])
-                      val targetExtent = targetMapTransform.tileExtent(col, row)
+                      val sourceExtent = sourceMapTransform.keyToExtent(key.getComponent[SpatialKey])
+                      val targetExtent = targetMapTransform.keyToExtent(col, row)
                       val resampled = tile.resample(
                         sourceExtent,
                         RasterExtent(targetExtent, tileSize, tileSize),
@@ -130,8 +130,8 @@ object ZoomResample {
                 gridBoundsAtZoom(sourceZoom, key.getComponent[SpatialKey], targetZoom)
                   .coordsIter
                   .map { case (col, row) =>
-                    val sourceExtent = sourceMapTransform.tileExtent(key.getComponent[SpatialKey])
-                    val targetExtent = targetMapTransform.tileExtent(col, row)
+                    val sourceExtent = sourceMapTransform.keyToExtent(key.getComponent[SpatialKey])
+                    val targetExtent = targetMapTransform.keyToExtent(col, row)
                     val resampled =
                       tile.resample(sourceExtent, RasterExtent(targetExtent, tileSize, tileSize), method)
                     (key.setComponent(SpatialKey(col, row)), resampled)

--- a/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
+++ b/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
@@ -90,8 +90,8 @@ object ZoomResample {
                 gbaz.map { gb =>
                   gb.coordsIter
                     .map { case (col, row) =>
-                      val sourceExtent = sourceMapTransform(key.getComponent[SpatialKey])
-                      val targetExtent = targetMapTransform(col, row)
+                      val sourceExtent = sourceMapTransform.tileExtent(key.getComponent[SpatialKey])
+                      val targetExtent = targetMapTransform.tileExtent(col, row)
                       val resampled = tile.resample(
                         sourceExtent,
                         RasterExtent(targetExtent, tileSize, tileSize),
@@ -130,8 +130,8 @@ object ZoomResample {
                 gridBoundsAtZoom(sourceZoom, key.getComponent[SpatialKey], targetZoom)
                   .coordsIter
                   .map { case (col, row) =>
-                    val sourceExtent = sourceMapTransform(key.getComponent[SpatialKey])
-                    val targetExtent = targetMapTransform(col, row)
+                    val sourceExtent = sourceMapTransform.tileExtent(key.getComponent[SpatialKey])
+                    val targetExtent = targetMapTransform.tileExtent(col, row)
                     val resampled =
                       tile.resample(sourceExtent, RasterExtent(targetExtent, tileSize, tileSize), method)
                     (key.setComponent(SpatialKey(col, row)), resampled)

--- a/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
+++ b/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
@@ -90,7 +90,7 @@ object ZoomResample {
                 gbaz.map { gb =>
                   gb.coordsIter
                     .map { case (col, row) =>
-                      val sourceExtent = sourceMapTransform(key)
+                      val sourceExtent = sourceMapTransform(key.getComponent[SpatialKey])
                       val targetExtent = targetMapTransform(col, row)
                       val resampled = tile.resample(
                         sourceExtent,
@@ -130,7 +130,7 @@ object ZoomResample {
                 gridBoundsAtZoom(sourceZoom, key.getComponent[SpatialKey], targetZoom)
                   .coordsIter
                   .map { case (col, row) =>
-                    val sourceExtent = sourceMapTransform(key)
+                    val sourceExtent = sourceMapTransform(key.getComponent[SpatialKey])
                     val targetExtent = targetMapTransform(col, row)
                     val resampled =
                       tile.resample(sourceExtent, RasterExtent(targetExtent, tileSize, tileSize), method)

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -55,7 +55,12 @@ object CutTiles {
             val outKey = inKey.translate(spatialComponent)
             logger.debug(s"Merge $inKey into $outKey of (${tileCols}, ${tileRows}) cells")
             val newTile = tile.prototype(cellType, tileCols, tileRows)
-            (outKey, newTile.merge(mapTransform(outKey.getComponent[SpatialKey]), extent, tile, resampleMethod))
+            (outKey, newTile.merge(
+               mapTransform.tileExtent(outKey.getComponent[SpatialKey]),
+               extent,
+               tile,
+               resampleMethod
+             ))
           }
       }
   }

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -21,7 +21,7 @@ import geotrellis.raster.merge._
 import geotrellis.raster.prototype._
 import geotrellis.raster.resample._
 import geotrellis.spark._
-import geotrellis.util.LazyLogging
+import geotrellis.util._
 
 import org.apache.spark.rdd._
 
@@ -55,7 +55,7 @@ object CutTiles {
             val outKey = inKey.translate(spatialComponent)
             logger.debug(s"Merge $inKey into $outKey of (${tileCols}, ${tileRows}) cells")
             val newTile = tile.prototype(cellType, tileCols, tileRows)
-            (outKey, newTile.merge(mapTransform(outKey), extent, tile, resampleMethod))
+            (outKey, newTile.merge(mapTransform(outKey.getComponent[SpatialKey]), extent, tile, resampleMethod))
           }
       }
   }

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -56,7 +56,7 @@ object CutTiles {
             logger.debug(s"Merge $inKey into $outKey of (${tileCols}, ${tileRows}) cells")
             val newTile = tile.prototype(cellType, tileCols, tileRows)
             (outKey, newTile.merge(
-               mapTransform.tileExtent(outKey.getComponent[SpatialKey]),
+               mapTransform.keyToExtent(outKey.getComponent[SpatialKey]),
                extent,
                tile,
                resampleMethod

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -107,12 +107,13 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
   @deprecated("Use this instead: MapKeyTransform.keyToExtent(key.getComponent[SpatialKey])", "1.2")
   def apply[K: SpatialComponent](key: K): Extent = apply(key.getComponent[SpatialKey])
 
-  def keyToExtent(key: SpatialKey): Extent = apply(key)
+  /** Get the [[Extent]] corresponding to a [[SpatialKey]] in some zoom level. */
+  def tileExtent(key: SpatialKey): Extent = apply(key)
 
   def apply(key: SpatialKey): Extent = apply(key.col, key.row)
 
   /** 'col' and 'row' correspond to a [[SpatialKey]] column and row in some grid. */
-  def coordsToExtent(col: Int, row: Int): Extent = apply(col, row)
+  def tileExtent(col: Int, row: Int): Extent = apply(col, row)
 
   def apply(col: Int, row: Int): Extent =
     Extent(

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -86,12 +86,13 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
     e1.expandToInclude(e2)
   }
 
+  /** Fetch the [[SpatialKey]] that corresponds to some coordinates in some CRS on the Earth. */
   def pointToKey(p: Point): SpatialKey = apply(p)
 
   def apply(p: Point): SpatialKey = apply(p.x, p.y)
 
   /** Fetch the [[SpatialKey]] that corresponds to some coordinates in some CRS on the Earth. */
-  def pointCoordsToKey(x: Double, y: Double): SpatialKey = apply(x, y)
+  def pointToKey(x: Double, y: Double): SpatialKey = apply(x, y)
 
   def apply(x: Double, y: Double): SpatialKey = {
     val tcol =
@@ -103,8 +104,7 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
     (tcol.floor.toInt, trow.floor.toInt)
   }
 
-  def keyLikeToExtent[K: SpatialComponent](key: K): Extent = apply(key)
-
+  @deprecated("Use this instead: MapKeyTransform.keyToExtent(key.getComponent[SpatialKey])", "1.2")
   def apply[K: SpatialComponent](key: K): Extent = apply(key.getComponent[SpatialKey])
 
   def keyToExtent(key: SpatialKey): Extent = apply(key)

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -108,12 +108,12 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
   def apply[K: SpatialComponent](key: K): Extent = apply(key.getComponent[SpatialKey])
 
   /** Get the [[Extent]] corresponding to a [[SpatialKey]] in some zoom level. */
-  def tileExtent(key: SpatialKey): Extent = apply(key)
+  def keyToExtent(key: SpatialKey): Extent = apply(key)
 
   def apply(key: SpatialKey): Extent = apply(key.col, key.row)
 
   /** 'col' and 'row' correspond to a [[SpatialKey]] column and row in some grid. */
-  def tileExtent(col: Int, row: Int): Extent = apply(col, row)
+  def keyToExtent(col: Int, row: Int): Extent = apply(col, row)
 
   def apply(col: Int, row: Int): Extent =
     Extent(


### PR DESCRIPTION
### TODO 

- [x] Named aliases for each `.apply` variant
- [x] Provide these transformations directly in the types they affect (where possible)
- [x] Deprecations?

### Motivation

`MapKeyTransform` is a "worker class", it does not itself represent data. It provides mechanisms for transformations involving `SpatialKey`s, namely:

- discovering the key corresponding to some Geometry
- discovering the `Extent` that corresponds to some key
- discovering the set of keys (`GridBounds`) that corresponds to some Geometry envelope (an `Extent`)

Until now, each of these transformations occurred through a very overloaded `.apply` method, making `MapKeyTransform` somewhat of a mysterious black box. This PR adds sensibly named aliases for each of these transformations, like `keyToExtent: SpatialKey => Extent`.

### Further Work

#### Duplicate Deprecations

If it's true that reducing API surface area increases discoverability and improves usability, is it necessary to have:

- both `apply: Point => SpatialKey` and `apply: (Double, Double) => SpatialKey`
- all of `apply: (Int, Int) => Extent` and `apply: SpatialKey => Extent` and `apply[K: SpatialComponent]: K => Extent`

given that the extra forms are simple pure transformations that could occur in application code?
For instance, as currently exists in the code base:

```scala
 def apply[K: SpatialComponent](key: K): Extent = apply(key.getComponent[SpatialKey])
```

My recommendation is to keep `SpatialKey => Extent` and `Point => SpatialKey` and deprecate the duplicates.

#### `.apply` Deprecations

Echoing the "surface area" argument, would it be prudent to deprecate the `.apply` methods as well, given that they were the original source of confusion? Replacing their usage with the named aliases within GT couldn't be more than a 15 minute find-replace job.

#### `geotrellis-core`

Each of these transformations can be modelled by the form `A.someAToB: LayoutDefinition => B`, where the data of the `A` is used implicitly inside the method. Here, the transformation is a method on `A`, not a function through `MapKeyTransform`. For the case of `SpatialKey` and `Extent`, it's: `SpatialKey.toExtent: LayoutDefinition => Extent`. This PR provides this method as well, so that users don't need to go through a `MapKeyTransform`.

Unfortunately, due to the way the project is structured, we can't provide type-local methods for the other types without incurring circular dependencies:

- `Point.toKey: LayoutDefinition => SpatialKey` 
  - `LayoutDefinition` lives in `geotrellis.spark.tiling`
  - `SpatialKey` lives in `geotrellis.spark`
  - `Point` lives in `geotrellis.vector`
- `GridBounds.toExtent: LayoutDefinition => Extent`
  - `GridBounds` lives in `geotrellis.raster`
  - `Extent` lives in `geotrellis.vector`

and so on. So `MapKeyTransform` who lives in `geotrellis.spark.tiling` has to act as a sort of
"type broker", a place for all these necessary transformations to live. This (and other issues) would be solved by a central `geotrellis-core` package, which would contain types useful to any conceivable GeoTrellis application (i.e. one shouldn't need to depend on `spark` just to get access to `SpatialKey`). This way, we could get rid of `MapKeyTransform`, and each transformation could occur directly on the class in question.