### PR TITLE
Expose GeomFactory into the user API and move vector project to use pureconfig

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -29,6 +29,5 @@ object GeomFactory extends LazyLogging {
   val precisionModel: PrecisionModel = JtsConfig.precisionModel
   lazy val simplifier: GeometryPrecisionReducer = JtsConfig.simplifier
 
-  val coordinateSequenceFactory: CoordinateSequenceFactory = CoordinateArraySequenceFactory.instance
-  val factory: GeometryFactory = new geom.GeometryFactory(precisionModel, 0, coordinateSequenceFactory)
+  val factory: GeometryFactory = new geom.GeometryFactory(precisionModel)
 }

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -16,57 +16,19 @@
 
 package geotrellis.vector
 
-import com.typesafe.config.ConfigFactory
+import geotrellis.util.LazyLogging
+import geotrellis.vector.conf.JtsConfig
+
 import com.vividsolutions.jts.geom
 import com.vividsolutions.jts.geom.impl.CoordinateArraySequenceFactory
 import com.vividsolutions.jts.geom.{CoordinateSequenceFactory, GeometryFactory, PrecisionModel}
 import com.vividsolutions.jts.precision.GeometryPrecisionReducer
-import geotrellis.util.LazyLogging
-
-import scala.util.Try
 
 object GeomFactory extends LazyLogging {
-
-  private[vector] val precisionType = {
-    val setting = Try(ConfigFactory.load().getString("geotrellis.jts.precision.type").toLowerCase)
-    if (setting.isSuccess)
-      setting.get
-    else {
-      logger.warn("No value specified for geotrellis.jts.precision.type; falling back to \"floating\"")
-      "floating"
-    }
-  }
-
-  private[vector] val precisionModel = precisionType match {
-    case "floating" => new PrecisionModel()
-    case "floating_single" => new PrecisionModel(PrecisionModel.FLOATING_SINGLE)
-    case "fixed" =>
-      val scaleFromConfig = Try(ConfigFactory.load().getDouble("geotrellis.jts.precision.scale"))
-      val scale =
-        if (scaleFromConfig.isSuccess)
-          scaleFromConfig.get
-        else {
-          logger.warn("No value specified in application.conf for geotrellis.jts.precision.scale; using default")
-          1e12
-        }
-      new PrecisionModel(scale)
-    case s => throw new IllegalArgumentException(s"""Unrecognized JTS precision model, ${precisionType}; expected "floating", "floating_single", or "fixed" """)
-  }
+  val precisionType: String = JtsConfig.precisionType
+  val precisionModel: PrecisionModel = JtsConfig.precisionModel
+  lazy val simplifier: GeometryPrecisionReducer = JtsConfig.simplifier
 
   val coordinateSequenceFactory: CoordinateSequenceFactory = CoordinateArraySequenceFactory.instance
   val factory: GeometryFactory = new geom.GeometryFactory(precisionModel, 0, coordinateSequenceFactory)
-
-  // 12 digits is maximum to avoid [[TopologyException]], see https://web.archive.org/web/20160226031453/http://tsusiatsoftware.net/jts/jts-faq/jts-faq.html#D9
-  private[vector] lazy val simplifier = {
-    val simplificationPrecision = Try(ConfigFactory.load().getDouble("geotrellis.jts.simplification.scale"))
-    val scale =
-      if (simplificationPrecision.isSuccess)
-        simplificationPrecision.get
-      else {
-        logger.warn("No geotrellis.jts.simplification.scale given, assuming default value")
-        1e12
-      }
-    new GeometryPrecisionReducer(new PrecisionModel(scale))
-  }
-
 }

--- a/vector/src/main/scala/geotrellis/vector/conf/JtsConfig.scala
+++ b/vector/src/main/scala/geotrellis/vector/conf/JtsConfig.scala
@@ -1,0 +1,27 @@
+package geotrellis.vector.conf
+
+import geotrellis.util.LazyLogging
+
+import com.vividsolutions.jts.geom.PrecisionModel
+import com.vividsolutions.jts.precision.GeometryPrecisionReducer
+
+case class Simplification(scale: Double = 1e12) {
+  // 12 digits is maximum to avoid [[TopologyException]], see https://web.archive.org/web/20160226031453/http://tsusiatsoftware.net/jts/jts-faq/jts-faq.html#D9
+  lazy val simplifier: GeometryPrecisionReducer = new GeometryPrecisionReducer(new PrecisionModel(scale))
+}
+case class Precision(`type`: String = "floating")
+case class JtsConfig(precision: Precision = Precision(), simplification: Simplification = Simplification()) extends LazyLogging {
+  val precisionType: String = precision.`type`
+  val precisionModel: PrecisionModel = precisionType match {
+    case "floating" => new PrecisionModel()
+    case "floating_single" => new PrecisionModel(PrecisionModel.FLOATING_SINGLE)
+    case "fixed" => new PrecisionModel(simplification.scale)
+    case _ => throw new IllegalArgumentException(s"""Unrecognized JTS precision model, ${precisionType}; expected "floating", "floating_single", or "fixed" """)
+  }
+  val simplifier: GeometryPrecisionReducer = simplification.simplifier
+}
+
+object JtsConfig {
+  lazy val conf: JtsConfig = pureconfig.loadConfigOrThrow[JtsConfig]("geotrellis.jts")
+  implicit def jtsConfigToClass(obj: JtsConfig.type): JtsConfig = conf
+}


### PR DESCRIPTION
## Overview

When working with JTS geometries directly in client code, it's useful to have access to the same `Geometry` and `CoordinateSequence` factories that GT is using (vs. creating local instances w/ potentially differing settings). All other members remain private to the `geotrellis.vector` package.

More controversially, this switches GT's default `CoordinateSequenceFactory` to `PackedCoordinateSequenceFactory` in order to reduce the number of objects allocated (`double[]` is used rather than `Coordinate[]`) and reduce pressure on the GC.

This shouldn't affect client implementations unless `CoordinateSequence`s are explicitly cast; this shouldn't occur and isn't necessary when the `CoordinateSequences` helper class is used.