### PR TITLE
Fix issue where data could be loaded prematurely

### DIFF
--- a/util/src/main/scala/geotrellis/util/StreamingByteReader.scala
+++ b/util/src/main/scala/geotrellis/util/StreamingByteReader.scala
@@ -46,12 +46,6 @@ class StreamingByteReader(rangeReader: RangeReader, chunkSize: Int = 65536) exte
       }
     }
     lazy val buffer: ByteBuffer = ByteBuffer.wrap(data).order(_byteOrder)
-
-    def bufferPosition =
-      loadedData match {
-        case Some(d) => buffer.position
-        case None => 0
-      }
   }
 
   private var _chunk: Option[Chunk] = None
@@ -62,90 +56,90 @@ class StreamingByteReader(rangeReader: RangeReader, chunkSize: Int = 65536) exte
     }
 
   private var _byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
-  def order = _byteOrder
+  def order: ByteOrder = _byteOrder
   def order(byteOrder: ByteOrder): Unit = {
     _byteOrder = byteOrder
     _chunk.foreach(_.buffer.order(byteOrder))
   }
 
-  def position: Long = chunk.offset + chunk.bufferPosition
-
+  private var _position: Long = 0
+  def position: Long = _position
   def position(newPoint: Long): ByteReader = {
-    if (isContained(newPoint)) {
-      chunk.buffer.position((newPoint - chunk.offset).toInt)
-      this
-    } else {
-      adjustChunk(newPoint)
-      this
-    }
+    _position = newPoint
+    this
   }
-
-  private def adjustChunk: Unit =
-    adjustChunk(position)
 
   private def adjustChunk(newPoint: Long): Chunk =
     adjustChunk(newPoint, chunkSize)
 
   private def adjustChunk(newPoint: Long, length: Int): Chunk = {
-    val c = new Chunk(newPoint, length, () => rangeReader.readRange(newPoint, length))
+    val c = new Chunk(newPoint, length, { () =>
+      rangeReader.readRange(newPoint, length)
+    })
     _chunk = Some(c)
     c
   }
 
+  private def bufferPosition: Int = (_position - chunk.offset).toInt
+
+  private def ensureChunk(len: Int, setChunkPos: Boolean): Unit = {
+    if (bufferPosition + len > chunk.length) {
+      adjustChunk(position, len)
+    }
+
+    if(setChunkPos) {
+      chunk.buffer.position(bufferPosition)
+    }
+  }
+
   def getBytes(length: Int): Array[Byte] = {
-    if (chunk.bufferPosition + length > chunk.length)
-      adjustChunk(position, length)
-    chunk.data.slice(chunk.bufferPosition, chunk.bufferPosition + length)
+    ensureChunk(length, setChunkPos = false)
+    val bytes = chunk.data.slice(bufferPosition, bufferPosition + length)
+    _position += length
+    bytes
   }
 
   def get: Byte = {
-    if (chunk.bufferPosition + 1 > chunk.length)
-      adjustChunk
+    ensureChunk(1, setChunkPos = true)
+    _position += 1
     chunk.buffer.get
   }
 
   def getChar: Char = {
-    if (chunk.bufferPosition + 2 > chunk.length)
-      adjustChunk
+    ensureChunk(2, setChunkPos = true)
+    _position += 2
     chunk.buffer.getChar
   }
 
   def getShort: Short = {
-    if (chunk.bufferPosition + 2 > chunk.length)
-      adjustChunk
+    ensureChunk(2, setChunkPos = true)
+    _position += 2
     chunk.buffer.getShort
   }
 
   def getInt: Int = {
-    if (chunk.bufferPosition + 4 > chunk.length)
-      adjustChunk
+    ensureChunk(4, setChunkPos = true)
+    _position += 4
     chunk.buffer.getInt
   }
 
   def getFloat: Float = {
-    if (chunk.bufferPosition + 4 > chunk.length)
-      adjustChunk
+    ensureChunk(4, setChunkPos = true)
+    _position += 4
     chunk.buffer.getFloat
   }
 
   def getDouble: Double = {
-    if (chunk.bufferPosition + 8 > chunk.length)
-      adjustChunk
+    ensureChunk(8, setChunkPos = true)
+    _position += 8
     chunk.buffer.getDouble
   }
 
   def getLong: Long = {
-    if (chunk.bufferPosition + 8 > chunk.length)
-      adjustChunk
+    ensureChunk(8, setChunkPos = true)
+    _position += 8
     chunk.buffer.getLong
   }
-
-  private def isContained(newPosition: Long): Boolean =
-    _chunk match {
-      case Some(c) =>
-        if (newPosition >= c.offset && newPosition <= c.offset + c.length) true else false
-      case None => false
-    }
 }
 
 /** The companion object of [[StreamingByteReader]] */

--- a/util/src/test/scala/geotrellis/util/StreamingByteReaderSpec.scala
+++ b/util/src/test/scala/geotrellis/util/StreamingByteReaderSpec.scala
@@ -43,6 +43,15 @@ class StreamingByteReaderSpec extends FunSpec with Matchers {
       br.position should be (0)
     }
 
+    it("should not read upon move within current change") {
+      val mockRangeReader = new MockRangeReader(arr)
+      val br = new StreamingByteReader(mockRangeReader, chunkSize = 10)
+      br.position(0)
+      br.position(8)
+
+      mockRangeReader.numberOfReads should be (0)
+    }
+
     it("should read the correct byte after moving position") {
       val br = new StreamingByteReader(new MockRangeReader(arr))
       br.position(5)


### PR DESCRIPTION
When the StreamingByteReader calls `position(x)` it would previously set the buffer position on the chunk which would force loading the data for that chunk.

This change tracks the ByteReader position separately to prevent loading data prematurely.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

