### PR TITLE
Make S3 Capability More Configurable

### DIFF
--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -87,16 +87,17 @@ That can be accomplished by sub-classing ``S3AttributeStore`` and/or
 ``S3ValueReader``, perhaps anonymously.
 
 .. code:: scala
+
    import geotrellis.spark.io.s3._
    import com.amazonaws.services.s3.{AmazonS3Client=>AWSAmazonS3Client}
-   
-   val aws: AWSAmazonS3Client = ???
+
+   val aws: AWSAmazonS3Client = ??? /* Special configuration happens here */
    val specialS3client = new AmazonS3Client(aws)
-   
+
    val attributeStore = new S3AttributeStore("my-bucket", "my-prefix") {
       override def s3Client = specialS3Client
    }
-   
+
    val valueReader = new S3ValueReader(attributeStore) {
       override def s3Client = specialS3Client
    }

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -75,3 +75,28 @@ that does that could look like this:
 
      ContextRDD(layer.tileToLayout[SpatialKey](meta._2), meta._2)
    }
+
+Work with S3 using a custom S3Client configuration
+==================================================
+
+**Motivation:** You would like to work with assets on S3, but you want
+to use an S3 client (or clients) with a configuration (various
+configurations) different form the default client configuration.
+
+That can be accomplished by sub-classing ``S3AttributeStore`` and/or
+``S3ValueReader``, perhaps anonymously.
+
+.. code:: scala
+   import geotrellis.spark.io.s3._
+   import com.amazonaws.services.s3.{AmazonS3Client=>AWSAmazonS3Client}
+   
+   val aws: AWSAmazonS3Client = ???
+   val specialS3client = new AmazonS3Client(aws)
+   
+   val attributeStore = new S3AttributeStore("my-bucket", "my-prefix") {
+      override def s3Client = specialS3Client
+   }
+   
+   val valueReader = new S3ValueReader(attributeStore) {
+      override def s3Client = specialS3Client
+   }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
@@ -36,7 +36,8 @@ import java.io.ByteArrayInputStream
  * @param prefix    path in the bucket for given LayerId
  */
 class S3AttributeStore(val bucket: String, val prefix: String) extends BlobLayerAttributeStore {
-  val s3Client: S3Client = S3Client.DEFAULT
+
+  def s3Client: S3Client = S3Client.DEFAULT
   import S3AttributeStore._
 
   /** NOTE:

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3ValueReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3ValueReader.scala
@@ -36,7 +36,7 @@ class S3ValueReader(
   val attributeStore: AttributeStore
 ) extends OverzoomingValueReader {
 
-  val s3Client: S3Client = S3Client.DEFAULT
+  def s3Client: S3Client = S3Client.DEFAULT
 
   def reader[K: AvroRecordCodec: JsonFormat: ClassTag, V: AvroRecordCodec](layerId: LayerId): Reader[K, V] = new Reader[K, V] {
     val header = attributeStore.readHeader[S3LayerHeader](layerId)


### PR DESCRIPTION
The `val s3Client` lines have been changed to `def s3Client` in both `S3ValueReader` and `S3AttributeStore`.  Examples of how to override them have been included, as well.

Connects https://github.com/locationtech/geotrellis/issues/2304