### PR TITLE
Allow Merge Queue To Handle Larger Inputs

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/index/MergeQueue.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/MergeQueue.scala
@@ -56,22 +56,24 @@ class MergeQueue(initialSize: Int = 1) {
     * Return a list of merged intervals.
     */
   def toSeq: Seq[(Long, Long)] = {
-    val stack = mutable.ListBuffer.empty[(Long, Long)]
+    var stack = List.empty[(Long, Long)]
 
-    if (!treeSet.isEmpty) stack.append(treeSet.pollFirst)
+    if (!treeSet.isEmpty) stack = (treeSet.pollFirst) +: stack
     while (!treeSet.isEmpty) {
       val (nextStart, nextEnd) = treeSet.pollFirst
-      val (currStart, currEnd) = stack.last
+      val (currStart, currEnd) = stack.head
 
       // Overlap
       if ((nextStart <= currStart && currStart <= nextEnd) || (nextStart <= (currEnd+fudge) && currEnd <= nextEnd)) {
         // If new interval ends after the current one, extend the current one
-        if (currEnd < nextEnd) stack(stack.length-1) = (currStart, nextEnd)
+        if (currEnd < nextEnd) {
+          stack = (currStart, nextEnd) +: (stack.tail)
+        }
       }
-      else stack.append((nextStart, nextEnd))
+      else stack = (nextStart, nextEnd) +: stack
     }
 
-    stack.toList
+    stack.reverse
   }
 
 }

--- a/spark/src/main/scala/geotrellis/spark/io/index/MergeQueue.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/MergeQueue.scala
@@ -57,15 +57,16 @@ class MergeQueue(initialSize: Int = 1) {
     */
   def toSeq: Seq[(Long, Long)] = {
     var stack = List.empty[(Long, Long)]
+    val ts = treeSet.clone.asInstanceOf[java.util.TreeSet[(Long,Long)]]
 
-    if (!treeSet.isEmpty) stack = (treeSet.pollFirst) +: stack
-    while (!treeSet.isEmpty) {
-      val (nextStart, nextEnd) = treeSet.pollFirst
+    if (!ts.isEmpty) stack = (ts.pollFirst) +: stack
+    while (!ts.isEmpty) {
+      val (nextStart, nextEnd) = ts.pollFirst
       val (currStart, currEnd) = stack.head
 
       // Overlap
       if (nextStart <= currStart && currStart <= nextEnd+fudge) {
-        // If new interval ends after the current one, extend the current one
+        // If new interval ends near the current one, extend the current one
         if (nextStart < currStart) {
           stack = (nextStart, currEnd) +: (stack.tail)
         }

--- a/spark/src/main/scala/geotrellis/spark/io/index/MergeQueue.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/MergeQueue.scala
@@ -31,10 +31,10 @@ object MergeQueue{
 private class RangeComparator extends java.util.Comparator[(Long, Long)] {
 
   def compare(r1: (Long, Long), r2: (Long, Long)): Int = {
-    val retval = (r1._1 - r2._1)
-    if (retval < 0) -1
+    val retval = (r1._2 - r2._2)
+    if (retval < 0) +1
     else if (retval == 0) 0
-    else +1
+    else -1
   }
 }
 
@@ -64,16 +64,16 @@ class MergeQueue(initialSize: Int = 1) {
       val (currStart, currEnd) = stack.head
 
       // Overlap
-      if ((nextStart <= currStart && currStart <= nextEnd) || (nextStart <= (currEnd+fudge) && currEnd <= nextEnd)) {
+      if (nextStart <= currStart && currStart <= nextEnd+fudge) {
         // If new interval ends after the current one, extend the current one
-        if (currEnd < nextEnd) {
-          stack = (currStart, nextEnd) +: (stack.tail)
+        if (nextStart < currStart) {
+          stack = (nextStart, currEnd) +: (stack.tail)
         }
       }
       else stack = (nextStart, nextEnd) +: stack
     }
 
-    stack.reverse
+    stack
   }
 
 }

--- a/spark/src/test/scala/geotrellis/spark/io/index/MergeQueueSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/MergeQueueSpec.scala
@@ -1,0 +1,58 @@
+package geotrellis.spark.io.index
+
+import java.time.{ZoneId, ZonedDateTime}
+
+import geotrellis.proj4.{LatLng, Sinusoidal}
+import geotrellis.raster._
+import geotrellis.spark.io._
+import geotrellis.spark._
+import geotrellis.spark.io.index.hilbert.HilbertSpaceTimeKeyIndex
+import geotrellis.spark.io.index.zcurve.ZSpaceTimeKeyIndex
+import geotrellis.spark.tiling._
+import geotrellis.vector.io._
+import geotrellis.vector.io.json.JsonFeatureCollection
+import geotrellis.vector._
+import org.scalatest._
+
+class MergeQueueSpec extends FunSpec {
+
+  //val mPoly = MultiPolygon(mPolys.flatMap(p => p.reproject(LatLng, Sinusoidal).polygons))
+
+  val seed = 32269
+  val rgen = new scala.util.Random(seed)
+
+  def randomSquare(bounds: Extent, side: Double) = {
+    val x = bounds.xmin + rgen.nextFloat()*(bounds.width - side)
+    val y = bounds.ymin + rgen.nextFloat()*(bounds.height - side)
+    Polygon(Point(x,y),Point(x+side,y),Point(x+side,y+side),Point(x,y+side),Point(x,y))
+  }
+
+  val polys = for (i <- 1 to 1500) yield randomSquare(LatLng.worldExtent,.5)
+  val mPoly = MultiPolygon(polys)
+
+  val worldKB = KeyBounds(SpaceTimeKey(0, 0, 1325376000000L), SpaceTimeKey(360, 180, 1355788800000L))
+  val layout = LayoutDefinition(LatLng.worldExtent, TileLayout(360, 180, 240, 240))
+  val md = TileLayerMetadata(
+    IntCellType,
+    layout,
+    LatLng.worldExtent,
+    LatLng,
+    worldKB)
+
+  val index = ZSpaceTimeKeyIndex.byDay(worldKB)
+  //val index = HilbertSpaceTimeKeyIndex(worldKB, 21, 9)
+
+  it("reproducing bad behavior...") {
+
+    val query = new LayerQuery[SpaceTimeKey, TileLayerMetadata[SpaceTimeKey]]
+      .where(Intersects(mPoly))
+      .where(Between(ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.of("Zulu")), ZonedDateTime.of(2012, 12, 31, 0, 0, 0, 0, ZoneId.of("Zulu"))))
+    val kbs = query(md)
+    val ranges = kbs.flatMap(kb => index.indexRanges(kb))
+    val cnt = ranges.size
+    println(s"ZIndex cnt: $cnt")
+
+    val mq = MergeQueue(ranges)
+    println(s"mq cnt: ${mq.size}")
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/io/index/MergeQueueSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/MergeQueueSpec.scala
@@ -31,7 +31,7 @@ class MergeQueueSpec extends FunSpec {
 
 
     val numSides = if(maxNumSides <= 3) 3 else rgen.nextInt(maxNumSides - 2) + 3
-    val polars = for(_ <- 3 to numSides) yield (rgen.nextDouble*2.0*Math.PI, rgen.nextDouble*maxSideLength)
+    val polars = for(_ <- 1 to numSides) yield (rgen.nextDouble*2.0*Math.PI, rgen.nextDouble*maxSideLength)
     polars.sortBy(_._1)
     val points = polars.map { tup =>
       val (r,theta) = tup

--- a/spark/src/test/scala/geotrellis/spark/io/index/MergeQueueSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/MergeQueueSpec.scala
@@ -59,7 +59,7 @@ class MergeQueueSpec extends FunSpec {
   val index = ZSpaceTimeKeyIndex.byDay(worldKB)
   //val index = HilbertSpaceTimeKeyIndex(worldKB, 21, 9)
 
-  it("reproducing bad behavior...") {
+  it("should work on high-cardinality range sets") {
 
     val query = new LayerQuery[SpaceTimeKey, TileLayerMetadata[SpaceTimeKey]]
       .where(Intersects(mPoly))


### PR DESCRIPTION
These changes simplify `MergeQueue` and improve its efficiency.  Thank you to @mteldridge for noticing this issue.

Connects https://github.com/locationtech/geotrellis/issues/2358