### PR TITLE
ClipToGrid funtionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,7 @@ lazy val slick = project
   .settings(commonSettings)
 
 lazy val spark = project
-  .dependsOn(util, raster, `raster-testkit` % "test")
+  .dependsOn(util, raster, `raster-testkit` % "test", `vector-testkit` % "test")
   .settings(commonSettings)
   .settings(
     // This takes care of a pseudo-cyclic dependency between the `spark` test scope, `spark-testkit`,

--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/ClipToGridExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/ClipToGridExamples.scala
@@ -1,0 +1,70 @@
+package geotrellis.doc.examples.distance
+
+object ClipToGridExamples {
+  def `Performing a polygonal sum from an RDD of Polygons to GeoTiffs on S3`: Unit = {
+    import geotrellis.raster._
+    import geotrellis.spark._
+    import geotrellis.spark.tiling._
+    import geotrellis.vector._
+
+    import org.apache.spark.HashPartitioner
+    import org.apache.spark.rdd.RDD
+
+    import java.net.URI
+    import java.util.UUID
+
+    // The extends of the GeoTiffs, along with the URIs
+    val geoTiffUris: RDD[Feature[Polygon, URI]] = ???
+    val polygons: RDD[Feature[Polygon, UUID]] = ???
+
+    // Choosing the appropriately resolute layout for the data is here considered a client concern.
+    val layout: LayoutDefinition = ???
+
+    // Abbreviation for the code to read the window of the GeoTiff off of S3
+    def read(uri: URI, window: Extent): Raster[Tile] = ???
+
+    val groupedPolys: RDD[(SpatialKey, Iterable[MultiPolygonFeature[UUID]])] =
+      polygons
+        .clipToGrid(layout)
+        .flatMap { case (key, feature) =>
+          val mpFeature: Option[MultiPolygonFeature[UUID]] =
+            feature.geom match {
+              case p: Polygon => Some(feature.mapGeom(_ => MultiPolygon(p)))
+              case mp: MultiPolygon => Some(feature.mapGeom(_ => mp))
+              case _ => None
+            }
+          mpFeature.map { mp => (key, mp) }
+        }
+        .groupByKey(new HashPartitioner(1000))
+
+    val rastersToKeys: RDD[(SpatialKey, URI)] =
+      geoTiffUris
+        .clipToGrid(layout)
+        .flatMap { case (key, feature) =>
+          // Filter out any non-polygonal intersections.
+          // Also, we will do the window read from the SpatialKey extent, so throw out polygon.
+          feature.geom match {
+            case p: Polygon => Some((key, feature.data))
+            case mp: MultiPolygon => Some((key, feature.data))
+            case _ => None
+          }
+        }
+
+    val joined: RDD[(SpatialKey, (Iterable[MultiPolygonFeature[UUID]], URI))] =
+      groupedPolys
+        .join(rastersToKeys)
+
+    val totals: Map[UUID, Long] =
+      joined
+        .flatMap { case (key, (features, uri)) =>
+          val raster = read(uri, layout.mapTransform.keyToExtent(key))
+
+          features.map { case Feature(mp, uuid) =>
+            (uuid, raster.tile.polygonalSum(raster.extent, mp).toLong)
+          }
+        }
+        .reduceByKey(_ + _)
+        .collect
+        .toMap
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.clip
+
+import geotrellis.raster.GridBounds
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.util._
+import geotrellis.vector._
+
+import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory
+import org.apache.spark.rdd._
+
+object ClipToGrid {
+  def apply[G <: Geometry, D](
+    rdd: RDD[Feature[G, D]],
+    layout: LayoutDefinition
+  ): RDD[(SpatialKey, Feature[Geometry, D])] =
+    apply[G, D, D](rdd, layout, { (_, d) => Some(d) })
+
+  def apply[G <: Geometry, D1, D2](
+    rdd: RDD[Feature[G, D1]],
+    layout: LayoutDefinition,
+    clipData: (Geometry, D1) => Option[D2]
+  ): RDD[(SpatialKey, Feature[Geometry, D2])] = {
+    val mapTransform: MapKeyTransform = layout.mapTransform
+
+    rdd.flatMap { f => clipGeom(mapTransform, clipData, f) }
+  }
+
+  private def clipGeom[G <: Geometry, D1, D2](
+    mapTransform: MapKeyTransform,
+    clipData: (Geometry, D1) => Option[D2],
+    feature: Feature[G, D1]
+  ): Iterator[(SpatialKey, Feature[Geometry, D2])] = {
+
+    def clipFeature(k: SpatialKey, contains: (Extent, G) => Boolean): Option[(SpatialKey, Feature[Geometry, D2])] = {
+      val extent = mapTransform(k)
+
+      val clipped: Option[Geometry] =
+        feature.geom match {
+          case p: Point =>
+            Some(p)
+          case g =>
+            g.intersection(extent).toGeometry
+        }
+
+      for(g <- clipped; d <- clipData(g, feature.data)) yield {
+        (k, Feature(g, d))
+      }
+    }
+
+    val iterator: Iterator[(SpatialKey, Feature[Geometry, D2])] =
+      feature.geom match {
+        case p: Point =>
+          val k = mapTransform(p)
+          Iterator(clipData(p, feature.data).map { d => (k, Feature(p, d)) }).flatten
+        case mp: MultiPoint =>
+          mp.points
+            .map(mapTransform(_))
+            .distinct
+            .map(clipFeature(_, { (x, y) => true }))
+            .flatten
+            .iterator
+        case l: Line =>
+          mapTransform.multiLineToKeys(MultiLine(l)).map(clipFeature(_, { (x,y) => false })).flatten
+        case ml: MultiLine =>
+          mapTransform.multiLineToKeys(ml).map(clipFeature(_, { (x,y) => false })).flatten
+        case p: Polygon =>
+          val pg = PreparedGeometryFactory.prepare(p.jtsGeom)
+          val contains = { (extent: Extent, geom: G) =>
+            pg.contains(extent.toPolygon.jtsGeom)
+          }
+
+          mapTransform.multiPolygonToKeys(MultiPolygon(p)).map(clipFeature(_, contains)).flatten
+        case mp: MultiPolygon =>
+          val pg = PreparedGeometryFactory.prepare(mp.jtsGeom)
+          val contains = { (extent: Extent, geom: G) =>
+            pg.contains(extent.toPolygon.jtsGeom)
+          }
+
+          mapTransform.multiPolygonToKeys(mp).map(clipFeature(_, contains)).flatten
+        case gc: GeometryCollection =>
+          val b: GridBounds = mapTransform(gc.envelope)
+
+          val keys: Iterator[SpatialKey] = for {
+            x <- Iterator.range(b.colMin, b.colMax+1)
+            y <- Iterator.range(b.rowMin, b.rowMax+1)
+          } yield SpatialKey(x, y)
+
+          keys.filter(k => mapTransform(k).toPolygon.intersects(gc))
+              .map(k => clipFeature(k, { (x,y) => false })).flatten
+      }
+
+    iterator
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
@@ -22,88 +22,183 @@ import geotrellis.spark.tiling._
 import geotrellis.util._
 import geotrellis.vector._
 
-import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory
+import com.vividsolutions.jts.geom.prep.{PreparedGeometry, PreparedGeometryFactory}
 import org.apache.spark.rdd._
 
 object ClipToGrid {
+  /** Trait which contains methods to be used in determining
+    * the most optimal way to clip geometries and features
+    * for ClipToGrid methods.
+    */
+  trait Predicates {
+    /** Returns true if the feature geometry covers the passed in extent */
+    def covers(e: Extent): Boolean
+    /** Returns true if the feature geometry is covered bythe passed in extent */
+    def coveredBy(e: Extent): Boolean
+  }
+
+  /** Clips a feature to the given extent, that uses the given predicates
+    * to avoid doing intersections where unnecessary.
+    */
+  def clipFeatureToExtent[G <: Geometry, D](
+    e: Extent,
+    feature: Feature[G, D],
+    preds: Predicates
+  ): Option[Feature[Geometry, D]] =
+    if(preds.covers(e)) { Some(Feature(e, feature.data)) }
+    else if(preds.coveredBy(e)) { Some(feature) }
+    else {
+      feature.geom.intersection(e).toGeometry.map { g =>
+        Feature(g, feature.data)
+      }
+    }
+
+  /** Clip each geometry in the RDD to the set of SpatialKeys
+    * which intersect it, where the SpatialKeys map to the
+    * given [[LayoutDefinition]].
+    */
+  def apply[G <: Geometry](
+    rdd: RDD[G],
+    layout: LayoutDefinition
+  )(implicit d: DummyImplicit): RDD[(SpatialKey, Geometry)] =
+    apply[G, Unit](rdd.map(Feature(_, ())), layout)
+      .mapValues(_.geom)
+
+  /** Clip each geometry in the RDD to the set of SpatialKeys
+    * which intersect it, where the SpatialKeys map to the
+    * given [[LayoutDefinition]], using the given method
+    * to clip each geometry to the extent.
+    */
+  def apply[G <: Geometry](
+    rdd: RDD[G],
+    layout: LayoutDefinition,
+    clipGeom: (Extent, G, Predicates) => Option[Geometry]
+  )(implicit d: DummyImplicit): RDD[(SpatialKey, Geometry)] =
+    apply[G, Unit](
+      rdd.map(Feature(_, ())),
+      layout,
+      { (e: Extent, f: Feature[G, Unit], p: Predicates) =>
+        clipGeom(e, f.geom, p).map(Feature(_, ()))
+      }
+    ).mapValues(_.geom)
+
+  /** Clip each geometry in the RDD to the set of SpatialKeys
+    * which intersect it, where the SpatialKeys map to the
+    * given [[LayoutDefinition]], using the given method
+    * to clip each geometry to the extent.
+    */
   def apply[G <: Geometry, D](
     rdd: RDD[Feature[G, D]],
     layout: LayoutDefinition
   ): RDD[(SpatialKey, Feature[Geometry, D])] =
-    apply[G, D, D](rdd, layout, { (_, d) => Some(d) })
+    apply[G, D](rdd, layout, clipFeatureToExtent[G,D] _)
 
-  def apply[G <: Geometry, D1, D2](
-    rdd: RDD[Feature[G, D1]],
+  /** Clip each geometry in the RDD to the set of SpatialKeys
+    * which intersect it, where the SpatialKeys map to the
+    * given [[LayoutDefinition]], using the given method
+    * to clip each geometry to the extent.
+    */
+  def apply[G <: Geometry, D](
+    rdd: RDD[Feature[G, D]],
     layout: LayoutDefinition,
-    clipData: (Geometry, D1) => Option[D2]
-  ): RDD[(SpatialKey, Feature[Geometry, D2])] = {
+    clipFeature: (Extent, Feature[G, D], Predicates) => Option[Feature[Geometry, D]]
+  ): RDD[(SpatialKey, Feature[Geometry, D])] = {
     val mapTransform: MapKeyTransform = layout.mapTransform
 
-    rdd.flatMap { f => clipGeom(mapTransform, clipData, f) }
+    rdd.flatMap { f => clipGeom(mapTransform, clipFeature, f) }
   }
 
-  private def clipGeom[G <: Geometry, D1, D2](
+  private def clipGeom[G <: Geometry, D](
     mapTransform: MapKeyTransform,
-    clipData: (Geometry, D1) => Option[D2],
-    feature: Feature[G, D1]
-  ): Iterator[(SpatialKey, Feature[Geometry, D2])] = {
+    clipFeature: (Extent, Feature[G, D], Predicates) => Option[Feature[Geometry, D]],
+    feature: Feature[G, D]
+  ): Iterator[(SpatialKey, Feature[Geometry, D])] = {
+    val pointPredicates =
+      new Predicates {
+        def covers(e: Extent) = false
+        def coveredBy(e: Extent) = true
+      }
 
-    def clipFeature(k: SpatialKey, contains: (Extent, G) => Boolean): Option[(SpatialKey, Feature[Geometry, D2])] = {
+    val mpOrLinePredicates =
+      new Predicates {
+        def covers(e: Extent) = false
+        def coveredBy(e: Extent) =
+          feature.geom.jtsGeom.coveredBy(e.toPolygon.jtsGeom)
+      }
+
+    def polyPredicates(pg: PreparedGeometry) =
+      new Predicates {
+        def covers(e: Extent) = pg.covers(e.toPolygon.jtsGeom)
+        def coveredBy(e: Extent) = pg.coveredBy(e.toPolygon.jtsGeom)
+      }
+
+    def gcPredicates =
+      new Predicates {
+        def covers(e: Extent) = feature.geom.jtsGeom.covers(e.toPolygon.jtsGeom)
+        def coveredBy(e: Extent) = feature.geom.jtsGeom.coveredBy(e.toPolygon.jtsGeom)
+      }
+
+    def clipToKey(
+      k: SpatialKey,
+      preds: Predicates
+    ): Option[(SpatialKey, Feature[Geometry, D])] = {
       val extent = mapTransform(k)
 
-      val clipped: Option[Geometry] =
-        feature.geom match {
-          case p: Point =>
-            Some(p)
-          case g =>
-            g.intersection(extent).toGeometry
-        }
-
-      for(g <- clipped; d <- clipData(g, feature.data)) yield {
-        (k, Feature(g, d))
-      }
+      clipFeature(extent, feature, preds).map(k -> _)
     }
 
-    val iterator: Iterator[(SpatialKey, Feature[Geometry, D2])] =
+    val iterator: Iterator[(SpatialKey, Feature[Geometry, D])] =
       feature.geom match {
         case p: Point =>
           val k = mapTransform(p)
-          Iterator(clipData(p, feature.data).map { d => (k, Feature(p, d)) }).flatten
+          clipToKey(k, pointPredicates).toSeq.iterator
         case mp: MultiPoint =>
           mp.points
             .map(mapTransform(_))
             .distinct
-            .map(clipFeature(_, { (x, y) => true }))
+            .map(clipToKey(_, mpOrLinePredicates))
             .flatten
             .iterator
         case l: Line =>
-          mapTransform.multiLineToKeys(MultiLine(l)).map(clipFeature(_, { (x,y) => false })).flatten
+          mapTransform.multiLineToKeys(MultiLine(l))
+            .map(clipToKey(_, mpOrLinePredicates))
+            .flatten
         case ml: MultiLine =>
-          mapTransform.multiLineToKeys(ml).map(clipFeature(_, { (x,y) => false })).flatten
+          mapTransform.multiLineToKeys(ml)
+            .map(clipToKey(_, mpOrLinePredicates))
+            .flatten
         case p: Polygon =>
           val pg = PreparedGeometryFactory.prepare(p.jtsGeom)
-          val contains = { (extent: Extent, geom: G) =>
-            pg.contains(extent.toPolygon.jtsGeom)
-          }
+          val preds = polyPredicates(pg)
 
-          mapTransform.multiPolygonToKeys(MultiPolygon(p)).map(clipFeature(_, contains)).flatten
+          mapTransform
+            .multiPolygonToKeys(MultiPolygon(p))
+            .map(clipToKey(_, preds))
+            .flatten
         case mp: MultiPolygon =>
           val pg = PreparedGeometryFactory.prepare(mp.jtsGeom)
-          val contains = { (extent: Extent, geom: G) =>
-            pg.contains(extent.toPolygon.jtsGeom)
+          val preds = polyPredicates(pg)
+
+          mapTransform.multiPolygonToKeys(mp)
+            .map(clipToKey(_, preds))
+            .flatten
+        case gc: GeometryCollection =>
+          def keysFromGC(g: GeometryCollection): List[SpatialKey] = {
+            var keys: List[SpatialKey] = List()
+            keys = keys ++ gc.points.map(mapTransform.apply)
+            keys = keys ++ gc.multiPoints.flatMap(_.points.map(mapTransform.apply))
+            keys = keys ++ gc.lines.flatMap { l => mapTransform.multiLineToKeys(MultiLine(l)) }
+            keys = keys ++ gc.multiLines.flatMap { ml => mapTransform.multiLineToKeys(ml) }
+            keys = keys ++ gc.polygons.flatMap { p => mapTransform.multiPolygonToKeys(MultiPolygon(p)) }
+            keys = keys ++ gc.multiPolygons.flatMap { mp => mapTransform.multiPolygonToKeys(mp) }
+            keys = keys ++ gc.geometryCollections.flatMap(keysFromGC)
+            keys
           }
 
-          mapTransform.multiPolygonToKeys(mp).map(clipFeature(_, contains)).flatten
-        case gc: GeometryCollection =>
-          val b: GridBounds = mapTransform(gc.envelope)
-
-          val keys: Iterator[SpatialKey] = for {
-            x <- Iterator.range(b.colMin, b.colMax+1)
-            y <- Iterator.range(b.rowMin, b.rowMax+1)
-          } yield SpatialKey(x, y)
-
-          keys.filter(k => mapTransform(k).toPolygon.intersects(gc))
-              .map(k => clipFeature(k, { (x,y) => false })).flatten
+          keysFromGC(gc)
+            .map(clipToKey(_, gcPredicates))
+            .flatten
+            .iterator
       }
 
     iterator

--- a/spark/src/main/scala/geotrellis/spark/clip/ClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/ClipToGridMethods.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.clip
+
+import geotrellis.spark._
+import geotrellis.spark.tiling.LayoutDefinition
+import geotrellis.util.MethodExtensions
+import geotrellis.vector._
+
+import org.apache.spark.rdd._
+
+trait ClipToGridMethods[G <: Geometry, D] extends MethodExtensions[RDD[Feature[G, D]]] {
+  def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Feature[Geometry, D])] =
+    ClipToGrid(self, layout)
+
+  def clipToGrid[D2](layout: LayoutDefinition, clipData: (Geometry, D) => Option[D2]): RDD[(SpatialKey, Feature[Geometry, D2])] =
+    ClipToGrid(self, layout, clipData)
+}

--- a/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
@@ -23,10 +23,13 @@ import geotrellis.vector._
 
 import org.apache.spark.rdd._
 
-trait ClipToGridMethods[G <: Geometry, D] extends MethodExtensions[RDD[Feature[G, D]]] {
+trait FeatureClipToGridMethods[G <: Geometry, D] extends MethodExtensions[RDD[Feature[G, D]]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Feature[Geometry, D])] =
     ClipToGrid(self, layout)
 
-  def clipToGrid[D2](layout: LayoutDefinition, clipData: (Geometry, D) => Option[D2]): RDD[(SpatialKey, Feature[Geometry, D2])] =
-    ClipToGrid(self, layout, clipData)
+  def clipToGrid(
+    layout: LayoutDefinition,
+    clipFeature: (Extent, Feature[Geometry, D], ClipToGrid.Predicates) => Option[Feature[Geometry, D]]
+  ): RDD[(SpatialKey, Feature[Geometry, D])] =
+    ClipToGrid(self, layout, clipFeature)
 }

--- a/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
@@ -16,16 +16,20 @@
 
 package geotrellis.spark.clip
 
+import geotrellis.spark._
+import geotrellis.spark.tiling.LayoutDefinition
+import geotrellis.util.MethodExtensions
 import geotrellis.vector._
 
 import org.apache.spark.rdd._
 
-trait Implicits {
-  implicit class withFeatureClipToGridMethods[G <: Geometry, D](val self: RDD[Feature[G, D]])
-      extends FeatureClipToGridMethods[G, D]
+trait GeometryClipToGridMethods[G <: Geometry] extends MethodExtensions[RDD[G]] {
+  def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Geometry)] =
+    ClipToGrid(self, layout)
 
-  implicit class withGeometryClipToGridMethods[G <: Geometry](val self: RDD[G])
-      extends GeometryClipToGridMethods[G]
+  def clipToGrid(
+    layout: LayoutDefinition,
+    clipGeom: (Extent, Geometry, ClipToGrid.Predicates) => Option[Geometry]
+  ): RDD[(SpatialKey, Geometry)] =
+    ClipToGrid(self, layout, clipGeom)
 }
-
-object Implicits extends Implicits

--- a/spark/src/main/scala/geotrellis/spark/clip/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/Implicits.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.clip
+
+import geotrellis.vector._
+
+import org.apache.spark.rdd._
+
+trait Implicits {
+  implicit class withClipToGridMethods[G <: Geometry, D](val self: RDD[Feature[G, D]])
+      extends ClipToGridMethods[G, D]
+}
+
+object Implicits extends Implicits

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -35,6 +35,7 @@ import java.time.Instant
 
 package object spark
     extends buffer.Implicits
+    with clip.Implicits
     with costdistance.Implicits
     with crop.Implicits
     with density.Implicits

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -18,9 +18,13 @@ package geotrellis.spark.tiling
 
 import geotrellis.spark._
 import geotrellis.raster._
+import geotrellis.raster.rasterize.{Rasterizer, Callback}
 import geotrellis.vector._
 import geotrellis.proj4._
 import geotrellis.util._
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.JavaConverters._
 
 object MapKeyTransform {
   def apply(crs: CRS, level: LayoutLevel): MapKeyTransform =
@@ -122,4 +126,55 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
       extent.xmin + (col + 1) * tileWidth,
       extent.ymax - row * tileHeight
     )
+
+  def multiLineToKeys(multiLine: MultiLine): Iterator[SpatialKey] = {
+    val extent = multiLine.envelope
+    val bounds: GridBounds = extentToBounds(extent)
+    val options = Rasterizer.Options(includePartial=true, sampleType=PixelIsArea)
+
+    val boundsExtent: Extent = boundsToExtent(bounds)
+    val rasterExtent = RasterExtent(boundsExtent, bounds.width, bounds.height)
+
+    /*
+     * Use the Rasterizer to construct  a list of tiles which meet
+     * the  query polygon.   That list  of tiles  is stored  as an
+     * array of  tuples which  is then  mapped-over to  produce an
+     * array of KeyBounds.
+     */
+    val tiles = new ConcurrentHashMap[(Int,Int), Unit]
+    val fn = new Callback {
+      def apply(col : Int, row : Int): Unit = {
+        val tile : (Int, Int) = (bounds.colMin + col, bounds.rowMin + row)
+        tiles.put(tile, Unit)
+      }
+    }
+
+    multiLine.foreach(rasterExtent, options)(fn)
+    tiles.keys.asScala.map { case (col, row) => SpatialKey(col, row) }
+  }
+
+  def multiPolygonToKeys(multiPolygon: MultiPolygon): Iterator[SpatialKey] = {
+    val extent = multiPolygon.envelope
+    val bounds: GridBounds = extentToBounds(extent)
+    val options = Rasterizer.Options(includePartial=true, sampleType=PixelIsArea)
+    val boundsExtent: Extent = boundsToExtent(bounds)
+    val rasterExtent = RasterExtent(boundsExtent, bounds.width, bounds.height)
+
+    /*
+     * Use the Rasterizer to construct  a list of tiles which meet
+     * the  query polygon.   That list  of tiles  is stored  as an
+     * array of  tuples which  is then  mapped-over to  produce an
+     * array of KeyBounds.
+     */
+    val tiles = new ConcurrentHashMap[(Int,Int), Unit]
+    val fn = new Callback {
+      def apply(col : Int, row : Int): Unit = {
+        val tile : (Int, Int) = (bounds.colMin + col, bounds.rowMin + row)
+        tiles.put(tile, Unit)
+      }
+    }
+
+    multiPolygon.foreach(rasterExtent, options)(fn)
+    tiles.keys.asScala.map { case (col, row) => SpatialKey(col, row) }
+  }
 }

--- a/spark/src/test/scala/geotrellis/spark/clip/ClipToGridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/clip/ClipToGridSpec.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.clip
+
+import geotrellis.raster.TileLayout
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.spark.testkit._
+import geotrellis.vector._
+import geotrellis.vector.testkit._
+
+import org.apache.spark.rdd.RDD
+
+import org.scalatest.FunSpec
+
+class ClipToGridSpec extends FunSpec with TestEnvironment {
+  describe("ClipToGrid") {
+    val layoutDefinition =
+      LayoutDefinition(
+        Extent(0, -20.0, 10.0, 0),
+        TileLayout(10, 10, 1, 1)
+      )
+
+    def checkCorrect(actual: RDD[(SpatialKey, Geometry)], expected: Vector[(SpatialKey, Geometry)]): Unit = {
+      val result = actual.collect().toVector
+      val resultKeys = result.map(_._1).sortBy(k => (k.col, k.row))
+      val expectedKeys = expected.map(_._1).sortBy(k => (k.col, k.row))
+      resultKeys should be (expectedKeys)
+
+      val resultMap = result.groupBy(_._1).map { case (k, seq) => (k, seq.map(_._2)) }.toMap
+      val expectedMap = expected.groupBy(_._1).map { case (k, seq) => (k, seq.map(_._2)) }.toMap
+
+      for((k, resultGeoms) <- resultMap) {
+        val expectedGeoms = expectedMap(k)
+
+        resultGeoms.sortBy { g => (g.envelope.xmin, g.envelope.ymax) }
+          .zip(expectedGeoms.sortBy { g => (g.envelope.xmin, g.envelope.ymax) })
+          .foreach { case (g1, g2) =>
+            withClue(s"Failed for $k:") {
+              g1 should matchGeom (g2, 0.0001)
+            }
+          }
+      }
+    }
+
+    def withKey[T](k: SpatialKey)(f: SpatialKey => T): (SpatialKey, T) =
+      (k, f(k))
+
+    it("should clip a point") {
+      val p = Point(0, -10.0)
+      val rdd = sc.parallelize(Array(p))
+      val result = ClipToGrid(rdd, layoutDefinition).collect().toVector
+      result.size should be (1)
+      result(0) should be ((SpatialKey(0, 5), p))
+    }
+
+    it("should clip a multipoint") {
+      val p1 = Point(0, -10.0)
+      val p2 = Point(0, -10.1)
+      val p3 = Point(0, 0)
+
+      val rdd = sc.parallelize(Array(MultiPoint(p1, p2, p3)))
+      val result = ClipToGrid(rdd, layoutDefinition).collect().toVector.sortBy(_._2.envelope.ymin)
+      result.size should be (2)
+      result(0)._1 should be (SpatialKey(0, 5))
+      result(0)._2 should be (an[MultiPoint])
+      result(0)._2.asInstanceOf[MultiPoint] should matchGeom (MultiPoint(p1, p2))
+      result(1)._1 should be (SpatialKey(0, 0))
+      result(1)._2 should be (p3)
+    }
+
+    it("should clip a line") {
+      val line =
+        Line(
+          (1.5, -14.2),
+          (1.5, -12.5),
+          (2.6, -12.5),
+          (2.6, -15.1),
+          (1.6, -15.1)
+        )
+
+      val rdd = sc.parallelize(Array(line))
+      val actual = ClipToGrid(rdd, layoutDefinition)
+
+      checkCorrect(actual,
+        Vector(
+          (SpatialKey(1, 6), Line((1.5, -14.0), (1.5, -12.5), (2.0, -12.5))),
+          (SpatialKey(2, 6), Line((2.0, -12.5), (2.6, -12.5), (2.6, -14.0))),
+          (SpatialKey(2, 7), Line((2.6, -14.0), (2.6, -15.1), (2.0, -15.1))),
+          (SpatialKey(1, 7),
+            MultiLine(
+              Line((2.0, -15.1), (1.6, -15.1)),
+              Line((1.5, -14.2), (1.5, -14.0))
+            )
+          )
+        )
+      )
+    }
+
+
+    it("should clip a line contained in one key") {
+      val line =
+        Line(
+          (1.5, -14.2),
+          (1.5, -14.1),
+          (1.6, -14.1),
+          (1.6, -15.1),
+          (1.55, -15.1)
+        )
+
+      val rdd = sc.parallelize(Array(line))
+      val actual = ClipToGrid(rdd, layoutDefinition)
+
+      checkCorrect(actual, Vector((SpatialKey(1, 7), line)))
+    }
+
+    it("should clip a polygon") {
+      val shell =
+        Line(
+          (1.5, -3.0),
+          (6.5, -3.0),
+          (6.5, -19.0),
+          (1.5, -19.0),
+          (1.5, -3.0)
+        )
+
+      val hole =
+        Line(
+          (3.5, -7.0),
+          (5.5, -7.0),
+          (5.5, -15.0),
+          (3.5, -15.0),
+          (3.5, -7.0)
+        )
+
+      val poly =
+        Polygon(shell, hole)
+
+      val shellExtent = Polygon(shell).envelope
+      val holeExtent = Polygon(hole).envelope
+
+      def outerPoly(k: SpatialKey): Polygon =
+        try {
+          layoutDefinition.mapTransform(k).intersection(shellExtent).get.toPolygon
+        } catch {
+          case e: Throwable => println(s"Failed at $k"); throw e
+        }
+
+      def innerPoly(k: SpatialKey): Polygon =
+        try {
+          (layoutDefinition.mapTransform(k).toPolygon - holeExtent.toPolygon).as[Polygon].get
+        } catch {
+          case e: Throwable => println(s"Failed at $k"); throw e
+        }
+
+      val rdd = sc.parallelize(Array(poly))
+      val actual = ClipToGrid(rdd, layoutDefinition)
+
+      checkCorrect(actual,
+        Vector(
+          // Outer - Upper
+          withKey(SpatialKey(1, 1))(outerPoly(_)),
+          withKey(SpatialKey(2, 1))(outerPoly(_)),
+          withKey(SpatialKey(3, 1))(outerPoly(_)),
+          withKey(SpatialKey(4, 1))(outerPoly(_)),
+          withKey(SpatialKey(5, 1))(outerPoly(_)),
+          withKey(SpatialKey(6, 1))(outerPoly(_)),
+
+          // Outer - Right
+          withKey(SpatialKey(6, 2))(outerPoly(_)),
+          withKey(SpatialKey(6, 3))(outerPoly(_)),
+          withKey(SpatialKey(6, 4))(outerPoly(_)),
+          withKey(SpatialKey(6, 5))(outerPoly(_)),
+          withKey(SpatialKey(6, 6))(outerPoly(_)),
+          withKey(SpatialKey(6, 7))(outerPoly(_)),
+          withKey(SpatialKey(6, 8))(outerPoly(_)),
+          withKey(SpatialKey(6, 9))(outerPoly(_)),
+
+          // Outer - Bottom
+          withKey(SpatialKey(5, 9))(outerPoly(_)),
+          withKey(SpatialKey(4, 9))(outerPoly(_)),
+          withKey(SpatialKey(3, 9))(outerPoly(_)),
+          withKey(SpatialKey(2, 9))(outerPoly(_)),
+          withKey(SpatialKey(1, 9))(outerPoly(_)),
+
+          // Outer - Left
+          withKey(SpatialKey(1, 8))(outerPoly(_)),
+          withKey(SpatialKey(1, 7))(outerPoly(_)),
+          withKey(SpatialKey(1, 6))(outerPoly(_)),
+          withKey(SpatialKey(1, 5))(outerPoly(_)),
+          withKey(SpatialKey(1, 4))(outerPoly(_)),
+          withKey(SpatialKey(1, 3))(outerPoly(_)),
+          withKey(SpatialKey(1, 2))(outerPoly(_)),
+
+          // Center - Upper
+          withKey(SpatialKey(2, 2))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(3, 2))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(4, 2))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(5, 2))(layoutDefinition.mapTransform.apply(_).toPolygon),
+
+          // Center - Bottom
+          withKey(SpatialKey(2, 8))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(3, 8))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(4, 8))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(5, 8))(layoutDefinition.mapTransform.apply(_).toPolygon),
+
+          // Center - Left
+          withKey(SpatialKey(2, 7))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(2, 6))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(2, 5))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(2, 4))(layoutDefinition.mapTransform.apply(_).toPolygon),
+          withKey(SpatialKey(2, 3))(layoutDefinition.mapTransform.apply(_).toPolygon),
+
+          // Inner - Upper
+          withKey(SpatialKey(3, 3))(innerPoly(_)),
+          withKey(SpatialKey(4, 3))(innerPoly(_)),
+          withKey(SpatialKey(5, 3))(innerPoly(_)),
+
+          // Inner - Right
+          withKey(SpatialKey(5, 4))(innerPoly(_)),
+          withKey(SpatialKey(5, 5))(innerPoly(_)),
+          withKey(SpatialKey(5, 6))(innerPoly(_)),
+          withKey(SpatialKey(5, 7))(innerPoly(_)),
+
+          // Inner - Bottom
+          withKey(SpatialKey(4, 7))(innerPoly(_)),
+          withKey(SpatialKey(3, 7))(innerPoly(_)),
+
+          // Inner - Left
+          withKey(SpatialKey(3, 6))(innerPoly(_)),
+          withKey(SpatialKey(3, 5))(innerPoly(_)),
+          withKey(SpatialKey(3, 4))(innerPoly(_))
+        )
+      )
+    }
+
+  }
+}

--- a/vector-testkit/src/main/scala/geotrellis/vector/testkit/package.scala
+++ b/vector-testkit/src/main/scala/geotrellis/vector/testkit/package.scala
@@ -33,14 +33,19 @@ package object testkit {
     def matchPoint(p1: Point, p2: Point, tolerance: Double): Boolean =
       math.abs(p1.x - p2.x) <= tolerance && math.abs(p1.y - p2.y) <= tolerance
 
-    def matchLine(l1: Line, l2: Line, tolerance: Double): Boolean =
+    def matchLine(l1: Line, l2: Line, tolerance: Double): Boolean = {
+      println(l1.normalized)
+      println(l2.normalized)
       l1.normalized.points.zip(l2.normalized.points)
         .map { case (p1, p2) => matchPoint(p1, p2, tolerance) }.foldLeft(true)(_ && _)
+    }
 
-    def matchPolygon(p1: Polygon, p2: Polygon, tolerance: Double): Boolean =
-      matchLine(p1.exterior, p2.exterior, tolerance) &&
-      p1.normalized.holes.zip(p2.normalized.holes)
+    def matchPolygon(p1: Polygon, p2: Polygon, tolerance: Double): Boolean = {
+      val (np1, np2) = (p1.normalized, p2.normalized)
+      matchLine(np1.exterior, np2.exterior, tolerance) &&
+      np1.holes.zip(np2.holes)
         .map { case (l1, l2) => matchLine(l1, l2, tolerance) }.foldLeft(true)(_ && _)
+    }
 
     def matchMultiPoint(mp1: MultiPoint, mp2: MultiPoint, tolerance: Double): Boolean =
       mp1.normalized.points.zip(mp2.normalized.points)
@@ -49,7 +54,6 @@ package object testkit {
     def matchMultiLine(ml1: MultiLine, ml2: MultiLine, tolerance: Double): Boolean =
       ml1.normalized.lines.zip(ml2.normalized.lines)
          .map { case (l1, l2) => matchLine(l1, l2, tolerance) }.foldLeft(true)(_ && _)
-
 
     def matchMultiPolygon(mp1: MultiPolygon, mp2: MultiPolygon, tolerance: Double): Boolean =
       mp1.normalized.polygons.zip(mp2.normalized.polygons)
@@ -66,6 +70,25 @@ package object testkit {
       ngc1.multiPolygons.zip(ngc2.multiPolygons).map { case (mp1, mp2) => matchMultiPolygon(mp1, mp2, tolerance) }.foldLeft(true)(_ && _) &&
       ngc1.geometryCollections.zip(ngc2.geometryCollections).map { case (gc1, gc2) => matchGeometryCollection(gc1, gc2, tolerance) }.foldLeft(true)(_ && _)
     }
+
+    def matchGeometry(g1: Geometry, g2: Geometry, tolerance: Double): Boolean =
+      g2 match {
+        case p: Point =>
+          g1.isInstanceOf[Point] && matchPoint(g1.asInstanceOf[Point], p, tolerance)
+        case mp: MultiPoint =>
+          g1.isInstanceOf[MultiPoint] && matchMultiPoint(g1.asInstanceOf[MultiPoint], mp, tolerance)
+        case l: Line =>
+          g1.isInstanceOf[Line] && matchLine(g1.asInstanceOf[Line], l, tolerance)
+        case ml: MultiLine =>
+          g1.isInstanceOf[MultiLine] && matchMultiLine(g1.asInstanceOf[MultiLine], ml, tolerance)
+        case p: Polygon =>
+          g1.isInstanceOf[Polygon] && matchPolygon(g1.asInstanceOf[Polygon], p, tolerance)
+        case mp: MultiPolygon =>
+          g1.isInstanceOf[MultiPolygon] && matchMultiPolygon(g1.asInstanceOf[MultiPolygon], mp, tolerance)
+        case gc: GeometryCollection =>
+          g1.isInstanceOf[GeometryCollection] && matchGeometryCollection(g1.asInstanceOf[GeometryCollection], gc, tolerance)
+      }
+
 
   }
 
@@ -117,4 +140,7 @@ package object testkit {
   def matchGeom(g: Extent): ExtentMatcher = matchGeom(g, 0.0)
   def matchGeom(g: Extent, tolerance: Double): ExtentMatcher = ExtentMatcher(g, tolerance)
 
+  def matchGeom(g: Geometry): GeometryMatcher[Geometry] = matchGeom(g, 0.0)
+  def matchGeom(g: Geometry, tolerance: Double): GeometryMatcher[Geometry] =
+    GeometryMatcher(g, tolerance, GeometryMatcher.matchGeometry)
 }


### PR DESCRIPTION
This PR adds `ClipToGrid`, which takes an RDD of Features and clips them to `SpatialKey`s based on `LayoutDefinition`.

This functionality is generally useful, but was moved from a version in [VectorPipe](https://github.com/geotrellis/vectorpipe) to here in service of a specific class of vector join problems, in service of #2116. I [added and example](https://github.com/locationtech/geotrellis/pull/2424/files#diff-d80a3e82172d43a81e629e86465decbf) in the `doc-examples` project that shows a polygonal summary of `PolygonFeature[UUID]`s that were in an RDD, based on a set of GeoTiffs on S3.

A full solution to #2116 will take some more thought, which I hear is in line with some work the GeoMesa folk are doing, and we can collaborate on.

Some other things to note:
- I broke out some of the logic in the LayerFilters for MultiPolygon and MultiLine so I could reuse that logic. It seemed like the most appropriate place for it was MapKeyTransform.
- I fixed up a deprecation warning message along the way.