### PR TITLE
Fixes to fractional polygon rasterizer

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizer.scala
@@ -127,7 +127,7 @@ object FractionalRasterizer {
             Point(pixelMaxX, pixelMinY),
             Point(pixelMinX, pixelMinY)
           ).jtsGeom
-          val fraction = (pixel.intersection(localPoly)).getArea / pixel.getArea
+          val fraction = if (localPoly.isEmpty) 0.0 else (util.Intersection.polygonalRegions(pixel, localPoly)).map(_.area).foldLeft(0.0)(_ + _) / pixel.getArea
 
           if (fraction > 0.0) {
             if (!seen.contains(pair)) {
@@ -157,7 +157,7 @@ object FractionalRasterizer {
             Point(pixelMaxX, pixelMinY),
             Point(pixelMinX, pixelMinY)
           ).jtsGeom
-          val fraction = (pixel.intersection(localPoly)).getArea / pixel.getArea
+          val fraction = if (localPoly.isEmpty) 0.0 else (util.Intersection.polygonalRegions(pixel, localPoly)).map(_.area).foldLeft(0.0)(_ + _) / pixel.getArea
 
           if (fraction > 0.0) {
             if (!seen.contains(pair)) {

--- a/vector/src/main/scala/geotrellis/vector/util/Intersection.scala
+++ b/vector/src/main/scala/geotrellis/vector/util/Intersection.scala
@@ -19,26 +19,33 @@ import geotrellis.vector._
 
 object Intersection {
 
+  def unpackGeometryCollection(gc: GeometryCollection): Seq[Geometry] =
+    gc.geometryCollections.flatMap(unpackGeometryCollection(_)) ++ gc.geometries.filter(!_.isInstanceOf[GeometryCollection])
+
+  private def polysFromGC(gc: GeometryCollection): Seq[Polygon] =
+    unpackGeometryCollection(gc).flatMap{ g => g match {
+      case p: Polygon => Seq(p)
+      case mp: MultiPolygon => mp.polygons
+      case _ => Seq.empty
+    }}
+
   private def polyGeomIntersection(poly: Polygon, geom: Geometry): Seq[Polygon] = {
     geom match {
       case poly2: Polygon => poly2.intersection(poly) match {
         case PolygonResult(p) => Seq(p)
         case MultiPolygonResult(mp) => mp.polygons.toSeq
-        case GeometryCollectionResult(gc) =>
-          gc.multiPolygons.flatMap{ mp => mp.polygons.toSeq } ++ gc.polygons
+        case GeometryCollectionResult(gc) => polysFromGC(gc)
         case _ => Seq.empty[Polygon]
       }
       case mp: MultiPolygon => mp.intersection(poly) match {
         case PolygonResult(p) => Seq(p)
         case MultiPolygonResult(mp) => mp.polygons.toSeq
-        case GeometryCollectionResult(gc) =>
-          gc.multiPolygons.flatMap{ mp => mp.polygons.toSeq } ++ gc.polygons
+        case GeometryCollectionResult(gc) => polysFromGC(gc)
         case _ => Seq.empty[Polygon]
       }
       case gc: GeometryCollection => gc.intersection(poly) match {
         // In testing, GeometryCollection.intersection only seems to return GeometryCollectionResult
-        case GeometryCollectionResult(res) =>
-          res.multiPolygons.flatMap{ mp => mp.polygons.toSeq } ++ res.polygons
+        case GeometryCollectionResult(res) => polysFromGC(res)
         case _ => Seq.empty[Polygon]
       }
       case _ =>
@@ -52,8 +59,7 @@ object Intersection {
     a match {
       case poly: Polygon => polyGeomIntersection(poly, b)
       case multipoly: MultiPolygon => multipoly.polygons.toSeq.flatMap{ p => polyGeomIntersection(p, b) }
-      case gc: GeometryCollection =>
-        (gc.multiPolygons.flatMap(_.polygons) ++ gc.polygons).flatMap{ p => polyGeomIntersection(p, b) }
+      case gc: GeometryCollection => polysFromGC(gc).flatMap{ p => polyGeomIntersection(p, b) }
       case _ => Seq.empty[Polygon] // Both participants must contain polygonal regions
     }
   }

--- a/vector/src/main/scala/geotrellis/vector/util/Intersection.scala
+++ b/vector/src/main/scala/geotrellis/vector/util/Intersection.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geotrellis.vector.util
+
+import geotrellis.vector._
+
+object Intersection {
+
+  private def polyGeomIntersection(poly: Polygon, geom: Geometry): Seq[Polygon] = {
+    geom match {
+      case poly2: Polygon => poly2.intersection(poly) match {
+        case PolygonResult(p) => Seq(p)
+        case MultiPolygonResult(mp) => mp.polygons.toSeq
+        case GeometryCollectionResult(gc) =>
+          gc.multiPolygons.flatMap{ mp => mp.polygons.toSeq } ++ gc.polygons
+        case _ => Seq.empty[Polygon]
+      }
+      case mp: MultiPolygon => mp.intersection(poly) match {
+        case PolygonResult(p) => Seq(p)
+        case MultiPolygonResult(mp) => mp.polygons.toSeq
+        case GeometryCollectionResult(gc) =>
+          gc.multiPolygons.flatMap{ mp => mp.polygons.toSeq } ++ gc.polygons
+        case _ => Seq.empty[Polygon]
+      }
+      case gc: GeometryCollection => gc.intersection(poly) match {
+        // In testing, GeometryCollection.intersection only seems to return GeometryCollectionResult
+        case GeometryCollectionResult(res) =>
+          res.multiPolygons.flatMap{ mp => mp.polygons.toSeq } ++ res.polygons
+        case _ => Seq.empty[Polygon]
+      }
+      case _ =>
+        Seq.empty
+    }
+  }
+
+  /** Returns only polygonal regions of an intersection
+   */
+  def polygonalRegions(a: Geometry, b: Geometry): Seq[Polygon] = {
+    a match {
+      case poly: Polygon => polyGeomIntersection(poly, b)
+      case multipoly: MultiPolygon => multipoly.polygons.toSeq.flatMap{ p => polyGeomIntersection(p, b) }
+      case gc: GeometryCollection =>
+        (gc.multiPolygons.flatMap(_.polygons) ++ gc.polygons).flatMap{ p => polyGeomIntersection(p, b) }
+      case _ => Seq.empty[Polygon] // Both participants must contain polygonal regions
+    }
+  }
+
+}

--- a/vector/src/test/scala/spec/geotrellis/vector/util/IntersectionSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/util/IntersectionSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package geotrellis.vector.util
+
+import geotrellis.vector._
+
+import org.scalatest._
+
+class IntersectionSpec extends FunSpec with Matchers {
+  describe("Intersection utils") {
+    it("should return only the polygonal portion of an intersection with a tangency") {
+      val lowertri = Polygon((0.0,0.0), (1.0,0.0), (0.0,1.0), (0.0,0.0))
+      val poly = Polygon((0.6,0.6), (0.75,0.25), (1.0,1.0), (-0.1,0.5), (0.6,0.6))
+
+      val GeometryCollectionResult(gc) = lowertri.intersection(poly)
+      val inter = gc.polygons.head
+
+      Intersection.polygonalRegions(lowertri, poly) should be (Seq(inter))
+    }
+
+    it("should produce no result for line-polygon intersection") {
+      Intersection.polygonalRegions(Polygon((0.0,0.0), (1.0,0.0), (0.0,1.0), (0.0,0.0)),
+                                    Line((-1.0,-1.0),(1.0,1.0))) should be (Seq.empty[Polygon])
+    }
+
+    it("should produce the correct result for non-intersecting polygons") {
+      Intersection.polygonalRegions(Polygon((0.0,0.0), (1.0,0.0), (0.0,1.0), (0.0,0.0)),
+                                    Polygon((1.0,1.0), (2.0,1.0), (1.0,2.0), (1.0,1.0))) should be (Seq.empty[Polygon])
+    }
+
+    it("should produce the correct result for geometry collection") {
+      val lowertri = Polygon((0.0,0.0), (1.0,0.0), (0.0,1.0), (0.0,0.0))
+      val poly = Polygon((0.6,0.6), (0.75,0.25), (1.0,1.0), (-0.1,0.5), (0.6,0.6))
+      val line = Line((-1.0,-1.0),(1.0,1.0))
+      val gc = GeometryCollection(Seq(poly, line))
+
+      val GeometryCollectionResult(res) = lowertri.intersection(poly)
+      val inter = res.polygons.head
+
+      Intersection.polygonalRegions(lowertri, gc) should be (Seq(inter))
+    }
+  }
+}


### PR DESCRIPTION
## Overview

In rare cases, a polygon-polygon intersection will result in a geometry collection.  In that situation, the FractionalRasterizer will fail.  This PR fixes that problem.

### Checklist

- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Notes

This PR also introduces a utility class in the vector library to assist in pulling salient information from intersection results.  This class can most likely be extended in useful ways, considering that intersections can have complicated type semantics and handling the many possible cases is error-prone.