### PR TITLE
Optimize TileRDDReproject

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -286,4 +286,19 @@ case class GridBounds(colMin: Int, rowMin: Int, colMax: Int, rowMax: Int) {
       other.rowMin >= rowMin &&
       other.colMax <= colMax &&
       other.rowMax <= rowMax
+
+  /** Split into windows, covering original GridBounds */
+  def split(cols: Int, rows: Int): Iterator[GridBounds] = {
+    for {
+      windowRowMin <- Iterator.range(start = rowMin, end = rowMax + 1, step = rows)
+      windowColMin <- Iterator.range(start = colMin, end = colMax + 1, step = cols)
+    } yield {
+      GridBounds(
+        colMin = windowColMin,
+        rowMin = windowRowMin,
+        colMax = math.min(windowColMin + cols - 1, colMax),
+        rowMax = math.min(windowRowMin + rows - 1, rowMax)
+      )
+    }
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/ascii/ReadState.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/ascii/ReadState.scala
@@ -35,7 +35,7 @@ trait ReadState {
 
   /**
     * Creates the Tile of the resampled Raster.
-    * By default creates an ArrayTile of the 
+    * By default creates an ArrayTile of the
     * type defined by getType.
     */
   def createTile(cols: Int, rows: Int): MutableArrayTile = ArrayTile.empty(getType, cols, rows)
@@ -97,7 +97,7 @@ trait ReadState {
     // TODO: only initialize the part we will read from
     val src_size = src_rows * src_cols
     initSource(0, src_size)
-    
+
     // this is the resampled destination array
     val dst_size = dst_cols * dst_rows
     val resampled = createTile(dst_cols, dst_rows)
@@ -123,12 +123,12 @@ trait ReadState {
 
         // start at the X-center of the first dst grid cell
         var x = xbase
-        
+
         // loop over cols
         cfor(0)(_ < dst_cols, _ + 1) { dst_col =>
           // calculate the X grid coordinate to read from
           val src_col = (x / src_cellwidth).asInstanceOf[Int]
-          
+
           // compute src and dst indices and ASSIGN!
           val src_i = src_span + src_col
 
@@ -139,7 +139,7 @@ trait ReadState {
             val dst_i = dst_span + dst_col
             assignFromSource(src_i, resampled, dst_i)
           }
-          
+
           // increase our X map coordinate
           x += dst_cellwidth
         }

--- a/raster/src/main/scala/geotrellis/raster/reproject/SinglebandRasterReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/SinglebandRasterReprojectMethods.scala
@@ -27,7 +27,7 @@ trait SinglebandRasterReprojectMethods extends RasterReprojectMethods[Singleband
   import Reproject.Options
 
   def reproject(
-    targetRasterExtent: RasterExtent, 
+    targetRasterExtent: RasterExtent,
     transform: Transform,
     inverseTransform: Transform,
     options: Options

--- a/raster/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/GridBoundsSpec.scala
@@ -162,4 +162,36 @@ class GridBoundsSpec extends FunSpec with Matchers{
       actual.sizeLong shouldBe expected.sizeLong
     }
   }
+
+  describe("GridBounds.split") {
+    it("should not split too small a GridBounds") {
+      val gbs = GridBounds(0,0,7,5)
+      val result = gbs.split(10, 15).toList
+      result.head should be (gbs)
+    }
+
+    it("should split even GridBounds") {
+      val gbs = GridBounds(0,0,9,9)
+      val result = gbs.split(5,5).toList
+      result.length should be (4)
+      result should contain allOf (
+        GridBounds(0,0,4,4),
+        GridBounds(5,0,9,4),
+        GridBounds(0,5,4,9),
+        GridBounds(5,5,9,9)
+      )
+    }
+
+    it("should split un-even GridBounds") {
+      val gbs = GridBounds(0,0,10,10)
+      val result = gbs.split(10,10).toList
+      result.length should be (4)
+      result should contain allOf (
+        GridBounds(0,0,9,9),
+        GridBounds(10,0,10,9),
+        GridBounds(0,10,9,10),
+        GridBounds(10,10,10,10)
+      )
+    }
+  }
 }

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -60,7 +60,8 @@ object TileRDDReproject {
     metadata: TileLayerMetadata[K],
     destCrs: CRS,
     targetLayout: Either[LayoutScheme, LayoutDefinition],
-    options: Options
+    options: Options,
+    sc: Option[SparkContext] = None
   ): (Int, RDD[(K, V)] with Metadata[TileLayerMetadata[K]]) = {
     val crs: CRS = metadata.crs
     val layout = metadata.layout

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -44,7 +44,7 @@ object TileRDDReproject {
     * @tparam           K           Key type; requires spatial component.
     * @tparam           V           Tile type; requires the ability to stitch, crop, reproject, merge, and create.
     *
-    * @param            bufferedTiles                An RDD of buffered tiles, created using the BufferTiles operation.
+    * @param            bufferedTiles      An RDD of buffered tiles, created using the BufferTiles operation.
     * @param            metadata           The raster metadata for this keyed tile set.
     * @param            destCrs            The CRS to reproject to.
     * @param            targetLayout       Either the layout scheme or layout definition to use when re-keying the reprojected layers.

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -80,46 +80,56 @@ object TileRDDReproject {
           }
       }
 
+    val (sampleKey, BufferedTile(sampleTile, sampleGridBounds)) = bufferedTiles.first() // XXX
+    val tileCols = sampleTile.cols // XXX metadata.layout.tileCols
+    val tileRows = sampleTile.rows // XXX metadata.layout.tileRows
+    val KeyBounds(SpatialKey(keyColMin, keyRowMin), SpatialKey(keyColMax, keyRowMax)) = metadata.bounds
+    val lb = scala.collection.mutable.ListBuffer.empty[K]
+
+    }
+
     val layerInfo: (Extent, CellSize, KeyBounds[K]) =
       bufferedTiles
         .mapPartitions({ partition =>
           val transform = Transform(crs, destCrs)
           val inverseTransform = Transform(destCrs, crs)
 
-          partition.map { case (key, BufferedTile(tile, gridBounds)) =>
+          partition.map { case (key, BufferedTile(_, _)) =>
             val innerExtent = mapTransform(key)
-            val innerRasterExtent = RasterExtent(innerExtent, gridBounds.width, gridBounds.height)
+            val innerRasterExtent = RasterExtent(innerExtent, sampleGridBounds.width, sampleGridBounds.height)
             val outerGridBounds =
               GridBounds(
-                -gridBounds.colMin,
-                -gridBounds.rowMin,
-                tile.cols - gridBounds.colMin - 1,
-                tile.rows - gridBounds.rowMin - 1
+                -sampleGridBounds.colMin,
+                -sampleGridBounds.rowMin,
+                tileCols - sampleGridBounds.colMin - 1,
+                tileRows - sampleGridBounds.rowMin - 1
               )
             val outerExtent = innerRasterExtent.extentFor(outerGridBounds, clamp = false)
 
             val window =
               if(options.matchLayerExtent) {
-                gridBounds
+                sampleGridBounds
               } else {
                 // Reproject extra cells that are half the buffer size, as to avoid
                 // any missed cells between tiles.
                 GridBounds(
-                  gridBounds.colMin / 2,
-                  gridBounds.rowMin / 2,
-                  (tile.cols + gridBounds.colMax - 1) / 2,
-                  (tile.rows + gridBounds.rowMax - 1) / 2
+                  sampleGridBounds.colMin / 2,
+                  sampleGridBounds.rowMin / 2,
+                  (tileCols + sampleGridBounds.colMax - 1) / 2,
+                  (tileRows + sampleGridBounds.rowMax - 1) / 2
                 )
               }
 
-            val Raster(newTile, newExtent) =
-              tile.reproject(outerExtent, window, transform, inverseTransform, rasterReprojectOptions)
+            val rasterExtent = RasterExtent(outerExtent, tileCols, tileRows)
+            val windowExtent = rasterExtent.extentFor(window)
+            val windowRasterExtent = RasterExtent(windowExtent, window.width, window.height)
+            val targetRasterExtent = ReprojectRasterExtent(windowRasterExtent, transform)
 
-            ((key, newExtent), newTile)
+            (key, targetRasterExtent.extent, targetRasterExtent.cols, targetRasterExtent.rows)
           }
         })
-        .map({ case ((key, extent), tile) =>
-          (extent, CellSize(extent, tile.cols, tile.rows), KeyBounds(key, key))
+        .map({ case (key, extent, cols, rows) =>
+          (extent, CellSize(extent, cols, rows), KeyBounds(key, key))
         })
         .reduce({ case ((e1, cs1, kb1), (e2, cs2, kb2)) =>
           val e = e1.combine(e2)

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -80,6 +80,55 @@ object TileRDDReproject {
           }
       }
 
+    val layerInfo: (Extent, CellSize, KeyBounds[K]) =
+      bufferedTiles
+        .mapPartitions({ partition =>
+          val transform = Transform(crs, destCrs)
+          val inverseTransform = Transform(destCrs, crs)
+
+          partition.map { case (key, BufferedTile(tile, gridBounds)) =>
+            val innerExtent = mapTransform(key)
+            val innerRasterExtent = RasterExtent(innerExtent, gridBounds.width, gridBounds.height)
+            val outerGridBounds =
+              GridBounds(
+                -gridBounds.colMin,
+                -gridBounds.rowMin,
+                tile.cols - gridBounds.colMin - 1,
+                tile.rows - gridBounds.rowMin - 1
+              )
+            val outerExtent = innerRasterExtent.extentFor(outerGridBounds, clamp = false)
+
+            val window =
+              if(options.matchLayerExtent) {
+                gridBounds
+              } else {
+                // Reproject extra cells that are half the buffer size, as to avoid
+                // any missed cells between tiles.
+                GridBounds(
+                  gridBounds.colMin / 2,
+                  gridBounds.rowMin / 2,
+                  (tile.cols + gridBounds.colMax - 1) / 2,
+                  (tile.rows + gridBounds.rowMax - 1) / 2
+                )
+              }
+
+            val Raster(newTile, newExtent) =
+              tile.reproject(outerExtent, window, transform, inverseTransform, rasterReprojectOptions)
+
+            ((key, newExtent), newTile)
+          }
+        })
+        .map({ case ((key, extent), tile) =>
+          (extent, CellSize(extent, tile.cols, tile.rows), KeyBounds(key, key))
+        })
+        .reduce({ case ((e1, cs1, kb1), (e2, cs2, kb2)) =>
+          val e = e1.combine(e2)
+          val cs = if (cs1.resolution < cs2.resolution) cs1 else cs2
+          val kb = kb1.combine(kb2)
+
+          (e, cs, kb)
+        })
+
     val reprojectedTiles =
       bufferedTiles
         .mapPartitions { partition =>

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -60,12 +60,12 @@ object TileRDDReproject {
     metadata: TileLayerMetadata[K],
     destCrs: CRS,
     targetLayout: Either[LayoutScheme, LayoutDefinition],
-    options: Options,
-    sc: Option[SparkContext] = None
+    options: Options
   ): (Int, RDD[(K, V)] with Metadata[TileLayerMetadata[K]]) = {
     val crs: CRS = metadata.crs
     val layout = metadata.layout
     val tileLayout: TileLayout = layout.tileLayout
+    val sc = bufferedTiles.context
 
     val rasterReprojectOptions =
       options.rasterReprojectOptions.parentGridExtent match {
@@ -81,27 +81,24 @@ object TileRDDReproject {
           }
       }
 
-    val (sampleKey, BufferedTile(sampleTile, sampleGridBounds)) = bufferedTiles.first() // XXX
+    val BufferedTile(sampleTile, sampleGridBounds) = bufferedTiles.first()._2 // XXX
     val tileCols = sampleTile.cols // XXX metadata.layout.tileCols
     val tileRows = sampleTile.rows // XXX metadata.layout.tileRows
-    val KeyBounds(SpatialKey(keyColMin, keyRowMin), SpatialKey(keyColMax, keyRowMax)) = metadata.bounds
-    val lb = scala.collection.mutable.ListBuffer.empty[K]
+    val KeyBounds(keyMin, keyMax) = metadata.bounds
+    val SpatialKey(keyColMin, keyRowMin) = keyMin.getComponent[SpatialKey]
+    val SpatialKey(keyColMax, keyRowMax) = keyMax.getComponent[SpatialKey]
+    val lb = scala.collection.mutable.ListBuffer.empty[SpatialKey]
 
-    if (sc != None) {
-      var col = keyColMin; while (col <= keyColMax) {
-        var row = keyRowMin; while (row <= keyRowMax) {
-          lb += sampleKey.setComponent(SpatialKey(col, row))
-          row += 1
-        }
-        col += 1
+    var col = keyColMin; while (col <= keyColMax) {
+      var row = keyRowMin; while (row <= keyRowMax) {
+        lb += SpatialKey(col, row)
+        row += 1
       }
+      col += 1
     }
 
-    val layerInfo: (Extent, CellSize, KeyBounds[K]) =
-      (sc match {
-        case Some(sc) => sc.parallelize(lb)
-        case None => bufferedTiles.map({ case (key, _) => key })
-      })
+    val layerInfo: (Extent, CellSize) =
+      sc.parallelize(lb)
         .mapPartitions({ partition =>
           val transform = Transform(crs, destCrs)
           val inverseTransform = Transform(destCrs, crs)
@@ -137,18 +134,17 @@ object TileRDDReproject {
             val windowRasterExtent = RasterExtent(windowExtent, window.width, window.height)
             val targetRasterExtent = ReprojectRasterExtent(windowRasterExtent, transform)
 
-            (key, targetRasterExtent.extent, targetRasterExtent.cols, targetRasterExtent.rows)
+            (targetRasterExtent.extent, targetRasterExtent.cols, targetRasterExtent.rows)
           }
         })
-        .map({ case (key, extent, cols, rows) =>
-          (extent, CellSize(extent, cols, rows), KeyBounds(key, key))
+        .map({ case (extent, cols, rows) =>
+          (extent, CellSize(extent, cols, rows))
         })
-        .reduce({ case ((e1, cs1, kb1), (e2, cs2, kb2)) =>
-          val e = e1.combine(e2)
-          val cs = if (cs1.resolution < cs2.resolution) cs1 else cs2
-          val kb = kb1.combine(kb2)
+        .reduce({ case ((e1, cs1), (e2, cs2)) =>
+          val extent = e1.combine(e2)
+          val cellSize = if (cs1.resolution < cs2.resolution) cs1 else cs2
 
-          (e, cs, kb)
+          (extent, cellSize)
         })
 
     val reprojectedTiles =
@@ -194,9 +190,9 @@ object TileRDDReproject {
       targetLayout match {
         case Left(layoutScheme) =>
           // If it's a floating layout scheme, the cell grid will line up and we always want to use nearest neighbor resampling
-          val (extent, cellSize, bounds) = layerInfo
+          val (extent, cellSize) = layerInfo
           val LayoutLevel(z, layout) = layoutScheme.levelFor(extent, cellSize)
-          val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
+          val kb = metadata.bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
           val m = TileLayerMetadata(metadata.cellType, layout, extent, destCrs, kb)
 
           layoutScheme match {
@@ -207,8 +203,8 @@ object TileRDDReproject {
           }
 
         case Right(layoutDefinition) =>
-          val (extent, cellSize, bounds) = layerInfo
-          val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
+          val (extent, cellSize) = layerInfo
+          val kb = metadata.bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
           val m = TileLayerMetadata(metadata.cellType, layoutDefinition, extent, destCrs, kb)
 
           (0, m, options.rasterReprojectOptions.method)

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -172,15 +172,23 @@ object TileRDDReproject {
       targetLayout match {
         case Left(layoutScheme) =>
           // If it's a floating layout scheme, the cell grid will line up and we always want to use nearest neighbor resampling
-          val (z, m) = reprojectedTiles.collectMetadata(destCrs, layoutScheme)
+          val (extent, cellSize, bounds) = layerInfo
+          val LayoutLevel(z, layout) = layoutScheme.levelFor(extent, cellSize)
+          val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
+          val m = TileLayerMetadata(metadata.cellType, layout, extent, destCrs, kb)
+
           layoutScheme match {
             case _: FloatingLayoutScheme =>
               (z, m, NearestNeighbor)
             case _ =>
               (z, m, options.rasterReprojectOptions.method)
           }
+
         case Right(layoutDefinition) =>
-          val m = reprojectedTiles.collectMetadata(destCrs, layoutDefinition)
+          val (extent, cellSize, bounds) = layerInfo
+          val kb = bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
+          val m = TileLayerMetadata(metadata.cellType, layoutDefinition, extent, destCrs, kb)
+
           (0, m, options.rasterReprojectOptions.method)
       }
 

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -87,15 +87,26 @@ object TileRDDReproject {
     val KeyBounds(SpatialKey(keyColMin, keyRowMin), SpatialKey(keyColMax, keyRowMax)) = metadata.bounds
     val lb = scala.collection.mutable.ListBuffer.empty[K]
 
+    if (sc != None) {
+      var col = keyColMin; while (col <= keyColMax) {
+        var row = keyRowMin; while (row <= keyRowMax) {
+          lb += sampleKey.setComponent(SpatialKey(col, row))
+          row += 1
+        }
+        col += 1
+      }
     }
 
     val layerInfo: (Extent, CellSize, KeyBounds[K]) =
-      bufferedTiles
+      (sc match {
+        case Some(sc) => sc.parallelize(lb)
+        case None => bufferedTiles.map({ case (key, _) => key })
+      })
         .mapPartitions({ partition =>
           val transform = Transform(crs, destCrs)
           val inverseTransform = Transform(destCrs, crs)
 
-          partition.map { case (key, BufferedTile(_, _)) =>
+          partition.map { key =>
             val innerExtent = mapTransform(key)
             val innerRasterExtent = RasterExtent(innerExtent, sampleGridBounds.width, sampleGridBounds.height)
             val outerGridBounds =

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -123,8 +123,12 @@ object TileRDDReproject {
     val reprojectSummary = matchReprojectRasterExtent(
       metadata.crs, destCrs,
       metadata.layout,
-      Some(metadata.bounds.asInstanceOf[KeyBounds[SpatialKey]])
-    )(sc)
+      metadata.bounds match {
+        case KeyBounds(s, e) =>
+          Some(KeyBounds(s.getComponent[SpatialKey], e.getComponent[SpatialKey]))
+        case _ =>
+          None
+      })(sc)
     logger.info(s"$reprojectSummary")
     val extent = reprojectSummary.extent
     val cellSize = reprojectSummary.cellSize

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -345,7 +345,7 @@ object TileRDDReproject {
   ) {
     /** Combine summary and project pixel counts to highest resolution */
     def combine(other: ReprojectSummary): ReprojectSummary = {
-      if (cellSize.resolution < other.cellSize.resolution)
+      if (cellSize.resolution <= other.cellSize.resolution)
         ReprojectSummary(
           sourcePixels + other.sourcePixels,
           pixels + other.rescaledPixelCount(cellSize),

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -354,7 +354,7 @@ object TileRDDReproject {
       else
         ReprojectSummary(
           sourcePixels + other.sourcePixels,
-          rescaledPixelCount(other.cellSize) + other.pixels
+          rescaledPixelCount(other.cellSize) + other.pixels,
           extent combine other.extent,
           other.cellSize)
     }

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -352,7 +352,11 @@ object TileRDDReproject {
           extent combine other.extent,
           cellSize)
       else
-        other.combine(this)
+        ReprojectSummary(
+          sourcePixels + other.sourcePixels,
+          rescaledPixelCount(other.cellSize) + other.pixels
+          extent combine other.extent,
+          other.cellSize)
     }
 
     /** How many pixels were added in reproject */


### PR DESCRIPTION
Connects https://github.com/locationtech/geotrellis/issues/2294
Connects https://github.com/locationtech/geotrellis/issues/2315
Supersedes  https://github.com/locationtech/geotrellis/pull/2300

In the RDD reproject step instead of projecting tiles to their raster extent, re-projecting and collecting the metadata from the results, use the key bounds and the source layout to perform the the reproject on raster extent as a side compute operation. Because every pixel covered by the `RasterExtent` is in the data source we do not have to consider buffer sizes.

Tracking the changes in the pixel count on per-tile basis allows to get more accurate track of possible increase in raster layer memory footprint. The final tileToLayout operation is going to use the most resolute cellSize for the whole layer so we must perform a rolling adjustment on accumulated pixel counts of reprojected raster extents. (Tiles in different parts of the layer will undergo be warped in different manners, depending on the projections involved) 

Notes:
Tracking the pixel count through the reprojected metadata and then adjusting it for possible changes in layout appears to be giving better results wrt #2294 but still needs verification.

Using spark to launch a job for reprojected metadata collect wrt #2315 appears solid and preferable to the side-collect.