### PR TITLE
Updated version to 2.0.0

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -15,7 +15,7 @@
  */
 
 object Version {
-  val geotrellis  = "1.2.0" + Environment.versionSuffix
+  val geotrellis  = "2.0.0" + Environment.versionSuffix
   val scala       = "2.11.11"
   val geotools    = "17.1"
   val sprayJson   = "1.3.3"


### PR DESCRIPTION
Update master to 2.0.0, now that the 1.2 release branch is created.

__NOTE__ Now `master` and `1.2` will diverge. From now on, all changes that need to be backported to 1.2 must be merged into master first, and then cherry-picked from master to the 1.2 release branch. 