### PR TITLE
Query Results Will Now Have the Correct KeyBounds and Extent

### DIFF
--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerCopier.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerCopier.scala
@@ -22,7 +22,9 @@ import geotrellis.spark.io.AttributeStore.Fields
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.avro._
 import org.apache.spark.SparkContext
@@ -37,9 +39,9 @@ class AccumuloLayerCopier(
   getLayerWriter: LayerId => AccumuloLayerWriter
 ) extends LayerCopier[LayerId] {
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerManager.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerManager.scala
@@ -22,7 +22,9 @@ import geotrellis.spark.io.AttributeStore.Fields
 import geotrellis.spark.io.avro.AvroRecordCodec
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -36,30 +38,30 @@ class AccumuloLayerManager(attributeStore: AccumuloAttributeStore, instance: Acc
     AccumuloLayerDeleter(attributeStore, instance).delete(id)
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     AccumuloLayerCopier(instance).copy[K, V, M](from, to)
 
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     AccumuloLayerMover(instance).move[K, V, M](from, to)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     AccumuloLayerReindexer(instance).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     AccumuloLayerReindexer(instance).reindex[K, V, M](id, keyIndex)
 }

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReindexer.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReindexer.scala
@@ -21,7 +21,9 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json.JsonFormat
@@ -59,9 +61,9 @@ class AccumuloLayerReindexer(
     id.copy(name = s"${id.name}-${ZonedDateTime.now.toInstant.toEpochMilli}")
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)
@@ -81,9 +83,9 @@ class AccumuloLayerReindexer(
   }
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerCopier.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerCopier.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.io.cassandra
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json.JsonFormat
@@ -32,9 +34,9 @@ class CassandraLayerCopier(
   getLayerWriter: LayerId => CassandraLayerWriter
 ) extends LayerCopier[LayerId] {
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerManager.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerManager.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro.AvroRecordCodec
 import geotrellis.spark.io.index._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json.JsonFormat
@@ -33,30 +35,30 @@ class CassandraLayerManager(attributeStore: CassandraAttributeStore, instance: C
     CassandraLayerDeleter(attributeStore, instance).delete(id)
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     CassandraLayerCopier(instance).copy[K, V, M](from, to)
 
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     CassandraLayerMover(instance).move[K, V, M](from, to)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     CassandraLayerReindexer(instance).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     CassandraLayerReindexer(instance).reindex[K, V, M](id, keyIndex)
 }

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerReindexer.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerReindexer.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json.JsonFormat
@@ -62,9 +64,9 @@ class CassandraLayerReindexer(
     id.copy(name = s"${id.name}-${ZonedDateTime.now.toInstant.toEpochMilli}")
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)
@@ -84,9 +86,9 @@ class CassandraLayerReindexer(
   }
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -20,6 +20,8 @@ API Changes
   - **New:** CollectionLayerReader now has an SPI interface.
   - **New:** ``ZoomResample`` can now be used on ``MultibandTileLayerRDD``\s.
   - **New:** A ``Partitioner`` can be specified in the ``reproject`` methods of ``TileLayerRDD``.
+  - **Change:** Querying a layer will now produce a result whose metadata will have an ``Extent`` and
+    ``KeyBounds`` of the queried region and not of the whole layer.
 
 1.2.1
 _____

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseCollectionLayerReader.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseCollectionLayerReader.scala
@@ -19,7 +19,10 @@ package geotrellis.spark.io.hbase
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
+
 import org.apache.spark.SparkContext
 import spray.json._
 
@@ -29,9 +32,9 @@ class HBaseCollectionLayerReader(val attributeStore: AttributeStore, instance: H
   extends CollectionLayerReader[LayerId] {
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, rasterQuery: LayerQuery[K, M], filterIndexOnly: Boolean) = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -43,10 +46,13 @@ class HBaseCollectionLayerReader(val attributeStore: AttributeStore, instance: H
 
     val queryKeyBounds = rasterQuery(metadata)
 
+    val layerMetadata = updateQueriedMetadata[K, M](queryKeyBounds, metadata)
+
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
 
     val seq = HBaseCollectionReader.read[K, V](instance, header.tileTable, id, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
-    new ContextCollection(seq, metadata)
+
+    new ContextCollection(seq, layerMetadata)
   }
 }
 

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerCopier.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerCopier.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.io.hbase
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json.JsonFormat
@@ -32,9 +34,9 @@ class HBaseLayerCopier(
   getLayerWriter: LayerId => HBaseLayerWriter
 ) extends LayerCopier[LayerId] {
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerManager.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerManager.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro.AvroRecordCodec
 import geotrellis.spark.io.index._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json.JsonFormat
@@ -33,30 +35,30 @@ class HBaseLayerManager(attributeStore: HBaseAttributeStore, instance: HBaseInst
     HBaseLayerDeleter(attributeStore, instance).delete(id)
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     HBaseLayerCopier(instance).copy[K, V, M](from, to)
 
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     HBaseLayerMover(instance).move[K, V, M](from, to)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     HBaseLayerReindexer(instance).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     HBaseLayerReindexer(instance).reindex[K, V, M](id, keyIndex)
 }

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerReader.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerReader.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.io.hbase
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json._
@@ -32,9 +34,9 @@ class HBaseLayerReader(val attributeStore: AttributeStore, instance: HBaseInstan
   val defaultNumPartitions = sc.defaultParallelism
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, tileQuery: LayerQuery[K, M], numPartitions: Int, filterIndexOnly: Boolean) = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -46,10 +48,13 @@ class HBaseLayerReader(val attributeStore: AttributeStore, instance: HBaseInstan
 
     val queryKeyBounds = tileQuery(metadata)
 
+    val layerMetadata = updateQueriedMetadata[K, M](queryKeyBounds, metadata)
+
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
 
     val rdd = HBaseRDDReader.read[K, V](instance, header.tileTable, id, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
-    new ContextRDD(rdd, metadata)
+
+    new ContextRDD(rdd, layerMetadata)
   }
 }
 

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerReindexer.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerReindexer.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json.JsonFormat
@@ -62,9 +64,9 @@ class HBaseLayerReindexer(
     id.copy(name = s"${id.name}-${ZonedDateTime.now.toInstant.toEpochMilli}")
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)
@@ -83,9 +85,9 @@ class HBaseLayerReindexer(
   }
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3CollectionLayerReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3CollectionLayerReader.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import spray.json.JsonFormat
 
@@ -39,9 +41,9 @@ class S3CollectionLayerReader(val attributeStore: AttributeStore) extends Collec
   def collectionReader: S3CollectionReader = S3CollectionReader
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, rasterQuery: LayerQuery[K, M], filterIndexOnly: Boolean) = {
     if(!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -55,12 +57,15 @@ class S3CollectionLayerReader(val attributeStore: AttributeStore) extends Collec
     val prefix = header.key
 
     val queryKeyBounds = rasterQuery(metadata)
+
+    val layerMetadata = updateQueriedMetadata[K, M](queryKeyBounds, metadata)
+
     val maxWidth = Index.digits(keyIndex.toIndex(keyIndex.keyBounds.maxKey))
     val keyPath = (index: BigInt) => makePath(prefix, Index.encode(index, maxWidth))
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
     val seq = collectionReader.read[K, V](bucket, keyPath, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
 
-    new ContextCollection(seq, metadata)
+    new ContextCollection(seq, layerMetadata)
   }
 }
 

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerCopier.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerCopier.scala
@@ -21,7 +21,9 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro.AvroRecordCodec
 import geotrellis.spark.io.index.KeyIndex
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import com.amazonaws.services.s3.model.ObjectListing
 import org.apache.avro.Schema
@@ -50,9 +52,9 @@ class S3LayerCopier(
   }
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerManager.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerManager.scala
@@ -22,7 +22,9 @@ import geotrellis.spark.io.AttributeStore.Fields
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd._
@@ -36,30 +38,30 @@ class S3LayerManager(attributeStore: S3AttributeStore)(implicit sc: SparkContext
     S3LayerDeleter(attributeStore).delete(id)
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     S3LayerCopier(attributeStore).copy[K, V, M](from, to)
 
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     S3LayerMover(attributeStore).move[K, V, M](from, to)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     S3LayerReindexer(attributeStore).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     S3LayerReindexer(attributeStore).reindex[K, V, M](id, keyIndex)
 }

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/PersistenceSpec.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/PersistenceSpec.scala
@@ -21,7 +21,9 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.rdd.RDD
 import org.scalatest._
@@ -45,9 +47,9 @@ case class PersistenceSpecLayerIds(
 )
 
 abstract class PersistenceSpec[
-  K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+  K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
   V: AvroRecordCodec: ClassTag,
-  M: JsonFormat: Component[?, Bounds[K]]
+  M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
 ] extends FunSpec with Matchers with BeforeAndAfterAll {
 
   type TestReader = FilteringLayerReader[LayerId]

--- a/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
@@ -89,11 +89,11 @@ object TileLayerMetadata {
   implicit def toLayoutDefinition(md: TileLayerMetadata[_]): LayoutDefinition =
     md.layout
 
-  implicit def extentComponent[K]: GetComponent[TileLayerMetadata[K], Extent] =
-    GetComponent(_.extent)
-
   implicit def crsComponent[K]: GetComponent[TileLayerMetadata[K], CRS] =
     GetComponent(_.crs)
+
+  implicit def extentComponent[K: SpatialComponent]: Component[TileLayerMetadata[K], Extent] =
+    Component(_.extent, (md, extent) => md.copy(extent = extent))
 
   implicit def layoutComponent[K: SpatialComponent]: Component[TileLayerMetadata[K], LayoutDefinition] =
     Component(_.layout, (md, l) => md.copy(layout = l))

--- a/spark/src/main/scala/geotrellis/spark/io/CollectionLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/CollectionLayerReader.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.io
 import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 import spray.json._
 
 import java.net.URI
@@ -30,15 +32,15 @@ abstract class CollectionLayerReader[ID] { self =>
   val attributeStore: AttributeStore
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, rasterQuery: LayerQuery[K, M], indexFilterOnly: Boolean): Seq[(K, V)] with Metadata[M]
 
   def reader[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ]: Reader[ID, Seq[(K, V)] with Metadata[M]] =
     new Reader[ID, Seq[(K, V)] with Metadata[M]] {
       def read(id: ID): Seq[(K, V)] with Metadata[M] =
@@ -46,23 +48,23 @@ abstract class CollectionLayerReader[ID] { self =>
     }
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, rasterQuery: LayerQuery[K, M]): Seq[(K, V)] with Metadata[M] =
     read[K, V, M](id, rasterQuery, false)
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID): Seq[(K, V)] with Metadata[M] =
     read[K, V, M](id, new LayerQuery[K, M])
 
   def query[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](layerId: ID): BoundLayerQuery[K, M, Seq[(K, V)] with Metadata[M]] =
     new BoundLayerQuery(new LayerQuery, read[K, V, M](layerId, _))
 }

--- a/spark/src/main/scala/geotrellis/spark/io/FilteringLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/FilteringLayerReader.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.io
 import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.rdd._
 import spray.json._
@@ -44,43 +46,43 @@ abstract class FilteringLayerReader[ID] extends LayerReader[ID] {
 
     */
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, rasterQuery: LayerQuery[K, M], numPartitions: Int, indexFilterOnly: Boolean): RDD[(K, V)] with Metadata[M]
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, rasterQuery: LayerQuery[K, M], numPartitions: Int): RDD[(K, V)] with Metadata[M] =
     read(id, rasterQuery, numPartitions, false)
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, rasterQuery: LayerQuery[K, M]): RDD[(K, V)] with Metadata[M] =
     read(id, rasterQuery, defaultNumPartitions)
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, numPartitions: Int): RDD[(K, V)] with Metadata[M] =
     read(id, new LayerQuery[K, M], numPartitions)
 
   def query[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](layerId: ID): BoundLayerQuery[K, M, RDD[(K, V)] with Metadata[M]] =
     new BoundLayerQuery(new LayerQuery, read(layerId, _))
 
   def query[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](layerId: ID, numPartitions: Int): BoundLayerQuery[K, M, RDD[(K, V)] with Metadata[M]] =
     new BoundLayerQuery(new LayerQuery, read(layerId, _, numPartitions))
 }

--- a/spark/src/main/scala/geotrellis/spark/io/GenericLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GenericLayerCopier.scala
@@ -19,8 +19,9 @@ package geotrellis.spark.io
 import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index.KeyIndex
+import geotrellis.spark.tiling._
 import geotrellis.util._
-
+import geotrellis.vector._
 
 import org.apache.avro.Schema
 import org.apache.spark.rdd.RDD
@@ -35,9 +36,9 @@ class GenericLayerCopier[Header: JsonFormat](
 ) extends LayerCopier[LayerId] {
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/GenericLayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GenericLayerMover.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.io
 import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import spray.json._
 
@@ -27,9 +29,9 @@ import scala.reflect.ClassTag
 
 class GenericLayerMover[ID](layerCopier: LayerCopier[ID], layerDeleter: LayerDeleter[ID]) extends LayerMover[ID] {
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: ID, to: ID): Unit = {
     layerCopier.copy[K, V, M](from, to)
     layerDeleter.delete(from)

--- a/spark/src/main/scala/geotrellis/spark/io/GenericLayerReindexer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GenericLayerReindexer.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.avro._
 import spray.json._
@@ -39,9 +41,9 @@ abstract class GenericLayerReindexer[Header:JsonFormat](
   def getTmpId(id: LayerId): LayerId
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)
@@ -53,9 +55,9 @@ abstract class GenericLayerReindexer[Header:JsonFormat](
   }
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)

--- a/spark/src/main/scala/geotrellis/spark/io/LayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerCopier.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.io
 import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import spray.json._
 
@@ -27,8 +29,8 @@ import scala.reflect.ClassTag
 
 trait LayerCopier[ID] {
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: ID, to: ID): Unit
 }

--- a/spark/src/main/scala/geotrellis/spark/io/LayerManager.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerManager.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io.avro.AvroRecordCodec
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -32,27 +34,27 @@ trait LayerManager[ID] {
   def delete(id: ID): Unit
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: ID, to: ID): Unit
 
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: ID, to: ID): Unit
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, keyIndexMethod: KeyIndexMethod[K]): Unit
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, keyIndex: KeyIndex[K]): Unit
 
 }

--- a/spark/src/main/scala/geotrellis/spark/io/LayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerMover.scala
@@ -19,7 +19,9 @@ package geotrellis.spark.io
 import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import spray.json._
 
@@ -27,8 +29,8 @@ import scala.reflect.ClassTag
 
 trait LayerMover[ID] {
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: ID, to: ID): Unit
 }

--- a/spark/src/main/scala/geotrellis/spark/io/LayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerReader.scala
@@ -19,11 +19,14 @@ package geotrellis.spark.io
 import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
-import org.apache.avro.Schema
+import geotrellis.vector._
 
+import org.apache.avro.Schema
 import org.apache.spark.rdd._
 import org.apache.spark.SparkContext
+
 import spray.json._
 import scalaz.std.vector._
 import scalaz.concurrent.{Strategy, Task}
@@ -38,22 +41,22 @@ trait LayerReader[ID] {
   def defaultNumPartitions: Int
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, numPartitions: Int): RDD[(K, V)] with Metadata[M]
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID): RDD[(K, V)] with Metadata[M] =
     read(id, defaultNumPartitions)
 
   def reader[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ]: Reader[ID, RDD[(K, V)] with Metadata[M]] =
     new Reader[ID, RDD[(K, V)] with Metadata[M]] {
       def read(id: ID): RDD[(K, V)] with Metadata[M] =

--- a/spark/src/main/scala/geotrellis/spark/io/LayerReindexer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerReindexer.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import spray.json._
 
@@ -28,14 +30,14 @@ import scala.reflect.ClassTag
 
 trait LayerReindexer[ID] {
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, keyIndex: KeyIndex[K]): Unit
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: ID, keyIndexMethod: KeyIndexMethod[K]): Unit
 }

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerCopier.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 import AttributeStore.Fields
 
 import spray.json.JsonFormat
@@ -33,9 +35,9 @@ object FileLayerCopier {
   def apply(sourceAttributeStore: FileAttributeStore, targetAttributeStore: FileAttributeStore): LayerCopier[LayerId] =
     new LayerCopier[LayerId] {
       def copy[
-        K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+        K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
         V: AvroRecordCodec: ClassTag,
-        M: JsonFormat: GetComponent[?, Bounds[K]]
+        M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
       ](from: LayerId, to: LayerId): Unit = {
         if(targetAttributeStore.layerExists(to))
           throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerManager.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerManager.scala
@@ -22,7 +22,9 @@ import geotrellis.spark.io.AttributeStore.Fields
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd._
@@ -36,30 +38,30 @@ class FileLayerManager(attributeStore: FileAttributeStore)(implicit sc: SparkCon
     FileLayerDeleter(attributeStore).delete(id)
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     FileLayerCopier(attributeStore).copy[K, V, M](from, to)
 
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     FileLayerMover(attributeStore).move[K, V, M](from, to)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     FileLayerReindexer(attributeStore).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     FileLayerReindexer(attributeStore).reindex[K, V, M](id, keyIndex)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerMover.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 import AttributeStore.Fields
 
 import spray.json.JsonFormat
@@ -33,9 +35,9 @@ object FileLayerMover {
   def apply(sourceAttributeStore: FileAttributeStore, targetAttributeStore: FileAttributeStore): LayerMover[LayerId] =
     new LayerMover[LayerId] {
       def move[
-        K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+        K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
         V: AvroRecordCodec: ClassTag,
-        M: JsonFormat: GetComponent[?, Bounds[K]]
+        M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
       ](from: LayerId, to: LayerId): Unit = {
         if(targetAttributeStore.layerExists(to))
           throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerReader.scala
@@ -20,7 +20,9 @@ import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import spray.json.JsonFormat
@@ -43,9 +45,9 @@ class FileLayerReader(
   val defaultNumPartitions = sc.defaultParallelism
 
   def read[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, tileQuery: LayerQuery[K, M], numPartitions: Int, filterIndexOnly: Boolean) = {
     if(!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -58,12 +60,15 @@ class FileLayerReader(
     val layerPath = header.path
 
     val queryKeyBounds = tileQuery(metadata)
+
+    val layerMetadata = updateQueriedMetadata[K, M](queryKeyBounds, metadata)
+
     val maxWidth = Index.digits(keyIndex.toIndex(keyIndex.keyBounds.maxKey))
     val keyPath = KeyPathGenerator(catalogPath, layerPath, maxWidth)
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
     val rdd = FileRDDReader.read[K, V](keyPath, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema), Some(numPartitions))
 
-    new ContextRDD(rdd, metadata)
+    new ContextRDD(rdd, layerMetadata)
   }
 }
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerCopier.scala
@@ -21,7 +21,9 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index.KeyIndex
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
@@ -39,9 +41,9 @@ class HadoopLayerCopier(
   (implicit sc: SparkContext) extends LayerCopier[LayerId] {
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerManager.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerManager.scala
@@ -22,7 +22,9 @@ import geotrellis.spark.io.AttributeStore.Fields
 import geotrellis.spark.io.avro.AvroRecordCodec
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -36,30 +38,30 @@ class HadoopLayerManager(attributeStore: HadoopAttributeStore)(implicit sc: Spar
     HadoopLayerDeleter(attributeStore).delete(id)
 
   def copy[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     HadoopLayerCopier(attributeStore).copy[K, V, M](from, to)
 
   def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit =
     HadoopLayerMover(attributeStore).move[K, V, M](from, to)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     HadoopLayerReindexer(attributeStore).reindex[K, V, M](id, keyIndex)
 
   def reindex[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     HadoopLayerReindexer(attributeStore).reindex[K, V, M](id, keyIndexMethod)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerMover.scala
@@ -21,7 +21,9 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
 import geotrellis.spark.io.index.KeyIndex
 import geotrellis.spark.io.json._
+import geotrellis.spark.tiling._
 import geotrellis.util._
+import geotrellis.vector._
 
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
@@ -40,9 +42,9 @@ class HadoopLayerMover(
 )(implicit sc: SparkContext) extends LayerMover[LayerId] {
 
   override def move[
-    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
+    K: AvroRecordCodec: Boundable: JsonFormat: ClassTag: SpatialComponent,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]: Component[?, LayoutDefinition]: Component[?, Extent]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)


### PR DESCRIPTION
## Overview

This PR makes it so that the resulting `TileLayerMetadata` of a `query` will contain the correct `KeyBounds` and `Extent` of the queried region. This is opposed to the current output which will have the `KeyBounds` and `Extent` for the whole layer.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

Closes #2543 
