### PR TITLE
Fix issue with creating BitCellType GeoTiffs

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
@@ -278,6 +278,16 @@ object GeoTiffTile {
       segmentBytes(i) = compressor.compress(bytes, i)
     }
 
+    // Our BitCellType rasters have the bits encoded in a order inside of each byte that is
+    // the reverse of what a GeoTiff wants.
+    if(tile.cellType == BitCellType) {
+      cfor(0)(_ < segmentCount, _ + 1) { i =>
+        cfor(0)(_ < segmentBytes(i).length, _ + 1) { j =>
+          segmentBytes(i)(j) = ((Integer.reverse(segmentBytes(i)(j)) >>> 24) & 0xFF).toByte
+        }
+      }
+    }
+
     apply(new ArraySegmentBytes(segmentBytes), compressor.createDecompressor, segmentLayout, options.compression, tile.cellType)
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterTests.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterTests.scala
@@ -75,4 +75,26 @@ class GeoTiffWriterTests extends FunSuite
       assertEqual(result.tile, gt1.tile)
     }
   }
+
+  test("Writing out a bit raster and reading it back again") {
+    val temp = File.createTempFile("geotiff-writer", ".tif")
+    val path = temp.getPath
+
+    // ExpandPacked8ToByte1
+
+    // val (p1, p2) = ("/Users/rob/data/DevelopedLand-ch.tiff", "/Users/rob/data/DevelopedLand-ch-2.tiff")
+    val (p1, p2) = ("/Users/rob/data/DevelopedLand-sm.tiff", "/Users/rob/data/DevelopedLand-sm-2.tiff")
+    // val (p1, p2) = ("/Users/rob/data/DevelopedLand-df.tiff", "/Users/rob/data/DevelopedLand-df-2.tiff")
+    val p3 = "/users/rob/data/DevelopedLand-sm-nb.tiff"
+    val base = SinglebandGeoTiff(geoTiffPath("small-bit-raster.tif"))
+    val tiff = SinglebandGeoTiff(base.tile, base.extent, base.crs)
+
+    GeoTiffWriter.write(tiff, path)
+
+    val reread = SinglebandGeoTiff(path)
+
+    addToPurge(path)
+
+    assertEqual(reread.raster.tile, base.raster.tile)
+  }
 }


### PR DESCRIPTION
For GeoTiffTiles with the equivalent of BitCellType, we pack the bits into bytes to write them out. This is the same as having a Byte type in GDAL with the `--co NBITS=1` flag set. We were writing these out in the incorrect order - our BitCellType bytes pack the bits in the reverse order of what a GeoTiff expects them to be. This PR fixes that.