### PR TITLE
Feature/scaffeine cache

### DIFF
--- a/proj4/build.sbt
+++ b/proj4/build.sbt
@@ -7,7 +7,9 @@ libraryDependencies ++= Seq(
   openCSV,
   parserCombinators,
   scalatest   % "test",
-  scalacheck  % "test")
+  scalacheck  % "test",
+  scaffeine
+)
 
 headers := Map(
   "scala" -> Apache2_0("2016", "Azavea"),

--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -17,12 +17,20 @@
 package geotrellis.proj4
 
 import geotrellis.proj4.io.wkt.WKT
+
 import org.osgeo.proj4j._
+import com.github.blemale.scaffeine.Scaffeine
 
 import scala.io.Source
 
+
 object CRS {
-  private lazy val proj4ToEpsgMap = new Memoize[String, Option[String]](readEpsgCodeFromFile)
+  private lazy val proj4ToEpsgMap =
+    Scaffeine()
+      .recordStats()
+      .build[String, Option[String]]()
+
+  //  new Memoize[String, Option[String]](readEpsgCodeFromFile)
   private val crsFactory = new CRSFactory
   private val filePrefix = "/geotrellis/proj4/nad/"
 
@@ -49,7 +57,7 @@ object CRS {
     * Returns the numeric EPSG code of a proj4string.
     */
   def getEpsgCode(proj4String: String): Option[Int] =
-    proj4ToEpsgMap(proj4String).map(_.toInt)
+    proj4ToEpsgMap.get(proj4String, { key => readEpsgCodeFromFile(key) }).map(_.toInt)
 
   /**
     * Creates a CoordinateReferenceSystem

--- a/proj4/src/main/scala/geotrellis/proj4/Memoize.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/Memoize.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @author Manuri Perera
  */
+@deprecated("This will be removed in 2.0", "1.2")
 class Memoize[T, R](f: T => R) extends (T => R) {
   val map: ConcurrentHashMap[T, R] = new ConcurrentHashMap()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,5 +50,6 @@ object Dependencies {
   val parserCombinators   = "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.0.6"
 
   val jsonSchemaValidator = "com.networknt"               % "json-schema-validator"    % "0.1.7"
-  val scaffeine           = "com.github.blemale"         %% "scaffeine"                % "2.1.0"
+
+  val scaffeine           = "com.github.blemale"         %% "scaffeine"                % "2.2.0"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,37 +17,38 @@
 import sbt._
 
 object Dependencies {
-  val typesafeConfig = "com.typesafe"       %  "config"          % "1.3.1"
-  val logging       = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
-  val scalatest     = "org.scalatest"       %%  "scalatest"      % "3.0.3"
-  val scalacheck    = "org.scalacheck"      %% "scalacheck"      % "1.13.5"
-  val jts           = "com.vividsolutions"  %  "jts-core"        % "1.14.0"
+  val typesafeConfig      = "com.typesafe"                %  "config"                  % "1.3.1"
+  val logging             = "com.typesafe.scala-logging" %% "scala-logging"            % "3.5.0"
+  val scalatest           = "org.scalatest"              %%  "scalatest"               % "3.0.3"
+  val scalacheck          = "org.scalacheck"             %% "scalacheck"               % "1.13.5"
+  val jts                 = "com.vividsolutions"          %  "jts-core"                % "1.14.0"
 
-  val monocleCore   = "com.github.julien-truffaut" %% "monocle-core"  % Version.monocle
-  val monocleMacro  = "com.github.julien-truffaut" %% "monocle-macro" % Version.monocle
+  val monocleCore         = "com.github.julien-truffaut" %% "monocle-core"             % Version.monocle
+  val monocleMacro        = "com.github.julien-truffaut" %% "monocle-macro"            % Version.monocle
 
-  val openCSV       = "com.opencsv" % "opencsv" % "3.9"
+  val openCSV             = "com.opencsv"                 % "opencsv"                  % "3.9"
 
-  val spire         = "org.spire-math" %% "spire" % "0.13.0"
+  val spire               = "org.spire-math"             %% "spire"                    % "0.13.0"
 
-  val sprayJson     = "io.spray" %% "spray-json" % Version.sprayJson
+  val sprayJson           = "io.spray"                   %% "spray-json"               % Version.sprayJson
 
-  val apacheMath    = "org.apache.commons" % "commons-math3" % "3.6.1"
+  val apacheMath          = "org.apache.commons"          % "commons-math3"            % "3.6.1"
 
-  val chronoscala   = "jp.ne.opt" %% "chronoscala" % "0.1.3"
+  val chronoscala         = "jp.ne.opt"                  %% "chronoscala"              % "0.1.3"
 
-  val awsSdkS3      = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.143"
+  val awsSdkS3            = "com.amazonaws"               % "aws-java-sdk-s3"          % "1.11.143"
 
-  val scalazStream  = "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a"
+  val scalazStream        = "org.scalaz.stream"          %% "scalaz-stream"            % "0.8.6a"
 
-  val sparkCore     = "org.apache.spark" %% "spark-core" % Version.spark
-  val hadoopClient  = "org.apache.hadoop" % "hadoop-client" % Version.hadoop
+  val sparkCore           = "org.apache.spark"           %% "spark-core"               % Version.spark
+  val hadoopClient        = "org.apache.hadoop"           % "hadoop-client"            % Version.hadoop
 
-  val avro          = "org.apache.avro" % "avro" % "1.8.2"
+  val avro                = "org.apache.avro"             % "avro"                     % "1.8.2"
 
-  val slickPG      = "com.github.tminglei" %% "slick-pg" % "0.15.0"
+  val slickPG             = "com.github.tminglei"        %% "slick-pg"                 % "0.15.0"
 
-  val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
+  val parserCombinators   = "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.0.6"
 
-  val jsonSchemaValidator = "com.networknt" % "json-schema-validator" % "0.1.7"
+  val jsonSchemaValidator = "com.networknt"               % "json-schema-validator"    % "0.1.7"
+  val scaffeine           = "com.github.blemale"         %% "scaffeine"                % "2.1.0"
 }

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -11,7 +11,9 @@ libraryDependencies ++= Seq(
   monocleCore, monocleMacro,
   chronoscala,
   scalazStream,
-  scalatest % "test"
+  scalatest % "test",
+  logging,
+  scaffeine
 )
 
 fork in Test := false

--- a/spark/src/main/resources/reference.conf
+++ b/spark/src/main/resources/reference.conf
@@ -20,3 +20,9 @@ geotrellis.file.threads {
 geotrellis.hadoop.threads {
   collection.read = default
 }
+
+geotrellis.attribute.caching {
+  expirationMinutes = 60
+  maxSize = 1000
+}
+

--- a/spark/src/main/scala/geotrellis/spark/util/cache/FileCache.scala
+++ b/spark/src/main/scala/geotrellis/spark/util/cache/FileCache.scala
@@ -20,6 +20,7 @@ import java.io.{File, FileInputStream, FileOutputStream}
 
 import org.apache.commons.io.IOUtils
 
+@deprecated("This will be removed in favor of a pluggable cache in 2.0", "1.2")
 class FileCache(cacheDirectory: String, fileChunk: Long => String) extends Cache[Long, Array[Byte]] {
   val cacheRoot = new File(cacheDirectory)
   if (! cacheRoot.exists) cacheRoot.mkdirs()

--- a/spark/src/main/scala/geotrellis/spark/util/cache/cache.scala
+++ b/spark/src/main/scala/geotrellis/spark/util/cache/cache.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable
  * K is the cache key
  * V is the cache value
  */
+@deprecated("This will be removed in favor of a pluggable cache in 2.0", "1.2")
 trait Cache[K,V] extends Serializable {
 
   /** Lookup the value for key k
@@ -60,6 +61,7 @@ trait Cache[K,V] extends Serializable {
 /** A Cache Strategy that completely ignores caching and always returns the input object
  * Operations on this cache execute in O(1) time
  */
+@deprecated("This will be removed in favor of a pluggable cache in 2.0", "1.2")
 class NoCache[K,V] extends Cache[K,V] {
   def lookup(k: K):Option[V] = None
   def insert(k: K, v: V):Boolean = false
@@ -69,6 +71,7 @@ class NoCache[K,V] extends Cache[K,V] {
 /** An unbounded hash-backed cache
  * Operations on this cache execute in O(1) time
  */
+@deprecated("This will be removed in favor of a pluggable cache in 2.0", "1.2")
 trait HashBackedCache[K,V] extends Cache[K,V] {
   val cache = new ConcurrentHashMap[K, V]()
 
@@ -80,6 +83,7 @@ trait HashBackedCache[K,V] extends Cache[K,V] {
 /** A hash backed cache with a size boundary
  * Operations on this cache may required O(N) time to execute (N = size of cache)
  */
+@deprecated("This will be removed in favor of a pluggable cache in 2.0", "1.2")
 trait BoundedCache[K,V] extends Cache[K,V] {
 
   /** Return the size of a a given cache item
@@ -142,6 +146,7 @@ trait BoundedCache[K,V] extends Cache[K,V] {
   def evicted(v: V): Unit = {}
 }
 
+@deprecated("This will be removed in favor of a pluggable cache in 2.0", "1.2")
 class LRUCache[K,V](val maxSize: Long, val sizeOf: V => Long = (v:V) => 1) extends HashBackedCache[K,V]  with BoundedCache[K,V] {
 
   /** Contains order of cache requests, with the key at the tail read most recently */


### PR DESCRIPTION
This PR deprecates the caches provided in `geotrellis.spark.util`, replaces their uses in the library with [scaffeine](https://github.com/blemale/scaffeine), and replaces the `AttributeStore` caching HashMap with one backed by Scaffeine.

Closes #1777 
Closes #2276
