### PR TITLE
Extend IO SPI to offer CollectionLayerReaders

### DIFF
--- a/accumulo/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
+++ b/accumulo/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
@@ -1,0 +1,1 @@
+geotrellis.spark.io.accumulo.AccumuloLayerProvider

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerProvider.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerProvider.scala
@@ -32,7 +32,7 @@ import java.net.URI
  * Layers table name is required to instantiate a [[LayerWriter]]
  */
 class AccumuloLayerProvider extends AttributeStoreProvider
-    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider {
+    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
   def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "accumulo"
 
   def attributeStore(uri: URI): AttributeStore = {
@@ -62,4 +62,10 @@ class AccumuloLayerProvider extends AttributeStoreProvider
     val instance = AccumuloInstance(uri)
     new AccumuloValueReader(instance, store)
   }
+
+  def collectionLayerReader(uri: URI, store: AttributeStore): CollectionLayerReader[LayerId] = {
+    val instance = AccumuloInstance(uri)
+    new AccumuloCollectionLayerReader(store)(instance)
+  }
+
 }

--- a/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
+++ b/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
@@ -1,0 +1,1 @@
+geotrellis.spark.io.cassandra.CassandraLayerProvider

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerProvider.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerProvider.scala
@@ -30,7 +30,7 @@ import java.net.URI
  * Layers table name is required to instantiate a [[LayerWriter]]
  */
 class CassandraLayerProvider extends AttributeStoreProvider
-    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider {
+    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
   def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "cassandra"
 
   def attributeStore(uri: URI): AttributeStore = {
@@ -63,4 +63,10 @@ class CassandraLayerProvider extends AttributeStoreProvider
     val instance = CassandraInstance(uri)
     new CassandraValueReader(instance, store)
   }
+
+  def collectionLayerReader(uri: URI, store: AttributeStore): CollectionLayerReader[LayerId] = {
+    val instance = CassandraInstance(uri)
+    new CassandraCollectionLayerReader(store, instance)
+  }
+
 }

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,6 +17,7 @@ API Changes
 
   - **Change:** Reprojection has improved performance due to one less shuffle stage and lower memory usage.
   ``TileRDDReproject`` loses dependency on ``TileReprojectMethods`` in favor of ``RasterRegionReproject``
+  - **New:** CollectionLayerReader now has an SPI interface.
 
 1.2.1
 _____

--- a/hbase/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
+++ b/hbase/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
@@ -1,0 +1,1 @@
+geotrellis.spark.io.hbase.HBaseLayerProvider

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerProvider.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerProvider.scala
@@ -31,7 +31,7 @@ import java.net.URI
  * Layers table name is required to instantiate a [[LayerWriter]]
  */
 class HBaseLayerProvider extends AttributeStoreProvider
-    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider {
+    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
   def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "hbase"
 
   def attributeStore(uri: URI): AttributeStore = {
@@ -59,4 +59,10 @@ class HBaseLayerProvider extends AttributeStoreProvider
     val instance = HBaseInstance(uri)
     new HBaseValueReader(instance, store)
   }
+
+  def collectionLayerReader(uri: URI, store: AttributeStore): CollectionLayerReader[LayerId] = {
+    val instance = HBaseInstance(uri)
+    new HBaseCollectionLayerReader(store, instance)
+  }
+
 }

--- a/s3/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
+++ b/s3/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
@@ -1,0 +1,1 @@
+geotrellis.spark.io.s3.S3LayerProvider

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerProvider.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerProvider.scala
@@ -28,7 +28,7 @@ import java.net.URI
  *  ex: `s3://<bucket>/<prefix-to-catalog>`
  */
 class S3LayerProvider extends AttributeStoreProvider
-    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider {
+    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
   def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "s3"
 
   def attributeStore(uri: URI): AttributeStore = {
@@ -54,4 +54,9 @@ class S3LayerProvider extends AttributeStoreProvider
   def valueReader(uri: URI, store: AttributeStore): ValueReader[LayerId] = {
     new S3ValueReader(store)
   }
+
+  def collectionLayerReader(uri: URI, store: AttributeStore): CollectionLayerReader[LayerId] = {
+    new S3CollectionLayerReader(store)
+  }
+
 }

--- a/spark/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
+++ b/spark/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
@@ -1,0 +1,2 @@
+geotrellis.spark.io.file.FileLayerProvider
+geotrellis.spark.io.hadoop.HadoopLayerProvider

--- a/spark/src/main/scala/geotrellis/spark/io/CollectionLayerReaderProvider.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/CollectionLayerReaderProvider.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.io
+
+import geotrellis.spark._
+import java.net.URI
+
+
+trait CollectionLayerReaderProvider {
+
+  def canProcess(uri: URI): Boolean
+
+  def collectionLayerReader(uri: URI, store: AttributeStore): CollectionLayerReader[LayerId]
+
+}

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerProvider.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerProvider.scala
@@ -28,7 +28,7 @@ import java.io.File
  *  ex: `file:/tmp/catalog`
  */
 class FileLayerProvider extends AttributeStoreProvider
-    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider {
+    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
 
   def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "file"
 
@@ -50,5 +50,10 @@ class FileLayerProvider extends AttributeStoreProvider
   def valueReader(uri: URI, store: AttributeStore): ValueReader[LayerId] = {
     val catalogPath = new File(uri).getCanonicalPath
     new FileValueReader(store, catalogPath)
+  }
+
+  def collectionLayerReader(uri: URI, store: AttributeStore): CollectionLayerReader[LayerId] = {
+    val catalogPath = new File(uri).getCanonicalPath
+    new FileCollectionLayerReader(store, catalogPath)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerProvider.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerProvider.scala
@@ -33,7 +33,7 @@ import java.net.URI
  * That support is provided by [[S3Attributestore]]
  */
 class HadoopLayerProvider extends AttributeStoreProvider
-    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider {
+    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
   val schemes: Array[String] = Array("hdfs", "hdfs+file", "s3n", "s3a", "wasb", "wasbs")
 
   private def trim(uri: URI): URI =
@@ -69,5 +69,12 @@ class HadoopLayerProvider extends AttributeStoreProvider
     val conf = new Configuration()
     val maxOpenFiles = params.getOrElse("maxOpenFiles", "16").toInt
     new HadoopValueReader(store, conf, maxOpenFiles)
+  }
+
+  def collectionLayerReader(uri: URI, store: AttributeStore) = {
+    val _uri = trim(uri)
+    val path = new Path(_uri)
+    val conf = new Configuration()
+    HadoopCollectionLayerReader(path, conf)
   }
 }


### PR DESCRIPTION
## Overview

A convenient method to build `ValueReader`s, `AttributeStore`s, and some other IO helper classes from the panoply of backends using a single URI has been a great convenience.  This PR extends this interface to provide access to `CollectionLayerReader`s via the same mechanism.  This is useful when one needs to make concurrent reads in a more conventional concurrency setting.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

