### PR TITLE
RasterRegionReproject benchmarks and optimization

### DIFF
--- a/bench/src/main/scala/geotrellis/raster/reproject/RasterizingReprojectBench.scala
+++ b/bench/src/main/scala/geotrellis/raster/reproject/RasterizingReprojectBench.scala
@@ -1,0 +1,50 @@
+package geotrellis.raster.reproject
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.BenchmarkParams
+
+import geotrellis.bench.init
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.vector._
+
+import scala.util.Random
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@State(Scope.Thread)
+class RasterizingReprojectBench  {
+  import RasterizingReprojectBench._
+
+  @Param(Array( "128", "256", "512", "1024", "2048", "4096", "8192"))
+  var size: Int = _
+
+  var raster: ProjectedRaster[Tile] = _
+  var destRE: ProjectedRasterExtent = _
+
+  val transform: Transform = Transform(srcCrs, destCrs)
+  val inverse: Transform = Transform(destCrs, srcCrs)
+
+  @Setup(Level.Trial)
+  def setup(params: BenchmarkParams): Unit = {
+    val len = size * size
+    raster = ProjectedRaster(ArrayTile(init(len)(Random.nextInt), size, size), srcExtent, srcCrs)
+    destRE = ProjectedRasterExtent(raster.projectedExtent.reproject(destCrs), destCrs, size, size)
+  }
+
+  @Benchmark
+  def standardReproject: Raster[Tile] = {
+    raster.raster.reproject(destRE: RasterExtent, transform, inverse)
+  }
+
+  @Benchmark
+  def rasterizingReproject: ProjectedRaster[Tile] = {
+    raster.regionReproject(destRE, NearestNeighbor)
+  }
+}
+
+object RasterizingReprojectBench {
+  val srcCrs = LatLng
+  val destCrs = ConusAlbers
+  val srcExtent = Extent(-109, 37, -102, 41)
+}

--- a/bench/src/main/scala/geotrellis/raster/reproject/RasterizingReprojectBench.scala
+++ b/bench/src/main/scala/geotrellis/raster/reproject/RasterizingReprojectBench.scala
@@ -16,7 +16,7 @@ import scala.util.Random
 class RasterizingReprojectBench  {
   import RasterizingReprojectBench._
 
-  @Param(Array( "128", "256", "512", "1024", "2048", "4096", "8192"))
+  @Param(Array("32", "64", "128", "256", "512", "1024", "2048", "4096", "8192"))
   var size: Int = _
 
   var raster: ProjectedRaster[Tile] = _

--- a/raster/src/main/scala/geotrellis/raster/ProjectedRaster.scala
+++ b/raster/src/main/scala/geotrellis/raster/ProjectedRaster.scala
@@ -66,4 +66,6 @@ case class ProjectedRaster[T <: CellGrid](raster: Raster[T], crs: CRS) {
   def tile = raster.tile
   def extent = raster.extent
   def projectedExtent = ProjectedExtent(extent, crs)
+  def cols = raster.cols
+  def rows = raster.rows
 }

--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
@@ -30,7 +30,7 @@ object RasterRegionReproject {
 
     def scanlineCols(xmin: Double, xmax: Double): (Array[Int], Array[Double]) = {
       val x0 = ((xmin - extent.xmin) / destRasterExtent.cellwidth + 0.5 - 1e-8).toInt
-      val x1 = ((xmax - extent.xmin) / destRasterExtent.cellwidth + 0.5).toInt - 1
+      val x1 = ((xmax - extent.xmin) / destRasterExtent.cellwidth + 0.5 + 1e-8).toInt - 1
       val locations = Array.ofDim[Int](x1 - x0 + 1)
       val result = Array.ofDim[Double](x1 - x0 + 1)
       cfor(x0)(_ <= x1, _ + 1){ i =>
@@ -68,7 +68,8 @@ object RasterRegionReproject {
               val xres = Array.ofDim[Double](xarr.size)
               val yres = Array.ofDim[Double](xarr.size)
 
-              rowTransform(xarr, yarr, xres, yres)
+              if (xarr.size > 0)
+                rowTransform(xarr, yarr, xres, yres)
 
               (pxarr, xres, yres)
             case p: Point =>
@@ -77,7 +78,7 @@ object RasterRegionReproject {
             case g: Geometry =>
               throw new IllegalStateException("Line-Polygon intersection cannot produce geometries that are not Points or Lines")
             }
-        }).reduce{ (a1, a2) => {
+        }).fold( (Array.empty[Int], Array.empty[Double], Array.empty[Double]) ){ (a1, a2) => {
           val (px1, x1, y1) = a1
           val (px2, x2, y2) = a2
           (px1 ++ px2, x1 ++ x2, y1 ++ y2)


### PR DESCRIPTION
The last implementation of `RasterRegionReproject` was 50 times slower than the classic raster reprojection code on a per-tile basis.  This PR aims to improve the performance by using the approximate `RowTransform` operations, which reduce the calls to proj4 by roughly an order of magnitude.  As these transforms are the bulk of the execution time, the net result should be a noticeable improvement in performance.

The general approach is to perform vector intersections with the target region, and convert the results into intervals which can be passed to `RowTransform.approximate`.  _[**NOTE:** If the polygon rasterizer had or has a way to generate each scanline separately, then this operation can most likely be sped up by hijacking that code.]_

The long and short of this PR comes down to this table:
```
Size   Region Reproject   Classic Reproject   Slowdown
  32     0.603 ±  0.024      0.098 ±  0.001     6.1531
  64     1.227 ±  0.019      0.238 ±  0.001     5.1555
 128     2.604 ±  0.058      0.648 ±  0.010     4.0185
 256     5.887 ±  0.284      1.833 ±  0.023     3.2117
 512    13.190 ±  0.155      5.005 ±  0.255     2.6354
1024    35.703 ±  0.992     16.330 ±  0.436     2.1863
2048   104.878 ±  3.839     61.901 ±  1.262     1.6943
4096   337.498 ± 13.333    245.318 ± 26.742     1.3758
8192  1275.197 ± 79.606    949.051 ± 43.732     1.3437
```

These results show that we have achieved a roughly 10x speedup over the previous `RasterRegionReproject` version.  It also shows that the vector intersections are a sizable sunk cost per scanline, but can be amortized out given a large enough tile.  The sad truth, however, is that one can expect reprojection through this method to be slower by roughly a factor of 5 than the classic version.  This is more than made up for by the elimination of a `cutTiles` step from TileRddReproject, but in cases where shuffle times are not so outlandish, it is conceivable that the slowdown noted in the table could dominate runtimes.  However, in most distributed environments, the loss of a shuffle is a huge win.