### PR TITLE
Moved to shields.io for maven badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GeoTrellis
 
-[![Build Status](https://api.travis-ci.org/locationtech/geotrellis.svg)](http://travis-ci.org/locationtech/geotrellis) [![Join the chat at https://gitter.im/geotrellis/geotrellis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/geotrellis/geotrellis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.locationtech.geotrellis/geotrellis-spark_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.locationtech.geotrellis/geotrellis-spark_2.11)
+[![Build Status](https://api.travis-ci.org/locationtech/geotrellis.svg)](http://travis-ci.org/locationtech/geotrellis) [![Join the chat at https://gitter.im/geotrellis/geotrellis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/geotrellis/geotrellis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Maven Central](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/org/locationtech/geotrellis/geotrellis-spark_2.11/maven-metadata.xml.svg)](http://search.maven.org/#search%7Cga%7C1%7Corg.locationtech.geotrellis)
 [![ReadTheDocs](https://readthedocs.org/projects/geotrellis/badge/?version=latest)](http://geotrellis.readthedocs.io/en/latest/)
 [![Changelog](https://img.shields.io/badge/changelog-v1.2.0-brightgreen.svg)](https://geotrellis.readthedocs.io/en/latest/CHANGELOG.html)
 [![Contributing](https://img.shields.io/badge/contributing-see%20conditions-brightgreen.svg)](https://github.com/locationtech/geotrellis/blob/master/docs/CONTRIBUTING.rst)


### PR DESCRIPTION
Moves from a one-off service someone was nice enough to stand up on Heroku to shields.io for our maven badge.

https://github.com/jirutka/maven-badges/issues/22#issuecomment-377363158