### PR TITLE
Lightweight BufferTiles operation

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTiles.scala
@@ -17,8 +17,10 @@
 package geotrellis.spark.buffer
 
 import geotrellis.spark._
+import geotrellis.spark.tiling._
 import geotrellis.raster._
 import geotrellis.raster.crop._
+import geotrellis.raster.prototype._
 import geotrellis.raster.stitch._
 import geotrellis.util._
 
@@ -27,6 +29,7 @@ import org.apache.spark.storage.StorageLevel
 
 import scala.reflect.ClassTag
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
 
 import Direction._
 
@@ -435,5 +438,143 @@ object BufferTiles {
         }.groupBy(_._1).mapValues { _.map(_._2) }.toSeq
 
     bufferWithNeighbors(grouped)
+  }
+
+  def apply[
+    K: SpatialComponent: Boundable: ClassTag,
+    V <: CellGrid: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V]),
+    M: GetComponent[?, LayoutDefinition]: GetComponent[?, Bounds[K]]
+  ](layer: RDD[(K, V)] with Metadata[M], getBufferSizes: K => Option[BufferSizes]): RDD[(K, BufferedTile[V])] = {
+    def dirToOffset(dir: Direction, xOfs: Int, yOfs: Int) = {
+      val (x, y) = dir match {
+        case TopLeft     => (0,0)
+        case Top         => (1,0)
+        case TopRight    => (2,0)
+        case Left        => (0,1)
+        case Center      => (1,1)
+        case Right       => (2,1)
+        case BottomLeft  => (0,2)
+        case Bottom      => (1,2)
+        case BottomRight => (2,2)
+      }
+      (x + xOfs, y + yOfs)
+    }
+
+    layer
+      .flatMap{ case (key, tile) => {
+        val SpatialKey(x, y) = key.getComponent[SpatialKey]
+        val cols = tile.cols
+        val rows = tile.rows
+
+        def bufferForNeighbor(dir: Direction): Option[(K, (K, Direction, V))] = dir match {
+          case Center => Some(key -> (key, Center, tile))
+          case Left => 
+            val k = key.setComponent(SpatialKey(x-1, y))
+            for ( bs <- getBufferSizes(k) ;
+                  slice <- Some(tile.crop(0, 0, bs.right - 1, rows - 1, Crop.Options(force = true))) ;
+                  res <- Some( k -> (k, Right, slice) )
+                ) yield res
+          case Right => 
+            val k = key.setComponent(SpatialKey(x+1, y))
+            for ( bs <- getBufferSizes(k) ;
+                  slice <- Some(tile.crop(cols - bs.left, 0, cols - 1, rows - 1, Crop.Options(force = true))) ;
+                  res <- Some( k -> (k, Left, slice) )
+                ) yield res
+          case Top => 
+            val k = key.setComponent(SpatialKey(x, y-1))
+            for ( bs <- getBufferSizes(k) ;
+                  slice <- Some(tile.crop(0, 0, cols - 1, bs.bottom - 1, Crop.Options(force = true))) ;
+                  res <- Some( k -> (k, Bottom, slice) )
+                ) yield res
+          case Bottom => 
+            val k = key.setComponent(SpatialKey(x, y+1))
+            for ( bs <- getBufferSizes(k) ;
+                  slice <- Some(tile.crop(0, rows - bs.top, cols - 1, rows - 1, Crop.Options(force = true))) ;
+                  res <- Some( k -> (k, Top, slice) )
+                ) yield res
+          case TopLeft => 
+            val k = key.setComponent(SpatialKey(x-1, y-1))
+            for ( bs <- getBufferSizes(k) ;
+                  slice <- Some(tile.crop(0, 0, bs.right - 1, bs.bottom - 1, Crop.Options(force = true))) ;
+                  res <- Some( k -> (k, BottomRight, slice) )
+                ) yield res
+          case TopRight => 
+            val k = key.setComponent(SpatialKey(x+1, y-1))
+            for ( bs <- getBufferSizes(k) ;
+                  slice <- Some(tile.crop(cols - bs.left, 0, cols - 1, bs.bottom - 1, Crop.Options(force = true))) ;
+                  res <- Some( k -> (k, BottomLeft, slice) )
+                ) yield res
+          case BottomLeft => 
+            val k = key.setComponent(SpatialKey(x-1, y+1))
+            for ( bs <- getBufferSizes(k) ;
+                  slice <- Some(tile.crop(0, rows - bs.top, bs.right - 1, rows - 1, Crop.Options(force = true))) ;
+                  res <- Some( k -> (k, TopRight, slice) )
+                ) yield res
+          case BottomRight => 
+            val k = key.setComponent(SpatialKey(x+1, y+1))
+            for ( bs <- getBufferSizes(k) ;
+                  slice <- Some(tile.crop(cols - bs.left, rows - bs.top, cols - 1, rows - 1, Crop.Options(force = true))) ;
+                  res <- Some( k -> (k, TopLeft, slice) )
+                ) yield res
+        }
+
+        Seq(Center, Left, Right, Bottom, Top, TopLeft, TopRight, BottomLeft, BottomRight).flatMap(bufferForNeighbor): Seq[(K, (K, Direction, V))]
+      }}
+      // .combineByKey(
+      //   { case tup => 
+      //     val (key, dir, tile) = tup
+      //     val bs = getBufferSizes(key)
+      //     val newtile = tile.prototype(tile.cols + bs.left + bs.right, tile.rows + bs.top + bs.bottom)
+      //     val ex = Extent(-bs.left, -bs.bottom, cols + bs.right, rows + bs.top, cols + bs.right)
+      //     (ex, newtile.merge(ex, dirToExtent(dir, bs, tile.cols, tile.rows), tile))
+      //   },
+      //   { case (combined, tup) =>
+      //     val (ex, whole) = combined
+      //     val (key, dir, tile) = tup
+      //     (ex, whole.merge(ex, dirToExtent(dir, getBufferSizes(key), ti
+      //   },
+      //   { (t1, t2) => t1.merge(t2) }
+      // )
+      // .mapValues(_._2)
+      .groupByKey
+      .mapValues{ iter =>
+        val stitcher = implicitly[Stitcher[V]]
+        val seq = iter.toSeq
+        val pieces = seq.map{ case (_, dir, tile) => (dir, tile) }.toMap
+        val key = seq.head._1
+
+        val lefts = 
+          Seq(Seq(TopLeft, Left, BottomLeft), Seq(Top, Center, Bottom), Seq(TopRight, Right, BottomRight))
+            .map(_.map{ x => pieces.get(x).map(_.cols).getOrElse(0) }.max)
+            .foldLeft(Seq(0)){ (acc, x) => acc :+ (acc.last + x) }
+        val tops = 
+          Seq(Seq(TopLeft, Top, TopRight), Seq(Left, Center, Right), Seq(BottomLeft, Bottom, BottomRight))
+            .map(_.map{ x => pieces.get(x).map(_.rows).getOrElse(0) }.max)
+            .foldLeft(Seq(0)){ (acc, x) => acc :+ (acc.last + x) }
+
+        val totalWidth = lefts.last
+        val totalHeight = tops.last
+
+        def loc(dir: Direction) = dir match {
+          case TopLeft     => (lefts(0), tops(0))
+          case Top         => (lefts(1), tops(0))
+          case TopRight    => (lefts(2), tops(0))
+          case Left        => (lefts(0), tops(1))
+          case Center      => (lefts(1), tops(1))
+          case Right       => (lefts(2), tops(1))
+          case BottomLeft  => (lefts(0), tops(2))
+          case Bottom      => (lefts(1), tops(2))
+          case BottomRight => (lefts(2), tops(2))
+        }
+
+        val toStitch = pieces.map{ case (dir, tile) => (tile, loc(dir)) }
+
+        println(s"For $key: stitching $pieces into $totalWidth x $totalHeight tile")
+
+        val stitched = stitcher.stitch(toStitch, totalWidth, totalHeight)
+
+        val bufferSizes = getBufferSizes(key).get
+        BufferedTile(stitched, GridBounds(bufferSizes.left, bufferSizes.top, pieces(Center).cols - bufferSizes.right - 1, pieces(Center).rows - bufferSizes.bottom - 1))
+      }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
@@ -17,8 +17,9 @@
 package geotrellis.spark.buffer
 
 import geotrellis.raster._
-import geotrellis.raster.stitch._
 import geotrellis.raster.crop._
+import geotrellis.raster.prototype._
+import geotrellis.raster.stitch._
 import geotrellis.spark._
 import geotrellis.util.MethodExtensions
 
@@ -28,7 +29,7 @@ import scala.reflect.ClassTag
 
 class BufferTilesMethods[
   K: SpatialComponent: ClassTag,
-  V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V])
+  V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V]): (? => TilePrototypeMethods[V])
 ](val self: RDD[(K, V)]) extends MethodExtensions[RDD[(K, V)]] {
   def bufferTiles(bufferSize: Int): RDD[(K, BufferedTile[V])] =
     BufferTiles(self, bufferSize)

--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
@@ -37,6 +37,7 @@ class BufferTilesMethods[
   def bufferTiles(bufferSize: Int, layerBounds: GridBounds): RDD[(K, BufferedTile[V])] =
     BufferTiles(self, bufferSize, layerBounds)
 
+  @deprecated("Please specify buffer sizes per key as a function K => BufferSizes", "1.2")
   def bufferTiles(bufferSizesPerKey: RDD[(K, BufferSizes)]): RDD[(K, BufferedTile[V])] =
     BufferTiles(self, bufferSizesPerKey)
 

--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
@@ -18,7 +18,6 @@ package geotrellis.spark.buffer
 
 import geotrellis.raster._
 import geotrellis.raster.crop._
-import geotrellis.raster.prototype._
 import geotrellis.raster.stitch._
 import geotrellis.spark._
 import geotrellis.util.MethodExtensions
@@ -29,7 +28,7 @@ import scala.reflect.ClassTag
 
 class BufferTilesMethods[
   K: SpatialComponent: ClassTag,
-  V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V]): (? => TilePrototypeMethods[V])
+  V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V])
 ](val self: RDD[(K, V)]) extends MethodExtensions[RDD[(K, V)]] {
   def bufferTiles(bufferSize: Int): RDD[(K, BufferedTile[V])] =
     BufferTiles(self, bufferSize)

--- a/spark/src/main/scala/geotrellis/spark/buffer/Direction.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/Direction.scala
@@ -29,6 +29,41 @@ object Direction {
   case object Left extends Direction
   case object TopLeft extends Direction
 
+  // NOTE: This object is nested to facilitate the common pattern of calling
+  // `import geotrellis.spark.buffer.Direction._` without namespace pollution
+  object DirectionOp {
+    
+    def opp(dir: Direction) = dir match {
+      case Center => Center
+      case Top => Bottom
+      case TopRight => BottomLeft
+      case Right => Left
+      case BottomRight => TopLeft
+      case Bottom => Top
+      case BottomLeft => TopRight
+      case Left => Right
+      case TopLeft => BottomRight
+    }
+
+    /** A function to determine the offset of a given neighbor direction in raster
+     *  ordering.
+     *
+     *  Given a SpatialComponent, we generate an offset pair that can be added to
+     *  the (row, column) of a SpatialKey to generate the SpatialKey of the
+     *  desired neighbor.
+     */
+    def offsetOf(dir: Direction) = dir match {
+      case Center      => ( 0, 0)
+      case Top         => ( 0,-1)
+      case TopRight    => ( 1,-1)
+      case Right       => ( 1, 0)
+      case BottomRight => ( 1, 1)
+      case Bottom      => ( 0, 1)
+      case BottomLeft  => (-1, 1)
+      case Left        => (-1, 0)
+      case TopLeft     => (-1,-1)
+    }    
+  }
   /** Adapter method until Direction moves fully out of spark package */
   private[geotrellis] def convertDirection(input: Direction): geotrellis.util.Direction =
     input match {

--- a/spark/src/main/scala/geotrellis/spark/buffer/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/Implicits.scala
@@ -17,8 +17,9 @@
 package geotrellis.spark.buffer
 
 import geotrellis.raster._
-import geotrellis.raster.stitch._
 import geotrellis.raster.crop._
+import geotrellis.raster.prototype._
+import geotrellis.raster.stitch._
 import geotrellis.spark._
 
 import org.apache.spark.rdd.RDD
@@ -35,11 +36,11 @@ trait Implicits {
 
   implicit class withBufferTilesMethodsWrapper[
     K: SpatialComponent: ClassTag,
-    V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V])
+    V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V]): (? => TilePrototypeMethods[V])
   ](self: RDD[(K, V)]) extends BufferTilesMethods[K, V](self)
 
   implicit class withCollectionsBufferTilesMethodsWrapper[
     K: SpatialComponent,
-    V <: CellGrid: Stitcher: (? => CropMethods[V])
+    V <: CellGrid: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V])
   ](self: Seq[(K, V)]) extends CollectionBufferTilesMethods[K, V](self)
 }

--- a/spark/src/main/scala/geotrellis/spark/buffer/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/Implicits.scala
@@ -18,7 +18,6 @@ package geotrellis.spark.buffer
 
 import geotrellis.raster._
 import geotrellis.raster.crop._
-import geotrellis.raster.prototype._
 import geotrellis.raster.stitch._
 import geotrellis.spark._
 
@@ -36,11 +35,11 @@ trait Implicits {
 
   implicit class withBufferTilesMethodsWrapper[
     K: SpatialComponent: ClassTag,
-    V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V]): (? => TilePrototypeMethods[V])
+    V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V])
   ](self: RDD[(K, V)]) extends BufferTilesMethods[K, V](self)
 
   implicit class withCollectionsBufferTilesMethodsWrapper[
     K: SpatialComponent,
-    V <: CellGrid: Stitcher: (? => CropMethods[V]): (? => TilePrototypeMethods[V])
+    V <: CellGrid: Stitcher: (? => CropMethods[V])
   ](self: Seq[(K, V)]) extends CollectionBufferTilesMethods[K, V](self)
 }

--- a/spark/src/test/scala/geotrellis/spark/buffer/BufferTilesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/buffer/BufferTilesSpec.scala
@@ -18,13 +18,31 @@ package geotrellis.spark.buffer
 
 import geotrellis.spark._
 import geotrellis.spark.io._
+import geotrellis.raster.crop._
+import geotrellis.raster.prototype._
 import geotrellis.raster.io.geotiff.SinglebandGeoTiff
+import geotrellis.raster.testkit._
 import geotrellis.spark.testkit._
 
 import org.scalatest.FunSpec
 
+object BufferTilesSpec {
+  def generateBufferSizes(bounds: Bounds[SpatialKey])(key: SpatialKey) = {
+    if (bounds includes key)
+      Some(BufferSizes(2,2,2,2))
+    else
+      None
+  }
 
-class BufferTilesSpec extends FunSpec with TestEnvironment {
+  def generateBufferSizesFromKeys(members: Set[SpatialKey])(key: SpatialKey) = {
+    if (members contains key)
+      Some(BufferSizes(2,2,2,2))
+    else
+      None
+  }
+}
+
+class BufferTilesSpec extends FunSpec with TestEnvironment with RasterMatchers {
 
   describe("The BufferTiles functionality") {
     val path = "raster/data/aspect.tif"
@@ -73,6 +91,37 @@ class BufferTilesSpec extends FunSpec with TestEnvironment {
     it("should work when the Collection is a square minus the other diagonal") {
       val partialCollection = ContextCollection(wholeCollection.filter({ case (k, _) => k.col != (4- k.row) }), cmetadata)
       BufferTiles(partialCollection, 1).length
+    }
+
+    it("the lightweight RDD version should work for the whole collection") {
+      val bounds = metadata.bounds
+
+      val buffers = BufferTiles(ContextRDD(wholeRdd, metadata), BufferTilesSpec.generateBufferSizes(bounds)(_)).collect
+      val tile11 = buffers.find{ case (key, _) => key == SpatialKey(1, 1) }.get._2.tile
+      val baseline = originalRaster.crop(98, 98, 201, 201, Crop.Options.DEFAULT)
+      assertEqual(baseline, tile11)
+    }
+
+    it("the lightweight RDD version should work with the main diagonal missing") {
+      val partialRdd = ContextRDD(wholeRdd.filter({ case (k, _) => k.col != k.row }), metadata)
+      val bounds = metadata.bounds
+      val members = partialRdd.collect.map(_._1).toSet
+
+      val blank = originalRaster.tile.prototype(100, 100)
+      println(blank)
+      val holey = originalRaster.tile.mapDouble{x => x}.mutable
+      println(holey)
+      for ( x <- 0 to 4 ) {
+        println(s"Updating tile ($x, $x)")
+        holey.update(x * 100, x * 100, blank)
+      }
+
+      val buffers = BufferTiles(partialRdd, BufferTilesSpec.generateBufferSizesFromKeys(members)(_)).collect
+      val tile11 = buffers.find{ case (key, _) => key == SpatialKey(2, 1) }.get._2.tile
+      println(tile11)
+      val baseline = holey.crop(198, 98, 301, 201, Crop.Options.DEFAULT)
+      println(baseline)
+      assertEqual(baseline, tile11)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/buffer/BufferTilesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/buffer/BufferTilesSpec.scala
@@ -96,7 +96,7 @@ class BufferTilesSpec extends FunSpec with TestEnvironment with RasterMatchers {
     it("the lightweight RDD version should work for the whole collection") {
       val bounds = metadata.bounds
 
-      val buffers = BufferTiles(ContextRDD(wholeRdd, metadata), BufferTilesSpec.generateBufferSizes(bounds)(_)).collect
+      val buffers = BufferTiles(ContextRDD(wholeRdd, metadata), { _: SpatialKey => BufferSizes(2,2,2,2) }).collect
       val tile11 = buffers.find{ case (key, _) => key == SpatialKey(1, 1) }.get._2.tile
       val baseline = originalRaster.crop(98, 98, 201, 201, Crop.Options.DEFAULT)
       assertEqual(baseline, tile11)
@@ -116,9 +116,10 @@ class BufferTilesSpec extends FunSpec with TestEnvironment with RasterMatchers {
         holey.update(x * 100, x * 100, blank)
       }
 
-      val buffers = BufferTiles(partialRdd, BufferTilesSpec.generateBufferSizesFromKeys(members)(_)).collect
+      val buffers = BufferTiles(partialRdd, { _: SpatialKey => BufferSizes(2,2,2,2) }).collect
       val tile11 = buffers.find{ case (key, _) => key == SpatialKey(2, 1) }.get._2.tile
       println(tile11)
+      // Holey crop!
       val baseline = holey.crop(198, 98, 301, 201, Crop.Options.DEFAULT)
       println(baseline)
       assertEqual(baseline, tile11)


### PR DESCRIPTION
The current version of `BufferTiles` relies on specifying the `BufferSizes` via an `RDD[(K, BufferSizes)]`.  This method requires a `join` that really hams up the works.  This PR proposes an alternative pathway that takes a function of type `K => BufferSizes`.  Presumably, the former RDD method can be converted to this approach in nearly all cases.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>