### PR TITLE
Build GeoTiff overviews by resampling the whole base tile

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffBuilder.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffBuilder.scala
@@ -62,7 +62,6 @@ trait GeoTiffBuilder[T <: CellGrid] extends Serializable {
     * @param segments keyed by (column, row) in tile layout
     * @param segmentLayout of the GeoTiff segments
     * @param cellType of desired tile
-    * @param storageMethod for multiband tiles
     * @param compression method for segments
     */
   def makeTile(


### PR DESCRIPTION
This approach avoids numerical differences in partial vs while tile resample.
They were particularly apparently with `NearestNeighbor` resample method.

Another change in this PR is the restriction that overviews will always have the same extent as the underlying raster. This change is to match GDAL behavior. It should be noted that it may cause stretching/squishing of the overview pixels where the overview pixel boundaries do not align with base layer pixel boundaries. This will happen when base raster pixel column/row count is not a multiple of the decimation factor.

In structured COG case however the base tile will always have a pixel count that is power of two and the case above will be avoided.

Additionally we trade memory for performance by forcing the base tile to ArrayTile before resampling.