### PR TITLE
Optimized toArrayTile for GeoTiffMultibandTile

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
@@ -322,7 +322,7 @@ abstract class GeoTiffMultibandTile(
     * Converts the GeoTiffMultibandTile to an
     * [[ArrayMultibandTile]] */
   def toArrayTile(): ArrayMultibandTile =
-    ArrayMultibandTile(bands.map(_.toArrayTile): _*)
+    crop(this.gridBounds)
 
   /**
    * Performs a crop on itself. The returned MultibandGeoTiffTile will


### PR DESCRIPTION
This PR optimizes `GeoTiffMultibandTile.toArrayTile` for pixel interleave so that the segments will no longer be reloaded.

This PR resolves #2087 