### PR TITLE
Time-Oblivious toSpatial Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ index.js
 nohup.out
 
 site/
+
+derby.log
+metastore_db/

--- a/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
@@ -21,6 +21,9 @@ import geotrellis.util._
 
 import org.apache.spark.rdd._
 
+import scala.reflect.ClassTag
+
+
 object Implicits extends Implicits
 
 trait Implicits {
@@ -36,4 +39,10 @@ trait Implicits {
     V,
     M[_]
   ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialMethods[K, V, M]
+
+  implicit class withSpaceTimeToSpatialMethods2[
+    K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
+    V: ClassTag,
+    M[_]
+  ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialMethods2[K, V, M]
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
@@ -40,9 +40,9 @@ trait Implicits {
     M[_]
   ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialMethods[K, V, M]
 
-  implicit class withSpaceTimeToSpatialMethodsOblivious[
+  implicit class withSpaceTimeToSpatialReduceMethods[
     K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
     V: ClassTag,
     M[_]
-  ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialObliviousMethods[K, V, M]
+  ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialReduceMethods[K, V, M]
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
@@ -40,9 +40,9 @@ trait Implicits {
     M[_]
   ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialMethods[K, V, M]
 
-  implicit class withSpaceTimeToSpatialMethods2[
+  implicit class withSpaceTimeToSpatialMethodsOblivious[
     K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
     V: ClassTag,
     M[_]
-  ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialMethods2[K, V, M]
+  ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialObliviousMethods[K, V, M]
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.filter
 import geotrellis.spark._
 import geotrellis.util._
 
+import org.apache.spark.Partitioner
 import org.apache.spark.rdd._
+
 import java.time.ZonedDateTime
 
 import scala.reflect.ClassTag
@@ -51,12 +53,12 @@ abstract class SpaceTimeToSpatialObliviousMethods[
   M[_]
 ] extends MethodExtensions[RDD[(K, V)] with Metadata[M[K]]] {
 
-  def toSpatialObliviousUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
-    ToSpatial(self, ensureUnique = true)
+  def toSpatialObliviousUnique(
+    mergeFunc: Option[(V, V) => V] = None,
+    partitioner: Option[Partitioner] = None
+  ): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+    ToSpatial(self, mergeFunc, partitioner)
 
   def toSpatialObliviousNonUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
-    ToSpatial(self, ensureUnique = false)
-
-  def toSpatialOblivious(ensureUnique: Boolean): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
-    ToSpatial(self, ensureUnique = ensureUnique)
+    ToSpatial(self)
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
@@ -40,20 +40,23 @@ abstract class SpaceTimeToSpatialMethods[
 
 /**
   * This exists because `reduceByKey` needs K and V to be members of
-  * `ClassTag` but adding that restriction to the type parameters of
-  * the class above would break the API.  Neither methods can be named
-  * `toSpatial` as that would hide the methods provided by the class
-  * above.
+  * the `ClassTag` type class, but adding that restriction to the type
+  * parameters of the class above would break the API.  Neither method
+  * can be named `toSpatial` as that would hide the methods provided
+  * by the class above.
   */
-abstract class SpaceTimeToSpatialMethods2[
+abstract class SpaceTimeToSpatialObliviousMethods[
   K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
   V: ClassTag,
   M[_]
 ] extends MethodExtensions[RDD[(K, V)] with Metadata[M[K]]] {
 
-  def toSpatialEnsureUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+  def toSpatialObliviousUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
     ToSpatial(self, ensureUnique = true)
 
-  def toSpatialNoEnsureUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+  def toSpatialObliviousNonUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
     ToSpatial(self, ensureUnique = false)
+
+  def toSpatialOblivious(ensureUnique: Boolean): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+    ToSpatial(self, ensureUnique = ensureUnique)
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
@@ -38,6 +38,9 @@ abstract class SpaceTimeToSpatialMethods[
 
   def toSpatial(dateTime: ZonedDateTime): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
     toSpatial(dateTime.toInstant.toEpochMilli)
+
+  def toSpatial(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+    ToSpatial(self)
 }
 
 /**
@@ -47,18 +50,21 @@ abstract class SpaceTimeToSpatialMethods[
   * can be named `toSpatial` as that would hide the methods provided
   * by the class above.
   */
-abstract class SpaceTimeToSpatialObliviousMethods[
+abstract class SpaceTimeToSpatialReduceMethods[
   K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
   V: ClassTag,
   M[_]
 ] extends MethodExtensions[RDD[(K, V)] with Metadata[M[K]]] {
 
-  def toSpatialObliviousUnique(
-    mergeFunc: Option[(V, V) => V] = None,
-    partitioner: Option[Partitioner] = None
+  def toSpatialReduce(
+    mergeFunc: (V, V) => V
   ): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
-    ToSpatial(self, mergeFunc, partitioner)
+    ToSpatial(self, Some(mergeFunc), None)
 
-  def toSpatialObliviousNonUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
-    ToSpatial(self)
+  def toSpatialReduce(
+    mergeFunc: (V, V) => V,
+    partitioner: Partitioner
+  ): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+    ToSpatial(self, Some(mergeFunc), Some(partitioner))
+
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
@@ -22,6 +22,9 @@ import geotrellis.util._
 import org.apache.spark.rdd._
 import java.time.ZonedDateTime
 
+import scala.reflect.ClassTag
+
+
 /** See [[geotrellis.spark.filter.ToSpatial]] to get explanations about Metadata (M[K]) constrains */
 abstract class SpaceTimeToSpatialMethods[
   K: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
@@ -33,4 +36,24 @@ abstract class SpaceTimeToSpatialMethods[
 
   def toSpatial(dateTime: ZonedDateTime): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
     toSpatial(dateTime.toInstant.toEpochMilli)
+}
+
+/**
+  * This exists because `reduceByKey` needs K and V to be members of
+  * `ClassTag` but adding that restriction to the type parameters of
+  * the class above would break the API.  Neither methods can be named
+  * `toSpatial` as that would hide the methods provided by the class
+  * above.
+  */
+abstract class SpaceTimeToSpatialMethods2[
+  K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
+  V: ClassTag,
+  M[_]
+] extends MethodExtensions[RDD[(K, V)] with Metadata[M[K]]] {
+
+  def toSpatialEnsureUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+    ToSpatial(self, ensureUnique = true)
+
+  def toSpatialNoEnsureUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+    ToSpatial(self, ensureUnique = false)
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/ToSpatial.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/ToSpatial.scala
@@ -125,8 +125,8 @@ object ToSpatial {
   }
 
   def apply[
-    K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
-    V: ClassTag,
+    K: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
+    V,
     M[_]
   ](rdd: RDD[(K, V)] with Metadata[M[K]]): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] = {
     val metadata = rdd.metadata.map(_.getComponent[SpatialKey])

--- a/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
@@ -66,12 +66,12 @@ class TileLayerRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
     }
 
     it ("should obliviously drop the temporal dimension when requested to do so (non-unique)") {
-      val spatial = tileLayerRdd.toSpatialObliviousNonUnique()
+      val spatial = tileLayerRdd.toSpatial()
       spatial.count should be (10)
     }
 
     it ("should obliviously drop the temporal dimension when requested to do so (unique)") {
-      val spatial = tileLayerRdd.toSpatialObliviousUnique()
+      val spatial = tileLayerRdd.toSpatialReduce((a, b) => a)
       spatial.count should be (4)
     }
 

--- a/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
@@ -64,6 +64,17 @@ class TileLayerRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
       val spatial = tileLayerRdd.toSpatial(1)
       spatial.first._1 should be (SpatialKey(0,0))
     }
+
+    it ("should obliviously drop the temporal dimension when requested to do so (non-unique)") {
+      val spatial = tileLayerRdd.toSpatialNoEnsureUnique()
+      spatial.count should be (10)
+    }
+
+    it ("should obliviously drop the temporal dimension when requested to do so (unique)") {
+      val spatial = tileLayerRdd.toSpatialEnsureUnique()
+      spatial.count should be (4)
+    }
+
   }
 
   describe("Spatial TileLayerRDD Filter Methods") {

--- a/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
@@ -66,12 +66,12 @@ class TileLayerRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
     }
 
     it ("should obliviously drop the temporal dimension when requested to do so (non-unique)") {
-      val spatial = tileLayerRdd.toSpatialNoEnsureUnique()
+      val spatial = tileLayerRdd.toSpatialObliviousNonUnique()
       spatial.count should be (10)
     }
 
     it ("should obliviously drop the temporal dimension when requested to do so (unique)") {
-      val spatial = tileLayerRdd.toSpatialEnsureUnique()
+      val spatial = tileLayerRdd.toSpatialObliviousUnique()
       spatial.count should be (4)
     }
 


### PR DESCRIPTION
I gave the methods the names `toSpatialEnsureUnique` and `toSpatialNoEnsureUnique` because they had to be put into a different implicit class than the `toSpatial` methods.  The reason that they had to be put into a different implicit class is because `reduceByKey` (needed to ensure unique keys) requires that `K` and `V` are members of the `ClassTag` class.  Adding that requirement to the existing implicit class would have changed the API.

Connects https://github.com/locationtech/geotrellis/issues/2368