### PR TITLE
Option[Partitioner] Parameter for TileRDDReproject

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -19,6 +19,7 @@ API Changes
   ``TileRDDReproject`` loses dependency on ``TileReprojectMethods`` in favor of ``RasterRegionReproject``
   - **New:** CollectionLayerReader now has an SPI interface.
   - **New:** ``ZoomResample`` can now be used on ``MultibandTileLayerRDD``\s.
+  - **New:** A ``Partitioner`` can be specified in the ``reproject`` methods of ``TileLayerRDD``.
 
 1.2.1
 _____

--- a/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
@@ -231,6 +231,14 @@ class TileRDDReprojectSpec extends FunSpec with TestEnvironment {
 
       actualPartitioner should be (expectedPartitioner)
     }
+
+    it("should have the designated Partitioner") {
+      val partitioner = new HashPartitioner(8)
+      val expectedPartitioner = Some(partitioner)
+      val actualPartitioner = rdd.reproject(ZoomedLayoutScheme(LatLng), expectedPartitioner)._2.partitioner
+
+      actualPartitioner should be (expectedPartitioner)
+    }
   }
 
   describe("Reprojected with the same scheme and CRS") {


### PR DESCRIPTION
## Overview

This PR adds an `Option[Partitioner]` parameter to `TileRDDReproject`. This will allow users to specify a `Partitioner` for the resulting `RDD` without having to do a `partitionBy`step afterwards . If no `Partitioner` is specified, then the resulting `RDD` will have the same `Partitioner` as its source.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Demo

```scala

val partitioner = new HashPartitioner(16)

rdd.reproject(ZoomedLayoutScheme(LatLng), Some(partitioner))
```

Closes #2554 