### PR TITLE
Fix mapTransform on GeoTiffSegmentLayout

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
@@ -203,6 +203,9 @@ object GeoTiffReader {
     hasPixelInterleave: Boolean,
     noDataValue: Option[Double]
   ) {
+    def rasterExtent: RasterExtent =
+      RasterExtent(extent = extent, cols = segmentLayout.totalCols, rows = segmentLayout.totalRows)
+
     def cellType: CellType = (bandType, noDataValue) match {
       case (BitBandType, _) =>
         BitCellType

--- a/spark/src/main/scala/geotrellis/spark/io/RasterReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/RasterReader.scala
@@ -98,8 +98,9 @@ object RasterReader {
 
     def readWindows(gbs: Array[GridBounds], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
       val geoTiff = GeoTiffReader.geoTiffSinglebandTile(info)
+      val re = info.rasterExtent
       geoTiff.crop(gbs.filter(geoTiff.gridBounds.intersects)).map { case (gb, tile) =>
-        (ProjectedExtent(info.mapTransform(gb), options.crs.getOrElse(info.crs)), tile)
+        (ProjectedExtent(re.extentFor(gb), options.crs.getOrElse(info.crs)), tile)
       }
     }
   }
@@ -119,8 +120,9 @@ object RasterReader {
 
     def readWindows(gbs: Array[GridBounds], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
       val geoTiff = GeoTiffReader.geoTiffMultibandTile(info)
+      val re = info.rasterExtent
       geoTiff.crop(gbs.filter(geoTiff.gridBounds.intersects)).map { case (gb, tile) =>
-        (ProjectedExtent(info.mapTransform(gb), options.crs.getOrElse(info.crs)), tile)
+        (ProjectedExtent(re.extentFor(gb), options.crs.getOrElse(info.crs)), tile)
       }
     }
   }
@@ -144,9 +146,10 @@ object RasterReader {
 
     def readWindows(gbs: Array[GridBounds], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
       val geoTiff = GeoTiffReader.geoTiffSinglebandTile(info)
+      val re = info.rasterExtent
       geoTiff.crop(gbs.filter(geoTiff.gridBounds.intersects)).map { case (gb, tile) =>
         (TemporalProjectedExtent(
-          info.mapTransform(gb),
+          extent = re.extentFor(gb),
           crs = options.crs.getOrElse(info.crs),
           options.parseTime(info.tags)),
         tile)
@@ -173,9 +176,10 @@ object RasterReader {
 
     def readWindows(gbs: Array[GridBounds], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
       val geoTiff = GeoTiffReader.geoTiffMultibandTile(info)
+      val re = info.rasterExtent
       geoTiff.crop(gbs.filter(geoTiff.gridBounds.intersects)).map { case (gb, tile) =>
         (TemporalProjectedExtent(
-          info.mapTransform(gb),
+          extent = re.extentFor(gb),
           crs = options.crs.getOrElse(info.crs),
           options.parseTime(info.tags)),
         tile)

--- a/spark/src/main/scala/geotrellis/spark/io/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/package.scala
@@ -44,7 +44,10 @@ package object io
 
   implicit class GeoTiffInfoMethods(that: GeoTiffReader.GeoTiffInfo) {
     def mapTransform =
-      MapKeyTransform(that.extent, that.segmentLayout.totalCols, that.segmentLayout.totalRows)
+      MapKeyTransform(
+        extent = that.extent,
+        layoutCols = that.segmentLayout.tileLayout.layoutCols,
+        layoutRows = that.segmentLayout.tileLayout.layoutRows)
   }
 
   // Custom exceptions


### PR DESCRIPTION
MapKeyTransform is intended to provide context for tile layouts, not pixels.
Also replacing its current usage with RasterExtent

Connects: https://github.com/locationtech/geotrellis/issues/2486
(Discovered during investigation)