### PR TITLE
ZoomResmaple for MultibandTileLayerRDDs

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -18,6 +18,7 @@ API Changes
   - **Change:** Reprojection has improved performance due to one less shuffle stage and lower memory usage.
   ``TileRDDReproject`` loses dependency on ``TileReprojectMethods`` in favor of ``RasterRegionReproject``
   - **New:** CollectionLayerReader now has an SPI interface.
+  - **New:** ``ZoomResample`` can now be used on ``MultibandTileLayerRDD``\s.
 
 1.2.1
 _____

--- a/spark/src/main/scala/geotrellis/spark/resample/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/resample/Implicits.scala
@@ -16,10 +16,20 @@
 
 package geotrellis.spark.resample
 
+import geotrellis.raster._
+import geotrellis.raster.resample._
 import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.util._
+import geotrellis.vector._
+
+import org.apache.spark.rdd._
 
 object Implicits extends Implicits
 
 trait Implicits {
-  implicit class withZoomResampleMethods[K: SpatialComponent](self: TileLayerRDD[K]) extends ZoomResampleMethods[K](self)
+  implicit class withLayerRDDZoomResampleMethods[
+    K: SpatialComponent,
+    V <: CellGrid: (? => TileResampleMethods[V])
+  ](self: RDD[(K, V)] with Metadata[TileLayerMetadata[K]]) extends LayerRDDZoomResampleMethods[K, V](self)
 }

--- a/spark/src/test/scala/geotrellis/spark/resample/ZoomResampleSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/resample/ZoomResampleSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.resample
 
 import geotrellis.raster._
 import geotrellis.raster.testkit._
-import geotrellis.raster.io.geotiff.SinglebandGeoTiff
+import geotrellis.raster.io.geotiff.{SinglebandGeoTiff, MultibandGeoTiff}
 import geotrellis.spark._
 import geotrellis.spark.testkit._
 import geotrellis.vector.Extent
@@ -37,6 +37,34 @@ class ZoomResampleMethodsSpec extends FunSpec
     val gt = SinglebandGeoTiff(path)
     val originalRaster = gt.raster.resample(500, 500)
     val (_, rdd) = createTileLayerRDD(originalRaster, 5, 5, gt.crs)
+    val md = rdd.metadata
+    val overall = md.extent
+    val Extent(xmin, ymin, xmax, ymax) = overall
+    val half = Extent(xmin, ymin, xmin + (xmax - xmin) / 2, ymin + (ymax - ymin) / 2)
+    val small = Extent(xmin, ymin, xmin + (xmax - xmin) / 5, ymin + (ymax - ymin) / 5)
+
+    it("should correctly crop by the rdd extent") {
+      val count = rdd.crop(overall).count
+      count should be (25)
+    }
+
+    it("should correctly increase the number of tiles by 2 when going up one level") {
+      val resampled = rdd.resampleToZoom(5, 6)
+      val count = resampled.count
+      count should be (rdd.count * 4)
+
+      val gridBounds = rdd.metadata.bounds.get.toGridBounds
+      val resampledGridBounds = resampled.metadata.bounds.get.toGridBounds
+
+      resampledGridBounds.sizeLong should be (gridBounds.sizeLong * 4)
+    }
+  }
+
+  describe("Zoom Resample on MultibandTileLayerRDD - aspect.tif") {
+    val path = "raster/data/aspect.tif"
+    val gt = MultibandGeoTiff(path)
+    val originalRaster = gt.raster.resample(500, 500)
+    val rdd = createMultibandTileLayerRDD(sc, originalRaster, TileLayout(5, 5, 100, 100), gt.crs)
     val md = rdd.metadata
     val overall = md.extent
     val Extent(xmin, ymin, xmax, ymax) = overall
@@ -90,6 +118,41 @@ class ZoomResampleMethodsSpec extends FunSpec
 
       result.foreach { z =>
         z should be (6)
+      }
+    }
+  }
+
+  describe("Zoom Resample on MultibandTileLayerRDD - manual example") {
+    it("should correctly resample and filter in a larger example") {
+      val tile =
+        createTile(
+          Array(
+            1, 1,  2, 2,  3, 3,  4, 4,
+            1, 1,  2, 2,  3, 3,  4, 4,
+
+            5, 5,  6, 6,  7, 7,  8, 8,
+            5, 5,  6, 6,  7, 7,  8, 8,
+
+            9, 9,  10, 10,  11, 11,  12, 12,
+            9, 9,  10, 10,  11, 11,  12, 12,
+
+            13, 13,  13, 13,  14, 14,  15, 15,
+            13, 13,  13, 13,  14, 14,  15, 15
+          ), 8, 8)
+      val layer =
+        createMultibandTileLayerRDD(
+          sc,
+          MultibandTile(tile, tile, tile),
+          TileLayout(2, 2, 4, 4)
+        )
+
+      val resampled = layer.resampleToZoom(1, 2, GridBounds(1, 1, 1, 1))
+      val count = resampled.count
+      count should be (1)
+      val result = resampled.collect.head._2
+
+      result.foreach { z =>
+        z should be (Array(6, 6, 6))
       }
     }
   }


### PR DESCRIPTION
## Overview

This PR makes it so that both `TileLayerRDD`s and `MultibandTileLayerRDD`s can use the `ZoomResample` method.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature