### PR TITLE
TileFeature method extensions

### DIFF
--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -5,7 +5,7 @@ name := "geotrellis-raster"
 libraryDependencies ++= Seq(
   typesafeConfig,
   jts,
-  cats,
+  scalaz,
   spire,
   monocleCore,
   monocleMacro,

--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -5,6 +5,7 @@ name := "geotrellis-raster"
 libraryDependencies ++= Seq(
   typesafeConfig,
   jts,
+  cats,
   spire,
   monocleCore,
   monocleMacro,

--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -5,7 +5,7 @@ name := "geotrellis-raster"
 libraryDependencies ++= Seq(
   typesafeConfig,
   jts,
-  cats,
+  catsCore,
   spire,
   monocleCore,
   monocleMacro,

--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -5,7 +5,7 @@ name := "geotrellis-raster"
 libraryDependencies ++= Seq(
   typesafeConfig,
   jts,
-  scalaz,
+  cats,
   spire,
   monocleCore,
   monocleMacro,
@@ -27,7 +27,7 @@ import geotrellis.raster.io.geotiff._
 import geotrellis.raster.render._
 """
 
-testOptions in Test += Tests.Setup{ () => 
+testOptions in Test += Tests.Setup{ () =>
   val testArchive = "raster/data/geotiff-test-files.zip"
   val testDirPath = "raster/data/geotiff-test-files"
   if(!(new File(testDirPath)).exists) {

--- a/raster/src/main/scala/geotrellis/raster/TileFeature.scala
+++ b/raster/src/main/scala/geotrellis/raster/TileFeature.scala
@@ -28,3 +28,7 @@ case class TileFeature[+T <: CellGrid, D](tile: T, data: D) extends CellGrid {
   def cols: Int = tile.cols
   def rows: Int = tile.rows
 }
+
+object TileFeature {
+  implicit def tileFeatureToCellGrid[T <: CellGrid, D](tf: TileFeature[T, D]): T = tf.tile
+}

--- a/raster/src/main/scala/geotrellis/raster/crop/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/crop/Implicits.scala
@@ -32,4 +32,8 @@ trait Implicits {
   implicit class withTileFeatureCropMethods[
     T <: CellGrid: (? => TileCropMethods[T]), D
   ](self: TileFeature[T, D]) extends TileFeatureCropMethods[T, D](self)
+
+  implicit class withRasterTileFeatureCropMethods[
+    T <: CellGrid : (? => TileCropMethods[T]), D
+  ](self: TileFeature[Raster[T], D]) extends RasterTileFeatureCropMethods[T, D](self)
 }

--- a/raster/src/main/scala/geotrellis/raster/crop/TileFeatureCropMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/crop/TileFeatureCropMethods.scala
@@ -18,6 +18,7 @@ package geotrellis.raster.crop
 
 import geotrellis.raster._
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
 
 class TileFeatureCropMethods[
     T <: CellGrid : (? => TileCropMethods[T]), 
@@ -30,4 +31,32 @@ class TileFeatureCropMethods[
 
   def crop(gb: GridBounds, options: Options): TileFeature[T, D] =
     TileFeature(self.tile.crop(gb, options), self.data)
+}
+
+class RasterTileFeatureCropMethods[
+    T <: CellGrid : (? => TileCropMethods[T]),
+    D
+  ](val self: TileFeature[Raster[T], D]) extends TileCropMethods[TileFeature[Raster[T], D]] {
+  import Crop.Options
+
+  def crop(extent: Extent, options: Options): TileFeature[Raster[T], D] = {
+    TileFeature(self.tile.crop(extent, options), self.data)
+  }
+
+  def crop(srcExtent: Extent, extent: Extent, options: Options): TileFeature[Raster[T], D] =
+    TileFeature(Raster(self.tile.tile.crop(srcExtent, extent, options), extent), self.data)
+
+  /**
+    * Given an Extent, produce a cropped [[Raster]].
+    */
+  def crop(extent: Extent): TileFeature[Raster[T], D] =
+    crop(extent, Options.DEFAULT)
+
+  /**
+    * Given a [[GridBounds]] and some cropping options, produce a new
+    * [[Raster]].
+    */
+  def crop(gb: GridBounds, options: Options): TileFeature[Raster[T], D] = {
+    TileFeature(self.tile.crop(gb, options), self.data)
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/crop/TileFeatureCropMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/crop/TileFeatureCropMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Azavea
+ * Copyright 2017 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,15 @@ package geotrellis.raster.crop
 import geotrellis.raster._
 import geotrellis.vector._
 
-object Implicits extends Implicits
+class TileFeatureCropMethods[
+    T <: CellGrid : (? => TileCropMethods[T]), 
+    D
+  ](val self: TileFeature[T, D]) extends TileCropMethods[TileFeature[T, D]] {
+  import Crop.Options
 
-/**
-  * Trait housing the implicit class which add extension methods for
-  * cropping to [[CellGrid]].
-  */
-trait Implicits {
-  implicit class withExtentCropMethods[T <: CellGrid: (? => CropMethods[T])](self: Raster[T])
-      extends RasterCropMethods[T](self)
+  def crop(srcExtent: Extent, extent: Extent, options: Options): TileFeature[T, D] =
+    TileFeature(self.tile.crop(srcExtent, extent, options), self.data)
 
-  implicit class withTileFeatureCropMethods[
-    T <: CellGrid: (? => TileCropMethods[T]), D
-  ](self: TileFeature[T, D]) extends TileFeatureCropMethods[T, D](self)
+  def crop(gb: GridBounds, options: Options): TileFeature[T, D] =
+    TileFeature(self.tile.crop(gb, options), self.data)
 }

--- a/raster/src/main/scala/geotrellis/raster/mask/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/mask/Implicits.scala
@@ -30,4 +30,9 @@ trait Implicits {
     def mask(geoms: Traversable[Geometry], options: Options): Raster[T] =
       self.mapTile(_.mask(self.extent, geoms, options))
   }
+
+  implicit class withRasterTileFeatureMaskMethods[T <: CellGrid: (? => TileMaskMethods[T]), D](val self: TileFeature[Raster[T], D]) extends RasterTileFeatureMaskMethods[T, D](self)
+
+  implicit class withTileFeatureMaskMethods[T <: CellGrid : (? => TileMaskMethods[T]), D](override val self: TileFeature[T, D]) extends TileFeatureMaskMethods[T, D](self)
+
 }

--- a/raster/src/main/scala/geotrellis/raster/mask/TileFeatureMaskMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/mask/TileFeatureMaskMethods.scala
@@ -1,0 +1,43 @@
+package geotrellis.raster.mask
+
+import geotrellis.raster._
+import geotrellis.raster.rasterize._
+import geotrellis.util.MethodExtensions
+import geotrellis.vector._
+
+class TileFeatureMaskMethods[
+  T <: CellGrid : (? => TileMaskMethods[T]),
+  D
+](val self: TileFeature[T, D]) extends TileMaskMethods[TileFeature[T, D]] {
+  def localMask(mask: TileFeature[T, D], readMask: Int, writeMask: Int): TileFeature[T, D] =
+    TileFeature(self.tile.localMask(mask.tile, readMask, writeMask), self.data)
+
+  def localMask(mask: T, readMask: Int, writeMask: Int): TileFeature[T, D] =
+    TileFeature(self.tile.localMask(mask, readMask, writeMask), self.data)
+
+  def localInverseMask(mask: TileFeature[T, D], readMask: Int, writeMask: Int): TileFeature[T, D] =
+    TileFeature(self.tile.localInverseMask(mask.tile, readMask, writeMask), self.data)
+
+  def localInverseMask(mask: T, readMask: Int, writeMask: Int): TileFeature[T, D] =
+    TileFeature(self.tile.localInverseMask(mask, readMask, writeMask), self.data)
+
+  def mask(extent: Extent, geoms: Traversable[Geometry], options: Rasterizer.Options): TileFeature[T, D] =
+    TileFeature(self.tile.mask(extent, geoms, options), self.data)
+}
+
+abstract class RasterTileFeatureMaskMethods[
+  T <: CellGrid : (? => TileMaskMethods[T]),
+  D
+](self: TileFeature[Raster[T], D]) extends MethodExtensions[TileFeature[Raster[T], D]] {
+  def mask(geom: Geometry): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.mask(geom), self.data)
+
+  def mask(geom: Geometry, options: Rasterizer.Options): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.mask(geom, options), self.data)
+
+  def mask(geoms: Traversable[Geometry]): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.mask(geoms), self.data)
+
+  def mask(geoms: Traversable[Geometry], options: Rasterizer.Options): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.mask(geoms, options), self.data)
+}

--- a/raster/src/main/scala/geotrellis/raster/merge/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/Implicits.scala
@@ -17,7 +17,7 @@
 package geotrellis.raster.merge
 
 import geotrellis.raster._
-import scalaz.Semigroup
+import cats.Semigroup
 
 object Implicits extends Implicits
 
@@ -29,12 +29,12 @@ trait Implicits {
   implicit class withRasterMergeMethods[T <: CellGrid: ? => TileMergeMethods[T]](self: Raster[T]) extends RasterMergeMethods[T](self)
 
   implicit class withTileFeatureMergeMethods[
-    T <: CellGrid: ? => TileMergeMethods[T], 
+    T <: CellGrid: ? => TileMergeMethods[T],
     D: Semigroup
   ](self: TileFeature[T, D]) extends TileFeatureMergeMethods[T,D](self)
 
   implicit class withRasterTileFeatureMergeMethods[
-    T <: CellGrid: ? => TileMergeMethods[T], 
+    T <: CellGrid: ? => TileMergeMethods[T],
     D: Semigroup
   ](self: TileFeature[Raster[T], D]) extends RasterTileFeatureMergeMethods[T,D](self)
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/Implicits.scala
@@ -17,7 +17,7 @@
 package geotrellis.raster.merge
 
 import geotrellis.raster._
-import cats.Semigroup
+import scalaz.Semigroup
 
 object Implicits extends Implicits
 

--- a/raster/src/main/scala/geotrellis/raster/merge/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/Implicits.scala
@@ -28,5 +28,13 @@ object Implicits extends Implicits
 trait Implicits {
   implicit class withRasterMergeMethods[T <: CellGrid: ? => TileMergeMethods[T]](self: Raster[T]) extends RasterMergeMethods[T](self)
 
-  implicit class withTileFeatureMergeMethods[T <: CellGrid: ? => TileMergeMethods[T], D: Semigroup](self: TileFeature[T, D]) extends TileFeatureMergeMethods[T,D](self)
+  implicit class withTileFeatureMergeMethods[
+    T <: CellGrid: ? => TileMergeMethods[T], 
+    D: Semigroup
+  ](self: TileFeature[T, D]) extends TileFeatureMergeMethods[T,D](self)
+
+  implicit class withRasterTileFeatureMergeMethods[
+    T <: CellGrid: ? => TileMergeMethods[T], 
+    D: Semigroup
+  ](self: TileFeature[Raster[T], D]) extends RasterTileFeatureMergeMethods[T,D](self)
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
@@ -19,17 +19,17 @@ package geotrellis.raster.merge
 import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.vector._
-import cats.Semigroup
+import scalaz.Semigroup
 
 class TileFeatureMergeMethods[
   T <: CellGrid : (? => TileMergeMethods[T]), 
   D : Semigroup
 ](val self: TileFeature[T, D]) extends TileMergeMethods[TileFeature[T, D]] {
   def merge(other: TileFeature[T, D]): TileFeature[T, D] =
-    TileFeature(self.tile.merge(other.tile), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.merge(other.tile), Semigroup[D].append(self.data, other.data))
   
   def merge(extent: Extent, otherExtent: Extent, other: TileFeature[T, D], method: ResampleMethod): TileFeature[T, D] =
-    TileFeature(self.tile.merge(extent, otherExtent, other.tile, method), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.merge(extent, otherExtent, other.tile, method), Semigroup[D].append(self.data, other.data))
 }
 
 class RasterTileFeatureMergeMethods[
@@ -37,8 +37,8 @@ class RasterTileFeatureMergeMethods[
   D : Semigroup
 ](self: TileFeature[Raster[T], D]) extends RasterMergeMethods[T](self.tile) {
   def merge(other: TileFeature[Raster[T], D]): TileFeature[Raster[T], D] =
-    TileFeature(self.tile.merge(other.tile), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.merge(other.tile), Semigroup[D].append(self.data, other.data))
   
   def merge(other: TileFeature[Raster[T], D], method: ResampleMethod): TileFeature[Raster[T], D] =
-    TileFeature(self.tile.merge(other.tile, method), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.merge(other.tile, method), Semigroup[D].append(self.data, other.data))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Azavea
+ * Copyright 2017 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,17 @@
 package geotrellis.raster.merge
 
 import geotrellis.raster._
+import geotrellis.raster.resample._
+import geotrellis.vector._
 import cats.Semigroup
 
-object Implicits extends Implicits
-
-/**
-  * A trait holding the implicit class which makes the extensions
-  * methods available.
-  */
-trait Implicits {
-  implicit class withRasterMergeMethods[T <: CellGrid: ? => TileMergeMethods[T]](self: Raster[T]) extends RasterMergeMethods[T](self)
-
-  implicit class withTileFeatureMergeMethods[T <: CellGrid: ? => TileMergeMethods[T], D: Semigroup](self: TileFeature[T, D]) extends TileFeatureMergeMethods[T,D](self)
+class TileFeatureMergeMethods[
+  T <: CellGrid : (? => TileMergeMethods[T]), 
+  D : Semigroup
+](val self: TileFeature[T, D]) extends TileMergeMethods[TileFeature[T, D]] {
+  def merge(other: TileFeature[T, D]): TileFeature[T, D] =
+    TileFeature(self.tile.merge(other.tile), Semigroup[D].combine(self.data, other.data))
+  
+  def merge(extent: Extent, otherExtent: Extent, other: TileFeature[T, D], method: ResampleMethod): TileFeature[T, D] =
+    TileFeature(self.tile.merge(extent, otherExtent, other.tile), Semigroup[D].combine(self.data, other.data))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
@@ -29,5 +29,16 @@ class TileFeatureMergeMethods[
     TileFeature(self.tile.merge(other.tile), Semigroup[D].combine(self.data, other.data))
   
   def merge(extent: Extent, otherExtent: Extent, other: TileFeature[T, D], method: ResampleMethod): TileFeature[T, D] =
-    TileFeature(self.tile.merge(extent, otherExtent, other.tile), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.merge(extent, otherExtent, other.tile, method), Semigroup[D].combine(self.data, other.data))
+}
+
+class RasterTileFeatureMergeMethods[
+  T <: CellGrid : (? => TileMergeMethods[T]), 
+  D : Semigroup
+](self: TileFeature[Raster[T], D]) extends RasterMergeMethods[T](self.tile) {
+  def merge(other: TileFeature[Raster[T], D]): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.merge(other.tile), Semigroup[D].combine(self.data, other.data))
+  
+  def merge(other: TileFeature[Raster[T], D], method: ResampleMethod): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.merge(other.tile, method), Semigroup[D].combine(self.data, other.data))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
@@ -19,26 +19,26 @@ package geotrellis.raster.merge
 import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.vector._
-import scalaz.Semigroup
+import cats.Semigroup
 
 class TileFeatureMergeMethods[
-  T <: CellGrid : (? => TileMergeMethods[T]), 
+  T <: CellGrid : (? => TileMergeMethods[T]),
   D : Semigroup
 ](val self: TileFeature[T, D]) extends TileMergeMethods[TileFeature[T, D]] {
   def merge(other: TileFeature[T, D]): TileFeature[T, D] =
-    TileFeature(self.tile.merge(other.tile), Semigroup[D].append(self.data, other.data))
-  
+    TileFeature(self.tile.merge(other.tile), Semigroup[D].combine(self.data, other.data))
+
   def merge(extent: Extent, otherExtent: Extent, other: TileFeature[T, D], method: ResampleMethod): TileFeature[T, D] =
-    TileFeature(self.tile.merge(extent, otherExtent, other.tile, method), Semigroup[D].append(self.data, other.data))
+    TileFeature(self.tile.merge(extent, otherExtent, other.tile, method), Semigroup[D].combine(self.data, other.data))
 }
 
 class RasterTileFeatureMergeMethods[
-  T <: CellGrid : (? => TileMergeMethods[T]), 
+  T <: CellGrid : (? => TileMergeMethods[T]),
   D : Semigroup
 ](self: TileFeature[Raster[T], D]) extends RasterMergeMethods[T](self.tile) {
   def merge(other: TileFeature[Raster[T], D]): TileFeature[Raster[T], D] =
-    TileFeature(self.tile.merge(other.tile), Semigroup[D].append(self.data, other.data))
-  
+    TileFeature(self.tile.merge(other.tile), Semigroup[D].combine(self.data, other.data))
+
   def merge(other: TileFeature[Raster[T], D], method: ResampleMethod): TileFeature[Raster[T], D] =
-    TileFeature(self.tile.merge(other.tile, method), Semigroup[D].append(self.data, other.data))
+    TileFeature(self.tile.merge(other.tile, method), Semigroup[D].combine(self.data, other.data))
 }

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -29,6 +29,7 @@ package object raster
     with interpolation.Implicits
     with mask.Implicits
     with merge.Implicits
+    with prototype.Implicits
     with reproject.Implicits
     with split.Implicits
     with summary.polygonal.Implicits

--- a/raster/src/main/scala/geotrellis/raster/prototype/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/prototype/Implicits.scala
@@ -1,7 +1,7 @@
 package geotrellis.raster.prototype
 
 import geotrellis.raster._
-import cats.Monoid
+import scalaz.Monoid
 
 object Implicits extends Implicits
 

--- a/raster/src/main/scala/geotrellis/raster/prototype/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/prototype/Implicits.scala
@@ -1,13 +1,13 @@
 package geotrellis.raster.prototype
 
 import geotrellis.raster._
-import scalaz.Monoid
+import cats.Monoid
 
 object Implicits extends Implicits
 
 trait Implicits {
   implicit class withTileFeaturePrototypeMethods[
-    T <: CellGrid : (? => TilePrototypeMethods[T]), 
+    T <: CellGrid : (? => TilePrototypeMethods[T]),
     D: Monoid
   ](self: TileFeature[T, D]) extends TileFeaturePrototypeMethods[T, D](self)
 }

--- a/raster/src/main/scala/geotrellis/raster/prototype/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/prototype/Implicits.scala
@@ -1,0 +1,13 @@
+package geotrellis.raster.prototype
+
+import geotrellis.raster._
+import cats.Monoid
+
+object Implicits extends Implicits
+
+trait Implicits {
+  implicit class withTileFeaturePrototypeMethods[
+    T <: CellGrid : (? => TilePrototypeMethods[T]), 
+    D: Monoid
+  ](self: TileFeature[T, D]) extends TileFeaturePrototypeMethods[T, D](self)
+}

--- a/raster/src/main/scala/geotrellis/raster/prototype/TileFeaturePrototypeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/prototype/TileFeaturePrototypeMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Azavea
+ * Copyright 2017 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package geotrellis.raster.crop
+package geotrellis.raster.prototype
 
 import geotrellis.raster._
-import geotrellis.vector._
+import cats.Monoid
 
-object Implicits extends Implicits
+class TileFeaturePrototypeMethods[
+  T <: CellGrid : (? => TilePrototypeMethods[T]), 
+  D: Monoid
+](val self: TileFeature[T, D]) extends TilePrototypeMethods[TileFeature[T, D]] {
+  def prototype(cols: Int, rows: Int): TileFeature[T, D] =
+    TileFeature(self.tile.prototype(cols, rows), Monoid[D].empty)
 
-/**
-  * Trait housing the implicit class which add extension methods for
-  * cropping to [[CellGrid]].
-  */
-trait Implicits {
-  implicit class withExtentCropMethods[T <: CellGrid: (? => CropMethods[T])](self: Raster[T])
-      extends RasterCropMethods[T](self)
-
-  implicit class withTileFeatureCropMethods[
-    T <: CellGrid: (? => TileCropMethods[T]), D
-  ](self: TileFeature[T, D]) extends TileFeatureCropMethods[T, D](self)
+  def prototype(cellType: CellType, cols: Int, rows: Int): TileFeature[T, D] =
+    TileFeature(self.tile.prototype(cellType, cols, rows), Monoid[D].empty)
 }

--- a/raster/src/main/scala/geotrellis/raster/prototype/TileFeaturePrototypeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/prototype/TileFeaturePrototypeMethods.scala
@@ -17,15 +17,15 @@
 package geotrellis.raster.prototype
 
 import geotrellis.raster._
-import cats.Monoid
+import scalaz.Monoid
 
 class TileFeaturePrototypeMethods[
   T <: CellGrid : (? => TilePrototypeMethods[T]), 
   D: Monoid
 ](val self: TileFeature[T, D]) extends TilePrototypeMethods[TileFeature[T, D]] {
   def prototype(cols: Int, rows: Int): TileFeature[T, D] =
-    TileFeature(self.tile.prototype(cols, rows), Monoid[D].empty)
+    TileFeature(self.tile.prototype(cols, rows), Monoid[D].zero)
 
   def prototype(cellType: CellType, cols: Int, rows: Int): TileFeature[T, D] =
-    TileFeature(self.tile.prototype(cellType, cols, rows), Monoid[D].empty)
+    TileFeature(self.tile.prototype(cellType, cols, rows), Monoid[D].zero)
 }

--- a/raster/src/main/scala/geotrellis/raster/prototype/TileFeaturePrototypeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/prototype/TileFeaturePrototypeMethods.scala
@@ -17,15 +17,15 @@
 package geotrellis.raster.prototype
 
 import geotrellis.raster._
-import scalaz.Monoid
+import cats.Monoid
 
 class TileFeaturePrototypeMethods[
-  T <: CellGrid : (? => TilePrototypeMethods[T]), 
+  T <: CellGrid : (? => TilePrototypeMethods[T]),
   D: Monoid
 ](val self: TileFeature[T, D]) extends TilePrototypeMethods[TileFeature[T, D]] {
   def prototype(cols: Int, rows: Int): TileFeature[T, D] =
-    TileFeature(self.tile.prototype(cols, rows), Monoid[D].zero)
+    TileFeature(self.tile.prototype(cols, rows), Monoid[D].empty)
 
   def prototype(cellType: CellType, cols: Int, rows: Int): TileFeature[T, D] =
-    TileFeature(self.tile.prototype(cellType, cols, rows), Monoid[D].zero)
+    TileFeature(self.tile.prototype(cellType, cols, rows), Monoid[D].empty)
 }

--- a/raster/src/main/scala/geotrellis/raster/reproject/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/Implicits.scala
@@ -23,8 +23,14 @@ object Implicits extends Implicits
 trait Implicits {
   implicit class withProjectedRasterReprojectMethods[T <: CellGrid](self: ProjectedRaster[T])(implicit ev: Raster[T] => RasterReprojectMethods[Raster[T]])
     extends ProjectedRasterReprojectMethods[T](self)
+
   implicit class withTileFeatureReprojectMethods[
     T <: CellGrid : (? => TileReprojectMethods[T]),
     D
   ](self: TileFeature[T,D]) extends TileFeatureReprojectMethods[T, D](self)
+
+  implicit class withRasterTileFeatureReprojectMethods[
+    T <: CellGrid : (? => TileReprojectMethods[T]),
+    D
+  ](self: TileFeature[Raster[T], D]) extends RasterTileFeatureReprojectMethods[T, D](self)
 }

--- a/raster/src/main/scala/geotrellis/raster/reproject/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/Implicits.scala
@@ -21,5 +21,10 @@ import geotrellis.raster._
 object Implicits extends Implicits
 
 trait Implicits {
-  implicit class withProjectedRasterReprojectMethods[T <: CellGrid](self: ProjectedRaster[T]) extends ProjectedRasterReprojectMethods[T](self)
+  implicit class withProjectedRasterReprojectMethods[T <: CellGrid](self: ProjectedRaster[T])(implicit ev: Raster[T] => RasterReprojectMethods[Raster[T]])
+    extends ProjectedRasterReprojectMethods[T](self)
+  implicit class withTileFeatureReprojectMethods[
+    T <: CellGrid : (? => TileReprojectMethods[T]),
+    D
+  ](self: TileFeature[T,D]) extends TileFeatureReprojectMethods[T, D](self)
 }

--- a/raster/src/main/scala/geotrellis/raster/reproject/TileFeatureReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/TileFeatureReprojectMethods.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.reproject
+
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.vector._
+
+class TileFeatureReprojectMethods[
+  T <: CellGrid : (? => TileReprojectMethods[T]), 
+  D
+](val self: TileFeature[T, D]) extends TileReprojectMethods[TileFeature[T, D]] {
+  import Reproject.Options
+
+  def reproject(srcExtent: Extent, 
+                targetRasterExtent: RasterExtent, 
+                transform: Transform, 
+                inverseTransform: Transform, 
+                options: Options): Raster[TileFeature[T, D]] = {
+    val Raster(tile, extent) = self.tile.reproject(srcExtent, targetRasterExtent, transform, inverseTransform, options)
+    Raster(TileFeature(tile, self.data), extent)
+  }
+
+  def reproject(srcExtent: Extent, src: CRS, dest: CRS, options: Options): Raster[TileFeature[T, D]] = {
+    val Raster(tile, extent) = self.tile.reproject(srcExtent, src, dest, options)
+    Raster(TileFeature(tile, self.data), extent)
+  }
+
+  def reproject(srcExtent: Extent, gridBounds: GridBounds, src: CRS, dest: CRS, options: Options): Raster[TileFeature[T, D]] = {
+    val Raster(tile, extent) = self.tile.reproject(srcExtent, gridBounds, src, dest, options)
+    Raster(TileFeature(tile, self.data), extent)
+  }
+
+  def reproject(srcExtent: Extent, 
+                gridBounds: GridBounds, 
+                transform: Transform, 
+                inverseTransform: Transform, 
+                options: Options): Raster[TileFeature[T, D]] = {
+    val Raster(tile, extent) = self.tile.reproject(srcExtent, gridBounds, transform, inverseTransform, options)
+    Raster(TileFeature(tile, self.data), extent)
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/reproject/TileFeatureReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/TileFeatureReprojectMethods.scala
@@ -19,6 +19,7 @@ package geotrellis.raster.reproject
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.vector._
+import geotrellis.util.MethodExtensions
 
 class TileFeatureReprojectMethods[
   T <: CellGrid : (? => TileReprojectMethods[T]), 
@@ -53,4 +54,35 @@ class TileFeatureReprojectMethods[
     val Raster(tile, extent) = self.tile.reproject(srcExtent, gridBounds, transform, inverseTransform, options)
     Raster(TileFeature(tile, self.data), extent)
   }
+}
+
+class RasterTileFeatureReprojectMethods[
+  T <: CellGrid : (? => TileReprojectMethods[T]), 
+  D
+](val self: TileFeature[Raster[T], D]) extends MethodExtensions[TileFeature[Raster[T], D]] {
+  import Reproject.Options
+
+  def reproject(targetRasterExtent: RasterExtent, transform: Transform, inverseTransform: Transform, options: Options): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.tile.reproject(self.tile.extent, targetRasterExtent, transform, inverseTransform, options), self.data)
+
+  def reproject(targetRasterExtent: RasterExtent, transform: Transform, inverseTransform: Transform): TileFeature[Raster[T], D] =
+    reproject(targetRasterExtent, transform, inverseTransform, Options.DEFAULT)
+
+  def reproject(src: CRS, dest: CRS, options: Options): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.tile.reproject(self.tile.extent, src, dest, options), self.data)
+
+  def reproject(src: CRS, dest: CRS): TileFeature[Raster[T], D] =
+    reproject(src, dest, Options.DEFAULT)
+
+  def reproject(gridBounds: GridBounds, src: CRS, dest: CRS, options: Options): TileFeature[Raster[T], D] = 
+    TileFeature(self.tile.tile.reproject(self.tile.extent, gridBounds, src, dest, options), self.data)
+
+  def reproject(gridBounds: GridBounds, src: CRS, dest: CRS): TileFeature[Raster[T], D] =
+    reproject(gridBounds, src, dest, Options.DEFAULT)
+
+  def reproject(gridBounds: GridBounds, transform: Transform, inverseTransform: Transform, options: Options): TileFeature[Raster[T], D] = 
+    TileFeature(self.tile.tile.reproject(self.tile.extent, gridBounds, transform, inverseTransform, options), self.data)
+
+  def reproject(gridBounds: GridBounds, transform: Transform, inverseTransform: Transform): TileFeature[Raster[T], D] =
+    reproject(gridBounds, transform, inverseTransform, Options.DEFAULT)
 }

--- a/raster/src/main/scala/geotrellis/raster/split/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/split/Implicits.scala
@@ -16,11 +16,12 @@
 
 package geotrellis.raster.split
 
-import geotrellis.raster.{RasterExtent, CellGrid, Raster}
+import geotrellis.raster.{RasterExtent, CellGrid, Raster, TileFeature}
 
 object Implicits extends Implicits
 
 trait Implicits {
   implicit class withRasterExtentSplitMethods(val self: RasterExtent) extends RasterExtentSplitMethods
   implicit class withRasterSplitMethods[T <: CellGrid: (? => SplitMethods[T])](val self: Raster[T]) extends RasterSplitMethods[T]
+  implicit class withTileFeatureSplitMethods[T <: CellGrid: (? => SplitMethods[T]), D](self: TileFeature[T, D]) extends TileFeatureSplitMethods[T, D](self)
 }

--- a/raster/src/main/scala/geotrellis/raster/split/TileFeatureSplitMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/split/TileFeatureSplitMethods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Azavea
+ * Copyright 2017 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package geotrellis.raster.crop
+package geotrellis.raster.split
 
 import geotrellis.raster._
-import geotrellis.vector._
 
-object Implicits extends Implicits
+class TileFeatureSplitMethods[
+  T <: CellGrid : (? => SplitMethods[T]), 
+  D
+](val self: TileFeature[T, D]) extends SplitMethods[TileFeature[T, D]] {
+  import Split.Options
 
-/**
-  * Trait housing the implicit class which add extension methods for
-  * cropping to [[CellGrid]].
-  */
-trait Implicits {
-  implicit class withExtentCropMethods[T <: CellGrid: (? => CropMethods[T])](self: Raster[T])
-      extends RasterCropMethods[T](self)
-
-  implicit class withTileFeatureCropMethods[
-    T <: CellGrid: (? => TileCropMethods[T]), D
-  ](self: TileFeature[T, D]) extends TileFeatureCropMethods[T, D](self)
+  def split(tileLayout: TileLayout, options: Options): Array[TileFeature[T, D]] = {
+    val results = self.tile.split(tileLayout, options)
+    results.map(t ⇒ TileFeature(t, self.data))
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/split/TileFeatureSplitMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/split/TileFeatureSplitMethods.scala
@@ -29,3 +29,4 @@ class TileFeatureSplitMethods[
     results.map(t ⇒ TileFeature(t, self.data))
   }
 }
+

--- a/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
+++ b/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
@@ -17,7 +17,7 @@
 package geotrellis.raster.stitch
 
 import geotrellis.raster._
-
+import cats.Semigroup
 
 /**
   * The Stitcher base trait.
@@ -107,4 +107,14 @@ object Stitcher {
     }
   }
 
+  implicit class TileFeatureStitcher[
+    T <: CellGrid: Stitcher,
+    D : Semigroup
+  ](val self: TileFeature[T, D]) extends Stitcher[TileFeature[T, D]] {
+    def stitch(pieces: Iterable[(TileFeature[T, D], (Int, Int))], cols: Int, rows: Int): TileFeature[T, D] = {
+      val newPieces = pieces.map{ piece ⇒ (piece._1.tile, piece._2) }
+      val newData = pieces.map(_._1.data).reduce(Semigroup[D].combine)
+      TileFeature(implicitly[Stitcher[T]].stitch(newPieces, cols, rows), newData)
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
+++ b/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
@@ -17,7 +17,7 @@
 package geotrellis.raster.stitch
 
 import geotrellis.raster._
-import cats.Semigroup
+import scalaz.Semigroup
 
 /**
   * The Stitcher base trait.
@@ -113,7 +113,7 @@ object Stitcher {
   ](val self: TileFeature[T, D]) extends Stitcher[TileFeature[T, D]] {
     def stitch(pieces: Iterable[(TileFeature[T, D], (Int, Int))], cols: Int, rows: Int): TileFeature[T, D] = {
       val newPieces = pieces.map{ piece ⇒ (piece._1.tile, piece._2) }
-      val newData = pieces.map(_._1.data).reduce(Semigroup[D].combine)
+      val newData = pieces.map(_._1.data).reduce(Semigroup[D].append(_, _))
       TileFeature(implicitly[Stitcher[T]].stitch(newPieces, cols, rows), newData)
     }
   }

--- a/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
+++ b/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
@@ -17,7 +17,7 @@
 package geotrellis.raster.stitch
 
 import geotrellis.raster._
-import scalaz.Semigroup
+import cats.Semigroup
 
 /**
   * The Stitcher base trait.
@@ -113,7 +113,7 @@ object Stitcher {
   ](val self: TileFeature[T, D]) extends Stitcher[TileFeature[T, D]] {
     def stitch(pieces: Iterable[(TileFeature[T, D], (Int, Int))], cols: Int, rows: Int): TileFeature[T, D] = {
       val newPieces = pieces.map{ piece ⇒ (piece._1.tile, piece._2) }
-      val newData = pieces.map(_._1.data).reduce(Semigroup[D].append(_, _))
+      val newData = pieces.map(_._1.data).reduce(Semigroup[D].combine)
       TileFeature(implicitly[Stitcher[T]].stitch(newPieces, cols, rows), newData)
     }
   }


### PR DESCRIPTION
`TileFeature[T <: CellGrid, D]` instances are essentially Tiles enriched with metadata.  They should be treated as Tiles in most respects, yet no method extensions were provided to allow these features to be manipulated with the same facility as Tiles.  This PR proposes method extensions over TileFeatures so that this first-class status is conferred onto this structure.

I have employed the Cats library here, as it provides all the required features for this proof-of-concept.  To make use of all the features in these method extensions, please
```scala
import cats.{Monoid, Semigroup}
import cats.implicits._
```
prior to using these methods.

This PR fixes #2138 

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>