### PR TITLE
Avoid `ListBuffer.prepend` and `ListBuffer.append`

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/viewshed/R2Viewshed.scala
+++ b/raster/src/main/scala/geotrellis/raster/viewshed/R2Viewshed.scala
@@ -347,7 +347,7 @@ object R2Viewshed extends Serializable {
       val seg = northSegs(i)
       alpha = thetaToAlpha(from, rays, seg.theta); terminated = false
       Rasterizer.foreachCellInGridLine(seg.x0, seg.y0, seg.x1, seg.y1, null, re, false)(callback)
-      if (!terminated && !seg.isRumpSegment) southRays.append(Ray(seg.theta, alpha))
+      if (!terminated && !seg.isRumpSegment) (southRays += Ray(seg.theta, alpha))
       i += 1
     }
 
@@ -358,7 +358,7 @@ object R2Viewshed extends Serializable {
       val seg = southSegs(i)
       alpha = thetaToAlpha(from, rays, seg.theta); terminated = false
       Rasterizer.foreachCellInGridLine(seg.x0, seg.y0, seg.x1, seg.y1, null, re, false)(callback)
-      if (!terminated && !seg.isRumpSegment) northRays.append(Ray(seg.theta, alpha))
+      if (!terminated && !seg.isRumpSegment) (northRays += Ray(seg.theta, alpha))
       i += 1
     }
 
@@ -377,7 +377,7 @@ object R2Viewshed extends Serializable {
         val seg = eastSegs(i)
         alpha = thetaToAlpha(from, rays, seg.theta); terminated = false
         Rasterizer.foreachCellInGridLine(seg.x0, seg.y0, seg.x1, seg.y1, null, re, false)(callback)
-        if (!terminated && !seg.isRumpSegment) westRays.append(Ray(seg.theta, alpha))
+        if (!terminated && !seg.isRumpSegment) (westRays += Ray(seg.theta, alpha))
         i += 1
       }
     }
@@ -397,7 +397,7 @@ object R2Viewshed extends Serializable {
         val seg = westSegs(i)
         alpha = thetaToAlpha(from, rays, seg.theta); terminated = false
         Rasterizer.foreachCellInGridLine(seg.x0, seg.y0, seg.x1, seg.y1, null, re, false)(callback)
-        if (!terminated && !seg.isRumpSegment) eastRays.append(Ray(seg.theta, alpha))
+        if (!terminated && !seg.isRumpSegment) (eastRays += Ray(seg.theta, alpha))
         i += 1
       }
     }

--- a/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
+++ b/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
@@ -65,7 +65,7 @@ object IterativeCostDistance {
       other
     }
     def add(pair: KeyCostPair): Unit = {
-      this.synchronized { list.append(pair) }
+      this.synchronized { list += pair }
     }
     def isZero: Boolean = list.isEmpty
     def merge(other: AccumulatorV2[KeyCostPair, Changes]): Unit =
@@ -96,7 +96,7 @@ object IterativeCostDistance {
 
     var row = bounds.rowMin; while (row <= bounds.rowMax) {
       var col = bounds.colMin; while (col <= bounds.colMax) {
-        keys.append(SpatialKey(col, row))
+        keys += SpatialKey(col, row)
         col += 1
       }
       row += 1

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulation.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulation.scala
@@ -445,7 +445,7 @@ case class DelaunayTriangulation(
         base = connector.next
         best = null
       }
-      
+
     }
 
     (first.flip.next, end, tris)
@@ -468,7 +468,7 @@ case class DelaunayTriangulation(
       e = rotCWSrc(e)
     } while (e != e0)
     do {
-      pts.prepend(Point.jtsCoord2Point(pointSet.getCoordinate(getDest(e))))
+      Point.jtsCoord2Point(pointSet.getCoordinate(getDest(e))) +=: pts
       setNext(getPrev(getFlip(e)), getNext(e))
       val b = getFlip(getNext(e))
       setIncidentEdge(getDest(e), b)
@@ -490,13 +490,13 @@ case class DelaunayTriangulation(
 
     decoupleVertex(vi)
 
-    // in the event of a boundary with no fill triangles, set the boundary 
-    // reference in case we destroyed the old boundary edge (happens when 
+    // in the event of a boundary with no fill triangles, set the boundary
+    // reference in case we destroyed the old boundary edge (happens when
     // corner points are deleted)
     if (bnd != None) {
       _boundary = getFlip(bnd.get)
     }
-  
+
     // merge triangles
     val edges = Map.empty[(Int, Int), Int]
     tris.foreach { case (ix, h) => {
@@ -517,7 +517,7 @@ case class DelaunayTriangulation(
             join(newtri, opp)
           case None =>
             edges.get(b.vert -> b.src) match {
-              case Some(opp) => 
+              case Some(opp) =>
                 edges -= (b.vert -> b.src)
                 join(newtri, opp)
               case None =>
@@ -584,7 +584,7 @@ case class DelaunayTriangulation(
       triverts += k
     }
 
-    triangleMap.getTriangles.foreach { case ((i1, i2, i3), t0) => 
+    triangleMap.getTriangles.foreach { case ((i1, i2, i3), t0) =>
       var t = t0
       var i = 0
 
@@ -620,7 +620,7 @@ case class DelaunayTriangulation(
       }
     }
 
-    allVertices.foreach{ v => 
+    allVertices.foreach{ v =>
       val t = edgeIncidentTo(v)
       if (!triedges.contains(t)) {
         println(s"edgeIncidentTo($v) refers to non-interior or stale edge [${getSrc(t)} -> ${getDest(t)}] (ID: ${t})")

--- a/vectortile/src/main/scala/geotrellis/vectortile/Layer.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/Layer.scala
@@ -339,9 +339,9 @@ ${sortedMeta.map({ case (k,v) => s"            ${k}: ${v}"}).mkString("\n")}
 
     features.foreach { f =>
       f.getType match {
-        case POINT => points.append(f)
-        case LINESTRING => lines.append(f)
-        case POLYGON => polys.append(f)
+        case POINT => points += f
+        case LINESTRING => lines += f
+        case POLYGON => polys += f
         case _ => Unit // `UNKNOWN` or `Unrecognized`.
       }
     }

--- a/vectortile/src/main/scala/geotrellis/vectortile/internal/package.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/internal/package.scala
@@ -54,7 +54,7 @@ package object internal {
       case (dx, dy) =>
         val here = (dx + cursor._1, dy + cursor._2)
 
-        points.append(here)
+        points += here
         cursor = here
     })
 
@@ -252,7 +252,7 @@ package object internal {
           val nextCursor: (Int, Int) = points.last
 
           /* Add the starting point to close the Line into a Polygon */
-          points.append(here)
+          points += here
 
           work(rest, lines += points, nextCursor)
         }
@@ -280,10 +280,10 @@ package object internal {
         val area = surveyor(line)
 
         if (area < 0) { /* New Interior Rings */
-          holes.append(tr(line))
+          holes += tr(line)
         } else { /* New Exterior Ring */
           /* Save the current state */
-          polys.append(Polygon(tr(currL), holes))
+          polys += Polygon(tr(currL), holes)
 
           /* Reset the state */
           currL = line
@@ -292,7 +292,7 @@ package object internal {
       })
 
       /* Save the final state */
-      polys.append(Polygon(tr(currL), holes))
+      polys += Polygon(tr(currL), holes)
 
       if (polys.length == 1) Left(polys.head) else Right(MultiPolygon(polys))
     }


### PR DESCRIPTION
## Overview

I discovered today that `.prepend` and `.append`, when used repeatedly (in a loop, say), are an order of magnitude slower than their operators, `+=:` and `+=` respectively:

```
[info] ListBufferBench.append10000     avgt    5  664.377 ± 10.276  us/op
[info] ListBufferBench.appendOp10000   avgt    5   58.740 ±  1.557  us/op
[info] ListBufferBench.prepend10000    avgt    5  848.419 ± 20.689  us/op
[info] ListBufferBench.prependOp10000  avgt    5   58.248 ±  1.813  us/op
```

Rule of thumb: Don't trust methods that take `a: A*` when you intend to only give it one thing.

This PR removes usage of these two methods for `ListBuffer` and `ArrayBuffer`. 

  