### PR TITLE
Fix partitioning in a bit CellType case

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/GeoTiffInfoReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GeoTiffInfoReader.scala
@@ -57,7 +57,7 @@ private [geotrellis] trait GeoTiffInfoReader extends LazyLogging {
           info.segmentLayout.listWindows(maxSize)
       }
 
-    info.segmentLayout.partitionWindowsBySegments(windows, partitionBytes / info.cellType.bytes)
+    info.segmentLayout.partitionWindowsBySegments(windows, partitionBytes / math.max(info.cellType.bytes, 1))
   }
 
   def readWindows[O, I, K, V](


### PR DESCRIPTION
Consider `BitCellType` as bytes when deciding on appropriate number of partitions.
Its expected that this "over-estimate" is acceptable in all cases.