### PR TITLE
Generate Largest-Possible Tiles

### DIFF
--- a/s3/src/test/scala/geotrellis/spark/io/s3/S3GeoTiffRDDSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/S3GeoTiffRDDSpec.scala
@@ -67,7 +67,7 @@ class S3GeoTiffRDDSpec
       val geoTiffBytes = Files.readAllBytes(Paths.get(testGeoTiffPath))
       mockClient.putObject(bucket, key, geoTiffBytes)
 
-      val options = S3GeoTiffRDD.Options(getS3Client = () => new MockS3Client, partitionBytes=1<<20)
+      val options = S3GeoTiffRDD.Options(getS3Client = () => new MockS3Client, partitionBytes=1<<20, maxTileSize = Some(64))
       val geometry = Line(Point(141.7066667, -17.5200000), Point(142.1333333, -17.7))
       val fn = {( _: Any, key: ProjectedExtent) => key }
       val source1 =

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDDSpec.scala
@@ -44,7 +44,7 @@ class HadoopGeoTiffRDDSpec
 
     it("should filter by geometry") {
       val testGeoTiffPath = new Path(localFS.getWorkingDirectory, "spark/src/test/resources/all-ones.tif")
-      val options = HadoopGeoTiffRDD.Options(partitionBytes=Some(1<<20))
+      val options = HadoopGeoTiffRDD.Options(partitionBytes=Some(1<<20), maxTileSize = Some(64))
       val geometry = Line(Point(141.7066667, -17.5200000), Point(142.1333333, -17.7))
       val fn = {( _: URI, key: ProjectedExtent) => key }
       val source1 =


### PR DESCRIPTION
@jbouffard found the `GeoTiffRDD` machinery to produce inconveniently-small tiles because tiles are currently no larger than segments (in particular the "all-ones" test image has segments of size 128x4 but he wanted tiles of size 256x256).

If the Hadoop and S3 range readers read only those segments which overlap the given window (and not all segments between the first and last segments that a window touches), then this change safely fixes the problem that Jake noticed.  If the range readers do not have that behavior, then perhaps tiles should be merged before they are returned (or perhaps not).