### PR TITLE
[WIP] Tobler walking speed focal op

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/tobler/Tobler.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/tobler/Tobler.scala
@@ -1,0 +1,16 @@
+package geotrellis.raster.mapalgebra.focal.tobler
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.local._
+import geotrellis.raster.mapalgebra.focal._
+
+object Tobler {
+
+  def apply(r: Tile, n: Neighborhood, bounds: Option[GridBounds], cs: CellSize, z: Double, target: TargetCell = TargetCell.All): Tile = {
+
+    val slope = Slope(r, n, bounds, cs ,z, target)
+
+    6 *: (math.E **: (((slope * math.Pi / 180.0).localTan + 0.05).localAbs * (-3.5)))
+  }
+
+}

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/tobler/ToblerMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/tobler/ToblerMethods.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.mapalgebra.focal.tobler
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.focal._
+import geotrellis.util.MethodExtensions
+
+trait ToblerMethods extends MethodExtensions[Tile] {
+
+  def tobler(cs: CellSize, zFactor: Double = 1.0, bounds: Option[GridBounds] = None, target: TargetCell = TargetCell.All): Tile =
+    Tobler(self, Square(1), bounds, cs, zFactor, target)
+
+}

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -59,6 +59,7 @@ package object raster
       with hydrology.HydrologyMethods
       with mapalgebra.focal.FocalMethods
       with mapalgebra.focal.hillshade.HillshadeMethods
+      with mapalgebra.focal.tobler.ToblerMethods
       with mapalgebra.local.LocalMethods
       with mapalgebra.zonal.ZonalMethods
       with mask.SinglebandTileMaskMethods

--- a/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/tobler/ToblerSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/tobler/ToblerSpec.scala
@@ -1,0 +1,31 @@
+package geotrellis.raster.mapalgebra.focal.tobler
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.focal._
+import geotrellis.raster.mapalgebra.focal.tobler._
+import geotrellis.raster.testkit._
+import geotrellis.util.Constants.{FLOAT_EPSILON => EPSILON}
+
+import scala.math.{abs, exp}
+
+import org.scalatest._
+
+class ToblerSpec extends FunSpec with Matchers with RasterMatchers with FocalOpSpec {
+
+  describe("Tobler") {
+    it ("should produce expected results") {
+      val elev = DoubleArrayTile.ofDim(5, 5).mapDouble{ (x, _, _) => x }
+      assert(elev.get(3, 3) == 3)
+
+      val slopeAngle = elev.slope(CellSize(1, 1))
+      assert(abs(slopeAngle.get(3,3) - 45) < EPSILON)
+      val slope = (slopeAngle * math.Pi / 180.0).localTan
+      assert(abs(slope.getDouble(3, 3) - 1.0) < EPSILON)
+
+      val tobler = elev.tobler(CellSize(1, 1))
+
+      (abs(tobler.getDouble(3,3) - 6 * exp(-3.5 * abs(1 + 0.05))) < EPSILON) should be (true)
+    }
+  }
+
+}

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/tobler/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/tobler/Implicits.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.mapalgebra.focal.tobler
+
+import geotrellis.spark._
+
+import reflect.ClassTag
+
+object Implicits extends Implicits
+
+trait Implicits  {
+  implicit class withToblerTileLayerRDDMethods[K](val self: TileLayerRDD[K])
+    (implicit val keyClassTag: ClassTag[K], implicit val _sc: SpatialComponent[K])
+      extends ToblerTileLayerRDDMethods[K] with Serializable
+
+  implicit class withToblerTileLayerCollectionMethods[K](val self: TileLayerCollection[K])
+    (implicit val _sc: SpatialComponent[K]) extends ToblerTileLayerCollectionMethods[K] with Serializable
+}

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/tobler/ToblerTileLayerCollectionMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/tobler/ToblerTileLayerCollectionMethods.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.mapalgebra.focal.tobler
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.focal._
+import geotrellis.raster.mapalgebra.focal.tobler._
+import geotrellis.spark.mapalgebra.focal._
+
+trait ToblerTileLayerCollectionMethods[K] extends CollectionFocalOperation[K] {
+  /** Calculates the Tobler walking speed approximation of each cell in a raster.
+   *
+   * @see [[geotrellis.raster.mapalgebra.focal.Tobler]]
+   */
+  def tobler(zFactor: Double = 1.0, target: TargetCell = TargetCell.All) = {
+    val n = Square(1)
+    focalWithCellSize(n) { (tile, bounds, cellSize) =>
+      Tobler(tile, n, bounds, cellSize, zFactor, target)
+    }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/tobler/ToblerTileLayerRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/tobler/ToblerTileLayerRDDMethods.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.mapalgebra.focal.tobler
+
+import geotrellis.raster._
+import geotrellis.spark.mapalgebra.focal._
+import geotrellis.raster.mapalgebra.focal.tobler._
+import geotrellis.raster.mapalgebra.focal._
+
+trait ToblerTileLayerRDDMethods[K] extends FocalOperation[K] {
+  /** Calculates the hillshade of each cell in a raster.
+   *
+   * @see [[geotrellis.raster.mapalgebra.focal.Hillshade]]
+   */
+  def tobler(zFactor: Double = 1.0, target: TargetCell = TargetCell.All) = {
+    val n = Square(1)
+    focalWithCellSize(n) { (tile, bounds, cellSize) =>
+      Tobler(tile, n, bounds, cellSize, zFactor, target)
+    }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -43,8 +43,9 @@ package object spark
     with filter.Implicits
     with join.Implicits
     with knn.Implicits
-    with mapalgebra.focal.hillshade.Implicits
     with mapalgebra.focal.Implicits
+    with mapalgebra.focal.hillshade.Implicits
+    with mapalgebra.focal.tobler.Implicits
     with mapalgebra.Implicits
     with mapalgebra.local.Implicits
     with mapalgebra.local.temporal.Implicits

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/tobler/ToblerSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/tobler/ToblerSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.mapalgebra.focal.tobler
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.focal.tobler._
+
+import geotrellis.spark._
+import geotrellis.spark.testkit._
+
+import geotrellis.vector.Extent
+
+import org.scalatest._
+import spire.syntax.cfor._
+
+class ToblerSpec extends FunSpec with TestEnvironment {
+
+  describe("Tobler walking speed") {
+
+    it("should get the same Tobler result for spark op as single raster op") {
+      val rasterOp = (tile: Tile, re: RasterExtent) => tile.tobler(re.cellSize)
+      val sparkOp = (rdd: TileLayerRDD[SpatialKey]) => rdd.tobler()
+
+      val path = "aspect.tif"
+
+      testGeoTiff(sc, path)(rasterOp, sparkOp)
+    }
+
+    it("should get the same Tobler result for spark op as single raster op (collection api)") {
+      val rasterOp = (tile: Tile, re: RasterExtent) => tile.tobler(re.cellSize)
+      val sparkOp = (collection: TileLayerCollection[SpatialKey]) => collection.tobler()
+
+      val path = "aspect.tif"
+
+      testGeoTiffCollection(sc, path)(rasterOp, sparkOp)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds methods to generate a Tobler walking speed layer from an elevation raster.

**There are issues inherent to this PR that must be resolved prior to merge!**

Notably, the use of this Tobler calculation is direction-agnostic, so all slopes are assumed to be uphill.  (This should be the Cosby distance—his father, after all, did walk to school uphill both ways.) Changes to the way we calculate slope are essential to improve this contribution.