### PR TITLE
Added some utilities for dealing with HSV color space

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/render/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/package.scala
@@ -49,4 +49,35 @@ package object render {
       RGBA(r, g, b, (alphaPct * 2.55).toInt)
     }
   }
+
+  object HSV {
+    private def convert(h: Double, s: Double, v: Double): (Double, Double, Double) = {
+      def mod(d: Double, n: Int) = {
+        val fraction = d - d.floor
+        (d.floor.longValue % n).toDouble + fraction
+      }
+
+      val c  = s*v
+      val h1 = h / 60.0
+      val x  = c*(1.0 - ((mod(h1,  2)) - 1.0).abs)
+      val (r,g,b) = if      (h1 < 1.0) (c, x, 0.0)
+                    else if (h1 < 2.0) (x, c, 0.0)
+                    else if (h1 < 3.0) (0.0, c, x)
+                    else if (h1 < 4.0) (0.0, x, c)
+                    else if (h1 < 5.0) (x, 0.0, c)
+                    else  /*h1 < 6.0*/ (c, 0.0, x)
+      val m = v-c
+      (r+m, g+m, b+m)
+    }
+
+    def toRGB(h: Double, s: Double, v: Double): Int = {
+      val (r, g, b) = convert(h, s, v)
+      RGB((r*255).toInt, (g*255).toInt, (b*255).toInt)
+    }
+
+    def toRGBA(h: Double, s: Double, v: Double, a: Double): Int = {
+      val (r, g, b) = convert(h, s, v)
+      RGBA((r*255).toInt, (g*255).toInt, (b*255).toInt, (a*255).toInt)
+    }
+  }
 }


### PR DESCRIPTION
We have simple tools for creating RGB(A) colors, but nothing comparable for the HSV color space.  HSV is a convenient space for building color maps for things like aspect, where the current stable of ramps doesn't make total sense.  This PR adds some simple HSV tools that allow for the production of RGB colors from HSV coordinates.

Note that the reverse translation from RGB to HSV is not provided.  If there is user demand, it can be quickly added.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>