### PR TITLE
Make `Point6D` a top-level type

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
@@ -36,6 +36,22 @@ import org.apache.spark.util.AccumulatorV2
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
+/**
+  * @param x:           x-coordinate (in the units used by the layer)
+  * @param y:           y-coordinate (in the units used by the layer)
+  * @param viewHeight:  view height (in units of "meters") if positive then height above the surface, if negative then absolute height
+  * @param angle:       the angle in radians (about the z-axis) of the "camera"
+  * @param fieldOfView: the field of view of the "camera" in radians
+  * @param altitude:    the absolute altitude to query; if -∞ then use the terrain height
+  */
+case class Point6D(
+  x: Double,
+  y: Double,
+  viewHeight: Double,
+  angle: Double,
+  fieldOfView: Double,
+  altitude: Double
+)
 
 /**
   * A Spark-enabled implementation of R2 [1] viewshed.
@@ -48,23 +64,6 @@ import scala.reflect.ClassTag
   * @author James McClain
   */
 object IterativeViewshed {
-
-  /**
-    * x:           x-coordinate (in the units used by the layer)
-    * y:           y-coordinate (in the units used by the layer)
-    * viewHeight:  view height (in units of "meters") if positive then height above the surface, if negative then absolute height
-    * angle:       the angle in radians (about the z-axis) of the "camera"
-    * fieldOfView: the field of view of the "camera" in radians
-    * altitude:    the absolute altitude to query; if -∞ then use the terrain height
-    */
-  case class Point6D(
-    x: Double,
-    y: Double,
-    viewHeight: Double,
-    angle: Double,
-    fieldOfView: Double,
-    altitude: Double
-  )
 
   implicit def coordinatesToPoints(points: Seq[jts.Coordinate]): Seq[Point6D] =
     points.map({ p => Point6D(p.x, p.y, p.z, 0, -1.0, Double.NegativeInfinity) })

--- a/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
@@ -44,7 +44,7 @@ import scala.reflect.ClassTag
   * @param fieldOfView: the field of view of the "camera" in radians
   * @param altitude:    the absolute altitude to query; if -∞ then use the terrain height
   */
-case class Point6D(
+case class Viewpoint(
   x: Double,
   y: Double,
   viewHeight: Double,
@@ -65,8 +65,8 @@ case class Point6D(
   */
 object IterativeViewshed {
 
-  implicit def coordinatesToPoints(points: Seq[jts.Coordinate]): Seq[Point6D] =
-    points.map({ p => Point6D(p.x, p.y, p.z, 0, -1.0, Double.NegativeInfinity) })
+  implicit def coordinatesToPoints(points: Seq[jts.Coordinate]): Seq[Viewpoint] =
+    points.map({ p => Viewpoint(p.x, p.y, p.z, 0, -1.0, Double.NegativeInfinity) })
 
   private val logger = Logger.getLogger(IterativeViewshed.getClass)
 
@@ -156,7 +156,7 @@ object IterativeViewshed {
     */
   private def pointInfo[K: (? => SpatialKey), V: (? => Tile)](
     rdd: RDD[(K, V)] with Metadata[TileLayerMetadata[K]])(
-    pi: (Point6D, Int)
+    pi: (Viewpoint, Int)
   )= {
     val (p, index) = pi
     val md = rdd.metadata
@@ -202,7 +202,7 @@ object IterativeViewshed {
     */
   def apply[K: (? => SpatialKey): ClassTag, V: (? => Tile)](
     elevation: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
-    ps: Seq[Point6D],
+    ps: Seq[Viewpoint],
     maxDistance: Double,
     curvature: Boolean = true,
     operator: AggregationOperator = Or,

--- a/spark/src/main/scala/geotrellis/spark/viewshed/RDDViewshedMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/RDDViewshedMethods.scala
@@ -19,7 +19,6 @@ package geotrellis.spark.viewshed
 import geotrellis.raster.{Tile, DoubleArrayTile}
 import geotrellis.raster.viewshed.R2Viewshed._
 import geotrellis.spark._
-import geotrellis.spark.viewshed.IterativeViewshed.Point6D
 import geotrellis.util.MethodExtensions
 
 import org.apache.spark.rdd.RDD

--- a/spark/src/main/scala/geotrellis/spark/viewshed/RDDViewshedMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/RDDViewshedMethods.scala
@@ -32,7 +32,7 @@ abstract class RDDViewshedMethods[K: (? => SpatialKey): ClassTag, V: (? => Tile)
     extends MethodExtensions[RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] {
 
   def viewshed(
-    points: Seq[Point6D],
+    points: Seq[Viewpoint],
     maxDistance: Double = Double.PositiveInfinity,
     curvature: Boolean = true,
     operator: AggregationOperator = Or

--- a/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
@@ -49,7 +49,7 @@ class IterativeViewshedSpec extends FunSpec
         val list = for (col <- 0 to 2; row <- 0 to 2) yield (SpatialKey(col, row), tile)
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
      }
-      val point = IterativeViewshed.Point6D(7, 7, -0.0, 0, -1.0, ninf)
+      val point = Point6D(7, 7, -0.0, 0, -1.0, ninf)
       val viewshed = rdd.viewshed(
         points = List(point),
         maxDistance = Double.PositiveInfinity,
@@ -74,7 +74,7 @@ class IterativeViewshedSpec extends FunSpec
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
       }
 
-      val point = IterativeViewshed.Point6D(7, 7, -0.0, 0, -1.0, ninf)
+      val point = Point6D(7, 7, -0.0, 0, -1.0, ninf)
       val viewshed = IterativeViewshed(rdd, List(point),
         maxDistance = Double.PositiveInfinity,
         curvature = false,
@@ -98,7 +98,7 @@ class IterativeViewshedSpec extends FunSpec
         val list = for (col <- 0 to 2; row <- 0 to 2) yield (if (col == 1 && row == 2) (SpatialKey(col, row), specialTile); else (SpatialKey(col, row), tile))
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
       }
-      val point = IterativeViewshed.Point6D(7, 7, -0.0, 0, -1.0, ninf)
+      val point = Point6D(7, 7, -0.0, 0, -1.0, ninf)
       val viewshed = rdd.viewshed(
         points = List(point),
         maxDistance = Double.PositiveInfinity,
@@ -132,9 +132,9 @@ class IterativeViewshedSpec extends FunSpec
         val list = for (col <- 0 to 2; row <- 0 to 2) yield (SpatialKey(col, row), tile)
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
       }
-      val point1 = IterativeViewshed.Point6D(2,  7, -0.0, 0, -1.0, ninf)
-      val point2 = IterativeViewshed.Point6D(7,  7, -0.0, 0, -1.0, ninf)
-      val point3 = IterativeViewshed.Point6D(12, 7, -0.0, 0, -1.0, ninf)
+      val point1 = Point6D(2,  7, -0.0, 0, -1.0, ninf)
+      val point2 = Point6D(7,  7, -0.0, 0, -1.0, ninf)
+      val point3 = Point6D(12, 7, -0.0, 0, -1.0, ninf)
       val viewshed = rdd.viewshed(
         points = List(point1, point2, point3),
         maxDistance = Double.PositiveInfinity,
@@ -167,9 +167,9 @@ class IterativeViewshedSpec extends FunSpec
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
       }
 
-      val point1 = IterativeViewshed.Point6D(2,  7, -0.0, 0, -1.0, ninf)
-      val point2 = IterativeViewshed.Point6D(7,  7, -0.0, 0, -1.0, ninf)
-      val point3 = IterativeViewshed.Point6D(12, 7, -0.0, 0, -1.0, ninf)
+      val point1 = Point6D(2,  7, -0.0, 0, -1.0, ninf)
+      val point2 = Point6D(7,  7, -0.0, 0, -1.0, ninf)
+      val point3 = Point6D(12, 7, -0.0, 0, -1.0, ninf)
       val expected = 3
       val viewshed = rdd.viewshed(
         points = List(point1, point2, point3),

--- a/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
@@ -49,7 +49,7 @@ class IterativeViewshedSpec extends FunSpec
         val list = for (col <- 0 to 2; row <- 0 to 2) yield (SpatialKey(col, row), tile)
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
      }
-      val point = Point6D(7, 7, -0.0, 0, -1.0, ninf)
+      val point = Viewpoint(7, 7, -0.0, 0, -1.0, ninf)
       val viewshed = rdd.viewshed(
         points = List(point),
         maxDistance = Double.PositiveInfinity,
@@ -74,7 +74,7 @@ class IterativeViewshedSpec extends FunSpec
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
       }
 
-      val point = Point6D(7, 7, -0.0, 0, -1.0, ninf)
+      val point = Viewpoint(7, 7, -0.0, 0, -1.0, ninf)
       val viewshed = IterativeViewshed(rdd, List(point),
         maxDistance = Double.PositiveInfinity,
         curvature = false,
@@ -98,7 +98,7 @@ class IterativeViewshedSpec extends FunSpec
         val list = for (col <- 0 to 2; row <- 0 to 2) yield (if (col == 1 && row == 2) (SpatialKey(col, row), specialTile); else (SpatialKey(col, row), tile))
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
       }
-      val point = Point6D(7, 7, -0.0, 0, -1.0, ninf)
+      val point = Viewpoint(7, 7, -0.0, 0, -1.0, ninf)
       val viewshed = rdd.viewshed(
         points = List(point),
         maxDistance = Double.PositiveInfinity,
@@ -132,9 +132,9 @@ class IterativeViewshedSpec extends FunSpec
         val list = for (col <- 0 to 2; row <- 0 to 2) yield (SpatialKey(col, row), tile)
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
       }
-      val point1 = Point6D(2,  7, -0.0, 0, -1.0, ninf)
-      val point2 = Point6D(7,  7, -0.0, 0, -1.0, ninf)
-      val point3 = Point6D(12, 7, -0.0, 0, -1.0, ninf)
+      val point1 = Viewpoint(2,  7, -0.0, 0, -1.0, ninf)
+      val point2 = Viewpoint(7,  7, -0.0, 0, -1.0, ninf)
+      val point3 = Viewpoint(12, 7, -0.0, 0, -1.0, ninf)
       val viewshed = rdd.viewshed(
         points = List(point1, point2, point3),
         maxDistance = Double.PositiveInfinity,
@@ -167,9 +167,9 @@ class IterativeViewshedSpec extends FunSpec
         ContextRDD(sc.parallelize(list), tileLayerMetadata)
       }
 
-      val point1 = Point6D(2,  7, -0.0, 0, -1.0, ninf)
-      val point2 = Point6D(7,  7, -0.0, 0, -1.0, ninf)
-      val point3 = Point6D(12, 7, -0.0, 0, -1.0, ninf)
+      val point1 = Viewpoint(2,  7, -0.0, 0, -1.0, ninf)
+      val point2 = Viewpoint(7,  7, -0.0, 0, -1.0, ninf)
+      val point3 = Viewpoint(12, 7, -0.0, 0, -1.0, ninf)
       val expected = 3
       val viewshed = rdd.viewshed(
         points = List(point1, point2, point3),


### PR DESCRIPTION
Hidden inside of `IterativeViewshed`, it wouldn't appear in Scaladocs and was a pain to import.

Ping @echeipesh .