### PR TITLE
Fix out of bound segment index when reading over-buffered GeoTiff window

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixes
 ^^^^^
 
 - `GeoTiffSegmentLayout.getIntersectingSegments bounds checking <https://github.com/locationtech/geotrellis/pull/2534>`__
+- `Fix for area of vectorizer that can throw topology exceptions <https://github.com/locationtech/geotrellis/pull/2530>`__
 
 
 1.2.0

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -15,7 +15,16 @@ API Changes
 
   - **Change:** Reprojection has improved performance due to one less shuffle stage and lower memory usage.
   ``TileRDDReproject`` loses dependency on ``TileReprojectMethods`` in favor of ``RasterRegionReproject``
-    
+
+1.2.1
+_____
+*2018 Jan 3*
+
+Fixes
+^^^^^
+
+- `GeoTiffSegmentLayout.getIntersectingSegments bounds checking <https://github.com/locationtech/geotrellis/pull/2534>`__
+
 
 1.2.0
 -----


### PR DESCRIPTION
## Overview

`GeoTiffSegmentLayout.getIntersectingSegments` did not perform bound checking. 
As a result if `GridBounds` parameter was outside of the bounds of segment layout an out of bounds index would be returned, resulting in failed segment lookup.

This issue was discovered in process of performing buffered window reads: https://github.com/raster-foundry/raster-foundry/pull/2734/commits/49fe952e80bdd9c7d715ee952650a0149feb44be

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [-] ~`docs` guides update, if necessary~
- [-] ~New user API has useful Scaladoc strings~
- [x] Unit tests added for bug-fix or new feature

  