### PR TITLE
MultibandTile PolygonalSummary Fix

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/DoubleHistogramSummary.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/DoubleHistogramSummary.scala
@@ -65,7 +65,7 @@ object MultibandTileDoubleHistogramSummary extends MultibandTilePolygonalSummary
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[Histogram[Double]], v2: Array[Histogram[Double]]): Array[Histogram[Double]] =
-    v1 zip v2 map { case (r1, r2) => DoubleHistogramSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, StreamingHistogram(), StreamingHistogram()) map { case (r1, r2) => DoubleHistogramSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[Histogram[Double]]]): Array[Histogram[Double]] =
     if (res.isEmpty)

--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/IntHistogramSummary.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/IntHistogramSummary.scala
@@ -66,7 +66,7 @@ object MultibandTileIntHistogramSummary extends MultibandTilePolygonalSummaryHan
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[Histogram[Int]], v2: Array[Histogram[Int]]): Array[Histogram[Int]] =
-    v1 zip v2 map { case (r1, r2) => IntHistogramSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, FastMapHistogram(), FastMapHistogram()) map { case (r1, r2) => IntHistogramSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[Histogram[Int]]]): Array[Histogram[Int]] =
     if (res.isEmpty)

--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/MaxSummary.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/MaxSummary.scala
@@ -72,7 +72,7 @@ object MultibandTileMaxSummary extends MultibandTilePolygonalSummaryHandler[Arra
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[Int], v2: Array[Int]): Array[Int] =
-    v1 zip v2 map { case (r1, r2) => MaxSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, NODATA, NODATA) map { case (r1, r2) => MaxSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[Int]]): Array[Int] =
     if (res.isEmpty)
@@ -137,7 +137,7 @@ object MultibandTileMaxDoubleSummary extends MultibandTilePolygonalSummaryHandle
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[Double], v2: Array[Double]): Array[Double] =
-    v1 zip v2 map { case (r1, r2) => MaxDoubleSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, Double.NaN, Double.NaN) map { case (r1, r2) => MaxDoubleSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[Double]]): Array[Double] =
     if (res.isEmpty)

--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/MeanSummary.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/MeanSummary.scala
@@ -99,7 +99,7 @@ object MultibandTileMeanSummary extends MultibandTilePolygonalSummaryHandler[Arr
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[MeanResult], v2: Array[MeanResult]): Array[MeanResult] =
-    v1 zip v2 map { case (r1, r2) => MeanSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, MeanResult(0.0, 0L), MeanResult(0.0, 0L)) map { case (r1, r2) => MeanSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[MeanResult]]): Array[MeanResult] =
     if (res.isEmpty)

--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/MinSummary.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/MinSummary.scala
@@ -72,7 +72,7 @@ object MultibandTileMinSummary extends MultibandTilePolygonalSummaryHandler[Arra
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[Int], v2: Array[Int]): Array[Int] =
-    v1 zip v2 map { case (r1, r2) => MinSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, NODATA, NODATA) map { case (r1, r2) => MinSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[Int]]): Array[Int] =
     if (res.isEmpty)
@@ -138,7 +138,7 @@ object MultibandTileMinDoubleSummary extends MultibandTilePolygonalSummaryHandle
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[Double], v2: Array[Double]): Array[Double] =
-    v1 zip v2 map { case (r1, r2) => MinDoubleSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, Double.NaN, Double.NaN) map { case (r1, r2) => MinDoubleSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[Double]]): Array[Double] =
     if (res.isEmpty)

--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/SumSummary.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/SumSummary.scala
@@ -81,7 +81,7 @@ object MultibandTileSumSummary extends MultibandTilePolygonalSummaryHandler[Arra
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[Long], v2: Array[Long]): Array[Long] =
-    v1 zip v2 map { case (r1, r2) => SumSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, 0L, 0L) map { case (r1, r2) => SumSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[Long]]): Array[Long] =
     if (res.isEmpty)
@@ -150,7 +150,7 @@ object MultibandTileSumDoubleSummary extends MultibandTilePolygonalSummaryHandle
     * Combine the results into a larger result.
     */
   def combineOp(v1: Array[Double], v2: Array[Double]): Array[Double] =
-    v1 zip v2 map { case (r1, r2) => SumDoubleSummary.combineOp(r1, r2) }
+    v1.zipAll(v2, 0.0, 0.0) map { case (r1, r2) => SumDoubleSummary.combineOp(r1, r2) }
 
   def combineResults(res: Seq[Array[Double]]): Array[Double] =
     if (res.isEmpty)

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/HistogramSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/HistogramSpec.scala
@@ -111,6 +111,8 @@ class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
       val histogram = multi.polygonalHistogram(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalHistogram(totalExtent, quarterExtent.toPolygon)
 
+      histogram.size should be (expected.size)
+
       histogram zip expected map { case (result, exp) =>
         result.minMaxValues should be (exp.minMaxValues)
         result.itemCount(1) should be (exp.itemCount(1))
@@ -129,6 +131,8 @@ class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
       val histogram = multi.polygonalHistogram(diamondPoly)
       val expected = multi.stitch.tile.polygonalHistogram(totalExtent, diamondPoly)
 
+      histogram.size should be (expected.size)
+
       histogram zip expected map { case (result, exp) =>
         result.minMaxValues should be (exp.minMaxValues)
         result.itemCount(1) should be (exp.itemCount(1))
@@ -146,6 +150,8 @@ class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
     it("should get correct histogram over polygon with hole for a MultibandTileRDD") {
       val histogram = multi.polygonalHistogram(polyWithHole)
       val expected = multi.stitch.tile.polygonalHistogram(totalExtent, polyWithHole)
+
+      histogram.size should be (expected.size)
 
       histogram zip expected map { case (result, exp) =>
         result.minMaxValues should be (exp.minMaxValues)
@@ -224,6 +230,8 @@ class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
       val histogram = multi.polygonalHistogram(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalHistogram(totalExtent, quarterExtent.toPolygon)
 
+      histogram.size should be (expected.size)
+
       histogram zip expected map { case (result, exp) =>
         result.minMaxValues should be (exp.minMaxValues)
         result.itemCount(1) should be (exp.itemCount(1))
@@ -262,6 +270,8 @@ class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
 
       val histogram = multi.polygonalHistogram(poly)
       val expected = multi.stitch.tile.polygonalHistogram(totalExtent, poly)
+
+      histogram.size should be (expected.size)
 
       histogram zip expected map { case (result, exp) =>
         result.minMaxValues should be (exp.minMaxValues)
@@ -322,6 +332,8 @@ class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
 
       val histogram = multi.polygonalHistogram(poly)
       val expected = multi.stitch.tile.polygonalHistogram(totalExtent, poly)
+
+      histogram.size should be (expected.size)
 
       histogram zip expected map { case (result, exp) =>
         result.minMaxValues should be (exp.minMaxValues)

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MaxDoubleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MaxDoubleSpec.scala
@@ -87,6 +87,8 @@ class MaxDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalMaxDouble(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMaxDouble(totalExtent, quarterExtent.toPolygon)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -102,6 +104,8 @@ class MaxDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
     it("should get correct double max over a two triangle multipolygon for MultibandTileRDD") {
       val result = multi.polygonalMaxDouble(mp)
       val expected = multi.stitch.tile.polygonalMaxDouble(totalExtent, mp)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)
@@ -156,6 +160,8 @@ class MaxDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalMaxDouble(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMaxDouble(totalExtent, quarterExtent.toPolygon)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -209,6 +215,8 @@ class MaxDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
 
       val result = multi.polygonalMaxDouble(mp)
       val expected = multi.stitch.tile.polygonalMaxDouble(totalExtent, mp)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MaxSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MaxSpec.scala
@@ -66,6 +66,8 @@ class MaxSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalMax(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMax(totalExtent, quarterExtent.toPolygon)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -118,6 +120,8 @@ class MaxSpec extends FunSpec with TestEnvironment with TestFiles {
 
       val result = multi.polygonalMax(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMax(totalExtent, quarterExtent.toPolygon)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MeanSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MeanSpec.scala
@@ -74,6 +74,8 @@ class MeanSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalMean(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMean(totalExtent, quarterExtent.toPolygon)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -124,6 +126,8 @@ class MeanSpec extends FunSpec with TestEnvironment with TestFiles {
       )
       val result = multi.polygonalMean(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMean(totalExtent, quarterExtent.toPolygon)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MinDoubleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MinDoubleSpec.scala
@@ -76,6 +76,8 @@ class MinDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalMinDouble(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMinDouble(totalExtent, quarterExtent.toPolygon)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -128,6 +130,8 @@ class MinDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
 
       val result = multi.polygonalMinDouble(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMinDouble(totalExtent, quarterExtent.toPolygon)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MinSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MinSpec.scala
@@ -76,6 +76,8 @@ class MinSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalMin(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMin(totalExtent, quarterExtent.toPolygon)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -128,6 +130,8 @@ class MinSpec extends FunSpec with TestEnvironment with TestFiles {
 
       val result = multi.polygonalMin(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalMin(totalExtent, quarterExtent.toPolygon)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/SumDoubleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/SumDoubleSpec.scala
@@ -86,6 +86,8 @@ class SumDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalSumDouble(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalSumDouble(totalExtent, quarterExtent.toPolygon)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -102,6 +104,8 @@ class SumDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalSumDouble(diamondPoly)
       val expected = multi.stitch.tile.polygonalSumDouble(totalExtent, diamondPoly)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -117,6 +121,8 @@ class SumDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
     it("should get correct double sum over polygon with hole for MultibandTileRDD") {
       val result = multi.polygonalSumDouble(polyWithHole)
       val expected = multi.stitch.tile.polygonalSumDouble(totalExtent, polyWithHole)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)
@@ -181,6 +187,8 @@ class SumDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalSumDouble(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalSumDouble(totalExtent, quarterExtent.toPolygon)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -197,6 +205,8 @@ class SumDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
       val result = multi.polygonalSumDouble(diamondPoly)
       val expected = multi.stitch.tile.polygonalSumDouble(totalExtent, diamondPoly)
 
+      result.size should be (expected.size)
+
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
@@ -212,6 +222,8 @@ class SumDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
     it("should get correct double sum over polygon with hole for MultibandTiles") {
       val result = multi.polygonalSumDouble(polyWithHole)
       val expected = multi.stitch.tile.polygonalSumDouble(totalExtent, polyWithHole)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/SumSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/SumSpec.scala
@@ -70,56 +70,62 @@ class SumSpec extends FunSpec
       Polygon(exterior, interior)
     }
 
-    it("should get correct double sum over whole raster extent") {
+    it("should get correct sum over whole raster extent") {
       ones.polygonalSum(totalExtent.toPolygon) should be(count)
     }
 
-    it("should get correct double sum over whole raster extent for MultibandTileRDD") {
+    it("should get correct sum over whole raster extent for MultibandTileRDD") {
       multi.polygonalSum(totalExtent.toPolygon) map { _ should be(count) }
     }
 
-    it("should get correct double sum over a quarter of the extent") {
+    it("should get correct sum over a quarter of the extent") {
       val result = ones.polygonalSum(quarterExtent.toPolygon)
       val expected = ones.stitch.tile.polygonalSum(totalExtent, quarterExtent.toPolygon)
 
       result should be (expected)
     }
 
-    it("should get correct double sum over a quarter of the extent for MultibandTileRDD") {
+    it("should get correct sum over a quarter of the extent for MultibandTileRDD") {
       val result = multi.polygonalSum(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalSum(totalExtent, quarterExtent.toPolygon)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
     }
 
-    it("should get correct double sum over half of the extent in diamond shape") {
+    it("should get correct sum over half of the extent in diamond shape") {
       val result = ones.polygonalSum(diamondPoly)
       val expected = ones.stitch.tile.polygonalSum(totalExtent, diamondPoly)
 
       result should be (expected)
     }
 
-    it("should get correct double sum over half of the extent in diamond shape for MultibandTileRDD") {
+    it("should get correct sum over half of the extent in diamond shape for MultibandTileRDD") {
       val result = multi.polygonalSum(diamondPoly)
       val expected = multi.stitch.tile.polygonalSum(totalExtent, diamondPoly)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)
       }
     }
 
-    it("should get correct double sum over polygon with hole") {
+    it("should get correct sum over polygon with hole") {
       val result = ones.polygonalSum(polyWithHole)
       val expected = ones.stitch.tile.polygonalSum(totalExtent, polyWithHole)
 
       result should be (expected)
     }
 
-    it("should get correct double sum over polygon with hole for MultibandTileRDD") {
+    it("should get correct sum over polygon with hole for MultibandTileRDD") {
       val result = multi.polygonalSum(polyWithHole)
       val expected = multi.stitch.tile.polygonalSum(totalExtent, polyWithHole)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)
@@ -169,7 +175,7 @@ class SumSpec extends FunSpec
       ones.polygonalSum(totalExtent.toPolygon) should be(count)
     }
 
-    it("should get correct double sum over whole raster extent for MultibandTiles") {
+    it("should get correct sum over whole raster extent for MultibandTiles") {
       multi.polygonalSum(totalExtent.toPolygon) map { _ should be(count) }
     }
 
@@ -180,9 +186,11 @@ class SumSpec extends FunSpec
       result should be (expected)
     }
 
-    it("should get correct double sum over a quarter of the extent for MultibandTiles") {
+    it("should get correct sum over a quarter of the extent for MultibandTiles") {
       val result = multi.polygonalSum(quarterExtent.toPolygon)
       val expected = multi.stitch.tile.polygonalSum(totalExtent, quarterExtent.toPolygon)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)
@@ -196,9 +204,11 @@ class SumSpec extends FunSpec
       result should be (expected)
     }
 
-    it("should get correct double sum over half of the extent in diamond shape for MultibandTiles") {
+    it("should get correct sum over half of the extent in diamond shape for MultibandTiles") {
       val result = multi.polygonalSum(diamondPoly)
       val expected = multi.stitch.tile.polygonalSum(totalExtent, diamondPoly)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)
@@ -212,9 +222,11 @@ class SumSpec extends FunSpec
       result should be (expected)
     }
 
-    it("should get correct double sum over polygon with hole for MultibandTiles") {
+    it("should get correct sum over polygon with hole for MultibandTiles") {
       val result = multi.polygonalSum(polyWithHole)
       val expected = multi.stitch.tile.polygonalSum(totalExtent, polyWithHole)
+
+      result.size should be (expected.size)
 
       result zip expected map { case (res, exp) =>
         res should be (exp)


### PR DESCRIPTION
This PR fixes a bug that caused polygonal summaries on  `RDD[(K, MultibandTile)]`s and `Seq[(K, MultibandTile)]`s to return the incorrect result. The cause of this issue was in the `combineOp` operation in each `MultibandtTileSummary` object. This line from `MultibandTileSumDoubleSummary` shows the logic in `combineOp` that was the source of the error.

    v1 zip v2 map { case (r1, r2) => SumDoubleSummary.combineOp(r1, r2) }

Because `v1` and `v2` can be different sizes, not all of the elements in each `Array` could be zipped together. Thus, leading to an incorrect number of elements being returned. The fix for this problem was to change `zip` to `zipAll`.