### PR TITLE
Reading/Writing COG Layer Attributes

### DIFF
--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerUpdater.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerUpdater.scala
@@ -40,7 +40,7 @@ class CassandraLayerUpdater(
     V: AvroRecordCodec: ClassTag,
     M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyBounds: KeyBounds[K], mergeFunc: (V, V) => V): Unit = {
-    val CassandraLayerHeader(_, _, keyspace, table) = attributeStore.readHeader[CassandraLayerHeader](id)
+    val CassandraLayerHeader(_, _, keyspace, table, _) = attributeStore.readHeader[CassandraLayerHeader](id)
     val layerWriter = new CassandraLayerWriter(attributeStore, instance, keyspace, table)
     layerWriter.update(id, rdd, mergeFunc)
   }
@@ -50,7 +50,7 @@ class CassandraLayerUpdater(
     V: AvroRecordCodec: ClassTag,
     M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
-    val CassandraLayerHeader(_, _, keyspace, table) = attributeStore.readHeader[CassandraLayerHeader](id)
+    val CassandraLayerHeader(_, _, keyspace, table, _) = attributeStore.readHeader[CassandraLayerHeader](id)
     val layerWriter = new CassandraLayerWriter(attributeStore, instance, keyspace, table)
     layerWriter.overwrite(id, rdd)
   }

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,11 @@ API Changes
   - **New:** Compression ``level`` of GeoTiffs can be specified in the ``DeflateCompression`` constructor.
   - **Change:**: The Ascii draw methods are now method extensions of ``Tile``.
   - **Change:** Replace `geotrellis.util.Functor` with `cats.Functor`
+  - **New:** A new type called ``LayerType`` has been created to help identify the nature of a layer (either Avro or COG).
+  - **New:** ``LayerHeader``\s now have an additional parameter: ``layerType``.
+  - **Change:** The attribute name for ``COGLayerStorageMetadata`` is now ``metadata`` instead of ``cog_metadata``.
+  - **New:** ``AttributeStore`` now has four new methods: ``layerType``, ``isCOGLayer``, ``readCOGLayerAttributes``,
+    and ``writeCOGLayerAttributes``.
 
 Fixes
 ^^^^^
@@ -36,6 +41,12 @@ Fixes
 - ``GeoTiffReader`` can now read tiffs that are missing the ``NewSubfileType`` tag.
 - Pyramiding code will once again respect resampling method and will now actually reduce shuffle volume by resampling
   tiles on map side of pyramid operation
+- Uncompressed GeoTiffMultibandTiles will now convert to the correct CellType.
+- COGLayer attributes can be accessed via the various read attribute methods in
+  ``AttributeStore`` (ie ``readMetadata``, ``readHeader``, etc)
+- The regex used to match files for the ``HadoopLayerAttributeStore`` and ``FileLayerAttributeStore`` has been
+  expanded to include more characters.
+- ``HadoopAttributeStore.availableAttributes`` has been fixed so that it'll now list all attribute files.
 
 
 1.2.1

--- a/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGCollectionLayerReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGCollectionLayerReader.scala
@@ -51,7 +51,7 @@ class S3COGCollectionLayerReader(
   ](id: LayerId, rasterQuery: LayerQuery[K, TileLayerMetadata[K]]) = {
     val header =
       try {
-        attributeStore.read[S3LayerHeader](LayerId(id.name, 0), COGAttributeStore.Fields.header)
+        attributeStore.readHeader[S3LayerHeader](LayerId(id.name, 0))
       } catch {
         // to follow GeoTrellis Layer Readers logic
         case e: AttributeNotFoundError => throw new LayerNotFoundError(id).initCause(e)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGLayerReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGLayerReader.scala
@@ -54,7 +54,7 @@ class S3COGLayerReader(
   ](id: LayerId, tileQuery: LayerQuery[K, TileLayerMetadata[K]], numPartitions: Int) = {
     val header =
       try {
-        attributeStore.read[S3LayerHeader](LayerId(id.name, 0), COGAttributeStore.Fields.header)
+        attributeStore.readHeader[S3LayerHeader](LayerId(id.name, 0))
       } catch {
         // to follow GeoTrellis Layer Readers logic
         case e: AttributeNotFoundError => throw new LayerNotFoundError(id).initCause(e)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGLayerWriter.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGLayerWriter.scala
@@ -41,15 +41,16 @@ class S3COGLayerWriter(
     val sc = cogLayer.layers.head._2.sparkContext
     val samplesAccumulator = sc.collectionAccumulator[IndexedSimpleSource](VRT.accumulatorName(layerName))
     val storageMetadata = COGLayerStorageMetadata(cogLayer.metadata, keyIndexes)
-    attributeStore.write(layerId0, COGAttributeStore.Fields.metadata, storageMetadata)
 
     val header = S3LayerHeader(
       keyClass = classTag[K].toString(),
       valueClass = classTag[V].toString(),
       bucket = bucket,
-      key = keyPrefix
+      key = keyPrefix,
+      layerType = COGLayerType
     )
-    attributeStore.write(layerId0, COGAttributeStore.Fields.header, header)
+
+    attributeStore.writeCOGLayerAttributes(layerId0, header, storageMetadata)
 
     val s3Client = getS3Client() // for saving VRT from Accumulator
 

--- a/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGValueReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGValueReader.scala
@@ -44,7 +44,7 @@ class S3COGValueReader(
   ](layerId: LayerId): Reader[K, V] = {
     val header =
       try {
-        attributeStore.read[S3LayerHeader](LayerId(layerId.name, 0), COGAttributeStore.Fields.header)
+        attributeStore.readHeader[S3LayerHeader](LayerId(layerId.name, 0))
       } catch {
         case e: AttributeNotFoundError => throw new LayerNotFoundError(layerId).initCause(e)
       }

--- a/s3/src/test/scala/geotrellis/spark/io/s3/cog/COGS3AttributeStoreSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/cog/COGS3AttributeStoreSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.io.s3.cog
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.cog._
+import geotrellis.spark.io.s3._
+import geotrellis.spark.io.s3.testkit._
+
+class COGS3AttributeStoreSpec extends COGAttributeStoreSpec {
+  val bucket = "attribute-store-test-mock-bucket"
+  val prefix = "catalog"
+
+  lazy val header = S3LayerHeader("geotrellis.spark.SpatialKey", "geotrellis.raster.Tile", bucket, prefix, COGLayerType)
+  lazy val attributeStore: AttributeStore = new S3AttributeStore(bucket, prefix) {
+    override val s3Client = new MockS3Client()
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/io/AttributeCaching.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/AttributeCaching.scala
@@ -43,6 +43,12 @@ trait AttributeCaching { self: AttributeStore =>
     else
       read[JsValue](layerId, attributeName).convertTo[T]
 
+  def cacheLayerType(layerId: LayerId, layerType: LayerType): LayerType =
+    if (enabled)
+      LayerType.fromString(cache.get(layerId -> "layerType", { _ => JsString(layerType.toString) }).convertTo[String])
+    else
+      layerType
+
   def cacheWrite[T: JsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
     if(enabled) cache.put(layerId -> attributeName, value.toJson)
     write[T](layerId, attributeName, value)

--- a/spark/src/main/scala/geotrellis/spark/io/AttributeCaching.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/AttributeCaching.scala
@@ -45,7 +45,7 @@ trait AttributeCaching { self: AttributeStore =>
 
   def cacheLayerType(layerId: LayerId, layerType: LayerType): LayerType =
     if (enabled)
-      LayerType.fromString(cache.get(layerId -> "layerType", { _ => JsString(layerType.toString) }).convertTo[String])
+      cache.get(layerId -> "layerType", { _ => layerType.toJson }).convertTo[LayerType]
     else
       layerType
 

--- a/spark/src/main/scala/geotrellis/spark/io/AttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/AttributeStore.scala
@@ -66,8 +66,11 @@ object AttributeStore {
   object Fields {
     val metadataBlob = "metadata"
     val header = "header"
-    val keyIndex = "keyIndex"
     val metadata = "metadata"
+  }
+
+  object AvroLayerFields {
+    val keyIndex = "keyIndex"
     val schema = "schema"
   }
 

--- a/spark/src/main/scala/geotrellis/spark/io/AttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/AttributeStore.scala
@@ -38,6 +38,13 @@ trait AttributeStore extends  AttributeCaching with LayerAttributeStore {
   def layerIds: Seq[LayerId]
   def availableAttributes(id: LayerId): Seq[String]
 
+  def isCOGLayer(id: LayerId): Boolean = {
+    layerType(id) match {
+      case COGLayerType => true
+      case _ => false
+    }
+  }
+
   def layerType(id: LayerId): LayerType = {
     lazy val layerType = readHeader[LayerHeader](id).layerType
     cacheLayerType(id, layerType)

--- a/spark/src/main/scala/geotrellis/spark/io/AttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/AttributeStore.scala
@@ -38,6 +38,11 @@ trait AttributeStore extends  AttributeCaching with LayerAttributeStore {
   def layerIds: Seq[LayerId]
   def availableAttributes(id: LayerId): Seq[String]
 
+  def layerType(id: LayerId): LayerType = {
+    lazy val layerType = readHeader[LayerHeader](id).layerType
+    cacheLayerType(id, layerType)
+  }
+
   def copy(from: LayerId, to: LayerId): Unit =
     copy(from, to, availableAttributes(from))
 

--- a/spark/src/main/scala/geotrellis/spark/io/LayerHeader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerHeader.scala
@@ -24,6 +24,7 @@ trait LayerHeader {
   def format: String
   def keyClass: String
   def valueClass: String
+  def layerType: LayerType
 }
 
 object LayerHeader {
@@ -32,16 +33,25 @@ object LayerHeader {
       JsObject(
         "format" -> JsString(md.format),
         "keyClass" -> JsString(md.keyClass),
-        "valueClass" -> JsString(md.valueClass)
+        "valueClass" -> JsString(md.valueClass),
+        "layerType" -> md.layerType.toJson
       )
 
     def read(value: JsValue): LayerHeader =
-      value.asJsObject.getFields("format", "keyClass", "valueClass") match {
+      value.asJsObject.getFields("format", "keyClass", "valueClass", "layerType") match {
+        case Seq(JsString(_format), JsString(_keyClass), JsString(_valueClass), _layerType) =>
+          new LayerHeader {
+            val format = _format
+            val keyClass = _keyClass
+            val valueClass = _valueClass
+            def layerType = _layerType.convertTo[LayerType]
+          }
         case Seq(JsString(_format), JsString(_keyClass), JsString(_valueClass)) =>
           new LayerHeader {
             val format = _format
             val keyClass = _keyClass
             val valueClass = _valueClass
+            def layerType = AvroLayerType
           }
         case _ =>
           throw new DeserializationException(s"LayerHeader expected, got: $value")

--- a/spark/src/main/scala/geotrellis/spark/io/LayerType.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerType.scala
@@ -1,0 +1,33 @@
+package geotrellis.spark.io
+
+import spray.json._
+
+
+trait LayerType {
+  lazy val name = this.getClass.getName.split("\\$").last.split("\\.").last
+  override def toString = name
+}
+
+object LayerType {
+  def fromString(str: String): LayerType =
+    str match {
+      case AvroLayerType.name => AvroLayerType
+      case COGLayerType.name => COGLayerType
+      case _ => throw new Exception(s"Could not derive LayerType from given string: $str")
+    }
+
+  implicit object LayerTypeFormat extends RootJsonFormat[LayerType] {
+      def write(layerType: LayerType) = JsString(layerType.name)
+
+      def read(value: JsValue): LayerType =
+        value match {
+          case JsString(layerType) =>
+            LayerType.fromString(layerType)
+          case v =>
+            throw new DeserializationException(s"LayerType expected, got $v")
+        }
+    }
+}
+
+case object AvroLayerType extends LayerType
+case object COGLayerType extends LayerType

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGCollectionLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGCollectionLayerReader.scala
@@ -51,7 +51,7 @@ abstract class COGCollectionLayerReader[ID] { self =>
   )(implicit getByteReader: URI => ByteReader, idToLayerId: ID => LayerId): Seq[(K, V)] with Metadata[TileLayerMetadata[K]] = {
     val COGLayerStorageMetadata(cogLayerMetadata, keyIndexes) =
       try {
-        attributeStore.read[COGLayerStorageMetadata[K]](LayerId(id.name, 0), "cog_metadata")
+        attributeStore.readMetadata[COGLayerStorageMetadata[K]](LayerId(id.name, 0))
       } catch {
         // to follow GeoTrellis Layer Readers logic
         case e: AttributeNotFoundError => throw new LayerNotFoundError(id).initCause(e)

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
@@ -72,7 +72,7 @@ abstract class COGLayerReader[ID] extends Serializable {
 
     val COGLayerStorageMetadata(cogLayerMetadata, keyIndexes) =
       try {
-        attributeStore.read[COGLayerStorageMetadata[K]](LayerId(id.name, 0), COGAttributeStore.Fields.metadata)
+        attributeStore.readMetadata[COGLayerStorageMetadata[K]](LayerId(id.name, 0))
       } catch {
         // to follow GeoTrellis Layer Readers logic
         case e: AttributeNotFoundError => throw new LayerNotFoundError(id).initCause(e)

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
@@ -162,7 +162,7 @@ trait COGLayerWriter extends LazyLogging with Serializable {
       case (keyBounds: KeyBounds[K], _) =>
         val COGLayerStorageMetadata(metadata, keyIndexes) =
           try {
-            attributeStore.read[COGLayerStorageMetadata[K]](LayerId(layerName, 0), "cog_metadata")
+            attributeStore.readMetadata[COGLayerStorageMetadata[K]](LayerId(layerName, 0))
           } catch {
             // to follow GeoTrellis Layer Readers logic
             case e: AttributeNotFoundError => throw new LayerNotFoundError(LayerId(layerName, 0)).initCause(e)

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGValueReader.scala
@@ -52,7 +52,7 @@ trait COGValueReader[ID] {
     exceptionHandler: K => PartialFunction[Throwable, Nothing] = { key: K => { case e: Throwable => throw e }: PartialFunction[Throwable, Nothing] }
    ): Reader[K, V] = new Reader[K, V] {
     val COGLayerStorageMetadata(cogLayerMetadata, keyIndexes) =
-      attributeStore.read[COGLayerStorageMetadata[K]](LayerId(layerId.name, 0), "cog_metadata")
+      attributeStore.readMetadata[COGLayerStorageMetadata[K]](LayerId(layerId.name, 0))
 
     def read(key: K): V = {
       val (zoomRange, spatialKey, overviewIndex, gridBounds) =

--- a/spark/src/main/scala/geotrellis/spark/io/cog/ZoomRange.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/ZoomRange.scala
@@ -6,6 +6,9 @@ case class ZoomRange(minZoom: Int, maxZoom: Int) {
   def isSingleZoom: Boolean = minZoom == maxZoom
 
   def slug: String = s"${minZoom}_${maxZoom}"
+
+  def zoomInRange(zoom: Int): Boolean =
+    zoom >= minZoom && zoom <= maxZoom
 }
 
 object ZoomRange {

--- a/spark/src/main/scala/geotrellis/spark/io/cog/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/package.scala
@@ -1,5 +1,6 @@
 package geotrellis.spark.io
 
+import geotrellis.spark.io.index.KeyIndex
 import geotrellis.spark.tiling.LayoutDefinition
 import geotrellis.vector.Extent
 
@@ -26,5 +27,13 @@ package object cog extends Implicits {
         extent.xmax - layout.cellwidth / 2,
         extent.ymax - layout.cellheight / 2
       )
+  }
+
+  implicit class withMappedKeyIndexesMethods[K](mappedKeyIndexes: Map[ZoomRange, KeyIndex[K]]) {
+    def keyIndexFromZoom(zoom: Int): Option[KeyIndex[K]] = {
+      val filteredIndexes = mappedKeyIndexes.filterKeys { _.zoomInRange(zoom) }
+
+      if (filteredIndexes.isEmpty) None else Some(filteredIndexes.head._2)
+    }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/cog/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/package.scala
@@ -28,12 +28,4 @@ package object cog extends Implicits {
         extent.ymax - layout.cellheight / 2
       )
   }
-
-  implicit class withMappedKeyIndexesMethods[K](mappedKeyIndexes: Map[ZoomRange, KeyIndex[K]]) {
-    def keyIndexFromZoom(zoom: Int): Option[KeyIndex[K]] = {
-      val filteredIndexes = mappedKeyIndexes.filterKeys { _.zoomInRange(zoom) }
-
-      if (filteredIndexes.isEmpty) None else Some(filteredIndexes.head._2)
-    }
-  }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/cog/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/package.scala
@@ -12,7 +12,8 @@ package object cog extends Implicits {
 
   object COGAttributeStore {
     object Fields {
-      val metadata = "cog_metadata"
+      val metadataBlob = "metadata"
+      val metadata = "metadata"
       val header   = "header"
     }
   }

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileAttributeStore.scala
@@ -123,7 +123,7 @@ object FileAttributeStore {
   val SEP = "__.__"
 
   val attributeRx = {
-    val slug = "[a-zA-Z0-9-]+"
+    val slug = "[a-zA-Z0-9-_.]+"
     new Regex(s"""($slug)$SEP($slug)${SEP}($slug).json""", "layer", "zoom", "attribute")
   }
 

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerHeader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerHeader.scala
@@ -16,13 +16,14 @@
 
 package geotrellis.spark.io.file
 
-import geotrellis.spark.io.LayerHeader
+import geotrellis.spark.io.{LayerHeader, LayerType, AvroLayerType}
 import spray.json._
 
 case class FileLayerHeader(
   keyClass: String,
   valueClass: String,
-  path: String
+  path: String,
+  layerType: LayerType = AvroLayerType
 ) extends LayerHeader {
   def format = "file"
 }
@@ -34,16 +35,26 @@ object FileLayerHeader {
         "format" -> JsString(md.format),
         "keyClass" -> JsString(md.keyClass),
         "valueClass" -> JsString(md.valueClass),
-        "path" -> JsString(md.path)
+        "path" -> JsString(md.path),
+        "layerType" -> md.layerType.toJson
       )
 
     def read(value: JsValue): FileLayerHeader =
-      value.asJsObject.getFields("keyClass", "valueClass", "path") match {
+      value.asJsObject.getFields("keyClass", "valueClass", "path", "layerType") match {
+        case Seq(JsString(keyClass), JsString(valueClass), JsString(path), layerType) =>
+          FileLayerHeader(
+            keyClass,
+            valueClass,
+            path,
+            layerType.convertTo[LayerType]
+          )
+
         case Seq(JsString(keyClass), JsString(valueClass), JsString(path)) =>
           FileLayerHeader(
             keyClass,
             valueClass,
-            path
+            path,
+            AvroLayerType
           )
 
         case _ =>

--- a/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGLayerReader.scala
@@ -53,7 +53,7 @@ class FileCOGLayerReader(
 
     val header =
       try {
-        attributeStore.read[FileLayerHeader](LayerId(id.name, 0), COGAttributeStore.Fields.header)
+        attributeStore.readHeader[FileLayerHeader](LayerId(id.name, 0))
       } catch {
         case e: AttributeNotFoundError => throw new LayerNotFoundError(id).initCause(e)
       }

--- a/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGLayerWriter.scala
@@ -4,7 +4,7 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.io.geotiff._
 import geotrellis.spark._
-import geotrellis.spark.io.AttributeStore
+import geotrellis.spark.io.{AttributeStore, COGLayerType}
 import geotrellis.spark.io.cog._
 import geotrellis.spark.io.cog.vrt.VRT
 import geotrellis.spark.io.cog.vrt.VRT.IndexedSimpleSource
@@ -39,15 +39,16 @@ class FileCOGLayerWriter(
     Filesystem.ensureDirectory(new File(catalogPathFile, layerName).getAbsolutePath)
 
     val storageMetadata = COGLayerStorageMetadata(cogLayer.metadata, keyIndexes)
-    attributeStore.write(layerId0, COGAttributeStore.Fields.metadata, storageMetadata)
 
     val header =
       FileLayerHeader(
         keyClass = classTag[K].toString(),
         valueClass = classTag[V].toString(),
-        path = catalogPath
+        path = catalogPath,
+        layerType = COGLayerType
       )
-    attributeStore.write(layerId0, COGAttributeStore.Fields.header, header)
+
+    attributeStore.writeCOGLayerAttributes(layerId0, header, storageMetadata)
 
     for(zoomRange <- cogLayer.layers.keys.toSeq.sorted(Ordering[ZoomRange].reverse)) {
       val keyIndex = keyIndexes(zoomRange)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
@@ -68,7 +68,7 @@ class HadoopAttributeStore(
     new Path(s"*${SEP}${attributeName}.json")
 
   def layerWildcard(layerId: LayerId): Path =
-    new Path(s"${layerId.name}${SEP}${layerId.name}${SEP}*.json")
+    new Path(s"${layerId.name}${SEP}${layerId.zoom}*.json")
 
   private def readFile[T: JsonFormat](path: Path): Option[(LayerId, T)] = {
     HdfsUtils
@@ -151,8 +151,11 @@ class HadoopAttributeStore(
       .distinct
 
   def availableAttributes(layerId: LayerId): Seq[String] = {
+    val metadataRelativeParentPath =
+      attributePath(layerId, AttributeStore.Fields.metadata).toUri.getPath.getParent()
+
     HdfsUtils
-      .listFiles(layerWildcard(layerId), hadoopConfiguration)
+      .listFiles(new Path(metadataRelativeParentPath, layerWildcard(layerId)), hadoopConfiguration)
       .map { path: Path =>
         val attributeRx(name, zoom, attribute) = path.getName
         attribute

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopAttributeStore.scala
@@ -168,7 +168,7 @@ object HadoopAttributeStore {
   final val SEP = "___"
 
   val attributeRx = {
-    val slug = "[a-zA-Z0-9-]+"
+    val slug = "[a-zA-Z0-9-_.]+"
     new Regex(s"""($slug)$SEP($slug)${SEP}($slug).json""", "layer", "zoom", "attribute")
   }
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerHeader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerHeader.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.spark.io.hadoop
 
-import geotrellis.spark.io.LayerHeader
+import geotrellis.spark.io.{LayerHeader, LayerType, AvroLayerType}
 
 import java.net.URI
 import spray.json._
@@ -24,7 +24,8 @@ import spray.json._
 case class HadoopLayerHeader(
   keyClass: String,
   valueClass: String,
-  path: URI
+  path: URI,
+  layerType: LayerType = AvroLayerType
 ) extends LayerHeader {
   def format = "hdfs"
 }
@@ -36,16 +37,27 @@ object HadoopLayerHeader {
         "format" -> JsString(md.format),
         "keyClass" -> JsString(md.keyClass),
         "valueClass" -> JsString(md.valueClass),
-        "path" -> JsString(md.path.toString)
+        "path" -> JsString(md.path.toString),
+        "layerType" -> md.layerType.toJson
       )
 
     def read(value: JsValue): HadoopLayerHeader =
-      value.asJsObject.getFields("keyClass", "valueClass", "path") match {
+      value.asJsObject.getFields("keyClass", "valueClass", "path", "layerType") match {
+        case Seq(JsString(keyClass), JsString(valueClass), JsString(path), layerType) =>
+          HadoopLayerHeader(
+            keyClass,
+            valueClass,
+            new URI(path),
+            layerType.convertTo[LayerType]
+          )
+
         case Seq(JsString(keyClass), JsString(valueClass), JsString(path)) =>
           HadoopLayerHeader(
-            keyClass, 
+            keyClass,
             valueClass,
-            new URI(path))
+            new URI(path),
+            AvroLayerType
+          )
         case _ =>
           throw new DeserializationException(s"HadoopLayerMetadata expected, got: $value")
       }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGLayerReader.scala
@@ -56,7 +56,7 @@ class HadoopCOGLayerReader(
   ](id: LayerId, tileQuery: LayerQuery[K, TileLayerMetadata[K]], numPartitions: Int) = {
     val header =
       try {
-        attributeStore.read[HadoopLayerHeader](LayerId(id.name, 0), COGAttributeStore.Fields.header)
+        attributeStore.readHeader[HadoopLayerHeader](LayerId(id.name, 0))
       } catch {
         case e: AttributeNotFoundError => throw new LayerNotFoundError(id).initCause(e)
       }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGLayerWriter.scala
@@ -7,7 +7,7 @@ import geotrellis.raster.io.geotiff.GeoTiff
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.io.geotiff.writer.GeoTiffWriter
 import geotrellis.spark._
-import geotrellis.spark.io.{InvalidLayerIdError, AttributeStore}
+import geotrellis.spark.io.{InvalidLayerIdError, AttributeStore, COGLayerType}
 import geotrellis.spark.io.cog._
 import geotrellis.spark.io.cog.vrt.VRT
 import geotrellis.spark.io.cog.vrt.VRT.IndexedSimpleSource
@@ -47,15 +47,16 @@ class HadoopCOGLayerWriter(
     }
 
     val storageMetadata = COGLayerStorageMetadata(cogLayer.metadata, keyIndexes)
-    attributeStore.write(layerId0, COGAttributeStore.Fields.metadata, storageMetadata)
 
     val header =
       HadoopLayerHeader(
         keyClass = classTag[K].toString(),
         valueClass = classTag[V].toString(),
-        path = new URI(rootPath)
+        path = new URI(rootPath),
+        layerType = COGLayerType
       )
-    attributeStore.write(layerId0, COGAttributeStore.Fields.header, header)
+
+    attributeStore.writeCOGLayerAttributes(layerId0, header, storageMetadata)
 
     for(zoomRange <- cogLayer.layers.keys.toSeq.sorted(Ordering[ZoomRange].reverse)) {
       val vrt = VRT(cogLayer.metadata.tileLayerMetadata(zoomRange.minZoom))

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGValueReader.scala
@@ -46,7 +46,7 @@ class HadoopCOGValueReader(
 
     val header =
       try {
-        attributeStore.read[HadoopLayerHeader](LayerId(layerId.name, 0), COGAttributeStore.Fields.header)
+        attributeStore.readHeader[HadoopLayerHeader](LayerId(layerId.name, 0))
       } catch {
         case e: AttributeNotFoundError => throw new LayerNotFoundError(layerId).initCause(e)
       }

--- a/spark/src/main/scala/geotrellis/spark/io/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/package.scala
@@ -53,6 +53,12 @@ package object io
   // Custom exceptions
   class LayerIOError(val message: String) extends Exception(message)
 
+  class AvroLayerAttributeError(attributeName: String, layerId: LayerId)
+    extends LayerIOError(s"AvroLayer: $layerId does not have the attribute: $attributeName")
+
+  class COGLayerAttributeError(attributeName: String, layerId: LayerId)
+    extends LayerIOError(s"COGLayer: $layerId does not have the attribute: $attributeName")
+
   class LayerReadError(layerId: LayerId)
     extends LayerIOError(s"LayerMetadata not found for layer $layerId")
 

--- a/spark/src/test/scala/geotrellis/spark/io/cog/COGAttributeStoreSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cog/COGAttributeStoreSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.io.cog
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.index._
+import geotrellis.spark.testkit.testfiles.cog._
+import geotrellis.spark.summary._
+import geotrellis.raster.io._
+import geotrellis.raster.histogram._
+import geotrellis.spark.testkit._
+
+import org.scalatest._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+abstract class COGAttributeStoreSpec
+    extends FunSpec
+    with Matchers
+    with TestEnvironment
+    with COGTestFiles {
+  def attributeStore: AttributeStore
+  def header: LayerHeader
+
+  val cogLayer = COGLayer.fromLayerRDD(spatialCea, zoomLevelCea)
+  val keyIndexes = cogLayer.metadata.zoomRangeInfos.map { case (z, b) => z -> ZCurveKeyIndexMethod.createIndex(b) }.toMap
+  val storageMetadata = COGLayerStorageMetadata(cogLayer.metadata, keyIndexes)
+
+  val layerId = LayerId("test-cog-layer", 0)
+
+  it("should write the COGLayerAttributes") {
+    attributeStore.writeCOGLayerAttributes(layerId, header, storageMetadata)
+  }
+
+  it("should read the COGLayerAttributes") {
+    attributeStore.readCOGLayerAttributes[LayerHeader, COGLayerStorageMetadata[SpatialKey]](layerId)
+  }
+
+  it("should be a COGLayer") {
+    attributeStore.isCOGLayer(layerId) should be (true)
+  }
+
+  it("should read the metadata of the catalog") {
+    attributeStore.readMetadata[COGLayerStorageMetadata[SpatialKey]](layerId)
+  }
+
+  it("should read the header of the catalog") {
+    attributeStore.readHeader[LayerHeader](layerId)
+  }
+
+  it("should read the keyIndexes of the catalog") {
+    attributeStore.readKeyIndexes[SpatialKey](layerId)
+  }
+}

--- a/spark/src/test/scala/geotrellis/spark/io/file/cog/COGFileAttributeStoreSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/file/cog/COGFileAttributeStoreSpec.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.io.file.cog
+
+import geotrellis.spark._
+import geotrellis.spark.io.{LayerHeader, COGLayerType}
+import geotrellis.spark.io.cog._
+import geotrellis.spark.io.file._
+
+class COGFileAttributeStoreSpec extends COGAttributeStoreSpec {
+  lazy val attributeStore = FileAttributeStore(outputLocalPath)
+  lazy val header = FileLayerHeader("geotrellis.spark.SpatialKey", "geotrellis.raster.Tile", outputLocalPath, COGLayerType)
+}

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/cog/COGHadoopAttributeStoreSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/cog/COGHadoopAttributeStoreSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.io.hadoop.cog
+
+import geotrellis.spark._
+import geotrellis.spark.io.{LayerHeader, COGLayerType}
+import geotrellis.spark.io.cog._
+import geotrellis.spark.io.hadoop._
+
+import java.net.URI
+
+class COGHadoopAttributeStoreSpec extends COGAttributeStoreSpec {
+  lazy val attributeStore = HadoopAttributeStore(outputLocalPath)
+  lazy val header = HadoopLayerHeader("geotrellis.spark.SpatialKey", "geotrellis.raster.Tile", new URI(outputLocalPath), COGLayerType)
+}


### PR DESCRIPTION
## Overview

This PR fixes multiple issues involving reading/writing COG layer attributes present in the current `AttributeStore`. Mainly, the inability to read/write COG layer attributes with the `readMetadata`, `readHeader`, and `readLayerAttributes` methods among others.

Before resolving the main issue, two other bugs with the `AttributeStore` were resolved. The first was the `HadoopAttributeStore.availableAttributes` method not returning any files and the second was expanding the regex for `HadoopAttributeStore` and `FileAttributeStore` so that they would match on more characters.

Once those bugs were fixed, support for COG layers was added to `AttributeStore` such that reading/writing attributes for COG layers is now more similar to how it is done for Avro layers.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Demo

Optional. Screenshots/REPL

### Notes

Currently, `readKeyIndex` is an unsupported operation for COG layers.

Closes #2624 #2602 #2601 
