### PR TITLE
Make GeoKeyDirectory parsing more fault tolerant

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyReader.scala
@@ -33,6 +33,10 @@ object GeoKeyReader {
     geoKeyDirectory: GeoKeyDirectory, index: Int = 0
   ): GeoKeyDirectory = {
 
+    /**
+      * Attempt to read GeoKey Entry; if tag does not match then assume there are no
+      * more valid geokeys and the header was written incorrectly so return `None`
+      */
     def readGeoKeyEntry(keyMetadata: GeoKeyMetadata,
       geoKeyDirectory: GeoKeyDirectory): Option[GeoKeyDirectory] = keyMetadata.tiffTagLocation match {
       case 0 => Some(readShort(keyMetadata, geoKeyDirectory))

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyReader.scala
@@ -34,10 +34,11 @@ object GeoKeyReader {
   ): GeoKeyDirectory = {
 
     def readGeoKeyEntry(keyMetadata: GeoKeyMetadata,
-      geoKeyDirectory: GeoKeyDirectory)  = keyMetadata.tiffTagLocation match {
-      case 0 => readShort(keyMetadata, geoKeyDirectory)
-      case DoublesTag => readDoubles(keyMetadata, geoKeyDirectory)
-      case AsciisTag => readAsciis(keyMetadata, geoKeyDirectory)
+      geoKeyDirectory: GeoKeyDirectory): Option[GeoKeyDirectory] = keyMetadata.tiffTagLocation match {
+      case 0 => Some(readShort(keyMetadata, geoKeyDirectory))
+      case DoublesTag => Some(readDoubles(keyMetadata, geoKeyDirectory))
+      case AsciisTag => Some(readAsciis(keyMetadata, geoKeyDirectory))
+      case _ => None
     }
 
     def readShort(keyMetadata: GeoKeyMetadata,
@@ -245,10 +246,10 @@ object GeoKeyReader {
           byteReader.getUnsignedShort,
           byteReader.getUnsignedShort
         )
-
-        val updatedDirectory = readGeoKeyEntry(keyEntryMetadata, geoKeyDirectory)
-
-        read(byteReader, imageDirectory, updatedDirectory, index + 1)
+        readGeoKeyEntry(keyEntryMetadata, geoKeyDirectory) match {
+          case Some(updatedDirectory) => read(byteReader, imageDirectory, updatedDirectory, index + 1)
+          case None => geoKeyDirectory
+        }
       }
     }
   }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -388,6 +388,12 @@ class GeoTiffReaderSpec extends FunSpec
       tile.polygonalMean(extent, extent.toPolygon) should be (mean +- MeanEpsilon)
     }
 
+    it("should read GeoTiff with incorrect GeoKey Directory header correctly (NumberOfKeys is wrong)") {
+      val MultibandGeoTiff(_, extent, _, _, _, _) = MultibandGeoTiff(geoTiffPath("incorrect-geokeydir.tif"))
+
+      extent should be (Extent(0.0, 0.0, 22.0, 49.0))
+    }
+
     it("should read GeoTiff with tags") {
       val tags = SinglebandGeoTiff.compressed(geoTiffPath("tags.tif")).tags.headTags
 


### PR DESCRIPTION
This commit makes the reading of GeoKeyDirectory entries more fault tolerant to
cover cases where the `NumberOfKeys` entry in the directory header has an
incorrect number of headers that is actually larger than the number of keys.
This manifested itself when attempting to read a tiff created by a geoprocessing
service from an ArcGIS server. The tiff could be read and parsed by other
tools (GDAL, QGIS) without issue but when attempting to open it with GeoTrellis
a `scala.MatchError` would be thrown in `readGeoKeyEntry`.

The workaround introduced here is that if a geokey is read and fails to match
then it likely means there are no longer any valid geokeys to read. I'm open to
other approaches to the workaround than the one offered here - one option is to
introduce a try/catch and only catch on `java.nio.Exception` which can happen if
the number of keys is large enough that reading too many keys (and ignoring
them) leads to a buffer underflow.

I also added a test case that tests the more fault tolerant parsing of the GeoKeyDirectory header.

Signed-off-by: Chris Brown <cbrown@azavea.com>