### PR TITLE
KeyFormats are Now Serializable

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/json/KeyFormats.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/json/KeyFormats.scala
@@ -23,7 +23,7 @@ import spray.json.DefaultJsonProtocol._
 
 object KeyFormats extends KeyFormats
 
-trait KeyFormats {
+trait KeyFormats extends Serializable {
   implicit object SpatialKeyFormat extends RootJsonFormat[SpatialKey] {
     def write(key: SpatialKey) =
       JsObject(


### PR DESCRIPTION
This PR makes the `KeyFormats` serializable. This is needed as serialization issues due to these objects have been encountered when using GeoPySpark EMR.

```
Py4JJavaError: An error occurred while calling o32.tileToLayout.
: org.apache.spark.SparkException: Task not serializable
	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:298)
	at org.apache.spark.util.ClosureCleaner$.org$apache$spark$util$ClosureCleaner$$clean(ClosureCleaner.scala:288)
	at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:108)
	at org.apache.spark.SparkContext.clean(SparkContext.scala:2094)
	at org.apache.spark.rdd.RDD$$anonfun$map$1.apply(RDD.scala:370)
	at org.apache.spark.rdd.RDD$$anonfun$map$1.apply(RDD.scala:369)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
	at org.apache.spark.rdd.RDD.withScope(RDD.scala:362)
	at org.apache.spark.rdd.RDD.map(RDD.scala:369)
	at geopyspark.geotrellis.TemporalTiledRasterLayer.tileToLayout(TemporalTiledRasterLayer.scala:211)
	at geopyspark.geotrellis.TemporalTiledRasterLayer.tileToLayout(TemporalTiledRasterLayer.scala:236)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:280)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:214)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.NotSerializableException: geotrellis.spark.io.json.KeyFormats$SpaceTimeKeyFormat$
Serialization stack:
	- object not serializable (class: geotrellis.spark.io.json.KeyFormats$SpaceTimeKeyFormat$, value: geotrellis.spark.io.json.KeyFormats$SpaceTimeKeyFormat$@1329ccc0)
	- field (class: geopyspark.geotrellis.TiledRasterLayer, name: evidence$2, type: interface spray.json.JsonFormat)
	- object (class geopyspark.geotrellis.TemporalTiledRasterLayer, geopyspark.geotrellis.TemporalTiledRasterLayer@39017a11)
	- field (class: geopyspark.geotrellis.TemporalTiledRasterLayer$$anonfun$22, name: $outer, type: class geopyspark.geotrellis.TemporalTiledRasterLayer)
	- object (class geopyspark.geotrellis.TemporalTiledRasterLayer$$anonfun$22, <function2>)
	- field (class: geopyspark.geotrellis.TemporalTiledRasterLayer$$anonfun$23, name: convertElem$1, type: interface scala.Function2)
	- object (class geopyspark.geotrellis.TemporalTiledRasterLayer$$anonfun$23, <function1>)
	at org.apache.spark.serializer.SerializationDebugger$.improveException(SerializationDebugger.scala:40)
	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:46)
	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:100)
	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:295)
	... 22 more
```