### PR TITLE
Refactor StreamingByteReader to avoid spire-math dependency

### DIFF
--- a/util/build.sbt
+++ b/util/build.sbt
@@ -2,7 +2,6 @@ import Dependencies._
 
 name := "geotrellis-util"
 libraryDependencies ++= Seq(
-  spire,
   logging,
   scalatest % Test
 )


### PR DESCRIPTION
Unfortunately spark includes spire-math in its class path.

Spark version 2.1.0 depends on `org.spire-math.spire_2.11-0.7.4` and version 2.2.0 depends on `org.spire-math.spire_2.11-0.13.0`.  The implementation of `Interval` differs between the two.

This has already caused binary compatibility woes in GeoPySpark, likely this would keep happening to people. Its easy enough to refactor the `StreamingByteReader` to avoid the `Interval` usage altogether and instead lean on `scala.collection.immutable.NumericRange` as a class that has a `start` and an `end`.
