### PR TITLE
Optimize TileRDDReproject using mutable region reprojection

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
@@ -21,6 +21,9 @@ trait RasterRegionReproject[T <: CellGrid] extends Serializable {
     * @param resampleMethod cell value resample method
     */
   def regionReproject(raster: Raster[T], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Raster[T]
+
+  def mutableRegionReproject(target: T, raster: Raster[T], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Unit
+
 }
 
 object RasterRegionReproject {
@@ -111,6 +114,27 @@ object RasterRegionReproject {
 
       Raster(buffer, rasterExtent.extent)
     }
+
+    def mutableRegionReproject(target: Tile, raster: Raster[Tile], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod) = {
+      val buffer = target.mutable
+      val trans = Proj4Transform(dest, src)
+      val resampler = Resample.apply(resampleMethod, raster.tile, raster.extent, CellSize(raster.rasterExtent.cellwidth, raster.rasterExtent.cellheight))
+
+      val rowcoords = rowCoords(region, rasterExtent, trans)
+
+      cfor(0)(_ < rasterExtent.rows, _ + 1){ i =>
+        val (pxs, xs, ys) = rowcoords(i)
+        if (raster.cellType.isFloatingPoint) {
+          cfor(0)(_ < xs.size, _ + 1){ s =>
+            buffer.setDouble(pxs(s), i, resampler.resampleDouble(xs(s), ys(s)))
+          }
+        } else {
+          cfor(0)(_ < xs.size, _ + 1){ s =>
+            buffer.set(pxs(s), i, resampler.resample(xs(s), ys(s)))
+          }
+        }
+      }
+    }
   }
 
   implicit val multibandInstance = new RasterRegionReproject[MultibandTile] {
@@ -120,6 +144,39 @@ object RasterRegionReproject {
 
       cfor(0)(_ < bands.length, _ + 1) { i =>
         bands(i) = raster.band(i).prototype(rasterExtent.cols, rasterExtent.rows).mutable
+      }
+
+      val resampler = (0 until raster.bandCount).map { i =>
+        Resample(resampleMethod, raster.band(i), raster.extent, raster.rasterExtent.cellSize)
+      }
+
+      if (raster.cellType.isFloatingPoint) {
+        Rasterizer.foreachCellByPolygon(region, rasterExtent) { (px, py) =>
+          val (x, y) = rasterExtent.gridToMap(px, py)
+          val (tx, ty) = trans(x, y)
+          cfor(0)(_ < bands.length, _ + 1) { i =>
+            bands(i).setDouble(px, py, resampler(i).resampleDouble(tx, ty))
+          }
+        }
+      } else {
+        Rasterizer.foreachCellByPolygon(region, rasterExtent) { (px, py) =>
+          val (x, y) = rasterExtent.gridToMap(px, py)
+          val (tx, ty) = trans(x, y)
+          cfor(0)(_ < bands.length, _ + 1) { i =>
+            bands(i).set(px, py, resampler(i).resample(tx, ty))
+          }
+        }
+      }
+
+      Raster(MultibandTile(bands), rasterExtent.extent)
+    }
+
+    def mutableRegionReproject(target: MultibandTile, raster: Raster[MultibandTile], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod) = {
+      val trans = Proj4Transform(dest, src)
+      val bands = Array.ofDim[MutableArrayTile](raster.tile.bandCount)
+
+      cfor(0)(_ < bands.length, _ + 1) { i =>
+        bands(i) = target.band(i).mutable
       }
 
       val resampler = (0 until raster.bandCount).map { i =>


### PR DESCRIPTION
This PR attempts to improve TileRDDReproject's performance by eliminating the merge step.  This is accomplished by using a mutable version of RasterRegionReproject to continually burn reprojected tiles into the same buffers.