### PR TITLE
Allow new geometries to snap to given PrecisionModel

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -16,6 +16,14 @@ API Changes
   - **Change:** Reprojection has improved performance due to one less shuffle stage and lower memory usage.
   ``TileRDDReproject`` loses dependency on ``TileReprojectMethods`` in favor of ``RasterRegionReproject``
 
+- ``geotrellis.vector``
+
+  - **Fix:** Allow a ``geotrellis.jts.precision.type = floating`` in ``application.conf`` to actually snap vertices of
+    GT geometries to the desired grid.
+
+  - **Change:** Exposed ``GeomFactory.factory`` to allow direct creation of JTS geometries, circumventing the snapping
+    of vertices to a fixed precision model.
+
 1.2.1
 _____
 *2018 Jan 3*

--- a/docs/guide/vectors.rst
+++ b/docs/guide/vectors.rst
@@ -5,33 +5,46 @@ Numerical Precision and Topology Exceptions
 ===========================================
 
 When doing any significant amount of geometric computation, there is the
-potential of encountering JTS TopologyExceptions or other numerical hiccups
-that arise, essentially, from asking too much of floating point numerical
-representations.  JTS offers the ability to snap coordinates to a grid, the
-scale of whose cells may be specified by the user.  This can often fix
-problems stemming from numerical error which makes two points that should be
-the same appear different due to miniscule rounding errors.
+potential of encountering JTS TopologyExceptions or other numerical hiccups.
+These arise from essentially asking too much of floating point numerical
+representations.  When they do arise, there are decisions that must be made at
+the application level to deal with these problems.
 
-However, GeoTrellis defaults to allowing the full floating point
-representation of coordinates.  To enable the fixed precision scheme, one must
-create an ``application.conf`` in ``your-project/src/main/resources/``
-containing the following lines:
+Our suggested means to deal with numerical issues is to switch to a
+fixed-precision numerical model.  This will “snap” your geometry to a grid
+whose spacing can be set based on the needs of the application.
+
+To enable the fixed precision scheme, one must create an ``application.conf``
+in ``your-project/src/main/resources/`` containing the following lines:
 
 ::
 
    geotrellis.jts.precision.type="fixed"
    geotrellis.jts.precision.scale=<scale factor>
 
-The scale factor should be ``10^x`` where ``x`` is the number of decimal
-places of precision you wish to keep.  The default scale factor is 1e12,
+The scale factor should be ``1e??`` where ``??`` is the number of decimal
+places of precision you wish to keep.  The default scale factor is ``1e12``,
 indicating that 12 decimal places after the decimal point should be kept.
-Values less than 1 (negative exponents) allow for very coarse grids.  For
-example, a scale factor of 1e-2 will round coordinate components to the
-nearest hundred.
+Scale factors less than 1 (negative exponents) allow for very coarse grids.
+For example, a scale factor of ``1e-2`` will round coordinate components to
+the nearest hundred.
 
-Note that ``geotrellis.jts.precision.type`` make take on the value
-``floating`` for the default double precision case, or ``floating_single`` to
-use single precision floating point values.
+When using the fixed precision model, we note that all geometries have their
+vertices snapped to the grid, which can be problematic for, say, the
+specification of polygons, where vertices of inner loops may be snapped
+outside the outer loop, or degenerate edges may be introduced if the endpoints
+are too close together.
+
+If one needs to avoid the snapping of some vertices, then one will have to
+supply JTS geometries to the vector object ``apply`` methods (i.e., ``Point``,
+``Line``, etc).  One can create these JTS objects using the methods of
+``GeomFactory.factory``.
+
+**Note:** By default, GeoTrellis does not snap coordinates, instead allowing
+the full double-precision floating point representation of coordinates.  This
+is equivalent to setting ``geotrellis.jts.precision.type`` to ``floating``.
+To use single-precision floating point values, set
+``geotrellis.jts.precision.type`` to ``floating_single``.
 
 Parsing GeoJson
 ===============

--- a/vector/src/main/resources/reference.conf
+++ b/vector/src/main/resources/reference.conf
@@ -17,8 +17,8 @@ geotrellis.jts = {
   precision.type = floating
 
   # For fixed precision grid for JTS coordinates; the following gives 12 decimal places of precision
-  # precision.type = fixed
-  # precision.scale = 1e12
+  #precision.type = fixed
+  #precision.scale = 1e12
 
   # In operations requiring simplification, the following dictates precision of simplified coordinates
   # Here, use 12 decimal places of precision

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -27,7 +27,7 @@ import scala.util.Try
 
 object GeomFactory extends LazyLogging {
 
-  val precisionType = {
+  private[vector] val precisionType = {
     val setting = Try(ConfigFactory.load().getString("geotrellis.jts.precision.type").toLowerCase)
     if (setting.isSuccess)
       setting.get
@@ -37,7 +37,7 @@ object GeomFactory extends LazyLogging {
     }
   }
 
-  lazy val fixedPrecisionScale =
+  private[vector] lazy val fixedPrecisionScale =
     Try(ConfigFactory.load().getDouble("geotrellis.jts.precision.scale"))
 
   private[vector] val precisionModel = precisionType match {

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -55,6 +55,11 @@ object GeomFactory extends LazyLogging {
     case s => throw new IllegalArgumentException(s"""Unrecognized JTS precision model, ${precisionType}; expected "floating", "floating_single", or "fixed" """)
   }
 
+  /** The JTS GeometryFactory used to create new geometries.
+   *
+   *  Use this factory object to create geometries that avoid automatic snapping
+   *  of geometry coordinates to the current precision model.
+   */
   val factory = new geom.GeometryFactory(precisionModel)
 
   // 12 digits is maximum to avoid [[TopologyException]], see https://web.archive.org/web/20160226031453/http://tsusiatsoftware.net/jts/jts-faq/jts-faq.html#D9

--- a/vector/src/main/scala/geotrellis/vector/MultiPoint.scala
+++ b/vector/src/main/scala/geotrellis/vector/MultiPoint.scala
@@ -42,7 +42,16 @@ object MultiPoint {
   }
 
   def apply(ps: Traversable[(Double, Double)])(implicit d: DummyImplicit): MultiPoint =
-    MultiPoint(factory.createMultiPoint(ps.map { p => new jts.Coordinate(p._1, p._2) }.toArray))
+    MultiPoint(
+      factory.createMultiPoint(
+        ps.map {
+          p => {
+            val c = new jts.Coordinate(p._1, p._2)
+            factory.getPrecisionModel.makePrecise(c)
+            c
+          }}.toArray
+      )
+    )
 
   implicit def jts2MultiPoint(jtsGeom: jts.MultiPoint): MultiPoint = apply(jtsGeom)
 }

--- a/vector/src/main/scala/geotrellis/vector/Point.scala
+++ b/vector/src/main/scala/geotrellis/vector/Point.scala
@@ -21,8 +21,11 @@ import com.vividsolutions.jts.algorithm.CGAlgorithms
 import GeomFactory._
 
 object Point {
-  def apply(x: Double, y: Double): Point =
-    Point(factory.createPoint(new jts.Coordinate(x, y)))
+  def apply(x: Double, y: Double): Point = {
+    val coord = new jts.Coordinate(x, y)
+    factory.getPrecisionModel.makePrecise(coord)
+    Point(factory.createPoint(coord))
+  }
 
   def apply(t: (Double, Double)): Point =
     apply(t._1, t._2)
@@ -40,11 +43,11 @@ case class Point(jtsGeom: jts.Point) extends Geometry
   assert(!jtsGeom.isEmpty)
 
   /** The Point's x-coordinate */
-  val x: Double =
+  def x: Double =
     jtsGeom.getX
 
   /** The Point's y-coordinate */
-  val y: Double =
+  def y: Double =
     jtsGeom.getY
 
   private[vector] def toCoordinate() =


### PR DESCRIPTION
## Overview

When working with geometries, numerical error can arise.  The easiest remedy is to use a fixed-precision model for representing geometries.  This will snap vertices to a grid with a user-defined spacing.  Or at least, that was the idea.  This PR actually makes that happen.  Previously, it was assumed that JTS would perform the snapping of vertices when the fixed-point model was used, but that was not the case.  After this PR, we will explicitly apply the precision model to new geometry; but it is also possible to circumvent the snapping process by explicitly creating JTS geometries and wrapping them in GT vector objects.

### Checklist

- [X] `docs/CHANGELOG.rst` updated, if necessary
- [X] `docs` guides update, if necessary
- [X] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

Closes #2525

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>