### PR TITLE
Add threads parameter to saveToS3 method

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3Methods.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/SaveToS3Methods.scala
@@ -29,7 +29,8 @@ class SaveToS3Methods[K](val self: RDD[(K, Array[Byte])]) extends MethodExtensio
     *
     * @param keyToUri A function from K (a key) to an S3 URI
     * @param putObjectModifier  Function that will be applied ot S3 PutObjectRequests, so that they can be modified (e.g. to change the ACL settings)
+    * @param threads   Number of threads dedicated for the IO
     */
-  def saveToS3(keyToUri: K => String, putObjectModifier: PutObjectRequest => PutObjectRequest = { p => p }): Unit =
+  def saveToS3(keyToUri: K => String, putObjectModifier: PutObjectRequest => PutObjectRequest = { p => p }, threads: Int = SaveToS3.DefaultThreadCount): Unit =
     SaveToS3(self, keyToUri, putObjectModifier)
 }


### PR DESCRIPTION
Uses `geotrellis.s3.threads.rdd.write` as default value, same as `S3RDDWriter`