### PR TITLE
migration-manager Support to GeoTrellis

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -25,6 +25,7 @@ object Version {
   val cassandra   = "3.2.0"
   val hbase       = "1.3.1"
   val geomesa     = "1.2.8"
+  val previousVersion = "1.1.0"
   lazy val hadoop = Environment.hadoopVersion
   lazy val spark  = Environment.sparkVersion
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,3 +24,5 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.4")
 
 addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.2")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")

--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -26,6 +26,10 @@ libraryDependencies := {
   }
 }
 
+mimaPreviousArtifacts := Set(
+  "org.locationtech.geotrellis" %% "geotrellis-raster" % Version.previousVersion
+)
+
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
 sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.genRaster).taskValue

--- a/s3/build.sbt
+++ b/s3/build.sbt
@@ -10,6 +10,10 @@ libraryDependencies ++= Seq(
 fork in Test := false
 parallelExecution in Test := false
 
+mimaPreviousArtifacts := Set(
+  "org.locationtech.geotrellis" %% "geotrellis-s3" % Version.previousVersion
+)
+
 initialCommands in console :=
   """
   import geotrellis.raster._

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -16,6 +16,10 @@ libraryDependencies ++= Seq(
   scaffeine
 )
 
+mimaPreviousArtifacts := Set(
+  "org.locationtech.geotrellis" %% "geotrellis-spark" % Version.previousVersion
+)
+
 fork in Test := false
 parallelExecution in Test := false
 


### PR DESCRIPTION
This PR adds [migration-manager](https://github.com/typesafehub/migration-manager) support to the `raster`, `spark`, and `s3` projects. By running `mimaReportBinaryIssues` in `sbt`, a list of potential binary compatibility issues between the current and previous version of the project will be shown.

This is what the output looks like when there are issues found:

```
[info] geotrellis-spark: found 21 potential binary incompatibilities while checking against org.locationtech.geotrellis:geotrellis-spark_2.11:1.1.0 
[error]  * abstract method overwrite(java.lang.Object,org.apache.spark.rdd.RDD,geotrellis.spark.io.avro.AvroRecordCodec,geotrellis.spark.Boundable,spray.json.JsonFormat,scala.reflect.ClassTag,geotrellis.spark.io.avro.AvroRecordCodec,scala.reflect.ClassTag,spray.json.JsonFormat,geotrellis.util.GetComponent,geotrellis.spark.merge.Mergable)Unit in class geotrellis.spark.io.LayerUpdater is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.LayerUpdater.overwrite")
[error]  * abstract method readWindows(Array[geotrellis.raster.GridBounds],geotrellis.raster.io.geotiff.reader.GeoTiffReader#GeoTiffInfo,java.lang.Object)scala.collection.Iterator in interface geotrellis.spark.io.RasterReader is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.RasterReader.readWindows")
[error]  * synthetic method geotrellis$spark$io$AttributeCaching$_setter_$geotrellis$spark$io$AttributeCaching$$expiration_=(Int)Unit in trait geotrellis.spark.io.AttributeCaching is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.AttributeCaching.geotrellis$spark$io$AttributeCaching$_setter_$geotrellis$spark$io$AttributeCaching$$expiration_=")
[error]  * synthetic method geotrellis$spark$io$AttributeCaching$_setter_$geotrellis$spark$io$AttributeCaching$$cache_=(com.github.blemale.scaffeine.Cache)Unit in trait geotrellis.spark.io.AttributeCaching is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.AttributeCaching.geotrellis$spark$io$AttributeCaching$_setter_$geotrellis$spark$io$AttributeCaching$$cache_=")
[error]  * synthetic method geotrellis$spark$io$AttributeCaching$$expiration()Int in trait geotrellis.spark.io.AttributeCaching is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.AttributeCaching.geotrellis$spark$io$AttributeCaching$$expiration")
[error]  * synthetic method geotrellis$spark$io$AttributeCaching$$maxSize()Int in trait geotrellis.spark.io.AttributeCaching is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.AttributeCaching.geotrellis$spark$io$AttributeCaching$$maxSize")
[error]  * synthetic method geotrellis$spark$io$AttributeCaching$$cache()com.github.blemale.scaffeine.Cache in trait geotrellis.spark.io.AttributeCaching is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.AttributeCaching.geotrellis$spark$io$AttributeCaching$$cache")
[error]  * synthetic method geotrellis$spark$io$AttributeCaching$_setter_$geotrellis$spark$io$AttributeCaching$$maxSize_=(Int)Unit in trait geotrellis.spark.io.AttributeCaching is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.AttributeCaching.geotrellis$spark$io$AttributeCaching$_setter_$geotrellis$spark$io$AttributeCaching$$maxSize_=")
[error]  * abstract method attributeStore()geotrellis.spark.io.AttributeStore in interface geotrellis.spark.io.ValueReader is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.ValueReader.attributeStore")
[error]  * the type hierarchy of object geotrellis.spark.io.package is different in current version. Missing types {geotrellis.spark.io.avro.codecs.VectorTileCodec}
[error]    filter with: ProblemFilters.exclude[MissingTypesProblem]("geotrellis.spark.io.package$")
[error]  * method vectorTileCodec()geotrellis.spark.io.avro.AvroRecordCodec in object geotrellis.spark.io.package does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("geotrellis.spark.io.package.vectorTileCodec")
[error]  * method validateUpdate(geotrellis.spark.LayerId,java.lang.Object,spray.json.JsonFormat,geotrellis.spark.io.avro.AvroRecordCodec,geotrellis.spark.Boundable,spray.json.JsonFormat,scala.reflect.ClassTag,geotrellis.spark.io.avro.AvroRecordCodec,geotrellis.util.GetComponent,geotrellis.spark.merge.Mergable,spray.json.JsonFormat)scala.Option in trait geotrellis.spark.io.LayerWriter is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.LayerWriter.validateUpdate")
[error]  * method update(java.lang.Object,org.apache.spark.rdd.RDD,scala.Function2,geotrellis.spark.io.avro.AvroRecordCodec,geotrellis.spark.Boundable,spray.json.JsonFormat,scala.reflect.ClassTag,geotrellis.spark.io.avro.AvroRecordCodec,scala.reflect.ClassTag,spray.json.JsonFormat,geotrellis.util.GetComponent,geotrellis.spark.merge.Mergable)Unit in trait geotrellis.spark.io.LayerWriter is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.LayerWriter.update")
[error]  * method overwrite(java.lang.Object,org.apache.spark.rdd.RDD,geotrellis.spark.io.avro.AvroRecordCodec,geotrellis.spark.Boundable,spray.json.JsonFormat,scala.reflect.ClassTag,geotrellis.spark.io.avro.AvroRecordCodec,scala.reflect.ClassTag,spray.json.JsonFormat,geotrellis.util.GetComponent,geotrellis.spark.merge.Mergable)Unit in trait geotrellis.spark.io.LayerWriter is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.io.LayerWriter.overwrite")
[error]  * method write(org.apache.spark.rdd.RDD,org.apache.hadoop.fs.Path,geotrellis.spark.io.index.KeyIndex,Int,geotrellis.spark.io.avro.AvroRecordCodec,scala.reflect.ClassTag,geotrellis.spark.io.avro.AvroRecordCodec,scala.reflect.ClassTag)Unit in object geotrellis.spark.io.hadoop.HadoopRDDWriter does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("geotrellis.spark.io.hadoop.HadoopRDDWriter.write")
[error]  * the type hierarchy of trait geotrellis.spark.io.avro.codecs.Implicits is different in current version. Missing types {geotrellis.spark.io.avro.codecs.VectorTileCodec}
[error]    filter with: ProblemFilters.exclude[MissingTypesProblem]("geotrellis.spark.io.avro.codecs.Implicits")
[error]  * trait geotrellis.spark.io.avro.codecs.VectorTileCodec does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("geotrellis.spark.io.avro.codecs.VectorTileCodec")
[error]  * the type hierarchy of object geotrellis.spark.io.avro.codecs.Implicits is different in current version. Missing types {geotrellis.spark.io.avro.codecs.VectorTileCodec}
[error]    filter with: ProblemFilters.exclude[MissingTypesProblem]("geotrellis.spark.io.avro.codecs.Implicits$")
[error]  * method vectorTileCodec()geotrellis.spark.io.avro.AvroRecordCodec in object geotrellis.spark.io.avro.codecs.Implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("geotrellis.spark.io.avro.codecs.Implicits.vectorTileCodec")
[error]  * method withZonalSummaryMultibandTileLayerCollectionMethods(scala.collection.Seq,geotrellis.util.GetComponent,scala.reflect.ClassTag,geotrellis.util.Component)geotrellis.spark.summary.polygonal.Implicits#withZonalSummaryMultibandTileLayerCollectionMethods in trait geotrellis.spark.summary.polygonal.Implicits is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.summary.polygonal.Implicits.withZonalSummaryMultibandTileLayerCollectionMethods")
[error]  * method withZonalSummaryMultibandTileLayerRDDMethods(org.apache.spark.rdd.RDD,geotrellis.util.GetComponent,scala.reflect.ClassTag,geotrellis.util.Component)geotrellis.spark.summary.polygonal.Implicits#withZonalSummaryMultibandTileLayerRDDMethods in trait geotrellis.spark.summary.polygonal.Implicits is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("geotrellis.spark.summary.polygonal.Implicits.withZonalSummaryMultibandTileLayerRDDMethods")
[trace] Stack trace suppressed: run last spark/*:mimaReportBinaryIssues for the full output.
```

As noted in the output, it is possible to write filters so that only certain types of errors/warnings are shown.