### PR TITLE
Optimize and Fix StreamingByteReader

### DIFF
--- a/util/build.sbt
+++ b/util/build.sbt
@@ -2,6 +2,7 @@ import Dependencies._
 
 name := "geotrellis-util"
 libraryDependencies ++= Seq(
+  spire,
   logging,
   scalatest % Test
 )


### PR DESCRIPTION
## Overview

This PR fixes the missing logic that is required when tracking position independently from buffer position. 

It also adds some logic to:
 - re-use existing buffer when incrementing to next read to prevent re-reading the same bytes
 - absorb reads that can be satisfied with current buffer
 - allow expanding the buffer on both sides and re-using existing bytes 

### Checklist

~- [ ] `docs/CHANGELOG.rst` updated, if necessary~
~- [ ] `docs` guides update, if necessary~
~- [ ] New user API has useful Scaladoc strings~
~- [ ] Unit tests added for bug-fix or new feature~

Connects: https://github.com/locationtech/geotrellis/pull/2564
