### PR TITLE
Improve S3 makePath function

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/package.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/package.scala
@@ -21,7 +21,9 @@ import org.apache.spark.rdd.RDD
 package object s3 {
   private[s3]
   def makePath(chunks: String*) =
-    chunks.filter(_.nonEmpty).mkString("/")
+    chunks
+      .collect { case str if str.nonEmpty => if(str.endsWith("/")) str.dropRight(1) else str }
+      .mkString("/")
 
   implicit class withSaveToS3Methods[K](rdd: RDD[(K, Array[Byte])]) extends SaveToS3Methods(rdd)
 }


### PR DESCRIPTION
Fixes writing to an "empty named" folder, if s3 URI is with a trailing slash.