### PR TITLE
sizeLong Bug Fix and Replacement of Deprecated GridBound Methods

### DIFF
--- a/raster-test/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
@@ -96,8 +96,7 @@ class GridBoundsSpec extends FunSpec with Matchers{
           GridBounds(0, 0, 75, 75),
           GridBounds(25, 25, 100, 100)
         )
-      println(GridBounds.distinct(gridBounds))
-      GridBounds.distinct(gridBounds).map(_.size).sum should be ((101 * 101) - (25 * 25 * 2))
+      GridBounds.distinct(gridBounds).map(_.sizeLong).sum should be ((101 * 101) - (25 * 25 * 2))
     }
   }
 
@@ -106,7 +105,7 @@ class GridBoundsSpec extends FunSpec with Matchers{
     it("should match the output of coordsIter") {
       val gbs = GridBounds(0, 0, 10, 10)
 
-      gbs.coordsIter.toSeq shouldBe gbs.coords.toSeq
+      gbs.coordsIter.toSeq shouldBe gbs.coordsIter.toSeq
     }
   }
 
@@ -150,7 +149,7 @@ class GridBoundsSpec extends FunSpec with Matchers{
       val expected = GridBounds(253, 255, 503, 505)
 
       actual shouldBe expected
-      actual.size shouldBe expected.size
+      actual.sizeLong shouldBe expected.sizeLong
     }
 
     it("should move to the left 10 and up 15") {
@@ -160,7 +159,7 @@ class GridBoundsSpec extends FunSpec with Matchers{
       val expected = GridBounds(2, 7, 22, 27)
 
       actual shouldBe expected
-      actual.size shouldBe expected.size
+      actual.sizeLong shouldBe expected.sizeLong
     }
   }
 }

--- a/raster-test/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
+++ b/raster-test/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
@@ -105,7 +105,7 @@ class GridBoundsSpec extends FunSpec with Matchers{
     it("should match the output of coordsIter") {
       val gbs = GridBounds(0, 0, 10, 10)
 
-      gbs.coordsIter.toSeq shouldBe gbs.coordsIter.toSeq
+      gbs.coordsIter.toSeq shouldBe gbs.coords.toSeq
     }
   }
 

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -80,7 +80,7 @@ case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
   def size: Int = width * height
 
   // TODO Mark for deprecation in 3.0 when 2.0 comes out!
-  def sizeLong: Long = width.toLong * width.toLong
+  def sizeLong: Long = width.toLong * height.toLong
 
   def isEmpty = sizeLong == 0
 

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -141,7 +141,7 @@ object TileRDDReproject {
       for {
         sourceBounds <- metadata.bounds.toOption
         targetBounds <- newMetadata.bounds.toOption
-        sizeRatio = targetBounds.toGridBounds.size.toDouble / sourceBounds.toGridBounds.size.toDouble
+        sizeRatio = targetBounds.toGridBounds.sizeLong.toDouble / sourceBounds.toGridBounds.sizeLong.toDouble
         if sizeRatio > 1.5
       } yield {
         val newPartitionCount = (bufferedTiles.partitions.length * sizeRatio).toInt

--- a/spark/src/test/scala/geotrellis/spark/io/AllOnesTestTileFeatureSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/AllOnesTestTileFeatureSpec.scala
@@ -41,7 +41,7 @@ trait AllOnesTestTileFeatureSpec { self: PersistenceSpec[SpatialKey, TileFeature
 
       it("query inside layer bounds") {
         val actual = query.where(Intersects(bounds1)).result.keys.collect()
-        val expected = for ((x, y) <- bounds1.coords) yield SpatialKey(x, y)
+        val expected = for ((x, y) <- bounds1.coordsIter.toSeq) yield SpatialKey(x, y)
 
         if (expected.diff(actual).nonEmpty)
           info(s"missing: ${(expected diff actual).toList}")
@@ -57,7 +57,7 @@ trait AllOnesTestTileFeatureSpec { self: PersistenceSpec[SpatialKey, TileFeature
 
       it("disjoint query on space") {
         val actual = query.where(Intersects(bounds1) or Intersects(bounds2)).result.keys.collect()
-        val expected = for ((x, y) <- bounds1.coords ++ bounds2.coords) yield SpatialKey(x, y)
+        val expected = for ((x, y) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq) yield SpatialKey(x, y)
 
         if (expected.diff(actual).nonEmpty)
           info(s"missing: ${(expected diff actual).toList}")
@@ -71,7 +71,7 @@ trait AllOnesTestTileFeatureSpec { self: PersistenceSpec[SpatialKey, TileFeature
         val extent = Extent(-10, -10, 10, 10) // this should intersect the four central tiles in 8x8 layout
         query.where(Intersects(extent)).result.keys.collect() should
         contain theSameElementsAs {
-          for ((col, row) <- GridBounds(3, 3, 4, 4).coords) yield SpatialKey(col, row)
+          for ((col, row) <- GridBounds(3, 3, 4, 4).coordsIter.toSeq) yield SpatialKey(col, row)
         }
       }
     }

--- a/spark/src/test/scala/geotrellis/spark/io/AllOnesTestTileSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/AllOnesTestTileSpec.scala
@@ -40,7 +40,7 @@ trait AllOnesTestTileSpec { self: PersistenceSpec[SpatialKey, Tile, TileLayerMet
 
       it("query inside layer bounds") {
         val actual = query.where(Intersects(bounds1)).result.keys.collect()
-        val expected = for ((x, y) <- bounds1.coords) yield SpatialKey(x, y)
+        val expected = for ((x, y) <- bounds1.coordsIter.toSeq) yield SpatialKey(x, y)
 
         if (expected.diff(actual).nonEmpty)
           info(s"missing: ${(expected diff actual).toList}")
@@ -56,7 +56,7 @@ trait AllOnesTestTileSpec { self: PersistenceSpec[SpatialKey, Tile, TileLayerMet
 
       it("disjoint query on space") {
         val actual = query.where(Intersects(bounds1) or Intersects(bounds2)).result.keys.collect()
-        val expected = for ((x, y) <- bounds1.coords ++ bounds2.coords) yield SpatialKey(x, y)
+        val expected = for ((x, y) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq) yield SpatialKey(x, y)
 
         if (expected.diff(actual).nonEmpty)
           info(s"missing: ${(expected diff actual).toList}")
@@ -70,7 +70,7 @@ trait AllOnesTestTileSpec { self: PersistenceSpec[SpatialKey, Tile, TileLayerMet
         val extent = Extent(-10, -10, 10, 10) // this should intersect the four central tiles in 8x8 layout
         query.where(Intersects(extent)).result.keys.collect() should
         contain theSameElementsAs {
-          for ((col, row) <- GridBounds(3, 3, 4, 4).coords) yield SpatialKey(col, row)
+          for ((col, row) <- GridBounds(3, 3, 4, 4).coordsIter.toSeq) yield SpatialKey(col, row)
         }
       }
     }

--- a/spark/src/test/scala/geotrellis/spark/io/CoordinateSpaceTimeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/CoordinateSpaceTimeSpec.scala
@@ -48,7 +48,7 @@ trait CoordinateSpaceTimeSpec { self: PersistenceSpec[SpaceTimeKey, Tile, TileLa
 
         val expected = {
           for {
-            (col, row) <- bounds1.coords ++ bounds2.coords
+            (col, row) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq
             time <- dates
           } yield SpaceTimeKey(col, row, time)
         }
@@ -67,7 +67,7 @@ trait CoordinateSpaceTimeSpec { self: PersistenceSpec[SpaceTimeKey, Tile, TileLa
 
         val expected = {
           for {
-            (col, row) <- bounds1.coords ++ bounds2.coords
+            (col, row) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq
             time <- dates diff Seq(dates(2))
           } yield {
             SpaceTimeKey(col, row, time)
@@ -88,7 +88,7 @@ trait CoordinateSpaceTimeSpec { self: PersistenceSpec[SpaceTimeKey, Tile, TileLa
 
         val expected = {
           for {
-            (col, row) <- bounds1.coords ++ bounds2.coords
+            (col, row) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq
             time <- Seq(dates(0), dates(4))
           } yield {
             SpaceTimeKey(col, row, time)

--- a/spark/src/test/scala/geotrellis/spark/io/CoordinateSpaceTimeTileFeatureSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/CoordinateSpaceTimeTileFeatureSpec.scala
@@ -47,7 +47,7 @@ trait CoordinateSpaceTimeTileFeatureSpec { self: PersistenceSpec[SpaceTimeKey, T
 
         val expected = {
           for {
-            (col, row) <- bounds1.coords ++ bounds2.coords
+            (col, row) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq
             time <- dates
           } yield SpaceTimeKey(col, row, time)
         }
@@ -66,7 +66,7 @@ trait CoordinateSpaceTimeTileFeatureSpec { self: PersistenceSpec[SpaceTimeKey, T
 
         val expected = {
           for {
-            (col, row) <- bounds1.coords ++ bounds2.coords
+            (col, row) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq
             time <- dates diff Seq(dates(2))
           } yield {
             SpaceTimeKey(col, row, time)
@@ -87,7 +87,7 @@ trait CoordinateSpaceTimeTileFeatureSpec { self: PersistenceSpec[SpaceTimeKey, T
 
         val expected = {
           for {
-            (col, row) <- bounds1.coords ++ bounds2.coords
+            (col, row) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq
             time <- Seq(dates(0), dates(4))
           } yield {
             SpaceTimeKey(col, row, time)

--- a/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
@@ -88,7 +88,7 @@ class LayerQuerySpec extends FunSpec
       Point(-125.0, 60.0)))
 
     def naiveKeys(polygon: MultiPolygon): List[SpatialKey] = {
-      (for ((x, y) <- bounds.coords
+      (for ((x, y) <- bounds.coordsIter.toSeq
         if polygon.intersects(md.mapTransform(SpatialKey(x, y)))) yield SpatialKey(x, y))
         .toList
     }
@@ -142,7 +142,7 @@ class LayerQuerySpec extends FunSpec
       val expected =  {
         val bounds = huc10LayerMetadata.bounds.get.toGridBounds
         for {
-          (x, y) <- bounds.coords
+          (x, y) <- bounds.coordsIter.toSeq
           if huc10.intersects(mapTransform(SpatialKey(x, y)))
         } yield SpatialKey(x, y)
       }
@@ -172,7 +172,7 @@ class LayerQuerySpec extends FunSpec
       val expected =  {
         val bounds = huc10LayerMetadata.bounds.get.toGridBounds
         for {
-          (x, y) <- bounds.coords
+          (x, y) <- bounds.coordsIter.toSeq
           //
           if ml.intersects(mapTransform(SpatialKey(x, y)))
         } yield SpatialKey(x, y)
@@ -189,7 +189,7 @@ class LayerQuerySpec extends FunSpec
     it("should generate KeyBounds for single region") {
       val bounds1 = GridBounds(1, 1, 3, 2)
       val query = new LayerQuery[SpatialKey, TileLayerMetadata[SpatialKey]].where(Intersects(bounds1))
-      val expected = for ((x, y) <- bounds1.coords) yield SpatialKey(x, y)
+      val expected = for ((x, y) <- bounds1.coordsIter.toSeq) yield SpatialKey(x, y)
 
       val found = query(md).flatMap(spatialKeyBoundsKeys)
       info(s"missing: ${(expected diff found).toList}")
@@ -202,7 +202,7 @@ class LayerQuerySpec extends FunSpec
       val bounds1 = GridBounds(1, 1, 3, 3)
       val bounds2 = GridBounds(4, 5, 6, 6)
       val query = new LayerQuery[SpatialKey, TileLayerMetadata[SpatialKey]].where(Intersects(bounds1) or Intersects(bounds2))
-      val expected = for ((x, y) <- bounds1.coords ++ bounds2.coords) yield SpatialKey(x, y)
+      val expected = for ((x, y) <- bounds1.coordsIter.toSeq ++ bounds2.coordsIter.toSeq) yield SpatialKey(x, y)
 
       val found = query(md).flatMap(spatialKeyBoundsKeys)
       info(s"missing: ${(expected diff found).toList}")

--- a/spark/src/test/scala/geotrellis/spark/resample/ZoomResampleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/resample/ZoomResampleSpec.scala
@@ -56,7 +56,7 @@ class ZoomResampleMethodsSpec extends FunSpec
       val gridBounds = rdd.metadata.bounds.get.toGridBounds
       val resampledGridBounds = resampled.metadata.bounds.get.toGridBounds
 
-      resampledGridBounds.size should be (gridBounds.size * 4)
+      resampledGridBounds.sizeLong should be (gridBounds.sizeLong * 4)
     }
   }
 


### PR DESCRIPTION
This PR replaces `size` to `sizeLong` and `coords` to coordsIter` in the GeoTrellis code base. In addition, a bug has been fixed in `sizeLong` so that it will now produce the correct result.

This PR resolves #2314