### PR TITLE
TileRDDReproject Will Now Preserve the Source RDD's Partitioner

### DIFF
--- a/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
@@ -30,6 +30,8 @@ import geotrellis.vector._
 import geotrellis.proj4._
 
 import spire.syntax.cfor._
+
+import org.apache.spark._
 import org.scalatest.FunSpec
 
 class TileRDDReprojectSpec extends FunSpec with TestEnvironment {
@@ -219,6 +221,15 @@ class TileRDDReprojectSpec extends FunSpec with TestEnvironment {
           }
         }
       }
+    }
+
+    it("should retain the source RDD's Partitioner") {
+      val partitioner = new HashPartitioner(8)
+      val expectedPartitioner = Some(partitioner)
+      val repartitioned = rdd.withContext{ _.partitionBy(partitioner) }
+      val actualPartitioner = repartitioned.reproject(ZoomedLayoutScheme(LatLng))._2.partitioner
+
+      actualPartitioner should be (expectedPartitioner)
     }
   }
 


### PR DESCRIPTION
## Overview

This PR makes it so that the resulting `RDD` of a `reproject` will have the same `Partitioner` as the source `RDD`. This is needed as it can help reduce the number of shuffle steps required, and in turn, improve the performance of a job.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature