### PR TITLE
GitHub PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Checklist
+
+- [ ] `docs/CHANGELOG.rst` updated, if necessary
+- [ ] `docs` guides update, if necessary
+- [ ] New user API has useful Scaladoc strings
+- [ ] Unit tests added for bug-fix or new feature
+
+### Demo
+
+Optional. Screenshots/REPL
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+Closes #XXX


### PR DESCRIPTION
Before each release we have a scramble to udpate the changelog and double check the documentation. This led to a discussion that it would be good to have a reminder in form of a PR template. 

Overall the intent is:
- Help keep ongoing work well documented and easily discoverable
- Encourage thinking about REPL usage of GeoTrellis API
- Provide more clear information for participation in PR review

Possible drawbacks are increasing the burden of accepting community contributions and longer PR times. Soliciting feedback on this general idea and specifics of the template: @metasim @lossyrob @fosskers @moradology @hectcastro @rossbernet @jpolchlo @jamesmcclain 

--------
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

### Demo

Optional. Screenshots/REPL

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #XXX
