### PR TITLE
[WIP] Extend Terraform EMR deployment scripts with Jupyterhub and Jupyter-scala

### DIFF
--- a/scripts/emr/Makefile
+++ b/scripts/emr/Makefile
@@ -17,6 +17,10 @@ KEY_PAIR_FILE=${TF_VAR_pem_path}
 endif
 endif
 
+ifndef TF_VAR_user
+export TF_VAR_user=${USER}
+endif
+
 terraform-init:
 	cd terraform; terraform init
 

--- a/scripts/emr/terraform/bootstrap.sh
+++ b/scripts/emr/terraform/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+OAUTH_CLIENT_ID=$1
+OAUTH_CLIENT_SECRET=$2
+
 # Parses a configuration file put in place by EMR to determine the role of this node
 is_master() {
   if [ $(jq '.isMaster' /mnt/var/lib/info/instance.json) = 'true' ]; then
@@ -10,17 +13,18 @@ is_master() {
 }
 
 if is_master; then
-    sudo yum -y update
+    echo "Updating system software ..."
+    sudo yum -y -q update
     curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash -
-    sudo yum install -y nodejs
+    sudo yum install -y -q nodejs
 
-    sudo pip-3.4 install jupyter
+    sudo pip-3.4 -q install jupyter
     sudo npm install -g configurable-http-proxy
-    sudo pip-3.4 install jupyterhub
-    sudo pip-3.4 install --upgrade notebook
+    sudo pip-3.4 -q install jupyterhub
+    sudo pip-3.4 -q install --upgrade notebook
 
-    sudo pip-3.4 install sudospawner
-    sudo pip-3.4 install "https://github.com/jupyterhub/oauthenticator/archive/f5e39b1ece62b8d075832054ed3213cc04f85030.zip"
+    sudo pip-3.4 -q install sudospawner
+    sudo pip-3.4 -q install "https://github.com/jupyterhub/oauthenticator/archive/f5e39b1ece62b8d075832054ed3213cc04f85030.zip"
 
     curl -L -o /tmp/jupyter-scala https://raw.githubusercontent.com/jupyter-scala/jupyter-scala/98bac7034f07e3e51d101846953aecbdb7a4bb5d/jupyter-scala
     chmod +x /tmp/jupyter-scala
@@ -58,6 +62,7 @@ user=\$1
 sudo useradd -m -G jupyterhub,hadoop \$user
 sudo -u hdfs hdfs dfs -mkdir /user/\$user
 
+sudo -u \$user /tmp/jupyter-scala
 EOF
     chmod +x /tmp/new_user
     sudo chown root:root /tmp/new_user
@@ -79,4 +84,5 @@ EOF
 
     # Execute
     cd /tmp
+    launch_hub &
 fi

--- a/scripts/emr/terraform/bootstrap.sh
+++ b/scripts/emr/terraform/bootstrap.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Parses a configuration file put in place by EMR to determine the role of this node
+is_master() {
+  if [ $(jq '.isMaster' /mnt/var/lib/info/instance.json) = 'true' ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+if is_master; then
+    sudo yum -y update
+    curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash -
+    sudo yum install -y nodejs
+
+    sudo pip-3.4 install jupyter
+    sudo npm install -g configurable-http-proxy
+    sudo pip-3.4 install jupyterhub
+    sudo pip-3.4 install --upgrade notebook
+
+    sudo pip-3.4 install sudospawner
+    sudo pip-3.4 install "https://github.com/jupyterhub/oauthenticator/archive/f5e39b1ece62b8d075832054ed3213cc04f85030.zip"
+
+    curl -L -o /tmp/jupyter-scala https://raw.githubusercontent.com/jupyter-scala/jupyter-scala/98bac7034f07e3e51d101846953aecbdb7a4bb5d/jupyter-scala
+    chmod +x /tmp/jupyter-scala
+    /tmp/jupyter-scala
+
+    # Set up user account to manage JupyterHub
+    sudo groupadd shadow
+    sudo chgrp shadow /etc/shadow
+    sudo chmod 640 /etc/shadow
+    sudo useradd -G shadow -r hublauncher
+    sudo groupadd jupyterhub
+
+    echo 'hublauncher ALL=(%jupyterhub) NOPASSWD: /usr/local/bin/sudospawner' | sudo tee -a /etc/sudoers
+    echo 'hublauncher ALL=(ALL) NOPASSWD: /usr/sbin/useradd' | sudo tee -a /etc/sudoers
+    echo 'hublauncher ALL=(hdfs) NOPASSWD: /usr/bin/hdfs' | sudo tee -a /etc/sudoers
+
+    # Environment setup
+    cat <<EOF > /tmp/oauth_profile.sh
+export AWS_DNS_NAME=$(aws ec2 describe-network-interfaces --filters Name=private-ip-address,Values=$(hostname -i) | jq -r '.[] | .[] | .Association.PublicDnsName')
+export OAUTH_CALLBACK_URL=http://\$AWS_DNS_NAME:8000/hub/oauth_callback
+export OAUTH_CLIENT_ID=$OAUTH_CLIENT_ID
+export OAUTH_CLIENT_SECRET=$OAUTH_CLIENT_SECRET
+
+alias launch_hub='sudo -u hublauncher -E env "PATH=/usr/local/bin:$PATH" jupyterhub --JupyterHub.spawner_class=sudospawner.SudoSpawner --SudoSpawner.sudospawner_path=/usr/local/bin/sudospawner --Spawner.notebook_dir=/home/{username}'
+EOF
+    sudo mv /tmp/oauth_profile.sh /etc/profile.d
+    . /etc/profile.d/oauth_profile.sh
+
+    # Setup required scripts/configurations for launching JupyterHub
+    cat <<EOF > /tmp/new_user
+#!/bin/bash
+
+user=\$1
+
+sudo useradd -m -G jupyterhub,hadoop \$user
+sudo -u hdfs hdfs dfs -mkdir /user/\$user
+
+EOF
+    chmod +x /tmp/new_user
+    sudo chown root:root /tmp/new_user
+    sudo mv /tmp/new_user /usr/local/bin
+    
+    cat <<EOF > /tmp/jupyterhub_config.py
+from oauthenticator.github import LocalGitHubOAuthenticator
+
+c = get_config()
+c.JupyterHub.authenticator_class = LocalGitHubOAuthenticator
+c.LocalGitHubOAuthenticator.create_system_users = True
+
+c.JupyterHub.spawner_class='sudospawner.SudoSpawner'
+c.SudoSpawner.sudospawner_path='/usr/local/bin/sudospawner'
+c.Spawner.notebook_dir='/home/{username}'
+c.LocalAuthenticator.add_user_cmd = ['new_user']
+
+EOF
+
+    # Execute
+    cd /tmp
+fi

--- a/scripts/emr/terraform/emr-spark.tf
+++ b/scripts/emr/terraform/emr-spark.tf
@@ -65,11 +65,25 @@ resource "aws_emr_cluster" "emr-spark-cluster" {
   provisioner "file" {
     source      = "bootstrap.sh"
     destination = "/tmp/bootstrap.sh"
+    connection {
+      type        = "ssh"
+      user        = "hadoop"
+      host        = "${aws_emr_cluster.emr-spark-cluster.master_public_dns}"
+      private_key = "${file("${var.pem_path}")}"
+    }
   }
 
-  bootstrap_action {
-    path = "file:///tmp/bootstrap.sh"
-    name = "Install JupyterHub"
+  provisioner "remote-exec" {
+    inline=[
+      "chmod +x /tmp/bootstrap.sh",
+      "/tmp/bootstrap.sh ${var.oauth_client_id} ${var.oauth_client_secret}"
+    ]
+    connection {
+      type        = "ssh"
+      user        = "hadoop"
+      host        = "${aws_emr_cluster.emr-spark-cluster.master_public_dns}"
+      private_key = "${file("${var.pem_path}")}"
+    }
   }
 }
 

--- a/scripts/emr/terraform/emr-spark.tf
+++ b/scripts/emr/terraform/emr-spark.tf
@@ -7,7 +7,7 @@ provider "aws" {
 
 # `aws_emr_cluster` is built-in to Terraform. We name ours `emr-spark-cluster`.
 resource "aws_emr_cluster" "emr-spark-cluster" {
-  name          = "EMR GeoTrellis Zeppelin"
+  name          = "EMR GeoTrellis - ${var.user}"
   release_label = "emr-5.8.0"
 
   # This it will work if only `Spark` is named here, but booting the cluster seems
@@ -60,6 +60,16 @@ resource "aws_emr_cluster" "emr-spark-cluster" {
       host        = "${aws_emr_cluster.emr-spark-cluster.master_public_dns}"
       private_key = "${file("${var.pem_path}")}"
     }
+  }
+
+  provisioner "file" {
+    source      = "bootstrap.sh"
+    destination = "/tmp/bootstrap.sh"
+  }
+
+  bootstrap_action {
+    path = "file:///tmp/bootstrap.sh"
+    name = "Install JupyterHub"
   }
 }
 

--- a/scripts/emr/terraform/variables.tf.json
+++ b/scripts/emr/terraform/variables.tf.json
@@ -28,6 +28,10 @@
     "worker_count": {
         "default": "2",
         "description": "The number of worker nodes to provision"
-    }
+    },
+    "user": {
+        "default": "anonymous",
+        "description": "User name applied to cluster"
+    },
   }
 }

--- a/scripts/emr/terraform/variables.tf.json
+++ b/scripts/emr/terraform/variables.tf.json
@@ -33,5 +33,11 @@
         "default": "anonymous",
         "description": "User name applied to cluster"
     },
+    "oauth_client_id": {
+        "description": "Client ID token for OAuth server"
+    },
+    "oauth_client_secret": {
+        "description": "Client secret token for OAuth server"
+    }
   }
 }


### PR DESCRIPTION
After an initial trial period, it appears that Zeppelin is not the answer to all one's hopes for an accessible, user-friendly, Spark-enabled Scala environment.  This PR takes a different tack to achieve the same end using Jupyter notebook and the `jupyter-scala` kernel.  

The approach offered here is somewhere in the middle of the bare-bones, just-make-it-work-quick-and-dirty and fully-featured-but-boy-are-you-gonna-need-to-do-some-configuration-to-get-this-working ends of the spectrum.  The simplest approach would be to set up JupyterHub and expect the user to log in as `hadoop:hadoop`.  This PR goes through the trouble of setting up GitHub oauth functionality.  This can easily be removed in favor of the quick-and-dirty method.  (The reason to add oauth was in the hope that this authenticator could be used to provide some mirroring of a third-party file share for persistent notebook storage so as not to lose work if the cluster suddenly vanishes.)

In order to test this PR as it stands, one will need to create an OAuth application using their github account.  Initially, the homepage URL and authorization callback URL values are unimportant, so provide dummy values there.  We need the client ID and client secret tokens to start our cluster.

Navigate to the `scripts/emr` directory under the repository root.  Specify the following environment variables:
- `TF_VAR_access_key`: AWS access key
- `TF_VAR_secret_key`: AWS secret key
- `TF_VAR_pem_path`: Path to the AWS account PEM on your local machine
- `TF_VAR_oauth_client_id`: From github OAuth application
- `TF_VAR_oauth_client_secret`: From github OAuth application

Now run `make terraform-init && make create-cluster`.  This will produce a URL for the cluster of the form `ec2-xx-xx-xx-xx.compute-1.amazonaws.com`.  Use that URL to update the GitHub OAuth application settings with `http://ec2-xx-xx-xx-xx.compute-1.amazonaws.com:8000` as the homepage URL, and `http://ec2-xx-xx-xx-xx.compute-1.amazonaws.com:8000/hub/oauth_callback` as the authorization callback URL.  Now visit `http://ec2-xx-xx-xx-xx.compute-1.amazonaws.com:8000`.

Logging in via github will create a new account on the cluster and display the new (empty) home directory in the file browser.  You may create a new scala notebook here or upload a notebook from your local machine.  A good starting point is `https://gist.github.com/jpolchlo/77ae121627a6e28b9b3d2f145a69acb7`.  This notebook shows how to use the `jupyter-scala` kernel to import dependencies (including GT) and use them in a notebook.  I have verified that vanilla Spark operations and GT Spark operations behave normally in this environment.

Things to try before merging this PR include:
- [ ] Using the `hadoop:hadoop` login instead of OAuth
- [ ] Finding a jupyter plugin that allows mirroring the contents of an S3 folder
- [ ] Switching to Google OAuth and mirroring a google drive folder (such a plugin definitely exists)

I'll take recommendations on other things that would be good to try.