### PR TITLE
Fix types in injected ClipToGrid methods

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/FeatureClipToGridMethods.scala
@@ -30,7 +30,7 @@ trait FeatureClipToGridMethods[G <: Geometry, D] extends MethodExtensions[RDD[Fe
 
   def clipToGrid(
     layout: LayoutDefinition,
-    clipFeature: (Extent, Feature[Geometry, D], ClipToGrid.Predicates) => Option[Feature[Geometry, D]]
+    clipFeature: (Extent, Feature[G, D], ClipToGrid.Predicates) => Option[Feature[Geometry, D]]
   ): RDD[(SpatialKey, Feature[Geometry, D])] =
     ClipToGrid(self, layout, clipFeature)
 }

--- a/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/clip/GeometryClipToGridMethods.scala
@@ -30,7 +30,7 @@ trait GeometryClipToGridMethods[G <: Geometry] extends MethodExtensions[RDD[G]] 
 
   def clipToGrid(
     layout: LayoutDefinition,
-    clipGeom: (Extent, Geometry, ClipToGrid.Predicates) => Option[Geometry]
+    clipGeom: (Extent, G, ClipToGrid.Predicates) => Option[Geometry]
   ): RDD[(SpatialKey, Geometry)] =
     ClipToGrid(self, layout, clipGeom)
 }


### PR DESCRIPTION
There were minor type typos in the injected methods' signatures that prevented them from being used with the built-in clipping functions.