### PR TITLE
ClipToGrid Optimizations

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
@@ -16,179 +16,111 @@
 
 package geotrellis.spark.clip
 
-import geotrellis.raster.GridBounds
 import geotrellis.spark._
 import geotrellis.spark.tiling._
-import geotrellis.util._
 import geotrellis.vector._
 
-import com.vividsolutions.jts.geom.prep.{PreparedGeometry, PreparedGeometryFactory}
+import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory
 import org.apache.spark.rdd._
 import scala.util.Try
 
 object ClipToGrid {
-  /** Trait which contains methods to be used in determining
-    * the most optimal way to clip geometries and features
-    * for ClipToGrid methods.
-    */
-  trait Predicates {
-    /** True if the feature geometry covers the passed-in [[Extent]]. */
-    def covers(e: Extent): Boolean
-    /** True if the feature geometry is covered by the passed-in [[Extent]]. */
-    def coveredBy(e: Extent): Boolean
-  }
-
-  /** Clips a feature to the given [[Extent]], using the given [[Predicates]]
-    * to avoid doing intersections where unnecessary.
-    */
-  def clipFeatureToExtent[G <: Geometry, D](
-    e: Extent,
-    f: Feature[G, D],
-    preds: Predicates
-  ): Option[Feature[Geometry, D]] = e match {
-    /* If a Feature covers the Extent, their intersection would be the Extent itself. */
-    case _ if preds.covers(e) => Some(Feature(e, f.data))
-    /* The Feature may be completely contained within the Extent. In that case, no clipping need occur at all. */
-    case _ if preds.coveredBy(e) => Some(f)
-    /* Otherwise, we need to perform a JTS intersection */
-    case _ => Try(f.geom.intersection(e)).toOption.flatMap(_.toGeometry.map(g => Feature(g, f.data)))
-  }
 
   /** Clip each geometry in the RDD to the set of SpatialKeys
     * which intersect it, where the SpatialKeys map to the
     * given [[LayoutDefinition]].
     */
-  def apply[G <: Geometry](
-    layout: LayoutDefinition,
-    rdd: RDD[G]
-  )(implicit d: DummyImplicit): RDD[(SpatialKey, Geometry)] =
-    apply[G, Unit](layout, rdd.map(Feature(_, ()))).mapValues(_.geom)
+  def geometries[G <: Geometry](layout: LayoutDefinition, rdd: RDD[G]): RDD[(SpatialKey, Geometry)] =
+    geometriesWith(layout, rdd, byExtent)
 
   /** Clip each geometry in the RDD to the set of SpatialKeys
     * which intersect it, where the SpatialKeys map to the
     * given [[LayoutDefinition]], using the given method
     * to clip each geometry to the extent.
     */
-  def apply[G <: Geometry](
-    clipGeom: (Extent, G, Predicates) => Option[Geometry],
+  def geometriesWith[G <: Geometry](
     layout: LayoutDefinition,
-    rdd: RDD[G]
-  )(implicit d: DummyImplicit): RDD[(SpatialKey, Geometry)] = {
-    val f = { (e: Extent, f: Feature[G, Unit], p: Predicates) => clipGeom(e, f.geom, p).map(Feature(_, ())) }
-
-    apply[G, Unit](f, layout, rdd.map(Feature(_, ()))).mapValues(_.geom)
-  }
+    rdd: RDD[G],
+    clipGeom: (Extent, Feature[G, Unit]) => Option[Feature[Geometry, Unit]]
+  ): RDD[(SpatialKey, Geometry)] =
+    featuresWith(layout, rdd.map(Feature(_, ())), clipGeom).mapValues(_.geom)
 
   /** Clip each geometry in the RDD to the set of SpatialKeys
     * which intersect it, where the SpatialKeys map to the
     * given [[LayoutDefinition]], using the given method
     * to clip each geometry to the extent.
     */
-  def apply[G <: Geometry, D](
+  def features[G <: Geometry, D](
     layout: LayoutDefinition,
     rdd: RDD[Feature[G, D]]
   ): RDD[(SpatialKey, Feature[Geometry, D])] =
-    apply[G, D](clipFeatureToExtent[G,D] _, layout, rdd)
+    featuresWith(layout, rdd, byExtent)
 
   /** Clip each geometry in the RDD to the set of SpatialKeys
     * which intersect it, where the SpatialKeys map to the
     * given [[LayoutDefinition]], using the given method
     * to clip each geometry to the extent.
     */
-  def apply[G <: Geometry, D](
-    clipFeature: (Extent, Feature[G, D], Predicates) => Option[Feature[Geometry, D]],
+  def featuresWith[G <: Geometry, D](
     layout: LayoutDefinition,
-    rdd: RDD[Feature[G, D]]
+    rdd: RDD[Feature[G, D]],
+    clipFeature: (Extent, Feature[G, D]) => Option[Feature[Geometry, D]]
   ): RDD[(SpatialKey, Feature[Geometry, D])] = {
     val mapTransform: MapKeyTransform = layout.mapTransform
 
-    rdd.flatMap { f => clipGeom(clipFeature, mapTransform, f) }
+    /* Associate each Feature with its SpatialKeys*/
+    val withKeys: RDD[(Iterator[SpatialKey], Feature[G,D])] =
+      rdd.map(f => (mapTransform.keysForGeometry(f.geom), f))
+
+    /* Clip every Feature */
+    withKeys.flatMap { case (ks, f) => ks.flatMap(k => clipFeature(k.extent(layout), f).map((k, _))) }
   }
 
-  /** Given a clipping function, clip a Geometry according to some
-    * sensible, pre-defined [[Predicates]].
+  /** Clips Features to fit the given Extent. Does its best to avoid unnecessary
+    * JTS interactions.
     */
-  private def clipGeom[G <: Geometry, D](
-    clipFeature: (Extent, Feature[G, D], Predicates) => Option[Feature[Geometry, D]],
-    mapTransform: MapKeyTransform,
-    feature: Feature[G, D]
-  ): Iterator[(SpatialKey, Feature[Geometry, D])] = {
+  def byExtent[G <: Geometry, D](extent: Extent, f: Feature[G, D]): Option[Feature[Geometry, D]] = f.geom match {
+    case g: Point                              => Some(f)
+    case g: MultiPoint if coveredBy(g, extent) => Some(f)
+    case g: MultiPoint                         => clip(extent, g).map(Feature(_, f.data))
+    case g: Line       if coveredBy(g, extent) => Some(f)
+    case g: Line                               => clip(extent, g).map(Feature(_, f.data))
+    case g: MultiLine  if coveredBy(g, extent) => Some(f)
+    case g: MultiLine                          => clip(extent, g).map(Feature(_, f.data))
+    case g =>  /* Polygon and MultiPolygon */
+      val pg = PreparedGeometryFactory.prepare(g.jtsGeom)
+      val ep = extent.toPolygon.jtsGeom
 
-    /* Perform the actual clipping */
-    def clipToKey(k: SpatialKey, preds: Predicates): Option[(SpatialKey, Feature[Geometry, D])] = {
-      val extent: Extent = mapTransform(k)
+      if (pg.covers(ep)) Some(Feature(extent, f.data))
+      else if (pg.coveredBy(ep)) Some(f)
+      else clip(extent, g).map(Feature(_, f.data))
+  }
 
-      clipFeature(extent, feature, preds).map(k -> _)
+  private def coveredBy[G <: Geometry](g: G, e: Extent): Boolean =
+    g.jtsGeom.coveredBy(e.toPolygon.jtsGeom)
+
+  private def clip[G <: Geometry](e: Extent, g: G): Option[Geometry] = {
+    val exPoly: Polygon = e.toPolygon
+
+    val clipped: Try[Geometry] = g match {
+      case mp: MultiPolygon => Try(MultiPolygon(mp.polygons.flatMap(_.intersection(exPoly).as[Polygon])))
+      case _ => Try(g.intersection(exPoly).toGeometry.get)
     }
 
-    val pointPredicates =
-      new Predicates {
-        def covers(e: Extent) = false
-        def coveredBy(e: Extent) = true
-      }
-
-    val mpOrLinePredicates =
-      new Predicates {
-        def covers(e: Extent) = false
-        def coveredBy(e: Extent) =
-          feature.geom.jtsGeom.coveredBy(e.toPolygon.jtsGeom)
-      }
-
-    def polyPredicates(pg: PreparedGeometry) =
-      new Predicates {
-        def covers(e: Extent) = pg.covers(e.toPolygon.jtsGeom)
-        def coveredBy(e: Extent) = pg.coveredBy(e.toPolygon.jtsGeom)
-      }
-
-    val gcPredicates =
-      new Predicates {
-        def covers(e: Extent) = feature.geom.jtsGeom.covers(e.toPolygon.jtsGeom)
-        def coveredBy(e: Extent) = feature.geom.jtsGeom.coveredBy(e.toPolygon.jtsGeom)
-      }
-
-    val iterator: Iterator[(SpatialKey, Feature[Geometry, D])] =
-      feature.geom match {
-        case p: Point => Iterator.single(mapTransform(p) -> feature)
-        case mp: MultiPoint =>
-          mp.points
-            .map(mapTransform(_))
-            .toSet
-            .flatMap { k: SpatialKey => clipToKey(k, mpOrLinePredicates) }
-            .iterator
-        case l: Line =>
-          mapTransform.multiLineToKeys(MultiLine(l))
-            .flatMap(clipToKey(_, mpOrLinePredicates))
-        case ml: MultiLine =>
-          mapTransform.multiLineToKeys(ml)
-            .flatMap(clipToKey(_, mpOrLinePredicates))
-        case p: Polygon =>
-          val pg = PreparedGeometryFactory.prepare(p.jtsGeom)
-          val preds = polyPredicates(pg)
-
-          mapTransform.multiPolygonToKeys(MultiPolygon(p))
-            .flatMap(clipToKey(_, preds))
-        case mp: MultiPolygon =>
-          val pg = PreparedGeometryFactory.prepare(mp.jtsGeom)
-          val preds = polyPredicates(pg)
-
-          mapTransform.multiPolygonToKeys(mp)
-            .flatMap(clipToKey(_, preds))
-        case gc: GeometryCollection =>
-          def keysFromGC(g: GeometryCollection): List[SpatialKey] = {
-            List(
-              gc.points.map(mapTransform.pointToKey),
-              gc.multiPoints.flatMap(_.points.map(mapTransform.pointToKey)),
-              gc.lines.flatMap { l => mapTransform.multiLineToKeys(MultiLine(l)) },
-              gc.multiLines.flatMap { ml => mapTransform.multiLineToKeys(ml) },
-              gc.polygons.flatMap { p => mapTransform.multiPolygonToKeys(MultiPolygon(p)) },
-              gc.multiPolygons.flatMap { mp => mapTransform.multiPolygonToKeys(mp) },
-              gc.geometryCollections.flatMap(keysFromGC)
-            ).flatten
-          }
-
-          keysFromGC(gc).flatMap(clipToKey(_, gcPredicates)).iterator
-      }
-
-    iterator
+    clipped.toOption
   }
+
+  /** Clips Features to a 3x3 grid surrounding the current Tile.
+    * This has been found to capture ''most'' Features which stretch
+    * outside their original Tile, and helps avoid the pain of
+    * restitching later.
+    */
+  def byBufferedExtent[G <: Geometry, D](
+    extent: Extent,
+    f: Feature[G, D]
+  ): Option[Feature[Geometry, D]] = f.geom match {
+    case g: Point => Some(f)  /* A `Point` will always fall within the Extent */
+    case _ => byExtent(extent.expandBy(extent.width, extent.height), f)
+  }
+
 }

--- a/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
@@ -30,42 +30,42 @@ object ClipToGrid {
     * which intersect it, where the SpatialKeys map to the
     * given [[LayoutDefinition]].
     */
-  def geometries[G <: Geometry](layout: LayoutDefinition, rdd: RDD[G]): RDD[(SpatialKey, Geometry)] =
-    geometriesWith(layout, rdd, byExtent)
+  def apply[G <: Geometry](layout: LayoutDefinition, rdd: RDD[G]): RDD[(SpatialKey, Geometry)] =
+    apply(layout, rdd, byExtent)
 
   /** Clip each geometry in the RDD to the set of SpatialKeys
     * which intersect it, where the SpatialKeys map to the
     * given [[LayoutDefinition]], using the given method
     * to clip each geometry to the extent.
     */
-  def geometriesWith[G <: Geometry](
+  def apply[G <: Geometry](
     layout: LayoutDefinition,
     rdd: RDD[G],
     clipGeom: (Extent, Feature[G, Unit]) => Option[Feature[Geometry, Unit]]
   ): RDD[(SpatialKey, Geometry)] =
-    featuresWith(layout, rdd.map(Feature(_, ())), clipGeom).mapValues(_.geom)
+    apply(layout, rdd.map(Feature(_, ())), clipGeom).mapValues(_.geom)
 
   /** Clip each geometry in the RDD to the set of SpatialKeys
     * which intersect it, where the SpatialKeys map to the
     * given [[LayoutDefinition]], using the given method
     * to clip each geometry to the extent.
     */
-  def features[G <: Geometry, D](
+  def apply[G <: Geometry, D](
     layout: LayoutDefinition,
     rdd: RDD[Feature[G, D]]
-  ): RDD[(SpatialKey, Feature[Geometry, D])] =
-    featuresWith(layout, rdd, byExtent)
+  )(implicit d: DummyImplicit): RDD[(SpatialKey, Feature[Geometry, D])] =
+    apply(layout, rdd, byExtent)
 
   /** Clip each geometry in the RDD to the set of SpatialKeys
     * which intersect it, where the SpatialKeys map to the
     * given [[LayoutDefinition]], using the given method
     * to clip each geometry to the extent.
     */
-  def featuresWith[G <: Geometry, D](
+  def apply[G <: Geometry, D](
     layout: LayoutDefinition,
     rdd: RDD[Feature[G, D]],
     clipFeature: (Extent, Feature[G, D]) => Option[Feature[Geometry, D]]
-  ): RDD[(SpatialKey, Feature[Geometry, D])] = {
+  )(implicit d: DummyImplicit): RDD[(SpatialKey, Feature[Geometry, D])] = {
     val mapTransform: MapKeyTransform = layout.mapTransform
 
     /* Associate each Feature with its SpatialKeys*/

--- a/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
@@ -25,11 +25,11 @@ import org.apache.spark.rdd._
 
 trait FeatureClipToGridMethods[G <: Geometry, D] extends MethodExtensions[RDD[Feature[G, D]]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Feature[Geometry, D])] =
-    ClipToGrid(self, layout)
+    ClipToGrid(layout, self)
 
   def clipToGrid(
-    layout: LayoutDefinition,
-    clipFeature: (Extent, Feature[Geometry, D], ClipToGrid.Predicates) => Option[Feature[Geometry, D]]
+    clipFeature: (Extent, Feature[Geometry, D], ClipToGrid.Predicates) => Option[Feature[Geometry, D]],
+    layout: LayoutDefinition
   ): RDD[(SpatialKey, Feature[Geometry, D])] =
-    ClipToGrid(self, layout, clipFeature)
+    ClipToGrid(clipFeature, layout, self)
 }

--- a/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
@@ -25,11 +25,11 @@ import org.apache.spark.rdd._
 
 trait FeatureClipToGridMethods[G <: Geometry, D] extends MethodExtensions[RDD[Feature[G, D]]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Feature[Geometry, D])] =
-    ClipToGrid(layout, self)
+    ClipToGrid.features(layout, self)
 
   def clipToGrid(
-    clipFeature: (Extent, Feature[Geometry, D], ClipToGrid.Predicates) => Option[Feature[Geometry, D]],
-    layout: LayoutDefinition
+    layout: LayoutDefinition,
+    clipFeature: (Extent, Feature[Geometry, D]) => Option[Feature[Geometry, D]]
   ): RDD[(SpatialKey, Feature[Geometry, D])] =
-    ClipToGrid(clipFeature, layout, self)
+    ClipToGrid.featuresWith(layout, self, clipFeature)
 }

--- a/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
@@ -25,11 +25,11 @@ import org.apache.spark.rdd._
 
 trait FeatureClipToGridMethods[G <: Geometry, D] extends MethodExtensions[RDD[Feature[G, D]]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Feature[Geometry, D])] =
-    ClipToGrid.features(layout, self)
+    ClipToGrid(layout, self)
 
   def clipToGrid(
     layout: LayoutDefinition,
     clipFeature: (Extent, Feature[Geometry, D]) => Option[Feature[Geometry, D]]
   ): RDD[(SpatialKey, Feature[Geometry, D])] =
-    ClipToGrid.featuresWith(layout, self, clipFeature)
+    ClipToGrid(layout, self, clipFeature)
 }

--- a/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
@@ -25,11 +25,11 @@ import org.apache.spark.rdd._
 
 trait GeometryClipToGridMethods[G <: Geometry] extends MethodExtensions[RDD[G]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Geometry)] =
-    ClipToGrid(self, layout)
+    ClipToGrid(layout, self)
 
   def clipToGrid(
-    layout: LayoutDefinition,
-    clipGeom: (Extent, Geometry, ClipToGrid.Predicates) => Option[Geometry]
+    clipGeom: (Extent, Geometry, ClipToGrid.Predicates) => Option[Geometry],
+    layout: LayoutDefinition
   ): RDD[(SpatialKey, Geometry)] =
-    ClipToGrid(self, layout, clipGeom)
+    ClipToGrid(clipGeom, layout, self)
 }

--- a/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
@@ -25,11 +25,11 @@ import org.apache.spark.rdd._
 
 trait GeometryClipToGridMethods[G <: Geometry] extends MethodExtensions[RDD[G]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Geometry)] =
-    ClipToGrid(layout, self)
+    ClipToGrid.geometries(layout, self)
 
   def clipToGrid(
-    clipGeom: (Extent, Geometry, ClipToGrid.Predicates) => Option[Geometry],
-    layout: LayoutDefinition
+    layout: LayoutDefinition,
+    clipGeom: (Extent, Feature[G, Unit]) => Option[Feature[Geometry, Unit]]
   ): RDD[(SpatialKey, Geometry)] =
-    ClipToGrid(clipGeom, layout, self)
+    ClipToGrid.geometriesWith(layout, self, clipGeom)
 }

--- a/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
@@ -25,11 +25,11 @@ import org.apache.spark.rdd._
 
 trait GeometryClipToGridMethods[G <: Geometry] extends MethodExtensions[RDD[G]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Geometry)] =
-    ClipToGrid.geometries(layout, self)
+    ClipToGrid(layout, self)
 
   def clipToGrid(
     layout: LayoutDefinition,
     clipGeom: (Extent, Feature[G, Unit]) => Option[Feature[Geometry, Unit]]
   ): RDD[(SpatialKey, Geometry)] =
-    ClipToGrid.geometriesWith(layout, self, clipGeom)
+    ClipToGrid(layout, self, clipGeom)
 }

--- a/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala
@@ -59,10 +59,7 @@ object RasterizeRDD {
   ): RDD[(SpatialKey, Tile)] with Metadata[LayoutDefinition] = {
     // key the geometry to intersecting tiles so it can be rasterized in the map-side combine
     val keyed: RDD[(SpatialKey, (Feature[Geometry, Double], SpatialKey))] =
-      features.flatMap { feature =>
-        layout.keysForGeometry(feature.geom).toIterator
-          .map(key => (key, (feature, key)) )
-      }
+      features.flatMap { f => layout.mapTransform.keysForGeometry(f.geom).map(key => (key, (f, key)) ) }
 
     val createTile = (tup: (Feature[Geometry, Double], SpatialKey)) => {
       val (feature, key) = tup
@@ -125,10 +122,7 @@ object RasterizeRDD {
 
     // key the geometry to intersecting tiles so it can be rasterized in the map-side combine
     val keyed: RDD[(SpatialKey, (Feature[Geometry, CellValue], SpatialKey))] =
-      features.flatMap { feature =>
-        layout.keysForGeometry(feature.geom).toIterator
-          .map(key => (key, (feature, key)) )
-      }
+      features.flatMap { f => layout.mapTransform.keysForGeometry(f.geom).map(key => (key, (f, key)) ) }
 
     val createTile = (tup: (Feature[Geometry, CellValue], SpatialKey)) => {
       val (feature, key) = tup

--- a/spark/src/main/scala/geotrellis/spark/tiling/LayoutDefinition.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/LayoutDefinition.scala
@@ -34,48 +34,6 @@ case class LayoutDefinition(override val extent: Extent, tileLayout: TileLayout)
   def layoutCols = tileLayout.layoutCols
   def layoutRows = tileLayout.layoutRows
 
-  /** Generate a set of tile keys that intersect given geometry */
-  def keysForGeometry(geom: Geometry): Set[SpatialKey] = {
-    val layoutRasterizerOptions = Rasterizer.Options(includePartial=true, sampleType=PixelIsArea)
-    val layoutRasterExtent = RasterExtent(extent, tileLayout.layoutCols, tileLayout.layoutRows)
-    val fudge = math.min(layoutRasterExtent.cellwidth, layoutRasterExtent.cellheight) * 0.01
-
-    def lineToPolygons(line: Line): Iterator[Polygon] = {
-      line.points
-        .toIterator
-        .sliding(2)
-        .map({ case List(a, b) =>
-          Polygon(
-            a, b,
-            Point(b.x+fudge, b.y+fudge),
-            Point(a.x+fudge, a.y+fudge),
-            a
-          ) })
-    }
-
-    def multiLineToPolygons(mline: MultiLine): Iterator[Polygon] = {
-      mline.lines.toIterator.flatMap({ line => lineToPolygons(line) })
-    }
-
-    val geoms = geom match {
-      case l: Line => lineToPolygons(l)
-      case ml: MultiLine => multiLineToPolygons(ml)
-      case g => List(g)
-    }
-    var keySet = Set.empty[SpatialKey]
-
-    geoms.foreach({geom =>
-      Rasterizer.foreachCellByGeometry(
-        geom,
-        layoutRasterExtent,
-        layoutRasterizerOptions
-      )({ (col: Int, row: Int) =>
-        keySet = keySet + SpatialKey(col, row)
-      })
-    })
-
-    keySet
-  }
 }
 
 object LayoutDefinition {

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -176,4 +176,26 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
     multiPolygon.foreach(rasterExtent, options)(fn)
     tiles.keys.asScala.map { case (col, row) => SpatialKey(col, row) }
   }
+
+  /** For some given [[Geometry]], find the SpatialKeys for all Tile extents
+    * that it touches.
+    */
+  def keysFromGeometry[G <: Geometry](g: G): Iterator[SpatialKey] = g match {
+    case p:  Point        => Iterator.single(pointToKey(p))
+    case mp: MultiPoint   => mp.points.map(pointToKey(_)).toSet.iterator
+    case l:  Line         => multiLineToKeys(MultiLine(l))
+    case ml: MultiLine    => multiLineToKeys(ml)
+    case p:  Polygon      => multiPolygonToKeys(MultiPolygon(p))
+    case mp: MultiPolygon => multiPolygonToKeys(mp)
+    case gc: GeometryCollection =>
+      List(
+        gc.points.map(pointToKey),
+        gc.multiPoints.flatMap(_.points.map(pointToKey)),
+        gc.lines.flatMap { l => multiLineToKeys(MultiLine(l)) },
+        gc.multiLines.flatMap { ml => multiLineToKeys(ml) },
+        gc.polygons.flatMap { p => multiPolygonToKeys(MultiPolygon(p)) },
+        gc.multiPolygons.flatMap { mp => multiPolygonToKeys(mp) },
+        gc.geometryCollections.flatMap(keysFromGeometry)
+      ).flatten.iterator
+  }
 }

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -177,10 +177,10 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
     tiles.keys.asScala.map { case (col, row) => SpatialKey(col, row) }
   }
 
-  /** For some given [[Geometry]], find the SpatialKeys for all Tile extents
+  /** For some given [[Geometry]], find the unique SpatialKeys for all Tile extents
     * that it touches.
     */
-  def keysFromGeometry[G <: Geometry](g: G): Iterator[SpatialKey] = g match {
+  def keysForGeometry[G <: Geometry](g: G): Iterator[SpatialKey] = g match {
     case p:  Point        => Iterator.single(pointToKey(p))
     case mp: MultiPoint   => mp.points.map(pointToKey(_)).toSet.iterator
     case l:  Line         => multiLineToKeys(MultiLine(l))
@@ -195,7 +195,7 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
         gc.multiLines.flatMap { ml => multiLineToKeys(ml) },
         gc.polygons.flatMap { p => multiPolygonToKeys(MultiPolygon(p)) },
         gc.multiPolygons.flatMap { mp => multiPolygonToKeys(mp) },
-        gc.geometryCollections.flatMap(keysFromGeometry)
-      ).flatten.iterator
+        gc.geometryCollections.flatMap(keysForGeometry)
+      ).flatten.toSet.iterator
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/clip/ClipToGridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/clip/ClipToGridSpec.scala
@@ -63,7 +63,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
     it("should clip a point") {
       val p = Point(0, -10.0)
       val rdd = sc.parallelize(Array(p))
-      val result = ClipToGrid(rdd, layoutDefinition).collect().toVector
+      val result = ClipToGrid(layoutDefinition, rdd).collect().toVector
       result.size should be (1)
       result(0) should be ((SpatialKey(0, 5), p))
     }
@@ -74,7 +74,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
       val p3 = Point(0, 0)
 
       val rdd = sc.parallelize(Array(MultiPoint(p1, p2, p3)))
-      val result = ClipToGrid(rdd, layoutDefinition).collect().toVector.sortBy(_._2.envelope.ymin)
+      val result = ClipToGrid(layoutDefinition, rdd).collect().toVector.sortBy(_._2.envelope.ymin)
       result.size should be (2)
       result(0)._1 should be (SpatialKey(0, 5))
       result(0)._2 should be (an[MultiPoint])
@@ -94,7 +94,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         )
 
       val rdd = sc.parallelize(Array(line))
-      val actual = ClipToGrid(rdd, layoutDefinition)
+      val actual = ClipToGrid(layoutDefinition, rdd)
 
       checkCorrect(actual,
         Vector(
@@ -123,7 +123,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         )
 
       val rdd = sc.parallelize(Array(line))
-      val actual = ClipToGrid(rdd, layoutDefinition)
+      val actual = ClipToGrid(layoutDefinition, rdd)
 
       checkCorrect(actual, Vector((SpatialKey(1, 7), line)))
     }
@@ -168,7 +168,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         }
 
       val rdd = sc.parallelize(Array(poly))
-      val actual = ClipToGrid(rdd, layoutDefinition)
+      val actual = ClipToGrid(layoutDefinition, rdd)
 
       checkCorrect(actual,
         Vector(

--- a/spark/src/test/scala/geotrellis/spark/clip/ClipToGridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/clip/ClipToGridSpec.scala
@@ -63,7 +63,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
     it("should clip a point") {
       val p = Point(0, -10.0)
       val rdd = sc.parallelize(Array(p))
-      val result = ClipToGrid.geometries(layoutDefinition, rdd).collect().toVector
+      val result = ClipToGrid(layoutDefinition, rdd).collect().toVector
       result.size should be (1)
       result(0) should be ((SpatialKey(0, 5), p))
     }
@@ -74,7 +74,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
       val p3 = Point(0, 0)
 
       val rdd = sc.parallelize(Array(MultiPoint(p1, p2, p3)))
-      val result = ClipToGrid.geometries(layoutDefinition, rdd).collect().toVector.sortBy(_._2.envelope.ymin)
+      val result = ClipToGrid(layoutDefinition, rdd).collect().toVector.sortBy(_._2.envelope.ymin)
       result.size should be (2)
       result(0)._1 should be (SpatialKey(0, 5))
       result(0)._2 should be (an[MultiPoint])
@@ -94,7 +94,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         )
 
       val rdd = sc.parallelize(Array(line))
-      val actual = ClipToGrid.geometries(layoutDefinition, rdd)
+      val actual = ClipToGrid(layoutDefinition, rdd)
 
       checkCorrect(actual,
         Vector(
@@ -123,7 +123,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         )
 
       val rdd = sc.parallelize(Array(line))
-      val actual = ClipToGrid.geometries(layoutDefinition, rdd)
+      val actual = ClipToGrid(layoutDefinition, rdd)
 
       checkCorrect(actual, Vector((SpatialKey(1, 7), line)))
     }
@@ -168,7 +168,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         }
 
       val rdd = sc.parallelize(Array(poly))
-      val actual = ClipToGrid.geometries(layoutDefinition, rdd)
+      val actual = ClipToGrid(layoutDefinition, rdd)
 
       checkCorrect(actual,
         Vector(

--- a/spark/src/test/scala/geotrellis/spark/clip/ClipToGridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/clip/ClipToGridSpec.scala
@@ -63,7 +63,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
     it("should clip a point") {
       val p = Point(0, -10.0)
       val rdd = sc.parallelize(Array(p))
-      val result = ClipToGrid(layoutDefinition, rdd).collect().toVector
+      val result = ClipToGrid.geometries(layoutDefinition, rdd).collect().toVector
       result.size should be (1)
       result(0) should be ((SpatialKey(0, 5), p))
     }
@@ -74,7 +74,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
       val p3 = Point(0, 0)
 
       val rdd = sc.parallelize(Array(MultiPoint(p1, p2, p3)))
-      val result = ClipToGrid(layoutDefinition, rdd).collect().toVector.sortBy(_._2.envelope.ymin)
+      val result = ClipToGrid.geometries(layoutDefinition, rdd).collect().toVector.sortBy(_._2.envelope.ymin)
       result.size should be (2)
       result(0)._1 should be (SpatialKey(0, 5))
       result(0)._2 should be (an[MultiPoint])
@@ -94,7 +94,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         )
 
       val rdd = sc.parallelize(Array(line))
-      val actual = ClipToGrid(layoutDefinition, rdd)
+      val actual = ClipToGrid.geometries(layoutDefinition, rdd)
 
       checkCorrect(actual,
         Vector(
@@ -123,7 +123,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         )
 
       val rdd = sc.parallelize(Array(line))
-      val actual = ClipToGrid(layoutDefinition, rdd)
+      val actual = ClipToGrid.geometries(layoutDefinition, rdd)
 
       checkCorrect(actual, Vector((SpatialKey(1, 7), line)))
     }
@@ -168,7 +168,7 @@ class ClipToGridSpec extends FunSpec with TestEnvironment {
         }
 
       val rdd = sc.parallelize(Array(poly))
-      val actual = ClipToGrid(layoutDefinition, rdd)
+      val actual = ClipToGrid.geometries(layoutDefinition, rdd)
 
       checkCorrect(actual,
         Vector(


### PR DESCRIPTION
### TODO

- [x] Port VectorPipe code
- [x] Remove `Predicates`
- [x] Remove `LayoutDefinition.keysForGeometry` in favour of `MapKeyTransform.keysForGeometry` ( @echeipesh )

### Motivation

Apologies to @lossyrob - I should have reviewed the original PR.

~~This PR optimizes certain sections of `ClipToGrid` based on benchmark results [from here](https://github.com/fosskers/scala-benchmarks).~~

This PR is a port of functionality from VectorPipe which was changed to incorporate the two core concepts of the original `ClipToGrid`, namely:

- efficient association of Geometries to SpatialKeys
- avoidance of JTS intersections where ever possible

This PR maintains the API exposed by the original `ClipToGrid` (save the removal of `Predicates`), brings back clipping by buffered Extents, allows for easier definition of new clipping functions, and also is easy to "hijack" (i.e. borrow the same logic to inject an error logging step, which is a requirement of VectorPipe).