### PR TITLE
4-Connected Line Drawing

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/rasterize/RasterizerSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/rasterize/RasterizerSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest._
 import geotrellis.raster.testkit._
 import scala.collection.mutable
 
-class RasterizeSpec extends FunSuite with RasterMatchers 
+class RasterizeSpec extends FunSuite with RasterMatchers
                                      with Matchers {
    test("Point Rasterization") {
       val e = Extent(0.0, 0.0, 10.0, 10.0)
@@ -34,11 +34,11 @@ class RasterizeSpec extends FunSuite with RasterMatchers
 
       val data = (0 until 99).toArray
       val tile = ArrayTile(data, re.cols, re.rows)
-      
+
       val p = PointFeature(Point(1.0,2.0), "point one: ")
       val p2 = PointFeature(Point(9.5, 9.5), "point two: ")
       val p3 = PointFeature(Point(0.1, 9.9), "point three: ")
-      
+
 
       var f2output:String = ""
 
@@ -54,7 +54,7 @@ class RasterizeSpec extends FunSuite with RasterMatchers
         f2output = f2output + p2.data + z.toString
       }
       assert( f2output === "point two: 9")
-     
+
       f2output = ""
       Rasterizer.foreachCellByPoint(p3.geom, re) { (col:Int, row:Int) =>
         val z = tile.get(col,row)
@@ -95,7 +95,7 @@ class RasterizeSpec extends FunSuite with RasterMatchers
 
     val line1 = LineFeature(Line((1.0,3.5),(1.0,8.5), (5.0, 9.0)), "line" )
     val result = mutable.ListBuffer[(Int,Int)]()
-    
+
     Rasterizer.foreachCellByLineString(line1.geom, re) { (col:Int, row:Int) =>
       result += ((col,row))
     }
@@ -118,7 +118,7 @@ class RasterizeSpec extends FunSuite with RasterMatchers
 
     val line1 = LineFeature(Line((1.0,3.5),(1.0,8.5), (5.0, 9.0),(1.0,4.5)), "line" )
     val result = mutable.ListBuffer[(Int,Int)]()
-    
+
     Rasterizer.foreachCellByLineString(line1.geom, re) { (col:Int, row:Int) =>
       result += ((col,row))
     }

--- a/raster-test/src/test/scala/geotrellis/raster/rasterize/RasterizerSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/rasterize/RasterizerSpec.scala
@@ -133,4 +133,39 @@ class RasterizeSpec extends FunSuite with RasterMatchers
                                        (2,4),
                                   (1,5)))
   }
+
+  test("4-connecting line drawing 1") {
+    val e = Extent(0, 0, 1024, 1024)
+    val re = RasterExtent(e, 1024, 1024)
+    val options = Rasterizer.Options(false, PixelIsArea)
+    val line = Line((0, 0), (1022, 1024))
+    val result4 = mutable.Set[(Int, Int)]()
+    val result8 = mutable.Set[(Int, Int)]()
+
+    Rasterizer.foreachCellByLineString(line, re, options)({ (col: Int, row: Int) =>
+      if (col == 512) result4 += ((col, row)) })
+    Rasterizer.foreachCellByLineString(line, re)({ (col: Int, row: Int) =>
+      if (col == 512) result8 += ((col, row)) })
+
+    (result4 diff result8) should be (Set((512,512)))
+    (result8 diff result4) should be (Set.empty)
+  }
+
+  test("4-connecting line drawing 2") {
+    val e = Extent(0, 0, 1024, 1024)
+    val re = RasterExtent(e, 1024, 1024)
+    val options = Rasterizer.Options(false, PixelIsArea)
+    val line = Line((0, 0), (1024, 1022))
+    val result4 = mutable.Set[(Int, Int)]()
+    val result8 = mutable.Set[(Int, Int)]()
+
+    Rasterizer.foreachCellByLineString(line, re, options)({ (col: Int, row: Int) =>
+      if (col == 512) result4 += ((col, row)) })
+    Rasterizer.foreachCellByLineString(line, re)({ (col: Int, row: Int) =>
+      if (col == 512) result8 += ((col, row)) })
+
+    (result4 diff result8) should be (Set((512,514)))
+    (result8 diff result4) should be (Set.empty)
+  }
+
 }

--- a/raster-test/src/test/scala/geotrellis/raster/rasterize/RasterizerSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/rasterize/RasterizerSpec.scala
@@ -137,12 +137,11 @@ class RasterizeSpec extends FunSuite with RasterMatchers
   test("4-connecting line drawing 1") {
     val e = Extent(0, 0, 1024, 1024)
     val re = RasterExtent(e, 1024, 1024)
-    val options = Rasterizer.Options(false, PixelIsArea)
     val line = Line((0, 0), (1022, 1024))
     val result4 = mutable.Set[(Int, Int)]()
     val result8 = mutable.Set[(Int, Int)]()
 
-    Rasterizer.foreachCellByLineString(line, re, options)({ (col: Int, row: Int) =>
+    Rasterizer.foreachCellByLineString(line, re, FourNeighbors)({ (col: Int, row: Int) =>
       if (col == 512) result4 += ((col, row)) })
     Rasterizer.foreachCellByLineString(line, re)({ (col: Int, row: Int) =>
       if (col == 512) result8 += ((col, row)) })
@@ -154,12 +153,11 @@ class RasterizeSpec extends FunSuite with RasterMatchers
   test("4-connecting line drawing 2") {
     val e = Extent(0, 0, 1024, 1024)
     val re = RasterExtent(e, 1024, 1024)
-    val options = Rasterizer.Options(false, PixelIsArea)
     val line = Line((0, 0), (1024, 1022))
     val result4 = mutable.Set[(Int, Int)]()
     val result8 = mutable.Set[(Int, Int)]()
 
-    Rasterizer.foreachCellByLineString(line, re, options)({ (col: Int, row: Int) =>
+    Rasterizer.foreachCellByLineString(line, re, FourNeighbors)({ (col: Int, row: Int) =>
       if (col == 512) result4 += ((col, row)) })
     Rasterizer.foreachCellByLineString(line, re)({ (col: Int, row: Int) =>
       if (col == 512) result8 += ((col, row)) })

--- a/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
@@ -206,15 +206,14 @@ object Rasterizer {
     * first point to the last point.
     */
   def foreachCellByLineString(line: Line, re: RasterExtent)(f: (Int, Int) => Unit) {
-    val cells = (for(coord <- line.jtsGeom.getCoordinates()) yield {
-      (re.mapXToGrid(coord.x), re.mapYToGrid(coord.y))
-    }).toList
-
-    for(i <- 1 until cells.size) {
-      foreachCellInGridLine(cells(i - 1)._1,
-                            cells(i - 1)._2,
-                            cells(i)._1,
-                            cells(i)._2, line, re, i != cells.size - 1)(f)
+    val coords = line.jtsGeom.getCoordinates()
+    var i = 1; while (i < coords.size) {
+      val x1 = re.mapXToGrid(coords(i-1).x)
+      val y1 = re.mapYToGrid(coords(i-1).y)
+      val x2 = re.mapXToGrid(coords(i+0).x)
+      val y2 = re.mapYToGrid(coords(i+0).y)
+      foreachCellInGridLine(x1, y1, x2, y2, line, re, i != coords.size - 1)(f)
+      i += 1
     }
   }
 


### PR DESCRIPTION
This adds 4-connected line drawing capability.

The API is "broken" in the sense that the line drawing subroutine now takes and pays attention to a potential `options` parameter whereas it did not before.  `Options.DEFAULT` preserves the original (8-connected) behavior, whereas 4-connected drawing is done when `options.sampleType == PixelIsArea`.

In terms of the API, it seemed as though the choice were
   - This
   - Awkwardly add something along side the existing API
   - Extend the `Options` case class (in terms of invasiveness, seems >= the approach taken here)

This PR should probably either be closed or given the "2.0" label.

Also, while typing this PR I realized that it does not solve the [vector rasterization problem](https://github.com/locationtech/geotrellis/pull/2266) for which it was intended because the line drawing code snaps line endpoints to the centers of pixels before drawing; because of that, the reported pixels are not guaranteed to cover the line.  The picture below has an example.

![example](https://user-images.githubusercontent.com/11281373/29459223-acdb92f0-83f0-11e7-9dde-b13911986b7c.png)

The blue line is the original with the tiles that should be reported.  The red is the snapped-to-centers line with the tiles that will be reported.  Since there are some tiles in the blue set that are not in the red set, this cannot be used.  (If the set of tiles is 3x3 but the set of pixels is 3nx3n, then there will be some pixels which should be drawn but which are not because there is no tile to contain them.)

I did not change endpoint-snapping behavior because seems like an even larger change than the one presented here, so the three-part list above applies.  I am planning to put in a [solution to the original](https://github.com/echeipesh/geotrellis/pull/11) problem that does not involve the line rasterizer.

Note: I said above that it appears from the code that the line endpoints are being snapped to the centers of the pixels.  Even if that is not correct -- if they are being snapped to a corner or the middle of an edge -- the fact that the endpoints are being converted to integers means that such an example can probably still be constructed.