### PR TITLE
Perserve/Set Partitioner When Performing Focal Operations on RDDs

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,7 @@ API Changes
     been extended from a fixed length of 8 bytes to an arbitrary length.  This change affects not only the
     ``geotrellis.spark`` package, but all backends (excluding ``geotrellis.geowave`` and ``geotrellis.geomesa``).
   - **New:** All focal operations now except an optional ``partitioner`` parameter.
+  - **New:** ``BufferTiles``\s ``apply`` methods and the ``bufferTiles`` methods now except an optional ``partitioner`` parameter.
 
 1.2.0
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -12,6 +12,7 @@ API Changes
   - **Change:**  The length of the key (the space-filling curve index or address) used for layer reading and writing has
     been extended from a fixed length of 8 bytes to an arbitrary length.  This change affects not only the
     ``geotrellis.spark`` package, but all backends (excluding ``geotrellis.geowave`` and ``geotrellis.geomesa``).
+  - **New:** All focal operations now except an optional ``partitioner`` parameter.
 
 1.2.0
 -----

--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTiles.scala
@@ -26,6 +26,7 @@ import geotrellis.util._
 import org.apache.log4j.Logger
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.Partitioner
 
 import scala.reflect.ClassTag
 import scala.collection.mutable.ArrayBuffer
@@ -379,8 +380,34 @@ object BufferTiles {
   def apply[
     K: SpatialComponent: ClassTag,
     V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V])
-  ](rdd: RDD[(K, V)], bufferSize: Int): RDD[(K, BufferedTile[V])] =
-    apply(rdd, { _: K => BufferSizes(bufferSize, bufferSize, bufferSize, bufferSize) })
+  ](
+    rdd: RDD[(K, V)],
+    bufferSize: Int
+  ): RDD[(K, BufferedTile[V])] =
+    apply(rdd, { _: K => BufferSizes(bufferSize, bufferSize, bufferSize, bufferSize) }, None)
+
+  /** Buffer the tiles of type V by a constant buffer size.
+    *
+    * This function will return each of the tiles with a buffer added to them by the contributions of adjacent, abutting tiles.
+    *
+    * @tparam         K                 The key of this tile set RDD, requiring a spatial component.
+    * @tparam         V                 The tile type, requires a Stitcher[V] and implicit conversion to CropMethods[V]
+    *
+    * @param          rdd               The keyed tile rdd.
+    * @param          bufferSize        Number of pixels to buffer the tile with. The tile will only be buffered by this amount on
+    *                                   any side if there is an adjacent, abutting tile to contribute the border pixels.
+    * @param          partitioner       The Partitioner to use when buffering over the tiles. If None, then the parent's Partitioner
+    *                                   will be used. If that is also None then the resulting RDD will have a HashPartitioner.
+    */
+  def apply[
+    K: SpatialComponent: ClassTag,
+    V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V])
+  ](
+    rdd: RDD[(K, V)],
+    bufferSize: Int,
+    partitioner: Option[Partitioner]
+  ): RDD[(K, BufferedTile[V])] =
+    apply(rdd, { _: K => BufferSizes(bufferSize, bufferSize, bufferSize, bufferSize) }, partitioner)
 
   /** Buffer the tiles of type V by a constant buffer size.
     *
@@ -399,14 +426,48 @@ object BufferTiles {
   def apply[
     K: SpatialComponent: ClassTag,
     V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V])
-  ](rdd: RDD[(K, V)], bufferSize: Int, layerBounds: GridBounds): RDD[(K, BufferedTile[V])] =
+  ](
+    rdd: RDD[(K, V)],
+    bufferSize: Int,
+    layerBounds: GridBounds
+  ): RDD[(K, BufferedTile[V])] =
+    apply(rdd, bufferSize, layerBounds, None)
+
+  /** Buffer the tiles of type V by a constant buffer size.
+    *
+    * This function will return each of the tiles with a buffer added to them by the contributions of adjacent, abutting tiles.
+    *
+    * @tparam         K                 The key of this tile set RDD, requiring a spatial component.
+    * @tparam         V                 The tile type, requires a Stitcher[V] and implicit conversion to CropMethods[V]
+    *
+    * @param          rdd               The keyed tile rdd.
+    * @param          bufferSize        Number of pixels to buffer the tile with. The tile will only be buffered by this amount on
+    *                                   any side if there is an adjacent, abutting tile to contribute the border pixels.
+    * @param          layerBounds       The boundries of the layer to consider for border pixel contribution. This avoids creating
+    *                                   border cells from valid tiles that would be used by keys outside of the bounds (and therefore
+    *                                   unused).
+    *                                   any side if there is an adjacent, abutting tile to contribute the border pixels.
+    *
+    * @param          partitioner       The Partitioner to use when buffering over the tiles. If None, then the parent's Partitioner
+    *                                   will be used. If that is also None then the resulting RDD will have a HashPartitioner.
+    */
+  def apply[
+    K: SpatialComponent: ClassTag,
+    V <: CellGrid: Stitcher: ClassTag: (? => CropMethods[V])
+  ](
+    rdd: RDD[(K, V)],
+    bufferSize: Int,
+    layerBounds: GridBounds,
+    partitioner: Option[Partitioner]
+  ): RDD[(K, BufferedTile[V])] =
     apply(
       rdd,
       { key: K =>
         val k = key.getComponent[SpatialKey]()
         layerBounds.contains(k.col, k.row)
       },
-      { _: K => BufferSizes(bufferSize, bufferSize, bufferSize, bufferSize) }
+      { _: K => BufferSizes(bufferSize, bufferSize, bufferSize, bufferSize) },
+      partitioner
     )
 
   /** Buffer the tiles of type V by a constant buffer size.
@@ -424,8 +485,36 @@ object BufferTiles {
   def apply[
     K: SpatialComponent: ClassTag,
     V <: CellGrid: Stitcher: (? => CropMethods[V])
-  ](layer: RDD[(K, V)],
-    getBufferSizes: K => BufferSizes): RDD[(K, BufferedTile[V])] = apply(layer, { _: K => true }, getBufferSizes)
+  ](
+    layer: RDD[(K, V)],
+    getBufferSizes: K => BufferSizes
+  ): RDD[(K, BufferedTile[V])] =
+    apply(layer, getBufferSizes, None)
+
+  /** Buffer the tiles of type V by a constant buffer size.
+    *
+    * This function will return each of the tiles with a buffer added to them by the contributions of adjacent, abutting tiles.
+    *
+    * @tparam         K                 The key of this tile set RDD, requiring a spatial component.
+    * @tparam         V                 The tile type, requires a Stitcher[V] and implicit conversion to CropMethods[V]
+    *
+    * @param          rdd               The keyed tile rdd.
+    * @param          getBufferSizes    A function indicating the number of pixels to buffer the tile with. The tile will only
+    *                                   be buffered by this amount on any side if there is an adjacent, abutting tile to
+    *                                   contribute the border pixels.
+    *
+    * @param          partitioner       The Partitioner to use when buffering over the tiles. If None, then the parent's Partitioner
+    *                                   will be used. If that is also None then the resulting RDD will have a HashPartitioner.
+    */
+  def apply[
+    K: SpatialComponent: ClassTag,
+    V <: CellGrid: Stitcher: (? => CropMethods[V])
+  ](
+    layer: RDD[(K, V)],
+    getBufferSizes: K => BufferSizes,
+    partitioner: Option[Partitioner]
+  ): RDD[(K, BufferedTile[V])] =
+    apply(layer, { _: K => true }, getBufferSizes, partitioner)
 
   /** Buffer the tiles of type V by a constant buffer size.
     *
@@ -447,6 +536,33 @@ object BufferTiles {
   ](layer: RDD[(K, V)],
     includeKey: K => Boolean,
     getBufferSizes: K => BufferSizes
+  ): RDD[(K, BufferedTile[V])] =
+    apply(layer, includeKey, getBufferSizes, None)
+
+  /** Buffer the tiles of type V by a constant buffer size.
+    *
+    * This function will return each of the tiles with a buffer added to them by the contributions of adjacent, abutting tiles.
+    *
+    * @tparam         K                 The key of this tile set RDD, requiring a spatial component.
+    * @tparam         V                 The tile type, requires a Stitcher[V] and implicit conversion to CropMethods[V]
+    *
+    * @param          rdd               The keyed tile rdd.
+    * @param          includeKey        A function indicating whether the tile corresponding to a key should be included in the
+    *                                   output.
+    * @param          getBufferSizes    A function indicating the number of pixels to buffer the tile with. The tile will only
+    *                                   be buffered by this amount on any side if there is an adjacent, abutting tile to
+    *                                   contribute the border pixels.
+    *
+    * @param          partitioner       The Partitioner to use when buffering over the tiles. If None, then the parent's Partitioner
+    *                                   will be used. If that is also None then the resulting RDD will have a HashPartitioner.
+    */
+  def apply[
+    K: SpatialComponent: ClassTag,
+    V <: CellGrid: Stitcher: (? => CropMethods[V])
+  ](layer: RDD[(K, V)],
+    includeKey: K => Boolean,
+    getBufferSizes: K => BufferSizes,
+    partitioner: Option[Partitioner]
   ): RDD[(K, BufferedTile[V])] = {
 
     val leftDirs = Seq(TopLeft, Left, BottomLeft)
@@ -456,7 +572,12 @@ object BufferTiles {
     val vmidDirs = Seq(Left, Center, Right)
     val botDirs = Seq(BottomLeft, Bottom, BottomRight)
 
-    val partitioner = layer.partitioner
+    val targetPartitioner =
+      (layer.partitioner, partitioner) match {
+        case (_, Some(_)) => partitioner
+        case (Some(_), None) => layer.partitioner
+        case (None, None) => None
+      }
 
     val sliced = layer
       .flatMap{ case (key, tile) => {
@@ -493,7 +614,7 @@ object BufferTiles {
       }}
 
     val grouped =
-      partitioner match {
+      targetPartitioner match {
         case Some(p) => sliced.groupByKey(p)
         case None => sliced.groupByKey
       }

--- a/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/buffer/BufferTilesMethods.scala
@@ -23,6 +23,7 @@ import geotrellis.spark._
 import geotrellis.util.MethodExtensions
 
 import org.apache.spark.rdd.RDD
+import org.apache.spark.Partitioner
 
 import scala.reflect.ClassTag
 
@@ -33,8 +34,18 @@ class BufferTilesMethods[
   def bufferTiles(bufferSize: Int): RDD[(K, BufferedTile[V])] =
     BufferTiles(self, bufferSize)
 
+  def bufferTiles(bufferSize: Int, partitioner: Option[Partitioner]): RDD[(K, BufferedTile[V])] =
+    BufferTiles(self, bufferSize, partitioner)
+
   def bufferTiles(bufferSize: Int, layerBounds: GridBounds): RDD[(K, BufferedTile[V])] =
     BufferTiles(self, bufferSize, layerBounds)
+
+  def bufferTiles(
+    bufferSize: Int,
+    layerBounds: GridBounds,
+    partitioner: Option[Partitioner]
+  ): RDD[(K, BufferedTile[V])] =
+    BufferTiles(self, bufferSize, layerBounds, partitioner)
 
   @deprecated("Please specify buffer sizes per key as a function K => BufferSizes", "1.2")
   def bufferTiles(bufferSizesPerKey: RDD[(K, BufferSizes)]): RDD[(K, BufferedTile[V])] =
@@ -42,4 +53,10 @@ class BufferTilesMethods[
 
   def bufferTiles(getBufferSizes: K => BufferSizes): RDD[(K, BufferedTile[V])] =
     BufferTiles(self, getBufferSizes)
+
+  def bufferTiles(
+    getBufferSizes: K => BufferSizes,
+    partitioner: Option[Partitioner]
+  ): RDD[(K, BufferedTile[V])] =
+    BufferTiles(self, getBufferSizes, partitioner)
 }

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalOperation.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalOperation.scala
@@ -33,18 +33,25 @@ object FocalOperation {
     bufferedTiles
       .mapValues { case BufferedTile(tile, gridBounds) => calc(tile, Some(gridBounds)) }
 
-  def apply[K: SpatialComponent: ClassTag](rdd: RDD[(K, Tile)], neighborhood: Neighborhood)
-      (calc: (Tile, Option[GridBounds]) => Tile)(implicit d: DummyImplicit): RDD[(K, Tile)] =
-    mapOverBufferedTiles(rdd.bufferTiles(neighborhood.extent), neighborhood)(calc)
+  def apply[K: SpatialComponent: ClassTag](
+    rdd: RDD[(K, Tile)],
+    neighborhood: Neighborhood,
+    partitioner: Option[Partitioner])
+    (calc: (Tile, Option[GridBounds]) => Tile)(implicit d: DummyImplicit): RDD[(K, Tile)] =
+      mapOverBufferedTiles(rdd.bufferTiles(neighborhood.extent, partitioner), neighborhood)(calc)
 
-  def apply[K: SpatialComponent: ClassTag](rdd: RDD[(K, Tile)], neighborhood: Neighborhood, layerBounds: GridBounds)
-      (calc: (Tile, Option[GridBounds]) => Tile): RDD[(K, Tile)] =
-    mapOverBufferedTiles(rdd.bufferTiles(neighborhood.extent, layerBounds), neighborhood)(calc)
+  def apply[K: SpatialComponent: ClassTag](
+    rdd: RDD[(K, Tile)],
+    neighborhood: Neighborhood,
+    layerBounds: GridBounds,
+    partitioner: Option[Partitioner])
+    (calc: (Tile, Option[GridBounds]) => Tile): RDD[(K, Tile)] =
+      mapOverBufferedTiles(rdd.bufferTiles(neighborhood.extent, layerBounds, partitioner), neighborhood)(calc)
 
-  def apply[K: SpatialComponent: ClassTag](rasterRDD: TileLayerRDD[K], neighborhood: Neighborhood)
+  def apply[K: SpatialComponent: ClassTag](rasterRDD: TileLayerRDD[K], neighborhood: Neighborhood, partitioner: Option[Partitioner])
       (calc: (Tile, Option[GridBounds]) => Tile): TileLayerRDD[K] =
     rasterRDD.withContext { rdd =>
-      apply(rdd, neighborhood, rasterRDD.metadata.gridBounds)(calc)
+      apply(rdd, neighborhood, rasterRDD.metadata.gridBounds, partitioner)(calc)
     }
 }
 
@@ -52,19 +59,11 @@ abstract class FocalOperation[K: SpatialComponent: ClassTag] extends MethodExten
 
   def focal(n: Neighborhood, partitioner: Option[Partitioner])
       (calc: (Tile, Option[GridBounds]) => Tile): TileLayerRDD[K] =
-        partitioner match {
-          case None => FocalOperation(self, n)(calc)
-          case Some(p) => FocalOperation(self.withContext { _.partitionBy(p) }, n)(calc)
-        }
+        FocalOperation(self, n, partitioner)(calc)
 
   def focalWithCellSize(n: Neighborhood, partitioner: Option[Partitioner])
       (calc: (Tile, Option[GridBounds], CellSize) => Tile): TileLayerRDD[K] = {
     val cellSize = self.metadata.layout.cellSize
-    partitioner match {
-      case None =>
-        FocalOperation(self, n){ (tile, bounds) => calc(tile, bounds, cellSize) }
-      case Some(p) =>
-        FocalOperation(self.withContext { _.partitionBy(p) }, n){ (tile, bounds) => calc(tile, bounds, cellSize) }
-    }
+    FocalOperation(self, n, partitioner){ (tile, bounds) => calc(tile, bounds, cellSize) }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalTileLayerRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/FocalTileLayerRDDMethods.scala
@@ -18,45 +18,82 @@ package geotrellis.spark.mapalgebra.focal
 
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
+import org.apache.spark.Partitioner
+
 
 trait FocalTileLayerRDDMethods[K] extends FocalOperation[K] {
 
-  def focalSum(n: Neighborhood, target: TargetCell = TargetCell.All) =
-    focal(n) { (tile, bounds) => Sum(tile, n, bounds, target) }
+  def focalSum(
+    n: Neighborhood,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) =
+    focal(n, partitioner) { (tile, bounds) => Sum(tile, n, bounds, target) }
 
-  def focalMin(n: Neighborhood, target: TargetCell = TargetCell.All) =
-    focal(n) { (tile, bounds) => Min(tile, n, bounds, target) }
+  def focalMin(
+    n: Neighborhood,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) =
+    focal(n, partitioner) { (tile, bounds) => Min(tile, n, bounds, target) }
 
-  def focalMax(n: Neighborhood, target: TargetCell = TargetCell.All) =
-    focal(n) { (tile, bounds) => Max(tile, n, bounds, target) }
+  def focalMax(
+    n: Neighborhood,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) =
+    focal(n, partitioner) { (tile, bounds) => Max(tile, n, bounds, target) }
 
-  def focalMean(n: Neighborhood, target: TargetCell = TargetCell.All) =
-    focal(n) { (tile, bounds) => Mean(tile, n, bounds, target) }
+  def focalMean(
+    n: Neighborhood,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) =
+    focal(n, partitioner) { (tile, bounds) => Mean(tile, n, bounds, target) }
 
-  def focalMedian(n: Neighborhood, target: TargetCell = TargetCell.All) =
-    focal(n) { (tile, bounds) => Median(tile, n, bounds, target) }
+  def focalMedian(
+    n: Neighborhood,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) =
+    focal(n, partitioner) { (tile, bounds) => Median(tile, n, bounds, target) }
 
-  def focalMode(n: Neighborhood, target: TargetCell = TargetCell.All) =
-    focal(n) { (tile, bounds) => Mode(tile, n, bounds, target) }
+  def focalMode(
+    n: Neighborhood,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) =
+    focal(n, partitioner) { (tile, bounds) => Mode(tile, n, bounds, target) }
 
-  def focalStandardDeviation(n: Neighborhood, target: TargetCell = TargetCell.All) =
-    focal(n) { (tile, bounds) => StandardDeviation(tile, n, bounds, target) }
+  def focalStandardDeviation(
+    n: Neighborhood,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) =
+    focal(n, partitioner) { (tile, bounds) => StandardDeviation(tile, n, bounds, target) }
 
-  def focalConway() = {
+  def focalConway(partitioner: Option[Partitioner] = None) = {
     val n = Square(1)
-    focal(n) { (tile, bounds) => Sum(tile, n, bounds, TargetCell.All) }
+    focal(n, partitioner) { (tile, bounds) => Sum(tile, n, bounds, TargetCell.All) }
   }
 
-  def focalConvolve(k: Kernel, target: TargetCell = TargetCell.All) =
-   focal(k) { (tile, bounds) => Convolve(tile, k, bounds, target) }
+  def focalConvolve(
+    k: Kernel,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) =
+   focal(k, partitioner) { (tile, bounds) => Convolve(tile, k, bounds, target) }
 
   /** Calculates the aspect of each cell in a raster.
    *
    * @see [[geotrellis.raster.mapalgebra.focal.Aspect]]
    */
-  def aspect(target: TargetCell = TargetCell.All) = {
+  def aspect(
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) = {
     val n = Square(1)
-    focalWithCellSize(n) { (tile, bounds, cellSize) =>
+    focalWithCellSize(n, partitioner) { (tile, bounds, cellSize) =>
       Aspect(tile, n, bounds, cellSize, target)
     }
   }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
@@ -65,9 +102,13 @@ trait FocalTileLayerRDDMethods[K] extends FocalOperation[K] {
    *
    * @see [[geotrellis.raster.mapalgebra.focal.Slope]]
    */
-  def slope(zFactor: Double = 1.0, target: TargetCell = TargetCell.All) = {
+  def slope(
+    zFactor: Double = 1.0,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) = {
     val n = Square(1)
-    focalWithCellSize(n) { (tile, bounds, cellSize) =>
+    focalWithCellSize(n, partitioner) { (tile, bounds, cellSize) =>
       Slope(tile, n, bounds, cellSize, zFactor, target)
     }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
   }

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/hillshade/HillshadeTileLayerRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/focal/hillshade/HillshadeTileLayerRDDMethods.scala
@@ -21,14 +21,23 @@ import geotrellis.spark.mapalgebra.focal._
 import geotrellis.raster.mapalgebra.focal.hillshade._
 import geotrellis.raster.mapalgebra.focal._
 
+import org.apache.spark.Partitioner
+
+
 trait HillshadeTileLayerRDDMethods[K] extends FocalOperation[K] {
   /** Calculates the hillshade of each cell in a raster.
    *
    * @see [[geotrellis.raster.mapalgebra.focal.Hillshade]]
    */
-  def hillshade(azimuth: Double = 315, altitude: Double = 45, zFactor: Double = 1, target: TargetCell = TargetCell.All) = {
+  def hillshade(
+    azimuth: Double = 315,
+    altitude: Double = 45,
+    zFactor: Double = 1,
+    target: TargetCell = TargetCell.All,
+    partitioner: Option[Partitioner] = None
+  ) = {
     val n = Square(1)
-    focalWithCellSize(n) { (tile, bounds, cellSize) =>
+    focalWithCellSize(n, partitioner) { (tile, bounds, cellSize) =>
       Hillshade(tile, n, bounds, cellSize, azimuth, altitude, zFactor, target)
     }.mapContext(_.copy(cellType = DoubleConstantNoDataCellType))
   }

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/PartitionerSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/PartitionerSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.mapalgebra.focal
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.focal._
+import geotrellis.spark._
+import geotrellis.spark.testkit._
+import geotrellis.raster.io.geotiff._
+
+import org.apache.spark._
+
+import org.scalatest.FunSpec
+import java.io._
+
+class PartitionerSpec extends FunSpec with TestEnvironment {
+
+  val tile = SinglebandGeoTiff(new File(inputHomeLocalPath, "aspect.tif").getPath).tile
+  val (_, rasterRDD) = createTileLayerRDD(tile, 4, 3)
+
+  describe("Focal Partitioner Spec") {
+
+    it("should retain the partitioner of the parent RDD") {
+      val partitionedParent = rasterRDD.withContext { _.partitionBy(new HashPartitioner(10)) }
+      val childRDD = partitionedParent.slope().focalMin(Square(1))
+
+      assert(childRDD.partitioner == partitionedParent.partitioner)
+    }
+
+    it("should retain its new partitioner") {
+      val targetPartitioner = Some(new HashPartitioner(10))
+      val minRDD = rasterRDD.slope(partitioner = targetPartitioner).focalMin(Square(1))
+
+      assert(minRDD.partitioner == targetPartitioner)
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR allows the user to set an optional `partitioner` parameter to all `RDD` `focal` methods. By default, no `partitioner` is set and thus the resulting `RDD` will have the same `partitioner` as its parent. If a user were to set a `partitioner`, then the `focal` operation will performed over the designated partitioning scheme.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

Closes #2539 
