### PR TITLE
Prevent Cast Exceptions When Reading From the Cache

### DIFF
--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStoreSpec.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStoreSpec.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.spark.io.accumulo
 
+import geotrellis.spark._
 import geotrellis.spark.io._
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 
@@ -28,4 +29,13 @@ class AccumuloAttributeStoreSpec extends AttributeStoreSpec {
   )
 
   lazy val attributeStore = new AccumuloAttributeStore(accumulo.connector, "attributes")
+
+  it("should read the Layer's Header as a LayerHeader and then an as an AccumuloLayerHeader") {
+    val header = AccumuloLayerHeader("SpatialKey", "Tile", attributeStore.attributeTable)
+
+    attributeStore.write[AccumuloLayerHeader](LayerId("test1", 1), "header", header)
+
+    attributeStore.readHeader[LayerHeader](LayerId("test1", 1))
+    attributeStore.readHeader[AccumuloLayerHeader](LayerId("test1", 1))
+  }
 }

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -26,8 +26,10 @@ Fixes
 
 - `StreamingHistogram.binCount now returns non-zero counts <https://github.com/locationtech/geotrellis/pull/2590>`__
 - `HilbertSpatialKeyIndex index offset <https://github.com/locationtech/geotrellis/pull/2586>`__
-  - **Note:** Existing spatial layers using Hilbert index will need to be updated, see PR for directions. 
-  
+  - **Note:** Existing spatial layers using Hilbert index will need to be updated, see PR for directions.
+- Fixed ``CastException`` that sometimes occured when reading cached attributes.
+
+
 1.2.1
 _____
 *2018 Jan 3*


### PR DESCRIPTION
## Overview

This PR resolves an issue where reading an attribute from the cache will fail if that attribute was read previously as a different type. For example, reading the `LayerHeader` from a layer and then reading an `AccumuloLayerHeader` from the same layer will result in a cast exception from trying to cast a `LayerHeader` as an `AccumuloLayerHeader`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature
