### PR TITLE
ClipToGrid Optimizations - Round 2

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/ClipToGrid.scala
@@ -25,6 +25,36 @@ import geotrellis.vector._
 import com.vividsolutions.jts.geom.prep.{PreparedGeometry, PreparedGeometryFactory}
 import org.apache.spark.rdd._
 
+/**
+  * These functions perform the following transformation:
+  *
+  * {{{
+  * RDD[Geometry] => RDD[(SpatialKey, Geometry)]
+  * }}}
+  *
+  * such that each original [[Geometry]] is clipped in some way. By default,
+  * this clips them to fit inside the [[Extent]] of each [[SpatialKey]]
+  * they touch.
+  *
+  * If you'd like more customized clipping behaviour, you can compose
+  * over the [[clipFeatureToExtent]] function below, or write your own
+  * entirely, while following its type signature. That can then be passed
+  * into the appropriate `apply` method below.
+  *
+  * A variety of overloads are provided here to help you work with either
+  * [[Geometry]] or [[Feature]]. The injected
+  *
+  * {{{
+  * RDD[Geometry].clipToGrid: LayoutDefinition => RDD[(SpatialKey, Geometry)]
+  * }}}
+  *
+  * may also be preferable to you.
+  *
+  * '''Note:''' If your custom clipping function relies on [[Predicates]],
+  * note that its method `coveredBy` will always return `true` if your Geometry
+  * fits inside the passed-in [[Extent]]. Please avoid writing clipping
+  * functions that do non-sensical things.
+  */
 object ClipToGrid {
   /** Trait which contains methods to be used in determining
     * the most optimal way to clip geometries and features
@@ -33,7 +63,7 @@ object ClipToGrid {
   trait Predicates extends Serializable {
     /** Returns true if the feature geometry covers the passed in extent */
     def covers(e: Extent): Boolean
-    /** Returns true if the feature geometry is covered bythe passed in extent */
+    /** Returns true if the feature geometry is covered by the passed in extent */
     def coveredBy(e: Extent): Boolean
   }
 

--- a/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
@@ -23,6 +23,7 @@ import geotrellis.vector._
 
 import org.apache.spark.rdd._
 
+/** See [[ClipToGrid]]. */
 trait FeatureClipToGridMethods[G <: Geometry, D] extends MethodExtensions[RDD[Feature[G, D]]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Feature[Geometry, D])] =
     ClipToGrid(self, layout)

--- a/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
@@ -23,6 +23,7 @@ import geotrellis.vector._
 
 import org.apache.spark.rdd._
 
+/** See [[ClipToGrid]]. */
 trait GeometryClipToGridMethods[G <: Geometry] extends MethodExtensions[RDD[G]] {
   def clipToGrid(layout: LayoutDefinition): RDD[(SpatialKey, Geometry)] =
     ClipToGrid(self, layout)

--- a/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala
@@ -60,7 +60,7 @@ object RasterizeRDD {
     // key the geometry to intersecting tiles so it can be rasterized in the map-side combine
     val keyed: RDD[(SpatialKey, (Feature[Geometry, Double], SpatialKey))] =
       features.flatMap { feature =>
-        layout.keysForGeometry(feature.geom).toIterator
+        layout.mapTransform.keysForGeometry(feature.geom).toIterator
           .map(key => (key, (feature, key)) )
       }
 
@@ -126,7 +126,7 @@ object RasterizeRDD {
     // key the geometry to intersecting tiles so it can be rasterized in the map-side combine
     val keyed: RDD[(SpatialKey, (Feature[Geometry, CellValue], SpatialKey))] =
       features.flatMap { feature =>
-        layout.keysForGeometry(feature.geom).toIterator
+        layout.mapTransform.keysForGeometry(feature.geom).toIterator
           .map(key => (key, (feature, key)) )
       }
 

--- a/spark/src/main/scala/geotrellis/spark/tiling/LayoutDefinition.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/LayoutDefinition.scala
@@ -33,49 +33,6 @@ case class LayoutDefinition(override val extent: Extent, tileLayout: TileLayout)
   def tileRows = tileLayout.tileRows
   def layoutCols = tileLayout.layoutCols
   def layoutRows = tileLayout.layoutRows
-
-  /** Generate a set of tile keys that intersect given geometry */
-  def keysForGeometry(geom: Geometry): Set[SpatialKey] = {
-    val layoutRasterizerOptions = Rasterizer.Options(includePartial=true, sampleType=PixelIsArea)
-    val layoutRasterExtent = RasterExtent(extent, tileLayout.layoutCols, tileLayout.layoutRows)
-    val fudge = math.min(layoutRasterExtent.cellwidth, layoutRasterExtent.cellheight) * 0.01
-
-    def lineToPolygons(line: Line): Iterator[Polygon] = {
-      line.points
-        .toIterator
-        .sliding(2)
-        .map({ case List(a, b) =>
-          Polygon(
-            a, b,
-            Point(b.x+fudge, b.y+fudge),
-            Point(a.x+fudge, a.y+fudge),
-            a
-          ) })
-    }
-
-    def multiLineToPolygons(mline: MultiLine): Iterator[Polygon] = {
-      mline.lines.toIterator.flatMap({ line => lineToPolygons(line) })
-    }
-
-    val geoms = geom match {
-      case l: Line => lineToPolygons(l)
-      case ml: MultiLine => multiLineToPolygons(ml)
-      case g => List(g)
-    }
-    var keySet = Set.empty[SpatialKey]
-
-    geoms.foreach({geom =>
-      Rasterizer.foreachCellByGeometry(
-        geom,
-        layoutRasterExtent,
-        layoutRasterizerOptions
-      )({ (col: Int, row: Int) =>
-        keySet = keySet + SpatialKey(col, row)
-      })
-    })
-
-    keySet
-  }
 }
 
 object LayoutDefinition {

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -25,7 +25,7 @@ import geotrellis.util._
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters._
-import scala.collection.mutable.{ Set => MSet }
+import scala.collection.mutable
 
 object MapKeyTransform {
   def apply(crs: CRS, level: LayoutLevel): MapKeyTransform =
@@ -135,21 +135,15 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
     val boundsExtent: Extent = boundsToExtent(bounds)
     val rasterExtent = RasterExtent(boundsExtent, bounds.width, bounds.height)
 
-    /*
-     * Use the Rasterizer to construct  a list of tiles which meet
-     * the  query polygon.   That list  of tiles  is stored  as an
-     * array of  tuples which  is then  mapped-over to  produce an
-     * array of KeyBounds.
-     */
-    val tiles: MSet[(Int, Int)] = MSet.empty
+    /* Use the Rasterizer to construct a list of tiles which meet the query polygon. */
+    val tiles: mutable.Set[SpatialKey] = mutable.Set.empty
     val fn = new Callback {
-      def apply(col: Int, row: Int): Unit = {
-        tiles += ((bounds.colMin + col, bounds.rowMin + row))
-      }
+      def apply(col: Int, row: Int): Unit =
+        tiles += SpatialKey(bounds.colMin + col, bounds.rowMin + row)
     }
 
     multiLine.lines.foreach { line => Rasterizer.foreachCellByLineStringDouble(line, rasterExtent)(fn) }
-    tiles.map { case (col, row) => SpatialKey(col, row) }.toSet
+    tiles.toSet
   }
 
   def multiPolygonToKeys(multiPolygon: MultiPolygon): Set[SpatialKey] = {
@@ -159,21 +153,15 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
     val boundsExtent: Extent = boundsToExtent(bounds)
     val rasterExtent = RasterExtent(boundsExtent, bounds.width, bounds.height)
 
-    /*
-     * Use the Rasterizer to construct  a list of tiles which meet
-     * the  query polygon.   That list  of tiles  is stored  as an
-     * array of  tuples which  is then  mapped-over to  produce an
-     * array of KeyBounds.
-     */
-    val tiles: MSet[(Int, Int)] = MSet.empty
+    /* Use the Rasterizer to construct a list of tiles which meet the query polygon. */
+    val tiles: mutable.Set[SpatialKey] = mutable.Set.empty
     val fn = new Callback {
-      def apply(col: Int, row: Int): Unit = {
-        tiles += ((bounds.colMin + col, bounds.rowMin + row))
-      }
+      def apply(col: Int, row: Int): Unit =
+        tiles += SpatialKey(bounds.colMin + col, bounds.rowMin + row)
     }
 
     multiPolygon.foreach(rasterExtent, options)(fn)
-    tiles.map { case (col, row) => SpatialKey(col, row) }.toSet
+    tiles.toSet
   }
 
   /** For some given [[Geometry]], find the unique SpatialKeys for all Tile extents

--- a/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/MapKeyTransform.scala
@@ -25,6 +25,7 @@ import geotrellis.util._
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters._
+import scala.collection.mutable.{ Set => MSet }
 
 object MapKeyTransform {
   def apply(crs: CRS, level: LayoutLevel): MapKeyTransform =
@@ -129,7 +130,7 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
       extent.ymax - row * tileHeight
     )
 
-  def multiLineToKeys(multiLine: MultiLine): Iterator[SpatialKey] = {
+  def multiLineToKeys(multiLine: MultiLine): Set[SpatialKey] = {
     val bounds: GridBounds = extentToBounds(multiLine.envelope)
     val boundsExtent: Extent = boundsToExtent(bounds)
     val rasterExtent = RasterExtent(boundsExtent, bounds.width, bounds.height)
@@ -140,19 +141,18 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
      * array of  tuples which  is then  mapped-over to  produce an
      * array of KeyBounds.
      */
-    val tiles = new ConcurrentHashMap[(Int,Int), Unit]
+    val tiles: MSet[(Int, Int)] = MSet.empty
     val fn = new Callback {
       def apply(col: Int, row: Int): Unit = {
-        val tile: (Int, Int) = (bounds.colMin + col, bounds.rowMin + row)
-        tiles.put(tile, Unit)
+        tiles += ((bounds.colMin + col, bounds.rowMin + row))
       }
     }
 
     multiLine.lines.foreach { line => Rasterizer.foreachCellByLineStringDouble(line, rasterExtent)(fn) }
-    tiles.keys.asScala.map { case (col, row) => SpatialKey(col, row) }
+    tiles.map { case (col, row) => SpatialKey(col, row) }.toSet
   }
 
-  def multiPolygonToKeys(multiPolygon: MultiPolygon): Iterator[SpatialKey] = {
+  def multiPolygonToKeys(multiPolygon: MultiPolygon): Set[SpatialKey] = {
     val extent = multiPolygon.envelope
     val bounds: GridBounds = extentToBounds(extent)
     val options = Rasterizer.Options(includePartial=true, sampleType=PixelIsArea)
@@ -165,15 +165,36 @@ class MapKeyTransform(val extent: Extent, val layoutCols: Int, val layoutRows: I
      * array of  tuples which  is then  mapped-over to  produce an
      * array of KeyBounds.
      */
-    val tiles = new ConcurrentHashMap[(Int,Int), Unit]
+    val tiles: MSet[(Int, Int)] = MSet.empty
     val fn = new Callback {
       def apply(col: Int, row: Int): Unit = {
-        val tile: (Int, Int) = (bounds.colMin + col, bounds.rowMin + row)
-        tiles.put(tile, Unit)
+        tiles += ((bounds.colMin + col, bounds.rowMin + row))
       }
     }
 
     multiPolygon.foreach(rasterExtent, options)(fn)
-    tiles.keys.asScala.map { case (col, row) => SpatialKey(col, row) }
+    tiles.map { case (col, row) => SpatialKey(col, row) }.toSet
+  }
+
+  /** For some given [[Geometry]], find the unique SpatialKeys for all Tile extents
+    * that it touches.
+    */
+  def keysForGeometry[G <: Geometry](g: G): Set[SpatialKey] = g match {
+    case p:  Point        => Set(pointToKey(p))
+    case mp: MultiPoint   => mp.points.map(pointToKey(_)).toSet
+    case l:  Line         => multiLineToKeys(MultiLine(l))
+    case ml: MultiLine    => multiLineToKeys(ml)
+    case p:  Polygon      => multiPolygonToKeys(MultiPolygon(p))
+    case mp: MultiPolygon => multiPolygonToKeys(mp)
+    case gc: GeometryCollection =>
+      List(
+        gc.points.map(pointToKey),
+        gc.multiPoints.flatMap(_.points.map(pointToKey)),
+        gc.lines.flatMap { l => multiLineToKeys(MultiLine(l)) },
+        gc.multiLines.flatMap { ml => multiLineToKeys(ml) },
+        gc.polygons.flatMap { p => multiPolygonToKeys(MultiPolygon(p)) },
+        gc.multiPolygons.flatMap { mp => multiPolygonToKeys(mp) },
+        gc.geometryCollections.flatMap(keysForGeometry)
+      ).flatten.toSet
   }
 }


### PR DESCRIPTION
### TODO

- [x] `MapKeyTransform.keysForGeometry`
- [x] Use it in `ClipToGrid`
- [ ] Factor out `coveredBy` ?

@echeipesh , we had decided that this was to be two PRs, but the changes to `MapKeyTransform` (the `Iterator -> Set` change) broke `ClipToGrid`. 

Closes #2453 .