### PR TITLE
Add `shapefile` And `geotools` To ETL Assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ lazy val hbase = project
   .settings(projectDependencies := { Seq((projectID in spark).value.exclude("com.google.protobuf", "protobuf-java")) })
 
 lazy val `spark-etl` = Project(id = "spark-etl", base = file("spark-etl")).
-  dependsOn(spark, s3, accumulo, cassandra, hbase).
+  dependsOn(spark, s3, accumulo, cassandra, hbase, shapefile, geotools).
   settings(commonSettings)
 
 lazy val geotools = project


### PR DESCRIPTION
If the ETL assembly is going to be used as the official (or quasi-official or recommended) überjar, I think that there is an argument to be made for including `shapefile` and `geotools` which are needed for many exploratory workflows.