### PR TITLE
Re-introduce use of defensive .clone in vertices method for Line

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/Line.scala
+++ b/vector/src/main/scala/geotrellis/vector/Line.scala
@@ -96,7 +96,7 @@ case class Line(jtsGeom: jts.LineString) extends Geometry
     val size = jtsGeom.getNumPoints
     val arr = Array.ofDim[Point](size)
     cfor(0)(_ < arr.size, _ + 1) { i =>
-      arr(i) = Point(jtsGeom.getPointN(i))
+      arr(i) = Point(jtsGeom.getPointN(i).clone.asInstanceOf[jts.Point])
     }
     arr
   }


### PR DESCRIPTION
Rolling back the change to get code base to consistent point. I agree with the trade off on performance vs immutability here, but the such usage of `.clone` is prevalent in `geotrellis.vector` and any changes there should be part of a single principled PR.

While not ideal I assume the need currently the need fulfilled by this change can be met by reaching into `line.jtsGeom` and iterating over `getPointN` directly.

Created issue for follow up discussion: https://github.com/locationtech/geotrellis/issues/2622

@mojodna @pomadchin @lossyrob 