### PR TITLE
Fix incomplete match warning in Rasterizer

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
@@ -375,7 +375,7 @@ object Rasterizer {
     }
 
     // Find cell of first intersection with extent and ray
-    val (initialPoint, finalPoint) = re.extent.intersection(Line((x0, y0), (x1, y1))) match {
+    val (initialPoint, finalPoint) = re.extent.toPolygon.intersection(Line((x0, y0), (x1, y1))) match {
       case NoResult => return
       case PointResult(p) => (p, None)
       case LineResult(l) =>
@@ -386,6 +386,8 @@ object Rasterizer {
           (p0, Some(p1))
         else
           (p1, Some(p0))
+      case _ =>
+        throw new RuntimeException("Impossible result of line segment intersection")
     }
 
     var (cellX, cellY) = {


### PR DESCRIPTION
Also implicit conversion from to polygon has caused the doc generation to break