### PR TITLE
Layer intersects point

### DIFF
--- a/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
@@ -145,6 +145,9 @@ class TileLayerRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
       val gb = filteredRdd.metadata.bounds.get.toGridBounds
 
       md.mapTransform(gb).center should be (md.extent.center)
+
+      val filteredViaIntersects = rdd.filter().where(Intersects(point)).result
+      filteredViaIntersects.count should be (1)
     }
 
     it("should filter query by point (temporal)") {
@@ -158,6 +161,9 @@ class TileLayerRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
       val gb = filteredRdd.metadata.bounds.get.toGridBounds
 
       md.mapTransform(gb).center should be (md.extent.center)
+
+      val filteredViaIntersects = rdd.filter().where(Intersects(point)).result
+      filteredViaIntersects.count should be (1)
     }
   }
 }


### PR DESCRIPTION
## Overview

Allow `Intersects` layer filter to be used with `Point`s, in addition to `Contains`. Allows for more generic handling of geometry in dynamic queries.

### Checklist

- [x] Unit tests added for bug-fix or new feature
- [x] fix `master` rebase.

  