### PR TITLE
Preserve Partitioner in RasterizeRDD.fromFeatureWithZIndex

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala
@@ -177,7 +177,7 @@ object RasterizeRDD {
         mergeCombiners = mergeTiles,
         partitioner.getOrElse(new HashPartitioner(features.getNumPartitions))
       )
-        .map({ (tup: (SpatialKey, (MutableArrayTile, MutableArrayTile))) => (tup._1, tup._2._1) })
+        .mapValues { tup  => tup._1 }
 
     ContextRDD(tiles.asInstanceOf[RDD[(SpatialKey, Tile)]], layout)
   }

--- a/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
@@ -32,6 +32,9 @@ import geotrellis.vector.io.json._
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import org.apache.spark._
+
+
 class RasterizeRDDSpec extends FunSpec with Matchers
     with TestEnvironment {
 
@@ -160,5 +163,22 @@ class RasterizeRDDSpec extends FunSpec with Matchers
       .collect().head._2
 
     tile.toArray.sum should be (336)
+  }
+
+  it("should retain the given partitioner") {
+    val features = sc.parallelize(List(
+      Feature(polygon0, CellValue(value = 1000, zindex = 0)),
+      Feature(polygon1, CellValue(value = 1, zindex = 3)),
+      Feature(polygon2, CellValue(value = 2, zindex = 2)),
+      Feature(polygon0, CellValue(value = 2000, zindex = 0)),
+      Feature(polygon0, CellValue(value = 3000, zindex = 0))
+    ))
+
+    val partitioner = Some(new HashPartitioner(8))
+
+    val tile = RasterizeRDD
+      .fromFeatureWithZIndex(features, ct, ld, partitioner = partitioner)
+
+    tile.partitioner should be (partitioner)
   }
 }


### PR DESCRIPTION
## Overview

This PR fixes a bug in `RasterizeRDD.fromFeatureWithZIndex` that caused the resulting `RDD` to have no `Partitioner` regardless if it was set or not. [This](https://github.com/locationtech/geotrellis/blob/master/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDD.scala?utf8=%E2%9C%93#L180) being the offending line that caused the `Partitioner` to be lost.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature