### PR TITLE
Fixed ambiguous import errors when compiling in IntelliJ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import Dependencies._
 import sbt.Keys._
 import de.heikoseeberger.sbtheader.license.Apache2_0
 
+addCommandAlias("testCore", ";util/test; ;proj4/test; raster/test; vector/test; spark/test")
+
 lazy val commonSettings = Seq(
   version := Version.geotrellis,
   scalaVersion := Version.scala,
@@ -76,7 +78,8 @@ lazy val commonSettings = Seq(
   headers := Map(
     "scala" -> Apache2_0("2016", "Azavea"),
     "conf" -> Apache2_0("2016", "Azavea", "#")
-  )
+  ),
+  cancelable in Global := true
 )
 
 lazy val root = Project("geotrellis", file(".")).
@@ -128,6 +131,9 @@ lazy val vector = project
   .dependsOn(proj4, util)
   .settings(commonSettings)
   .settings(
+    // This takes care of a pseudo-cyclic dependency between the `vector` test scope, `vector-testkit`,
+    // and `vector` main (compile) scope. sbt is happy with this. IntelliJ requires that `vector-testkit`
+    // be added to the `vector` module dependencies manually (via "Open Module Settings" context menu for "vector" module).
     unmanagedClasspath in Test ++= (fullClasspath in (LocalProject("vector-testkit"), Compile)).value
   )
 
@@ -143,9 +149,10 @@ lazy val raster = project
   .dependsOn(util, macros, vector)
   .settings(commonSettings)
   .settings(
-    unmanagedClasspath in Test ++= (fullClasspath in (LocalProject("raster-testkit"), Compile)).value
-  )
-  .settings(
+    // This takes care of a pseudo-cyclic dependency between the `raster` test scope, `raster-testkit`, `vector-testkit`
+    // and `raster` main (compile) scope. sbt is happy with this. IntelliJ requires that `raster-testkit` & `vector-testkit`
+    // be added to the `raster` module dependencies manually (via "Open Module Settings" context menu for "raster" module).
+    unmanagedClasspath in Test ++= (fullClasspath in (LocalProject("raster-testkit"), Compile)).value,
     unmanagedClasspath in Test ++= (fullClasspath in (LocalProject("vector-testkit"), Compile)).value
   )
 
@@ -178,6 +185,9 @@ lazy val s3 = project
   )
   .settings(commonSettings)
   .settings(
+    // This takes care of a pseudo-cyclic dependency between the `s3` test scope, `s3-testkit`,
+    // and `s3` main (compile) scope. sbt is happy with this. IntelliJ requires that `s3-testkit`
+    // be added to the `s3` module dependencies manually (via "Open Module Settings" context menu for "s3" module).
     unmanagedClasspath in Test ++= (fullClasspath in (LocalProject("s3-testkit"), Compile)).value
   )
 

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeowaveLayerReader.scala
@@ -181,7 +181,7 @@ object GeowaveLayerReader {
 
         GridCoverage2DConverters.getCellType(gc)
       }
-      case s: String => CellType.fromString(s)
+      case s: String => CellType.fromName(s)
     }
 
     val bounds = KeyBounds(

--- a/s3/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/GeoTiffS3InputFormatSpec.scala
@@ -19,14 +19,10 @@ package geotrellis.spark.io.s3
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.vector._
-import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.s3.testkit._
 import geotrellis.spark.testkit.TestEnvironment
 
-import org.apache.hadoop.conf.Configuration
-import com.amazonaws.auth.AWSCredentials
-import org.apache.hadoop.mapreduce.{TaskAttemptContext, InputSplit}
 import org.scalatest._
 
 import java.nio.file.{Paths, Files}

--- a/spark-etl/src/test/scala/geotrellis/spark/etl/EtlSpec.scala
+++ b/spark-etl/src/test/scala/geotrellis/spark/etl/EtlSpec.scala
@@ -63,7 +63,7 @@ class EtlSpec extends FunSuite {
       crs = Some("EPSG:3857"),
       resolutionThreshold = Some(0.1),
       cellSize = Some(CellSize(256.2, 256.1)),
-      cellType = Some(CellType.fromString("int8")),
+      cellType = Some(CellType.fromName("int8")),
       encoding = Some("geotiff"),
       breaks = Some("0:ffffe5ff;0.1:f7fcb9ff;0.2:d9f0a3ff;0.3:addd8eff;0.4:78c679ff;0.5:41ab5dff;0.6:238443ff;0.7:006837ff;1:004529ff"),
       maxZoom = Some(13)

--- a/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerFilter.scala
@@ -16,17 +16,16 @@
 
 package geotrellis.spark.io
 
+import java.time.ZonedDateTime
+
 import geotrellis.proj4._
-import geotrellis.raster._
-import geotrellis.raster.{GridBounds, RasterExtent, PixelIsArea}
-import geotrellis.raster.rasterize.Rasterizer.Options
+import geotrellis.raster.GridBounds
 import geotrellis.spark._
 import geotrellis.spark.tiling._
-import geotrellis.vector._
 import geotrellis.util._
+import geotrellis.vector._
 
 import scala.annotation.implicitNotFound
-import java.time.ZonedDateTime
 
 @implicitNotFound("Unable to filter ${K} by ${F} given ${M}, Please provide LayerFilter[${K}, ${F}, ${T}, ${M}]")
 trait LayerFilter[K, F, T, M] {
@@ -72,9 +71,6 @@ object LayerFilter {
 
 
 object Intersects {
-  import geotrellis.raster.rasterize.{Rasterizer, Callback}
-  import collection.JavaConverters._
-  import java.util.concurrent.ConcurrentHashMap
 
   def apply[T](value: T) = LayerFilter.Value[Intersects.type, T](value)
 
@@ -253,7 +249,7 @@ object Between {
 object Contains {
   def apply[T](value: T) = LayerFilter.Value[Contains.type, T](value)
 
-  /** Define Intersects filter for Extent */
+  /** Define Contains filter for Point */
   implicit def forPoint[K: SpatialComponent: Boundable, M: (? => MapKeyTransform)] =
     new LayerFilter[K, Contains.type, Point, M] {
     def apply(metadata: M, kb: KeyBounds[K], point: Point) = {

--- a/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
@@ -21,7 +21,7 @@ import geotrellis.spark._
 import geotrellis.vector._
 import geotrellis.proj4._
 import geotrellis.spark.tiling._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 import geotrellis.vector.io._
 import geotrellis.vector.io.wkt._
@@ -29,7 +29,7 @@ import geotrellis.vector.io.wkt._
 import org.scalatest._
 
 class LayerQuerySpec extends FunSpec
-  with TestEnvironment with TestFiles with Matchers {
+  with TestEnvironment with SparkTestFiles with Matchers {
 
   def spatialKeyBoundsKeys(kb: KeyBounds[SpatialKey]) = {
     for {

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDDSpec.scala
@@ -21,7 +21,7 @@ import geotrellis.raster.testkit.RasterMatchers
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop.formats._
 import geotrellis.spark.testkit._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.tiling._
 import geotrellis.vector._
 import geotrellis.vector.ProjectedExtent
@@ -39,7 +39,7 @@ class HadoopGeoTiffRDDSpec
     with Matchers
     with RasterMatchers
     with TestEnvironment
-    with TestFiles {
+    with SparkTestFiles {
   describe("HadoopGeoTiffRDD") {
 
     it("should filter by geometry") {

--- a/spark/src/test/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriterSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriterSpec.scala
@@ -24,7 +24,7 @@ import geotrellis.proj4._
 import geotrellis.vector._
 import geotrellis.spark.testkit._
 
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 
 import org.scalatest._
 import java.io.File
@@ -33,27 +33,27 @@ class HadoopSlippyTileWriterSpec
     extends FunSpec
     with Matchers
     with TestEnvironment
-    with TestFiles
+    with SparkTestFiles
 {
   describe("HadoopSlippyTileWriter") {
     val testPath = new File(outputLocalPath, "slippy-write-test").getPath
 
     it("can write slippy tiles") {
-      val mapTransform = ZoomedLayoutScheme(WebMercator).levelForZoom(TestFiles.ZOOM_LEVEL).layout.mapTransform
+      val mapTransform = ZoomedLayoutScheme(WebMercator).levelForZoom(SparkTestFiles.ZOOM_LEVEL).layout.mapTransform
 
       val writer =
         new HadoopSlippyTileWriter[Tile](testPath, "tif")({ (key, tile) =>
           SinglebandGeoTiff(tile, mapTransform(key), WebMercator).toByteArray
         })
 
-      writer.write(TestFiles.ZOOM_LEVEL, AllOnesTestFile)
+      writer.write(SparkTestFiles.ZOOM_LEVEL, AllOnesTestFile)
 
       val reader =
         new FileSlippyTileReader[Tile](testPath)({ (key, bytes) =>
           SinglebandGeoTiff(bytes).tile
         })
 
-      rastersEqual(reader.read(TestFiles.ZOOM_LEVEL), AllOnesTestFile)
+      rastersEqual(reader.read(SparkTestFiles.ZOOM_LEVEL), AllOnesTestFile)
 
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/local/LocalMapSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/local/LocalMapSpec.scala
@@ -20,14 +20,14 @@ import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.TileLayerRDD
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 
 import java.time.ZonedDateTime
 
 import org.scalatest._
 
-class LocalMapSpec extends FunSpec with TestEnvironment with TestFiles {
+class LocalMapSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Local Map Operations") {
     it("should map an integer function over an integer raster rdd") {

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/local/MajoritySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/local/MajoritySpec.scala
@@ -20,12 +20,12 @@ import geotrellis.raster._
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 
 import org.scalatest.FunSpec
 
-class MajoritySpec extends FunSpec with TestEnvironment with TestFiles {
+class MajoritySpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Majority Operation") {
     val ones = AllOnesTestFile

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/local/MaxSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/local/MaxSpec.scala
@@ -20,12 +20,12 @@ import geotrellis.spark._
 import geotrellis.raster._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.TileLayerRDD
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 
 import org.scalatest.FunSpec
 
-class MaxSpec extends FunSpec with TestEnvironment with TestFiles {
+class MaxSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Max Operation") {
     val inc = IncreasingTestFile

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/local/MinoritySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/local/MinoritySpec.scala
@@ -20,12 +20,12 @@ import geotrellis.raster._
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 
 import org.scalatest.FunSpec
 
-class MinoritySpec extends FunSpec with TestEnvironment with TestFiles {
+class MinoritySpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Minority Operation") {
     val ones = AllOnesTestFile

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/zonal/HistogramSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/zonal/HistogramSpec.scala
@@ -19,7 +19,7 @@ package geotrellis.spark.mapalgebra.zonal
 import Implicits._
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.raster._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.spark.testkit._
@@ -30,7 +30,7 @@ import org.scalatest.FunSpec
 
 import collection._
 
-class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
+class HistogramSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Histogram Zonal Operation") {
     it("gives correct histogram for example raster rdds") {

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/zonal/PercentageSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/zonal/PercentageSpec.scala
@@ -19,7 +19,7 @@ package geotrellis.spark.mapalgebra.zonal
 import Implicits._
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 
 import geotrellis.raster._
@@ -32,7 +32,7 @@ import org.scalatest.FunSpec
 import org.apache.spark.rdd.RDD
 import spire.syntax.cfor._
 
-class PercentageSpec extends FunSpec with TestEnvironment with TestFiles {
+class PercentageSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Percentage Zonal Operation") {
     it("gives correct percentage for example raster rdds") {

--- a/spark/src/test/scala/geotrellis/spark/mask/TileRDDMaskMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mask/TileRDDMaskMethodsSpec.scala
@@ -19,7 +19,7 @@ package geotrellis.spark.mask
 import geotrellis.raster._
 import geotrellis.raster.testkit._
 import geotrellis.spark._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 import geotrellis.vector._
 
@@ -30,7 +30,7 @@ import scala.util.Random
 class TileRDDMaskMethodsSpec extends FunSpec
     with Matchers
     with TestEnvironment
-    with TestFiles
+    with SparkTestFiles
     with TileLayerRDDBuilders
     with RasterMatchers {
   describe("TileLayerRDDMask") {

--- a/spark/src/test/scala/geotrellis/spark/summary/StatsTileCollectionMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/StatsTileCollectionMethodsSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.summary
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 
 import geotrellis.raster._
@@ -30,7 +30,7 @@ import org.scalatest.FunSpec
 
 import collection._
 
-class StatsTileCollectionMethodsSpec extends FunSpec with TestEnvironment with TestFiles {
+class StatsTileCollectionMethodsSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Collection Stats Method Operations") {
 

--- a/spark/src/test/scala/geotrellis/spark/summary/StatsTileRDDMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/StatsTileRDDMethodsSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.summary
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 
 import geotrellis.raster._
@@ -30,7 +30,7 @@ import org.scalatest.FunSpec
 
 import collection._
 
-class StatsTileRDDMethodsSpec extends FunSpec with TestEnvironment with TestFiles {
+class StatsTileRDDMethodsSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("RDD Stats Method Operations") {
 

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/HistogramSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/HistogramSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.summary.polygonal
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.raster._
 import geotrellis.raster.summary.polygonal._
 import geotrellis.vector._
@@ -29,7 +29,7 @@ import org.scalatest.FunSpec
 
 import collection.immutable.HashMap
 
-class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
+class HistogramSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Histogram Zonal Summary Operation") {
     val modHundred = Mod10000TestFile

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MaxDoubleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MaxDoubleSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.summary.polygonal
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.raster.summary.polygonal._
 import geotrellis.spark.testkit._
 
@@ -27,7 +27,7 @@ import geotrellis.vector._
 
 import org.scalatest.FunSpec
 
-class MaxDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
+class MaxDoubleSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Max Double Zonal Summary Operation") {
     val inc = IncreasingTestFile

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MaxSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MaxSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.summary.polygonal
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.raster.summary.polygonal._
 import geotrellis.spark.testkit._
 
@@ -27,7 +27,7 @@ import geotrellis.vector._
 
 import org.scalatest.FunSpec
 
-class MaxSpec extends FunSpec with TestEnvironment with TestFiles {
+class MaxSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Max Zonal Summary Operation") {
     val inc = IncreasingTestFile

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MeanSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MeanSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.summary.polygonal
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.raster.summary.polygonal._
 import geotrellis.spark.testkit._
 
@@ -27,7 +27,7 @@ import geotrellis.vector._
 
 import org.scalatest.FunSpec
 
-class MeanSpec extends FunSpec with TestEnvironment with TestFiles {
+class MeanSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Mean Zonal Summary Operation") {
     val inc = IncreasingTestFile

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MinDoubleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MinDoubleSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.summary.polygonal
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.raster.summary.polygonal._
 import geotrellis.spark.testkit._
 
@@ -27,7 +27,7 @@ import geotrellis.vector._
 
 import org.scalatest.FunSpec
 
-class MinDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
+class MinDoubleSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Min Double Zonal Summary Operation") {
     val inc = IncreasingTestFile

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/MinSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/MinSpec.scala
@@ -19,7 +19,7 @@ package geotrellis.spark.summary.polygonal
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.raster.summary.polygonal._
 import geotrellis.spark.testkit._
 
@@ -27,7 +27,7 @@ import geotrellis.vector._
 
 import org.scalatest.FunSpec
 
-class MinSpec extends FunSpec with TestEnvironment with TestFiles {
+class MinSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Min Zonal Summary Operation") {
     val inc = IncreasingTestFile

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/SumDoubleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/SumDoubleSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.summary.polygonal
 
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.raster.summary.polygonal._
 import geotrellis.spark.testkit._
 
@@ -27,7 +27,7 @@ import geotrellis.vector._
 
 import org.scalatest.FunSpec
 
-class SumDoubleSpec extends FunSpec with TestEnvironment with TestFiles {
+class SumDoubleSpec extends FunSpec with TestEnvironment with SparkTestFiles {
 
   describe("Sum Double Zonal Summary Operation") {
     val ones = AllOnesTestFile

--- a/spark/src/test/scala/geotrellis/spark/summary/polygonal/SumSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/summary/polygonal/SumSpec.scala
@@ -17,9 +17,7 @@
 package geotrellis.spark.summary.polygonal
 
 import geotrellis.spark._
-import geotrellis.spark.io.hadoop._
-import geotrellis.spark.testkit.testfiles._
-import geotrellis.raster.summary.polygonal._
+import geotrellis.spark.testkit.testfiles.{TestFiles ⇒ SparkTestFiles, _}
 import geotrellis.spark.testkit._
 
 import geotrellis.raster._
@@ -29,7 +27,7 @@ import org.scalatest.FunSpec
 
 class SumSpec extends FunSpec
     with TestEnvironment
-    with TestFiles
+    with SparkTestFiles
 {
 
   describe("Sum Zonal Summary Operation") {

--- a/vector/src/test/scala/spec/geotrellis/vector/PolygonSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/PolygonSpec.scala
@@ -16,10 +16,8 @@
 
 package geotrellis.vector
 
+import com.vividsolutions.jts.{geom ⇒ jts}
 import geotrellis.vector.testkit._
-
-import com.vividsolutions.jts.{geom=>jts}
-
 import org.scalatest._
 
 class PolygonSpec extends FunSpec with Matchers {


### PR DESCRIPTION
...caused in-part by the confluence of abiguous ordering rules in IntelliJ
and dynamic sbt dependencies between the test-kit projects and their
parent feature projects. Most of these issues could have also been
resolved by moving `geotrellis.raster.TestFiles` into
`geotrellis.raster.testkit.TestFiles`, but I took the approach of
aliasing imports in case external code depends on that packaging
structure.
Also fixed a couple deprecation warnings.

Signed-off-by: Simeon H.K. Fitch <fitch@astraea.io>