### PR TITLE
Fix Tile Sizes for maxTileSize < Segment Dimension

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/RasterReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/RasterReader.scala
@@ -61,16 +61,16 @@ object RasterReader {
     }
   }
 
-  private def best(m: Int, n: Int): Int = {
+  private def best(maxSize: Int, segment: Int): Int = {
     var i: Int = 1
-    var result: Int = m
+    var result: Int = -1
     // Search for the largest factor of n that is > 1 and <= m.  If
     // one cannot be found, give up and return m.
-    while (i < math.sqrt(n) && result == m) {
-      if ((n % i == 0) && ((n/i) <= m)) result = (n/i)
+    while (i < math.sqrt(segment) && result == -1) {
+      if ((segment % i == 0) && ((segment/i) <= maxSize)) result = (segment/i)
       i += 1
     }
-    result
+    if (result == -1) maxSize; else result
   }
 
   def listWindows(

--- a/spark/src/main/scala/geotrellis/spark/io/RasterReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/RasterReader.scala
@@ -64,8 +64,8 @@ object RasterReader {
   private def best(maxSize: Int, segment: Int): Int = {
     var i: Int = 1
     var result: Int = -1
-    // Search for the largest factor of n that is > 1 and <= m.  If
-    // one cannot be found, give up and return m.
+    // Search for the largest factor of segment that is > 1 and <=
+    // maxSize.  If one cannot be found, give up and return maxSize.
     while (i < math.sqrt(segment) && result == -1) {
       if ((segment % i == 0) && ((segment/i) <= maxSize)) result = (segment/i)
       i += 1


### PR DESCRIPTION
The code was producing tiles of the second-largest possible size when `maxSize` was a factor of the `segment` size.  Now they are of the largest possible size.

@jbouffard please test.

Connects https://github.com/locationtech/geotrellis/issues/2437