### PR TITLE
Deserialization Exception Message Typo Fix

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/json/KeyFormats.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/json/KeyFormats.scala
@@ -53,7 +53,7 @@ trait KeyFormats {
         case Seq(JsNumber(col), JsNumber(row), JsNumber(time)) =>
           SpaceTimeKey(col.toInt, row.toInt, time.toLong)
         case _ =>
-          throw new DeserializationException("SpatialKey expected")
+          throw new DeserializationException("SpaceTimeKey expected")
       }
   }
 


### PR DESCRIPTION
This PR fixes a typo in `SpaceTimeKey`'s deserialization exception message so it now displays the correct type.

This Pr resolves #2310 