### PR TITLE
Exact line to grid cell rasterization

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
@@ -328,6 +328,19 @@ object Rasterizer {
   }
 
   /**
+    * Iterates over the cells determined by the segments of a
+    * LineString.  The iteration happens in the direction from the
+    * first point to the last point.
+    */
+  @deprecated("This function will be deprecated in 2.0 in favor of richer options on foreachCellByGeometry", "1.2")
+  def foreachCellByLineStringDouble(line: Line, re: RasterExtent)(f: (Int, Int) => Unit) {
+    val coords = line.jtsGeom.getCoordinates()
+    var i = 1; while (i < coords.size) {
+      foreachCellInGridLine(coords(i-1).x, coords(i-1).y, coords(i+0).x, coords(i+0).y, re, line.isClosed || i != coords.size - 1)(f)
+      i += 1
+    }
+  }
+  /**
     * Implementation drawn from ``A Fast Voxel Traversal Algorithm for Ray
     * Tracing'' by John Amanatides and Andrew Woo.  Dept. of Computer Science,
     * University of Toronto.
@@ -345,7 +358,7 @@ object Rasterizer {
     * @param    skipLast           Boolean flag
     * @param    f                  Function to apply: f(cols, row, feature)
     */
-  def foreachCellInGridLineExact(
+  private def foreachCellInGridLineDouble(
     x0: Double, y0: Double,
     x1: Double, y1: Double,
     re: RasterExtent,

--- a/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
@@ -336,7 +336,7 @@ object Rasterizer {
   def foreachCellByLineStringDouble(line: Line, re: RasterExtent)(f: (Int, Int) => Unit) {
     val coords = line.jtsGeom.getCoordinates()
     var i = 1; while (i < coords.size) {
-      foreachCellInGridLine(coords(i-1).x, coords(i-1).y, coords(i+0).x, coords(i+0).y, re, line.isClosed || i != coords.size - 1)(f)
+      foreachCellInGridLineDouble(coords(i-1).x, coords(i-1).y, coords(i+0).x, coords(i+0).y, re, line.isClosed || i != coords.size - 1)(f)
       i += 1
     }
   }

--- a/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
@@ -393,8 +393,8 @@ object Rasterizer {
     val stepX = math.signum(x1 - x0).toInt
     val stepY = math.signum(y0 - y1).toInt
 
-    val firstX = (re.gridColToMap(cellX) + re.gridColToMap(cellX + stepX)) / 2.0
-    val firstY = (re.gridRowToMap(cellY) + re.gridRowToMap(cellY + stepY)) / 2.0
+    val firstX = if (stepX==0) Double.PositiveInfinity else (re.gridColToMap(cellX) + re.gridColToMap(cellX + stepX)) / 2.0
+    val firstY = if (stepY==0) Double.PositiveInfinity else (re.gridRowToMap(cellY) + re.gridRowToMap(cellY + stepY)) / 2.0
 
     val (dx, dy) = (finalPoint.get.x - initialPoint.x, finalPoint.get.y - initialPoint.y)
     var (tMaxX, tMaxY) = ((firstX - initialPoint.x) / dx, (firstY - initialPoint.y) / dy)
@@ -409,7 +409,7 @@ object Rasterizer {
         tMaxY += tDeltaY
         cellY += stepY
       }
-    } while (cellX != finalX || cellY!= finalY)
+    } while (cellX != finalX || cellY != finalY)
 
     if (!skipLast)
       f(cellX, cellY)

--- a/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
@@ -402,12 +402,37 @@ object Rasterizer {
 
     do {
       f(cellX, cellY)
-      if (tMaxX <= tMaxY) {
-        tMaxX += tDeltaX
-        cellX += stepX
+      if (math.abs(tMaxX - tMaxY) < EPSILON) {
+        // crossing at grid intersection
+        (stepX, stepY) match {
+          case ( 1, -1) =>
+            cellX += stepX
+            tMaxX += tDeltaX
+          case ( 1,  1) => 
+            cellX += stepX
+            cellY += stepY
+            tMaxX += tDeltaX
+            tMaxY += tDeltaY
+          case (-1,  1) =>
+            cellY += stepY
+            tMaxY += tDeltaY
+          case (-1, -1) =>
+            cellX += stepX
+            cellY += stepY
+            tMaxX += tDeltaX
+            tMaxY += tDeltaY
+          case _ =>
+            throw new RuntimeException(s"Arrived at illegal configuration: stepX=$stepX, stepY=$stepY")
+        }
       } else {
-        tMaxY += tDeltaY
-        cellY += stepY
+        // regular crossing
+        if (tMaxX < tMaxY) {
+          tMaxX += tDeltaX
+          cellX += stepX
+        } else {
+          tMaxY += tDeltaY
+          cellY += stepY
+        }
       }
     } while (cellX != finalX || cellY != finalY)
 

--- a/raster/src/test/scala/geotrellis/raster/rasterize/RasterizerSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/rasterize/RasterizerSpec.scala
@@ -177,7 +177,7 @@ class RasterizeSpec extends FunSuite with RasterMatchers
     val (x1, y1) = (0, 10)
     val line = Line((x0, y0), (x1, y1))
 
-    Rasterizer.foreachCellInGridLineExact(x0, y0, x1, y1, re, false){ (x, y) => result += x -> y }
+    Rasterizer.foreachCellByLineStringDouble(line, re){ (x, y) => result += x -> y }
 
     def lineInCell(cx: Int, cy: Int): Boolean = {
       val w = re.cellwidth/2
@@ -201,7 +201,7 @@ class RasterizeSpec extends FunSuite with RasterMatchers
     val (x1, y1) = (5, 3)
     val line = Line((x0, y0), (x1, y1))
 
-    Rasterizer.foreachCellInGridLineExact(x0, y0, x1, y1, re, false){ (x, y) => result += x -> y }
+    Rasterizer.foreachCellByLineStringDouble(line, re){ (x, y) => result += x -> y }
 
     def lineInCell(cx: Int, cy: Int): Boolean = {
       val w = re.cellwidth/2


### PR DESCRIPTION
As described in #2336, rasterizing lines snaps points to their pixel centers.  This can cause problems in certain applications when it is expected that the exact line geometry should be used.  This PR intends to fix this problem by introducing the `Rasterizer.foreachCellInGridLineExact` method.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>