### PR TITLE
Fix Tile.flipHorizontal for floating point tiles

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,7 +25,7 @@ Fixes
 
 - `GeoTiffSegmentLayout.getIntersectingSegments bounds checking <https://github.com/locationtech/geotrellis/pull/2534>`__
 - `Fix for area of vectorizer that can throw topology exceptions <https://github.com/locationtech/geotrellis/pull/2530>`__
-
+- `Fix Tile.flipHorizontal for floating point tiles <https://github.com/locationtech/geotrellis/pull/2535>`__
 
 1.2.0
 -----

--- a/raster/src/main/scala/geotrellis/raster/transform/TransformTileMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/transform/TransformTileMethods.scala
@@ -115,8 +115,8 @@ trait TransformTileMethods extends TransformMethods[Tile] {
     } else {
       cfor(0)(_ < cols, _ + 1) { col =>
         cfor(0)(_ < rows, _ + 1) { row =>
-          tile.setDouble(col, rows - 1 - row, tile.getDouble(col, row))
-          tile.setDouble(col, row, tile.getDouble(col, rows - 1 - row))
+          tile.setDouble(col, rows - 1 - row, self.getDouble(col, row))
+          tile.setDouble(col, row, self.getDouble(col, rows - 1 - row))
         }
       }
     }


### PR DESCRIPTION
## Overview

Floating point branch of the function performed assignment from target tile to target tile, rather than the from the source tile, resulting in NoData tiles.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [-] `docs` guides update, if necessary
- [-] New user API has useful Scaladoc strings
- [-] Unit tests added for bug-fix or new feature

Closes #2507
