### PR TITLE
`Line.head` and `Line.last`

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/Line.scala
+++ b/vector/src/main/scala/geotrellis/vector/Line.scala
@@ -82,6 +82,12 @@ case class Line(jtsGeom: jts.LineString) extends Geometry
   lazy val boundary: OneDimensionBoundaryResult =
     jtsGeom.getBoundary
 
+  /* The first [[Point]] in this Line, which we know to exist. */
+  def head: Point = jtsGeom.getPointN(0)
+
+  /* The last [[Point]] in this Line, which we know to exist. */
+  def last: Point = jtsGeom.getPointN(jtsGeom.getNumPoints - 1)
+
   /** Returns the points which determine this line (i.e. its vertices */
   def points: Array[Point] = vertices
 

--- a/vector/src/test/scala/spec/geotrellis/vector/dissolve/DissoveMethodsSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/dissolve/DissoveMethodsSpec.scala
@@ -86,10 +86,10 @@ class DissolveMethodsSpec extends FunSpec
 
     it("should handle two line segments intersecting") {
       val s = MultiLine(Line((0, 0), (1, 1)), Line((1, 0), (0, 1)))
-      s.dissolve.as[MultiLine].get.lines.sortBy(_.points.head.x) should be(List(
+      s.dissolve.as[MultiLine].get.lines.sortBy(_.head.x) should be(List(
         Line(Point(0, 0), Point(1, 1)),
         Line(Point(1, 0), Point(0, 1))
-      ).sortBy(_.points.head.x))
+      ).sortBy(_.head.x))
     }
 
     it("should not throw exceptions when dissolving a multiline that throws a topology exception in JTS for .union call") {

--- a/vectortile/src/main/scala/geotrellis/vectortile/internal/package.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/internal/package.scala
@@ -214,7 +214,7 @@ package object internal {
           )
 
           /* Find new cursor position */
-          curs = fromProjection(l.points.last, topLeft, resolution)
+          curs = fromProjection(l.last, topLeft, resolution)
 
           buff.appendAll(Seq(MoveTo(Array(diffs.head)), LineTo(diffs.tail)))
         })


### PR DESCRIPTION
This PR adds two efficient functions for quickly grabbing either the first or last `Point` in a `Line`.
This lets us skip having to call `Line.points`, which is expensive.