### PR TITLE
Allow rasterizer to store z value at double precision

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/rasterize/CellValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/CellValue.scala
@@ -3,5 +3,5 @@ package geotrellis.raster.rasterize
 import geotrellis.raster.CellType
 
 
-/** Cell value with its zindex and celltype to be used by the rasterizer. */
-case class CellValue(value: Double, zindex: Double, celltype: CellType)
+/** Cell value with its zindex to be used by the rasterizer. */
+case class CellValue(value: Double, zindex: Double)

--- a/raster/src/main/scala/geotrellis/raster/rasterize/CellValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/CellValue.scala
@@ -1,5 +1,7 @@
 package geotrellis.raster.rasterize
 
+import geotrellis.raster.CellType
 
-/** Cell value with its zindex used by the rasterizer. */
-case class CellValue(value: Double, zindex: Short)
+
+/** Cell value with its zindex and celltype to be used by the rasterizer. */
+case class CellValue(value: Double, zindex: Double, celltype: CellType)

--- a/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala
@@ -119,7 +119,8 @@ object RasterizeRDD {
     cellType: CellType,
     layout: LayoutDefinition,
     options: Rasterizer.Options = Rasterizer.Options.DEFAULT,
-    partitioner: Option[Partitioner] = None
+    partitioner: Option[Partitioner] = None,
+    zIndexCellType: CellType = ByteConstantNoDataCellType
   ): RDD[(SpatialKey, Tile)] with Metadata[LayoutDefinition] = {
 
     // key the geometry to intersecting tiles so it can be rasterized in the map-side combine
@@ -132,7 +133,7 @@ object RasterizeRDD {
     val createTile = (tup: (Feature[Geometry, CellValue], SpatialKey)) => {
       val (feature, key) = tup
       val tile = ArrayTile.empty(cellType, layout.tileCols, layout.tileRows)
-      val ztile = ArrayTile.empty(feature.data.celltype, layout.tileCols, layout.tileRows)
+      val ztile = ArrayTile.empty(zIndexCellType, layout.tileCols, layout.tileRows)
       val re = RasterExtent(layout.mapTransform(key), layout.tileCols, layout.tileRows)
 
       feature.geom.foreach(re, options)({ (x: Int, y: Int) =>

--- a/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
@@ -134,11 +134,11 @@ class RasterizeRDDSpec extends FunSpec with Matchers
 
   it("rasterize feature with z-buffer 1"){
     val features = sc.parallelize(List(
-      Feature(polygon0, CellValue(value = 1000, zindex = 0)),
-      Feature(polygon1, CellValue(value = 1, zindex = 1)),
-      Feature(polygon2, CellValue(value = 2, zindex = 2)),
-      Feature(polygon0, CellValue(value = 2000, zindex = 0)),
-      Feature(polygon0, CellValue(value = 3000, zindex = 0))
+      Feature(polygon0, CellValue(value = 1000, zindex = 0, ShortConstantNoDataCellType)),
+      Feature(polygon1, CellValue(value = 1, zindex = 1, ShortConstantNoDataCellType)),
+      Feature(polygon2, CellValue(value = 2, zindex = 2, ShortConstantNoDataCellType)),
+      Feature(polygon0, CellValue(value = 2000, zindex = 0, ShortConstantNoDataCellType)),
+      Feature(polygon0, CellValue(value = 3000, zindex = 0, ShortConstantNoDataCellType))
     ))
     val tile = RasterizeRDD
       .fromFeatureWithZIndex(features, ct, ld)
@@ -149,11 +149,11 @@ class RasterizeRDDSpec extends FunSpec with Matchers
 
   it("rasterize feature with z-buffer 2"){
     val features = sc.parallelize(List(
-      Feature(polygon0, CellValue(value = 1000, zindex = 0)),
-      Feature(polygon1, CellValue(value = 1, zindex = 3)),
-      Feature(polygon2, CellValue(value = 2, zindex = 2)),
-      Feature(polygon0, CellValue(value = 2000, zindex = 0)),
-      Feature(polygon0, CellValue(value = 3000, zindex = 0))
+      Feature(polygon0, CellValue(value = 1000, zindex = 0, ShortConstantNoDataCellType)),
+      Feature(polygon1, CellValue(value = 1, zindex = 3, ShortConstantNoDataCellType)),
+      Feature(polygon2, CellValue(value = 2, zindex = 2, ShortConstantNoDataCellType)),
+      Feature(polygon0, CellValue(value = 2000, zindex = 0, ShortConstantNoDataCellType)),
+      Feature(polygon0, CellValue(value = 3000, zindex = 0, ShortConstantNoDataCellType))
     ))
     val tile = RasterizeRDD
       .fromFeatureWithZIndex(features, ct, ld)

--- a/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
@@ -134,11 +134,11 @@ class RasterizeRDDSpec extends FunSpec with Matchers
 
   it("rasterize feature with z-buffer 1"){
     val features = sc.parallelize(List(
-      Feature(polygon0, CellValue(value = 1000, zindex = 0, ShortConstantNoDataCellType)),
-      Feature(polygon1, CellValue(value = 1, zindex = 1, ShortConstantNoDataCellType)),
-      Feature(polygon2, CellValue(value = 2, zindex = 2, ShortConstantNoDataCellType)),
-      Feature(polygon0, CellValue(value = 2000, zindex = 0, ShortConstantNoDataCellType)),
-      Feature(polygon0, CellValue(value = 3000, zindex = 0, ShortConstantNoDataCellType))
+      Feature(polygon0, CellValue(value = 1000, zindex = 0)),
+      Feature(polygon1, CellValue(value = 1, zindex = 1)),
+      Feature(polygon2, CellValue(value = 2, zindex = 2)),
+      Feature(polygon0, CellValue(value = 2000, zindex = 0)),
+      Feature(polygon0, CellValue(value = 3000, zindex = 0))
     ))
     val tile = RasterizeRDD
       .fromFeatureWithZIndex(features, ct, ld)
@@ -149,11 +149,11 @@ class RasterizeRDDSpec extends FunSpec with Matchers
 
   it("rasterize feature with z-buffer 2"){
     val features = sc.parallelize(List(
-      Feature(polygon0, CellValue(value = 1000, zindex = 0, ShortConstantNoDataCellType)),
-      Feature(polygon1, CellValue(value = 1, zindex = 3, ShortConstantNoDataCellType)),
-      Feature(polygon2, CellValue(value = 2, zindex = 2, ShortConstantNoDataCellType)),
-      Feature(polygon0, CellValue(value = 2000, zindex = 0, ShortConstantNoDataCellType)),
-      Feature(polygon0, CellValue(value = 3000, zindex = 0, ShortConstantNoDataCellType))
+      Feature(polygon0, CellValue(value = 1000, zindex = 0)),
+      Feature(polygon1, CellValue(value = 1, zindex = 3)),
+      Feature(polygon2, CellValue(value = 2, zindex = 2)),
+      Feature(polygon0, CellValue(value = 2000, zindex = 0)),
+      Feature(polygon0, CellValue(value = 3000, zindex = 0))
     ))
     val tile = RasterizeRDD
       .fromFeatureWithZIndex(features, ct, ld)


### PR DESCRIPTION
This PR allows rasterization to store values at double precision (which is immediately useful for elevation rasters) and allows the z values to be stored with a provided `CellType`