### PR TITLE
Let spatiotemporal layers be regridded

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -97,7 +97,7 @@ object Regrid {
       val tiled: RDD[(K, V)] =
         layer
           .flatMap{ case (key, oldTile) => {
-            val SpatialKey(oldX, oldY) = key
+            val SpatialKey(oldX, oldY) = key.getComponent[SpatialKey]
 
             val oldXstart = oldX.toLong * oldW.toLong
             val oldYstart = oldY.toLong * oldH.toLong


### PR DESCRIPTION
Fixes #2459 

Minor repair of oversight w.r.t. tile layers with SpaceTimeKeys.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>