### PR TITLE
Allow specification of JTS precision model in application.conf

### DIFF
--- a/docs/guide/vectors.rst
+++ b/docs/guide/vectors.rst
@@ -1,6 +1,38 @@
 Using Vectors
 *************
 
+Numerical Precision and Topology Exceptions
+===========================================
+
+When doing any significant amount of geometric computation, there is the
+potential of encountering JTS TopologyExceptions or other numerical hiccups
+that arise, essentially, from asking too much of floating point numerical
+representations.  JTS offers the ability to snap coordinates to a grid, the
+scale of whose cells may be specified by the user.  This can often fix
+problems stemming from numerical error which makes two points that should be
+the same appear different due to miniscule rounding errors.
+
+However, GeoTrellis defaults to allowing the full floating point
+representation of coordinates.  To enable the fixed precision scheme, one must
+create an ``application.conf`` in ``your-project/src/main/resources/``
+containing the following lines:
+
+::
+
+   geotrellis.jts.precision.type="fixed"
+   geotrellis.jts.precision.scale=<scale factor>
+
+The scale factor should be ``10^x`` where ``x`` is the number of decimal
+places of precision you wish to keep.  The default scale factor is 1e12,
+indicating that 12 decimal places after the decimal point should be kept.
+Values less than 1 (negative exponents) allow for very coarse grids.  For
+example, a scale factor of 1e-2 will round coordinate components to the
+nearest hundred.
+
+Note that ``geotrellis.jts.precision.type`` make take on the value
+``floating`` for the default double precision case, or ``floating_single`` to
+use single precision floating point values.
+
 Parsing GeoJson
 ===============
 

--- a/vector/build.sbt
+++ b/vector/build.sbt
@@ -3,6 +3,7 @@ import Dependencies._
 name := "geotrellis-vector"
 libraryDependencies ++= Seq(
   jts,
+  typesafeConfig,
   sprayJson,
   apacheMath,
   spire)

--- a/vector/src/main/resources/reference.conf
+++ b/vector/src/main/resources/reference.conf
@@ -1,0 +1,26 @@
+# Copyright 2017 Azavea
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+geotrellis.jts = {
+  # Use double precision floating point values for JTS geometry coordinates
+  precision.type = floating
+
+  # For fixed precision grid for JTS coordinates; the following gives 12 decimal places of precision
+  # precision.type = fixed
+  # precision.scale = 1e12
+
+  # In operations requiring simplification, the following dictates precision of simplified coordinates
+  # Here, use 12 decimal places of precision
+  simplification.scale = 1e12
+}

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -37,7 +37,7 @@ private[vector] object GeomFactory {
 
   val factory = new geom.GeometryFactory(precisionModel)
 
-  // 12 digits is maximum to avoid [[TopologyException]], see http://tsusiatsoftware.net/jts/jts-faq/jts-faq.html#D9
+  // 12 digits is maximum to avoid [[TopologyException]], see https://web.archive.org/web/20160226031453/http://tsusiatsoftware.net/jts/jts-faq/jts-faq.html#D9
   lazy val simplifier = new GeometryPrecisionReducer(new PrecisionModel(1e12))
 
 }

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -29,11 +29,11 @@ private[vector] object GeomFactory {
 
   val precisionModel = precisionType match {
     case "floating" => new PrecisionModel()
-    case "floating_single" => new PrecisionModel(PrecisionModel.Type.FLOATING_SINGLE)
+    case "floating_single" => new PrecisionModel(PrecisionModel.FLOATING_SINGLE)
     case "fixed" => 
-      val scale = Try(new PrecisionModel(ConfigFactory.load().getDouble("geotrellis.jts.precision.scale"))).getOrElse(1e12)
+      val scale = new PrecisionModel(Try(ConfigFactory.load().getDouble("geotrellis.jts.precision.scale")).getOrElse(1e12))
       new PrecisionModel(scale)
-    case s => throw new IllegalArgumentException(s"Unrecognized JTS precision model; expected \"floating\", \"floating_single\", or \"fixed\"")
+    case s => throw new IllegalArgumentException("Unrecognized JTS precision model; expected \"floating\", \"floating_single\", or \"fixed\"")
   }
 
   val factory = new geom.GeometryFactory(precisionModel)

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -38,6 +38,6 @@ private[vector] object GeomFactory {
   val factory = new geom.GeometryFactory(precisionModel)
 
   // 12 digits is maximum to avoid [[TopologyException]], see http://tsusiatsoftware.net/jts/jts-faq/jts-faq.html#D9
-  lazy val simplifier = new GeometryPrecisionReducer(new PrecisionModel(12))
+  lazy val simplifier = new GeometryPrecisionReducer(new PrecisionModel(1e12))
 
 }

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -33,6 +33,7 @@ private[vector] object GeomFactory {
     case "fixed" => 
       val scale = Try(new PrecisionModel(ConfigFactory.load().getDouble("geotrellis.jts.precision.scale"))).getOrElse(1e12)
       new PrecisionModel(scale)
+    case s => throw new IllegalArgumentException(s"Unrecognized JTS precision model; expected \"floating\", \"floating_single\", or \"fixed\"")
   }
 
   val factory = new geom.GeometryFactory(precisionModel)


### PR DESCRIPTION
Fixes #2219 

Currently, `geotrellis.vector.GeomFactory` defaults to use JTS's floating `PrecisionModel`.  This means that all geometry will naturally be represented with double-precision coordinates.  This can lead to TopologyExceptions.  We want to be able to specify the precision model for numerically robust geometric code.  This PR uses the `com.typesafe.config` mechanisms to allow for an application.conf which specifies the precision model.

The config key `geotrellis.jts.precision.type` can take on one of three string values: "floating", "floating_single", and "fixed".  See the [JTS docs](https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/PrecisionModel.html) for details.  In the event of a fixed precision model, the user may also give the scale parameter as `geotrellis.jts.precision.scale`; this defaults to 1e12, or 12 decimal places of precision.  [Note that this PR fixes a bug where the scale parameter was given as simply 12, which is a misreading of what the scale parameter means.]