### PR TITLE
New GridBounds Methods: buffer and offset

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
@@ -109,4 +109,58 @@ class GridBoundsSpec extends FunSpec with Matchers{
       gbs.coordsIter.toSeq shouldBe gbs.coords.toSeq
     }
   }
+
+  describe("GridBounds.buffer") {
+    it("should not produce a GridBounds with negative values") {
+      val gps = GridBounds(0, 0, 10, 10)
+
+      gps.buffer(5) shouldBe GridBounds(0, 0, 15, 15)
+    }
+
+    it("should produce a GridBounds with negative values when clamp is false") {
+      val gps = GridBounds(256, 0, 500, 256)
+
+      gps.buffer(128, 128, clamp = false) shouldBe GridBounds(128, -128, 628, 384)
+    }
+
+    it("should only buffer the cols") {
+      val gps = GridBounds(5, 5, 20, 20)
+
+      gps.buffer(5, 0) shouldBe GridBounds(0, 5, 25, 20)
+    }
+
+    it("should only buffer the rows") {
+      val gps = GridBounds(0, 15, 20, 35)
+
+      gps.buffer(0, 10) shouldBe GridBounds(0, 5, 20, 45)
+    }
+
+    it("should buffer both cols and rows") {
+      val gps = GridBounds(100, 100, 250, 250)
+
+      gps.buffer(25) shouldBe GridBounds(75, 75, 275, 275)
+    }
+  }
+
+  describe("GridBounds.offset") {
+    it("should move right 3 and down 5") {
+      val gps = GridBounds(250, 250, 500, 500)
+
+      val actual = gps.offset(3, 5)
+      val expected = GridBounds(253, 255, 503, 505)
+
+      actual shouldBe expected
+      actual.size shouldBe expected.size
+    }
+
+    it("should move to the left 10 and up 15") {
+      val gps = GridBounds(12, 22, 32, 42)
+
+      val actual = gps.offset(-10, -15)
+      val expected = GridBounds(2, 7, 22, 27)
+
+      actual shouldBe expected
+      actual.size shouldBe expected.size
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -106,6 +106,64 @@ case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
     !(rowMax < other.rowMin || other.rowMax < rowMin)
 
   /**
+   * Creates a new [[GridBounds]] using a buffer around this
+   * GridBounds.
+   *
+   * @note This will not buffer past 0 regardless of how much the buffer
+   *       falls below it.
+   *
+   * @param bufferSize The amount this GridBounds should be buffered by.
+   */
+  def buffer(bufferSize: Int): GridBounds =
+    buffer(bufferSize, bufferSize)
+
+  /**
+   * Creates a new [[GridBounds]] using a buffer around this
+   * GridBounds.
+   *
+   * @note This will not buffer past 0 regardless of how much the buffer
+   *       falls below it.
+   *
+   * @param colBuffer The amount the cols within this GridBounds should be buffered.
+   * @param rowBuffer The amount the rows within this GridBounds should be buffered.
+   * @param clamp     Determines whether or not to clamp the GridBounds to the grid
+   *                  such that it no value will be under 0; defaults to true. If false,
+   *                  then the resulting GridBounds can contain negative values outside
+   *                  of the grid boundaries.
+   */
+  def buffer(colBuffer: Int, rowBuffer: Int, clamp: Boolean = true): GridBounds =
+    GridBounds(
+      if (clamp) math.max(colMin - colBuffer, 0) else colMin - colBuffer,
+      if (clamp) math.max(rowMin - rowBuffer, 0) else rowMin - rowBuffer,
+      colMax + colBuffer,
+      rowMax + rowBuffer
+    )
+
+  /**
+   * Offsets this [[GridBounds]] to a new location relative to its current
+   * position
+   *
+   * @param boundsOffset The amount the GridBounds should be shifted.
+   */
+  def offset(boundsOffset: Int): GridBounds =
+    offset(boundsOffset, boundsOffset)
+
+  /**
+   * Offsets this [[GridBounds]] to a new location relative to its current
+   * position
+   *
+   * @param colOffset The amount the cols should be shifted.
+   * @param rowOffset The amount the rows should be shifted.
+   */
+  def offset(colOffset: Int, rowOffset: Int): GridBounds =
+    GridBounds(
+      colMin + colOffset,
+      rowMin + rowOffset,
+      colMax + colOffset,
+      rowMax + rowOffset
+    )
+
+  /**
     * Another name for the 'minus' method.
     *
     * @param  other  The other GridBounds


### PR DESCRIPTION
This PR adds two new methods to `GridBounds`: `buffer` and `offset`. These will allow the user to create a new `GridBounds` by buffering around a preexisting one and to transpose a `GridBounds` to a new location, respectively.