### PR TITLE
Uncompressed MultibandGeoTiffs Will Now Convert to the Correct CellType

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixes
 - `HilbertSpatialKeyIndex index offset <https://github.com/locationtech/geotrellis/pull/2586>`__
   - **Note:** Existing spatial layers using Hilbert index will need to be updated, see PR for directions.
 - Fixed ``CastException`` that sometimes occured when reading cached attributes.
+- Uncompressed GeoTiffMultibandTiles will now convert to the correct CellType
 
 
 1.2.1

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
@@ -699,7 +699,7 @@ abstract class GeoTiffMultibandTile(
       segmentLayout,
       compression,
       bandCount,
-      cellType,
+      newCellType,
       Some(bandType),
       overviews = overviews.map(_.convert(newCellType))
     )

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
@@ -127,6 +127,28 @@ class GeoTiffMultibandTileSpec extends FunSpec
     }
   }
 
+  describe("Multiband cellType conversion") {
+    it("should convert the cellType with convert") {
+      val actual =
+        MultibandGeoTiff.compressed(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(UShortCellType)
+
+      val expected =
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(UShortCellType)
+
+      assertEqual(expected, actual)
+    }
+
+    it("should convert the cellType with interpretAs") {
+      val actual =
+        MultibandGeoTiff.compressed(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.interpretAs(UShortCellType)
+
+      val expected =
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.interpretAs(UShortCellType)
+
+      assertEqual(expected, actual)
+    }
+  }
+
   describe("Multiband subset combine methods") {
     it("should work the same on integer-valued GeoTiff tiles as Array tiles") {
       val actual = {


### PR DESCRIPTION
## Overview

This PR fixes an oversight that caused `convert` and `interpretAs` to not work on `GeoTiffMultibandTile`s.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

Closes #2616 
