### PR TITLE
Apply new grid to existing layer

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -53,6 +53,7 @@ package object spark
     with matching.Implicits
     with merge.Implicits
     with partition.Implicits
+    with regrid.Implicits
     with reproject.Implicits
     with resample.Implicits
     with rasterize.Implicits

--- a/spark/src/main/scala/geotrellis/spark/regrid/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Implicits.scala
@@ -17,7 +17,7 @@ object Implicits extends Implicits
 trait Implicits {
   implicit class withRegridMethods[
     K: SpatialComponent: ClassTag,
-    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]),
     M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
   ](self: RDD[(K, V)] with Metadata[M]) extends RegridMethods[K, V, M](self)
 }

--- a/spark/src/main/scala/geotrellis/spark/regrid/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Implicits.scala
@@ -1,0 +1,23 @@
+package geotrellis.spark.regrid
+
+import geotrellis.raster._
+import geotrellis.raster.crop._
+import geotrellis.raster.prototype._
+import geotrellis.raster.stitch._
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.util._
+
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+object Implicits extends Implicits
+
+trait Implicits {
+  implicit class withRegridMethods[
+    K: SpatialComponent: ClassTag,
+    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+    M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
+  ](self: RDD[(K, V)] with Metadata[M]) extends RegridMethods[K, V, M](self)
+}

--- a/spark/src/main/scala/geotrellis/spark/regrid/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Implicits.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.spark.regrid
 
 import geotrellis.raster._

--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -27,7 +27,7 @@ object Regrid {
     }
   }
 
-  def regrid[
+  def apply[
     K: SpatialComponent: ClassTag,
     V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
     M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
@@ -124,10 +124,10 @@ object Regrid {
     }
   }
 
-  def regrid[
+  def apply[
     K: SpatialComponent: ClassTag,
     V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
     M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
-  ](layer: RDD[(K, V)] with Metadata[M], tileSize: Int): RDD[(K, V)] with Metadata[M] = regrid(layer, tileSize, tileSize)
+  ](layer: RDD[(K, V)] with Metadata[M], tileSize: Int): RDD[(K, V)] with Metadata[M] = apply(layer, tileSize, tileSize)
 
 }

--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -9,143 +9,243 @@ import geotrellis.raster.stitch._
 import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import scala.reflect._
 import scala.collection.mutable
 
 object Regrid {
 
+  private case class Interval[N : Ordering](start: N, end: N) {
+    val ord = implicitly[Ordering[N]]
+    // let the interval be start to end, inclusive
+    def intersect(that: Interval[N]) = {
+        Interval(if (ord.compare(this.start, that.start) > 0) this.start else that.start, 
+                 if (ord.compare(this.end, that.end) < 0) this.end else that.end)
+    }
+  }
+
   def regrid[
     K: SpatialComponent: ClassTag,
     V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
     M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
-  ](layer: RDD[(K, V)] with Metadata[M], tileSize: Int): RDD[(K, V)] with Metadata[M] = {
+  ](layer: RDD[(K, V)] with Metadata[M], tileCols: Int, tileRows: Int): RDD[(K, V)] with Metadata[M] = {
     // println(layer.metadata.toJson.prettyPrint)
     val md = layer.metadata
     val ld = md.getComponent[LayoutDefinition]
 
-    if(ld.tileLayout.tileCols == tileSize) {
+    if(ld.tileLayout.tileCols == tileCols && ld.tileLayout.tileRows == tileRows) {
       layer
     } else {
       val ceil = { x: Double => math.ceil(x).toInt }
 
       val tl = ld.tileLayout
-      val oldTileSize = tl.tileCols
-      if(tileSize > oldTileSize) {
-        val r = tileSize / oldTileSize
-        val ntl = TileLayout(ceil(tl.layoutCols / r.toDouble), ceil(tl.layoutRows / r.toDouble), tileSize, tileSize)
-        val layoutDefinition =
-          LayoutDefinition(
-            ld.extent,
-            ntl
-          )
+      val oldEx = ld.extent
+      val CellSize(cellW, cellH) = ld.cellSize
 
-        val bounds =
-          md.getComponent[Bounds[K]] match {
-            case KeyBounds(minKey, maxKey) =>
-              val newMinKey = {
-                val SpatialKey(minKeyCol, minKeyRow) = minKey.getComponent[SpatialKey]
-                val sk = SpatialKey(minKeyCol / r, minKeyRow / r)
-                minKey.setComponent[SpatialKey](sk)
+      val (oldW, oldH) = (tl.tileCols, tl.tileRows)
+      val (newW, newH) = (tileCols, tileRows)
+      val ntl = TileLayout(ceil(tl.layoutCols * oldW / newW.toDouble), ceil(tl.layoutRows * oldH / newH.toDouble), tileCols, tileRows)
+
+      // Set up a new layout where the upper-left corner of the (0,0) spatial key
+      // is preserved, and the right and bottom edges are are adjusted to cover
+      // the new extent of the resized tiles
+      val nld = LayoutDefinition(
+        Extent(
+          oldEx.xmin, 
+          oldEx.ymax - cellH * tl.layoutRows * oldH, 
+          oldEx.xmin + cellW * tl.layoutCols * oldW, 
+          oldEx.ymax), 
+        ntl)
+
+      val bounds =
+        md.getComponent[Bounds[K]] match {
+          case KeyBounds(minKey, maxKey) =>
+            val newMinKey = {
+              val sk = nld.mapTransform(ld.mapTransform(minKey.getComponent[SpatialKey]).northWest)
+              minKey.setComponent[SpatialKey](sk)
+            }
+            val newMaxKey = {
+              val sk = nld.mapTransform(ld.mapTransform(maxKey.getComponent[SpatialKey]).southEast)
+              maxKey.setComponent[SpatialKey](sk)
+            }
+            KeyBounds(newMinKey, newMaxKey)
+          case EmptyBounds =>
+            EmptyBounds
+        }
+
+      val newMd =
+        md.setComponent[LayoutDefinition](nld)
+          .setComponent[Bounds[K]](bounds)
+
+      val tiled: RDD[(K, V)] =
+        layer
+          .flatMap{ case (key, oldTile) => {
+            val SpatialKey(oldX, oldY) = key
+
+            val oldXstart = oldX.toLong * oldW.toLong
+            val oldYstart = oldY.toLong * oldH.toLong
+            val oldXrange = Interval(oldXstart, oldXstart + oldW - 1)
+            val oldYrange = Interval(oldYstart, oldYstart + oldH - 1)
+
+            val tileEx = ld.mapTransform(key)
+            val newBounds = nld.mapTransform(tileEx)
+
+            for (
+              x <- newBounds.colMin to newBounds.colMax ;
+              newXrange = {
+                val newXstart = x * tileCols.toLong
+                Interval(newXstart, newXstart + tileCols - 1)
+              } ;
+              y <- newBounds.rowMin to newBounds.rowMax ;
+              newYrange = {
+                val newYstart = y * tileRows.toLong
+                Interval(newYstart, newYstart + tileRows - 1)
               }
-              val newMaxKey = {
-                val SpatialKey(maxKeyCol, maxKeyRow) = maxKey.getComponent[SpatialKey]
-                val sk = SpatialKey(ceil(maxKeyCol / r.toDouble), ceil(maxKeyRow / r.toDouble))
-                maxKey.setComponent[SpatialKey](sk)
-              }
-              KeyBounds(newMinKey, newMaxKey)
-            case EmptyBounds =>
-              EmptyBounds
-          }
+            ) yield {
+              val newKey = key.setComponent[SpatialKey](SpatialKey(x, y))
+              val xSpan: Interval[Long] = oldXrange intersect newXrange
+              val ySpan: Interval[Long] = oldYrange intersect newYrange
+              newKey -> 
+                (oldTile.crop((xSpan.start - oldXstart).toInt, 
+                              (ySpan.start - oldYstart).toInt, 
+                              (xSpan.end - oldXstart).toInt, 
+                              (ySpan.end - oldYstart).toInt),
+                 ((xSpan.start - newXrange.start).toInt, (ySpan.start - newYrange.start).toInt)
+                )
+            }
+          }}
+          .groupByKey
+          .mapValues { tiles => implicitly[Stitcher[V]].stitch(tiles, tileCols, tileRows) }
 
-        val newMd =
-          md.setComponent[LayoutDefinition](layoutDefinition)
-            .setComponent[Bounds[K]](bounds)
+      ContextRDD(tiled, newMd)
 
-        val tiled =
-          layer
-            .map { case (key, tile) =>
-                   val sk = key.getComponent[SpatialKey]
-                   val newKey = key.setComponent[SpatialKey](SpatialKey(sk.col / r, sk.row / r))
-                                                            (newKey, (key, tile))
-                 }
-        .groupByKey
-        .map { case (key, tiles) =>
-               val pieces =
-                 tiles.map { case (oldKey, oldTile) =>
-                             val SpatialKey(oldCol, oldRow) = oldKey.getComponent[SpatialKey]
-                             val updateCol = (oldCol % r) * oldTileSize
-                             val updateRow = (oldRow % r) * oldTileSize
-                             (oldTile, (updateCol, updateRow))
-                           }
-               val newTile =
-                   implicitly[Stitcher[V]].stitch(pieces, tileSize, tileSize)
+      // val ceil = { x: Double => math.ceil(x).toInt }
 
-               (key, newTile)
-             }
+      // val tl = ld.tileLayout
+      // val oldTileCols = tl.tileCols
+      // val oldTileRows = tl.tileRows
+      // if(tileSize > oldTileSize) {
+      //   val r = tileSize / oldTileSize
+      //   val ntl = TileLayout(ceil(tl.layoutCols / r.toDouble), ceil(tl.layoutRows / r.toDouble), tileSize, tileSize)
+      //   val layoutDefinition =
+      //     LayoutDefinition(
+      //       ld.extent,
+      //       ntl
+      //     )
 
-        ContextRDD(tiled, newMd)
-      } else {
-        val r = oldTileSize / tileSize
-        val ntl = TileLayout(tl.layoutCols * r, tl.layoutRows * r, tileSize, tileSize)
-        val layoutDefinition =
-          LayoutDefinition(
-            ld.extent,
-            ntl
-          )
+      //   val bounds =
+      //     md.getComponent[Bounds[K]] match {
+      //       case KeyBounds(minKey, maxKey) =>
+      //         val newMinKey = {
+      //           val SpatialKey(minKeyCol, minKeyRow) = minKey.getComponent[SpatialKey]
+      //           val sk = SpatialKey(minKeyCol / r, minKeyRow / r)
+      //           minKey.setComponent[SpatialKey](sk)
+      //         }
+      //         val newMaxKey = {
+      //           val SpatialKey(maxKeyCol, maxKeyRow) = maxKey.getComponent[SpatialKey]
+      //           val sk = SpatialKey(ceil(maxKeyCol / r.toDouble), ceil(maxKeyRow / r.toDouble))
+      //           maxKey.setComponent[SpatialKey](sk)
+      //         }
+      //         KeyBounds(newMinKey, newMaxKey)
+      //       case EmptyBounds =>
+      //         EmptyBounds
+      //     }
 
-        val bounds =
-          md.getComponent[Bounds[K]] match {
-            case KeyBounds(minKey, maxKey) =>
-              val newMinKey = {
-                val SpatialKey(minKeyCol, minKeyRow) = minKey.getComponent[SpatialKey]
-                val sk = SpatialKey(minKeyCol * r, minKeyRow * r)
-                minKey.setComponent[SpatialKey](sk)
-              }
-              val newMaxKey = {
-                val SpatialKey(maxKeyCol, maxKeyRow) = maxKey.getComponent[SpatialKey]
-                val sk = SpatialKey((maxKeyCol + 1) * r - 1, (maxKeyRow + 1) * r - 1)
-                maxKey.setComponent[SpatialKey](sk)
-              }
-              KeyBounds(newMinKey, newMaxKey)
-            case EmptyBounds =>
-              EmptyBounds
-          }
+      //   val newMd =
+      //     md.setComponent[LayoutDefinition](layoutDefinition)
+      //       .setComponent[Bounds[K]](bounds)
 
-        val newMd =
-          md.setComponent[LayoutDefinition](layoutDefinition)
-            .setComponent[Bounds[K]](bounds)
+      //   val tiled =
+      //     layer
+      //       .map { case (key, tile) =>
+      //              val sk = key.getComponent[SpatialKey]
+      //              val newKey = key.setComponent[SpatialKey](SpatialKey(sk.col / r, sk.row / r))
+      //                                                       (newKey, (key, tile))
+      //            }
+      //   .groupByKey
+      //   .map { case (key, tiles) =>
+      //          val pieces =
+      //            tiles.map { case (oldKey, oldTile) =>
+      //                        val SpatialKey(oldCol, oldRow) = oldKey.getComponent[SpatialKey]
+      //                        val updateCol = (oldCol % r) * oldTileSize
+      //                        val updateRow = (oldRow % r) * oldTileSize
+      //                        (oldTile, (updateCol, updateRow))
+      //                      }
+      //          val newTile =
+      //              implicitly[Stitcher[V]].stitch(pieces, tileSize, tileSize)
 
-        val layoutCols = r
-        val layoutRows = r
+      //          (key, newTile)
+      //        }
 
-        val tiled =
-          layer.flatMap { case (key, tile) =>
-                          val result = mutable.ListBuffer[(K, V)]()
-                          val thisKey = key.getComponent[SpatialKey]
-                          for(layoutRow <- 0 until layoutRows) {
-                            for(layoutCol <- 0 until layoutCols) {
-                              val sk = SpatialKey(thisKey.col * layoutCols + layoutCol, thisKey.row * layoutRows + layoutRow)
-                              val newTile =
-                                tile.crop(
-                                  GridBounds(
-                                    layoutCol * tileSize,
-                                    layoutRow * tileSize,
-                                    (layoutCol + 1) * tileSize - 1,
-                                    (layoutRow + 1) * tileSize - 1
-                                  )
-                                )
+      //   ContextRDD(tiled, newMd)
+      // } else {
+      //   val r = oldTileSize / tileSize
+      //   val ntl = TileLayout(tl.layoutCols * r, tl.layoutRows * r, tileSize, tileSize)
+      //   val layoutDefinition =
+      //     LayoutDefinition(
+      //       ld.extent,
+      //       ntl
+      //     )
 
-                              result += ((key.setComponent[SpatialKey](sk), newTile))
-                            }
-                          }
+      //   val bounds =
+      //     md.getComponent[Bounds[K]] match {
+      //       case KeyBounds(minKey, maxKey) =>
+      //         val newMinKey = {
+      //           val SpatialKey(minKeyCol, minKeyRow) = minKey.getComponent[SpatialKey]
+      //           val sk = SpatialKey(minKeyCol * r, minKeyRow * r)
+      //           minKey.setComponent[SpatialKey](sk)
+      //         }
+      //         val newMaxKey = {
+      //           val SpatialKey(maxKeyCol, maxKeyRow) = maxKey.getComponent[SpatialKey]
+      //           val sk = SpatialKey((maxKeyCol + 1) * r - 1, (maxKeyRow + 1) * r - 1)
+      //           maxKey.setComponent[SpatialKey](sk)
+      //         }
+      //         KeyBounds(newMinKey, newMaxKey)
+      //       case EmptyBounds =>
+      //         EmptyBounds
+      //     }
 
-                          result
-                        }
+      //   val newMd =
+      //     md.setComponent[LayoutDefinition](layoutDefinition)
+      //       .setComponent[Bounds[K]](bounds)
 
-        ContextRDD(tiled, newMd)
-      }
+      //   val layoutCols = r
+      //   val layoutRows = r
+
+      //   val tiled =
+      //     layer.flatMap { case (key, tile) =>
+      //                     val result = mutable.ListBuffer[(K, V)]()
+      //                     val thisKey = key.getComponent[SpatialKey]
+      //                     for(layoutRow <- 0 until layoutRows) {
+      //                       for(layoutCol <- 0 until layoutCols) {
+      //                         val sk = SpatialKey(thisKey.col * layoutCols + layoutCol, thisKey.row * layoutRows + layoutRow)
+      //                         val newTile =
+      //                           tile.crop(
+      //                             GridBounds(
+      //                               layoutCol * tileSize,
+      //                               layoutRow * tileSize,
+      //                               (layoutCol + 1) * tileSize - 1,
+      //                               (layoutRow + 1) * tileSize - 1
+      //                             )
+      //                           )
+
+      //                         result += ((key.setComponent[SpatialKey](sk), newTile))
+      //                       }
+      //                     }
+
+      //                     result
+      //                   }
+
+      //   ContextRDD(tiled, newMd)
+      // }
     }
   }
+
+  def regrid[
+    K: SpatialComponent: ClassTag,
+    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+    M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
+  ](layer: RDD[(K, V)] with Metadata[M], tileSize: Int): RDD[(K, V)] with Metadata[M] = regrid(layer, tileSize, tileSize)
 
 }

--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.spark.regrid
 
 import org.apache.spark.rdd.RDD
@@ -17,7 +33,7 @@ object Regrid {
 
   private case class Interval[N : Ordering](start: N, end: N) {
     val ord = implicitly[Ordering[N]]
-    assert(ord.compare(start, end) < 1)
+    assert(ord.compare(start, end) < 1, "Row/col intervals must begin before they end")
 
     // let the interval be start to end, inclusive
     def intersect(that: Interval[N]) = {

--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -1,0 +1,151 @@
+package geotrellis.spark.regrid
+
+import org.apache.spark.rdd.RDD
+
+import geotrellis.raster._
+import geotrellis.raster.crop._
+import geotrellis.raster.prototype._
+import geotrellis.raster.stitch._
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.util._
+
+import scala.reflect._
+import scala.collection.mutable
+
+object Regrid {
+
+  def regrid[
+    K: SpatialComponent: ClassTag,
+    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+    M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
+  ](layer: RDD[(K, V)] with Metadata[M], tileSize: Int): RDD[(K, V)] with Metadata[M] = {
+    // println(layer.metadata.toJson.prettyPrint)
+    val md = layer.metadata
+    val ld = md.getComponent[LayoutDefinition]
+
+    if(ld.tileLayout.tileCols == tileSize) {
+      layer
+    } else {
+      val ceil = { x: Double => math.ceil(x).toInt }
+
+      val tl = ld.tileLayout
+      val oldTileSize = tl.tileCols
+      if(tileSize > oldTileSize) {
+        val r = tileSize / oldTileSize
+        val ntl = TileLayout(ceil(tl.layoutCols / r.toDouble), ceil(tl.layoutRows / r.toDouble), tileSize, tileSize)
+        val layoutDefinition =
+          LayoutDefinition(
+            ld.extent,
+            ntl
+          )
+
+        val bounds =
+          md.getComponent[Bounds[K]] match {
+            case KeyBounds(minKey, maxKey) =>
+              val newMinKey = {
+                val SpatialKey(minKeyCol, minKeyRow) = minKey.getComponent[SpatialKey]
+                val sk = SpatialKey(minKeyCol / r, minKeyRow / r)
+                minKey.setComponent[SpatialKey](sk)
+              }
+              val newMaxKey = {
+                val SpatialKey(maxKeyCol, maxKeyRow) = maxKey.getComponent[SpatialKey]
+                val sk = SpatialKey(ceil(maxKeyCol / r.toDouble), ceil(maxKeyRow / r.toDouble))
+                maxKey.setComponent[SpatialKey](sk)
+              }
+              KeyBounds(newMinKey, newMaxKey)
+            case EmptyBounds =>
+              EmptyBounds
+          }
+
+        val newMd =
+          md.setComponent[LayoutDefinition](layoutDefinition)
+            .setComponent[Bounds[K]](bounds)
+
+        val tiled =
+          layer
+            .map { case (key, tile) =>
+                   val sk = key.getComponent[SpatialKey]
+                   val newKey = key.setComponent[SpatialKey](SpatialKey(sk.col / r, sk.row / r))
+                                                            (newKey, (key, tile))
+                 }
+        .groupByKey
+        .map { case (key, tiles) =>
+               val pieces =
+                 tiles.map { case (oldKey, oldTile) =>
+                             val SpatialKey(oldCol, oldRow) = oldKey.getComponent[SpatialKey]
+                             val updateCol = (oldCol % r) * oldTileSize
+                             val updateRow = (oldRow % r) * oldTileSize
+                             (oldTile, (updateCol, updateRow))
+                           }
+               val newTile =
+                   implicitly[Stitcher[V]].stitch(pieces, tileSize, tileSize)
+
+               (key, newTile)
+             }
+
+        ContextRDD(tiled, newMd)
+      } else {
+        val r = oldTileSize / tileSize
+        val ntl = TileLayout(tl.layoutCols * r, tl.layoutRows * r, tileSize, tileSize)
+        val layoutDefinition =
+          LayoutDefinition(
+            ld.extent,
+            ntl
+          )
+
+        val bounds =
+          md.getComponent[Bounds[K]] match {
+            case KeyBounds(minKey, maxKey) =>
+              val newMinKey = {
+                val SpatialKey(minKeyCol, minKeyRow) = minKey.getComponent[SpatialKey]
+                val sk = SpatialKey(minKeyCol * r, minKeyRow * r)
+                minKey.setComponent[SpatialKey](sk)
+              }
+              val newMaxKey = {
+                val SpatialKey(maxKeyCol, maxKeyRow) = maxKey.getComponent[SpatialKey]
+                val sk = SpatialKey((maxKeyCol + 1) * r - 1, (maxKeyRow + 1) * r - 1)
+                maxKey.setComponent[SpatialKey](sk)
+              }
+              KeyBounds(newMinKey, newMaxKey)
+            case EmptyBounds =>
+              EmptyBounds
+          }
+
+        val newMd =
+          md.setComponent[LayoutDefinition](layoutDefinition)
+            .setComponent[Bounds[K]](bounds)
+
+        val layoutCols = r
+        val layoutRows = r
+
+        val tiled =
+          layer.flatMap { case (key, tile) =>
+                          val result = mutable.ListBuffer[(K, V)]()
+                          val thisKey = key.getComponent[SpatialKey]
+                          for(layoutRow <- 0 until layoutRows) {
+                            for(layoutCol <- 0 until layoutCols) {
+                              val sk = SpatialKey(thisKey.col * layoutCols + layoutCol, thisKey.row * layoutRows + layoutRow)
+                              val newTile =
+                                tile.crop(
+                                  GridBounds(
+                                    layoutCol * tileSize,
+                                    layoutRow * tileSize,
+                                    (layoutCol + 1) * tileSize - 1,
+                                    (layoutRow + 1) * tileSize - 1
+                                  )
+                                )
+
+                              result += ((key.setComponent[SpatialKey](sk), newTile))
+                            }
+                          }
+
+                          result
+                        }
+
+        ContextRDD(tiled, newMd)
+      }
+    }
+  }
+
+}

--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -12,13 +12,12 @@ import geotrellis.util._
 import geotrellis.vector._
 
 import scala.reflect._
-import scala.collection.mutable
 
 object Regrid {
 
   private case class Interval[N : Ordering](start: N, end: N) {
     val ord = implicitly[Ordering[N]]
-    // assert(ord.compare(start, end) < 1)
+    assert(ord.compare(start, end) < 1)
 
     // let the interval be start to end, inclusive
     def intersect(that: Interval[N]) = {
@@ -29,7 +28,7 @@ object Regrid {
 
   def apply[
     K: SpatialComponent: ClassTag,
-    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]),
     M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
   ](layer: RDD[(K, V)] with Metadata[M], tileCols: Int, tileRows: Int): RDD[(K, V)] with Metadata[M] = {
     val md = layer.metadata
@@ -89,9 +88,6 @@ object Regrid {
             val oldXrange = Interval(oldXstart, oldXstart + oldW - 1)
             val oldYrange = Interval(oldYstart, oldYstart + oldH - 1)
 
-            val tileEx = ld.mapTransform(key)
-            val newBounds = nld.mapTransform(tileEx)
-
             for (
               x <- (oldXstart / tileCols).toInt to (oldXrange.end.toDouble / tileCols).toInt ;
               newXrange = {
@@ -126,7 +122,7 @@ object Regrid {
 
   def apply[
     K: SpatialComponent: ClassTag,
-    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+    V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]),
     M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
   ](layer: RDD[(K, V)] with Metadata[M], tileSize: Int): RDD[(K, V)] with Metadata[M] = apply(layer, tileSize, tileSize)
 

--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -18,6 +18,7 @@ object Regrid {
 
   private case class Interval[N : Ordering](start: N, end: N) {
     val ord = implicitly[Ordering[N]]
+    assert(ord.compare(start, end) < 1)
     // let the interval be start to end, inclusive
     def intersect(that: Interval[N]) = {
         Interval(if (ord.compare(this.start, that.start) > 0) this.start else that.start, 
@@ -52,24 +53,26 @@ object Regrid {
       // the new extent of the resized tiles
       val nld = LayoutDefinition(
         Extent(
-          oldEx.xmin, 
-          oldEx.ymax - cellH * tl.layoutRows * oldH, 
-          oldEx.xmin + cellW * tl.layoutCols * oldW, 
-          oldEx.ymax), 
+          oldEx.xmin,
+          oldEx.ymax - cellH * ntl.layoutRows * tileRows,
+          oldEx.xmin + cellW * ntl.layoutCols * tileCols,
+          oldEx.ymax),
         ntl)
+      // println(s"Created new LayoutDefinition with ${nld.extent} and $ntl from ${ld.extent} and ${ld.tileLayout}")
 
       val bounds =
         md.getComponent[Bounds[K]] match {
           case KeyBounds(minKey, maxKey) =>
-            val newMinKey = {
-              val sk = nld.mapTransform(ld.mapTransform(minKey.getComponent[SpatialKey]).northWest)
-              minKey.setComponent[SpatialKey](sk)
-            }
-            val newMaxKey = {
-              val sk = nld.mapTransform(ld.mapTransform(maxKey.getComponent[SpatialKey]).southEast)
-              maxKey.setComponent[SpatialKey](sk)
-            }
-            KeyBounds(newMinKey, newMaxKey)
+            val ulSK = minKey.getComponent[SpatialKey]
+            val lrSK = maxKey.getComponent[SpatialKey]
+            val pxXrange = Interval(ulSK._1 * oldW.toLong, (lrSK._1 + 1) * oldW.toLong - 1)
+            val pxYrange = Interval(ulSK._2 * oldH.toLong, (lrSK._2 + 1) * oldH.toLong - 1)
+
+            val newMinKey = SpatialKey((pxXrange.start / tileCols).toInt, (pxYrange.start / tileRows).toInt)
+            val newMaxKey = SpatialKey((pxXrange.end / tileCols).toInt, (pxYrange.end / tileRows).toInt)
+
+            // println(s"In bounds calculation: $minKey became $newMinKey and $maxKey became $newMaxKey")
+            KeyBounds(minKey.setComponent[SpatialKey](newMinKey), maxKey.setComponent[SpatialKey](newMaxKey))
           case EmptyBounds =>
             EmptyBounds
         }
@@ -91,19 +94,27 @@ object Regrid {
             val tileEx = ld.mapTransform(key)
             val newBounds = nld.mapTransform(tileEx)
 
+            val xBounds = (oldXstart / tileCols).toInt to (oldXrange.end.toDouble / tileCols).toInt
+            val yBounds = (oldYstart / tileRows).toInt to (oldYrange.end.toDouble / tileRows).toInt
+
+            // println(s"For $key:\n\tIntersects $newBounds in new layout (x: $xBounds, y: $yBounds) (pixel ranges, x=$oldXrange, y=$oldYrange)")
+
             for (
-              x <- newBounds.colMin to newBounds.colMax ;
+              // x <- newBounds.colMin to newBounds.colMax ;
+              x <- xBounds ;
               newXrange = {
                 val newXstart = x * tileCols.toLong
                 Interval(newXstart, newXstart + tileCols - 1)
               } ;
-              y <- newBounds.rowMin to newBounds.rowMax ;
+              // y <- newBounds.rowMin to newBounds.rowMax ;
+              y <- yBounds ;
               newYrange = {
                 val newYstart = y * tileRows.toLong
                 Interval(newYstart, newYstart + tileRows - 1)
               }
             ) yield {
               val newKey = key.setComponent[SpatialKey](SpatialKey(x, y))
+
               val xSpan: Interval[Long] = oldXrange intersect newXrange
               val ySpan: Interval[Long] = oldYrange intersect newYrange
               newKey -> 
@@ -119,126 +130,6 @@ object Regrid {
           .mapValues { tiles => implicitly[Stitcher[V]].stitch(tiles, tileCols, tileRows) }
 
       ContextRDD(tiled, newMd)
-
-      // val ceil = { x: Double => math.ceil(x).toInt }
-
-      // val tl = ld.tileLayout
-      // val oldTileCols = tl.tileCols
-      // val oldTileRows = tl.tileRows
-      // if(tileSize > oldTileSize) {
-      //   val r = tileSize / oldTileSize
-      //   val ntl = TileLayout(ceil(tl.layoutCols / r.toDouble), ceil(tl.layoutRows / r.toDouble), tileSize, tileSize)
-      //   val layoutDefinition =
-      //     LayoutDefinition(
-      //       ld.extent,
-      //       ntl
-      //     )
-
-      //   val bounds =
-      //     md.getComponent[Bounds[K]] match {
-      //       case KeyBounds(minKey, maxKey) =>
-      //         val newMinKey = {
-      //           val SpatialKey(minKeyCol, minKeyRow) = minKey.getComponent[SpatialKey]
-      //           val sk = SpatialKey(minKeyCol / r, minKeyRow / r)
-      //           minKey.setComponent[SpatialKey](sk)
-      //         }
-      //         val newMaxKey = {
-      //           val SpatialKey(maxKeyCol, maxKeyRow) = maxKey.getComponent[SpatialKey]
-      //           val sk = SpatialKey(ceil(maxKeyCol / r.toDouble), ceil(maxKeyRow / r.toDouble))
-      //           maxKey.setComponent[SpatialKey](sk)
-      //         }
-      //         KeyBounds(newMinKey, newMaxKey)
-      //       case EmptyBounds =>
-      //         EmptyBounds
-      //     }
-
-      //   val newMd =
-      //     md.setComponent[LayoutDefinition](layoutDefinition)
-      //       .setComponent[Bounds[K]](bounds)
-
-      //   val tiled =
-      //     layer
-      //       .map { case (key, tile) =>
-      //              val sk = key.getComponent[SpatialKey]
-      //              val newKey = key.setComponent[SpatialKey](SpatialKey(sk.col / r, sk.row / r))
-      //                                                       (newKey, (key, tile))
-      //            }
-      //   .groupByKey
-      //   .map { case (key, tiles) =>
-      //          val pieces =
-      //            tiles.map { case (oldKey, oldTile) =>
-      //                        val SpatialKey(oldCol, oldRow) = oldKey.getComponent[SpatialKey]
-      //                        val updateCol = (oldCol % r) * oldTileSize
-      //                        val updateRow = (oldRow % r) * oldTileSize
-      //                        (oldTile, (updateCol, updateRow))
-      //                      }
-      //          val newTile =
-      //              implicitly[Stitcher[V]].stitch(pieces, tileSize, tileSize)
-
-      //          (key, newTile)
-      //        }
-
-      //   ContextRDD(tiled, newMd)
-      // } else {
-      //   val r = oldTileSize / tileSize
-      //   val ntl = TileLayout(tl.layoutCols * r, tl.layoutRows * r, tileSize, tileSize)
-      //   val layoutDefinition =
-      //     LayoutDefinition(
-      //       ld.extent,
-      //       ntl
-      //     )
-
-      //   val bounds =
-      //     md.getComponent[Bounds[K]] match {
-      //       case KeyBounds(minKey, maxKey) =>
-      //         val newMinKey = {
-      //           val SpatialKey(minKeyCol, minKeyRow) = minKey.getComponent[SpatialKey]
-      //           val sk = SpatialKey(minKeyCol * r, minKeyRow * r)
-      //           minKey.setComponent[SpatialKey](sk)
-      //         }
-      //         val newMaxKey = {
-      //           val SpatialKey(maxKeyCol, maxKeyRow) = maxKey.getComponent[SpatialKey]
-      //           val sk = SpatialKey((maxKeyCol + 1) * r - 1, (maxKeyRow + 1) * r - 1)
-      //           maxKey.setComponent[SpatialKey](sk)
-      //         }
-      //         KeyBounds(newMinKey, newMaxKey)
-      //       case EmptyBounds =>
-      //         EmptyBounds
-      //     }
-
-      //   val newMd =
-      //     md.setComponent[LayoutDefinition](layoutDefinition)
-      //       .setComponent[Bounds[K]](bounds)
-
-      //   val layoutCols = r
-      //   val layoutRows = r
-
-      //   val tiled =
-      //     layer.flatMap { case (key, tile) =>
-      //                     val result = mutable.ListBuffer[(K, V)]()
-      //                     val thisKey = key.getComponent[SpatialKey]
-      //                     for(layoutRow <- 0 until layoutRows) {
-      //                       for(layoutCol <- 0 until layoutCols) {
-      //                         val sk = SpatialKey(thisKey.col * layoutCols + layoutCol, thisKey.row * layoutRows + layoutRow)
-      //                         val newTile =
-      //                           tile.crop(
-      //                             GridBounds(
-      //                               layoutCol * tileSize,
-      //                               layoutRow * tileSize,
-      //                               (layoutCol + 1) * tileSize - 1,
-      //                               (layoutRow + 1) * tileSize - 1
-      //                             )
-      //                           )
-
-      //                         result += ((key.setComponent[SpatialKey](sk), newTile))
-      //                       }
-      //                     }
-
-      //                     result
-      //                   }
-
-      //   ContextRDD(tiled, newMd)
-      // }
     }
   }
 

--- a/spark/src/main/scala/geotrellis/spark/regrid/RegridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/RegridMethods.scala
@@ -1,0 +1,25 @@
+package geotrellis.spark.regrid
+
+import geotrellis.raster._
+import geotrellis.raster.crop._
+import geotrellis.raster.prototype._
+import geotrellis.raster.stitch._
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.util._
+
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+class RegridMethods[
+  K: SpatialComponent: ClassTag,
+  V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+  M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
+](val self: RDD[(K, V)] with Metadata[M]) extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
+
+  def regrid(tileCols: Int, tileRows: Int): RDD[(K, V)] with Metadata[M] = Regrid(self, tileCols, tileRows)
+
+  def regrid(tileSize: Int): RDD[(K, V)] with Metadata[M] = Regrid(self, tileSize)
+
+}  

--- a/spark/src/main/scala/geotrellis/spark/regrid/RegridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/RegridMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.spark.regrid
 
 import geotrellis.raster._

--- a/spark/src/main/scala/geotrellis/spark/regrid/RegridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/RegridMethods.scala
@@ -14,7 +14,7 @@ import scala.reflect.ClassTag
 
 class RegridMethods[
   K: SpatialComponent: ClassTag,
-  V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+  V <: CellGrid: ClassTag: Stitcher: (? => CropMethods[V]),
   M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
 ](val self: RDD[(K, V)] with Metadata[M]) extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
 

--- a/spark/src/test/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/test/scala/geotrellis/spark/regrid/Regrid.scala
@@ -1,0 +1,69 @@
+package geotrellis.spark.regrid
+
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.raster.testkit._
+import geotrellis.spark._
+import geotrellis.spark.testkit._
+import geotrellis.spark.tiling._
+import geotrellis.vector._
+
+import org.scalatest._
+
+class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
+
+  val simpleLayer = {
+    val tiles = 
+      for ( x <- 0 to 3 ;
+            y <- 0 to 2
+      ) yield {
+        val tile = IntArrayTile.ofDim(32, 32)
+        (SpatialKey(x, y), tile.map{ (tx, ty, _) => math.max(tx + 32 * x, ty + 32 * y) })
+      }
+    val rdd = sc.parallelize(tiles)
+    val ex = Extent(0,0,12.8,9.6)
+    val ld = LayoutDefinition(GridExtent(ex, 0.1, 0.1), 32, 32)
+    val md = TileLayerMetadata[SpatialKey](IntConstantNoDataCellType,
+                                           ld,
+                                           ex,
+                                           LatLng,
+                                           KeyBounds[SpatialKey](SpatialKey(0,0), SpatialKey(3,2)))
+    ContextRDD(rdd, md)
+  }
+
+  describe("Regridding") {
+    it("should allow chipping into smaller tiles") {
+      val newLayer = Regrid.regrid(simpleLayer, 16, 16)
+
+      import geotrellis.raster.render._
+      val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
+      newLayer.stitch.tile.renderPng(cm).write("regrid_16.png")
+
+      assert(simpleLayer.stitch.dimensions == newLayer.stitch.dimensions)
+      assertEqual(simpleLayer.stitch, newLayer.stitch)
+    }
+
+    it("should allow joining into larger tiles") {
+      val newLayer = Regrid.regrid(simpleLayer, 64, 64)
+
+      import geotrellis.raster.render._
+      val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
+      newLayer.stitch.tile.renderPng(cm).write("regrid_64.png")
+
+      assert(newLayer.stitch.dimensions == (128, 128))
+      assertEqual(simpleLayer.stitch, newLayer.stitch.tile.crop(0,0,127,95))
+    }
+
+    it("should allow breaking into non-square tiles") {
+      val newLayer = Regrid.regrid(simpleLayer, 50, 25)
+
+      import geotrellis.raster.render._
+      val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
+      newLayer.stitch.tile.renderPng(cm).write("regrid_50_25.png")
+
+      assert(newLayer.stitch.dimensions == (150, 100))
+      assertEqual(simpleLayer.stitch, newLayer.stitch.tile.crop(0,0,127,95))
+    }
+  }
+
+}

--- a/spark/src/test/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/test/scala/geotrellis/spark/regrid/Regrid.scala
@@ -35,9 +35,9 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
     it("should allow chipping into smaller tiles") {
       val newLayer = Regrid.regrid(simpleLayer, 16, 16)
 
-      import geotrellis.raster.render._
-      val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
-      newLayer.stitch.tile.renderPng(cm).write("regrid_16.png")
+      // import geotrellis.raster.render._
+      // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
+      // newLayer.stitch.tile.renderPng(cm).write("regrid_16.png")
 
       assert(simpleLayer.stitch.dimensions == newLayer.stitch.dimensions)
       assertEqual(simpleLayer.stitch, newLayer.stitch)
@@ -46,9 +46,9 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
     it("should allow joining into larger tiles") {
       val newLayer = Regrid.regrid(simpleLayer, 64, 64)
 
-      import geotrellis.raster.render._
-      val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
-      newLayer.stitch.tile.renderPng(cm).write("regrid_64.png")
+      // import geotrellis.raster.render._
+      // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
+      // newLayer.stitch.tile.renderPng(cm).write("regrid_64.png")
 
       assert(newLayer.stitch.dimensions == (128, 128))
       assertEqual(simpleLayer.stitch, newLayer.stitch.tile.crop(0,0,127,95))
@@ -57,9 +57,9 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
     it("should allow breaking into non-square tiles") {
       val newLayer = Regrid.regrid(simpleLayer, 50, 25)
 
-      import geotrellis.raster.render._
-      val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
-      newLayer.stitch.tile.renderPng(cm).write("regrid_50_25.png")
+      // import geotrellis.raster.render._
+      // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
+      // newLayer.stitch.tile.renderPng(cm).write("regrid_50_25.png")
 
       assert(newLayer.stitch.dimensions == (150, 100))
       assertEqual(simpleLayer.stitch, newLayer.stitch.tile.crop(0,0,127,95))

--- a/spark/src/test/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/test/scala/geotrellis/spark/regrid/Regrid.scala
@@ -33,7 +33,7 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
 
   describe("Regridding") {
     it("should allow chipping into smaller tiles") {
-      val newLayer = Regrid.regrid(simpleLayer, 16, 16)
+      val newLayer = simpleLayer.regrid(16)
 
       // import geotrellis.raster.render._
       // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
@@ -44,7 +44,7 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
     }
 
     it("should allow joining into larger tiles") {
-      val newLayer = Regrid.regrid(simpleLayer, 64, 64)
+      val newLayer = simpleLayer.regrid(64)
 
       // import geotrellis.raster.render._
       // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
@@ -55,7 +55,7 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
     }
 
     it("should allow breaking into non-square tiles") {
-      val newLayer = Regrid.regrid(simpleLayer, 50, 25)
+      val newLayer = simpleLayer.regrid(50, 25)
 
       // import geotrellis.raster.render._
       // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)

--- a/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
@@ -35,10 +35,6 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
     it("should allow chipping into smaller tiles") {
       val newLayer = simpleLayer.regrid(16)
 
-      // import geotrellis.raster.render._
-      // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
-      // newLayer.stitch.tile.renderPng(cm).write("regrid_16.png")
-
       assert(simpleLayer.stitch.dimensions == newLayer.stitch.dimensions)
       assertEqual(simpleLayer.stitch, newLayer.stitch)
     }
@@ -46,20 +42,12 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
     it("should allow joining into larger tiles") {
       val newLayer = simpleLayer.regrid(64)
 
-      // import geotrellis.raster.render._
-      // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
-      // newLayer.stitch.tile.renderPng(cm).write("regrid_64.png")
-
       assert(newLayer.stitch.dimensions == (128, 128))
       assertEqual(simpleLayer.stitch, newLayer.stitch.tile.crop(0,0,127,95))
     }
 
     it("should allow breaking into non-square tiles") {
       val newLayer = simpleLayer.regrid(50, 25)
-
-      // import geotrellis.raster.render._
-      // val cm = ColorMap((0 to 128).toArray, ColorRamps.Plasma)
-      // newLayer.stitch.tile.renderPng(cm).write("regrid_50_25.png")
 
       assert(newLayer.stitch.dimensions == (150, 100))
       assertEqual(simpleLayer.stitch, newLayer.stitch.tile.crop(0,0,127,95))

--- a/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.spark.regrid
 
 import geotrellis.proj4._


### PR DESCRIPTION
Fixes #2283 

When presented with a layer containing Tiles of a set resolution, it may be desirable to generate a layer with the same pixel data in a different tile resolution.  This will produce a layer over the same extent with the same cellSize but different KeyBounds.  The exact area of tile coverage may differ (i.e., regridding a 10X10 layout of 32x32 tiles to 100x100 tiles will yield a 4x4 layout, implying a 400x400 overall size—though the tiles on the right and bottom edges will have a large complement of no data cells), but the defined pixels will have the same content (that is, a stitch() of both layers will be the same, modulo the no data cells on the boundary required for padding).