### PR TITLE
Fix TileRDDMetadata generation

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -155,7 +155,7 @@ object TileRDDReproject {
           }
 
         case Right(layoutDefinition) =>
-          val kb = metadata.bounds.setSpatialBounds(KeyBounds(layout.mapTransform(extent)))
+          val kb = metadata.bounds.setSpatialBounds(KeyBounds(layoutDefinition.mapTransform(extent)))
           val m = TileLayerMetadata(metadata.cellType, layoutDefinition, extent, destCrs, kb)
 
           (0, m, options.rasterReprojectOptions.method)


### PR DESCRIPTION
Resolves: https://github.com/locationtech/geotrellis/issues/2484

Type-o caused using the source layout definition rather than target layout definition when generating reprojected metadata
