### PR TITLE
LayerProviders Can Now Handle a URI That is Missing a Scheme

### DIFF
--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerProvider.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerProvider.scala
@@ -33,7 +33,11 @@ import java.net.URI
  */
 class AccumuloLayerProvider extends AttributeStoreProvider
     with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
-  def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "accumulo"
+
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => if (str.toLowerCase == "accumulo") true else false
+    case null => false
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val instance = AccumuloInstance(uri)

--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloLayerProviderSpec.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloLayerProviderSpec.scala
@@ -42,4 +42,10 @@ class AccumuloLayerProviderSpec extends FunSpec with TestEnvironment {
     assert(reader.isInstanceOf[AccumuloValueReader])
   }
 
+  it("should not be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("//root:@localhost/fake?attributes=attributes&layers=tiles")
+    val provider = new AccumuloLayerProvider
+
+    provider.canProcess(badURI) should be (false)
+  }
 }

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerProvider.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerProvider.scala
@@ -31,7 +31,11 @@ import java.net.URI
  */
 class CassandraLayerProvider extends AttributeStoreProvider
     with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
-  def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "cassandra"
+
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => if (str.toLowerCase == "cassandra") true else false
+    case null => false
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val params = UriUtils.getParams(uri)

--- a/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraLayerProviderSpec.scala
+++ b/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraLayerProviderSpec.scala
@@ -43,4 +43,10 @@ class CassandraLayerProviderSpec extends FunSpec with CassandraTestEnvironment {
     assert(reader.isInstanceOf[CassandraValueReader])
   }
 
+  it("should not be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("//127.0.0.1/geotrellis?attributes=attributes&layers=tiles")
+    val provider = new CassandraLayerProvider
+
+    provider.canProcess(badURI) should be (false)
+  }
 }

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerProvider.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerProvider.scala
@@ -32,7 +32,11 @@ import java.net.URI
  */
 class HBaseLayerProvider extends AttributeStoreProvider
     with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
-  def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "hbase"
+
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => if (str.toLowerCase == "hbase") true else false
+    case null => false
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val instance = HBaseInstance(uri)

--- a/hbase/src/test/scala/geotrellis/spark/io/hbase/HBaseLayerProviderSpec.scala
+++ b/hbase/src/test/scala/geotrellis/spark/io/hbase/HBaseLayerProviderSpec.scala
@@ -43,4 +43,10 @@ class HBaseLayerProviderSpec extends FunSpec with HBaseTestEnvironment {
     assert(reader.isInstanceOf[HBaseValueReader])
   }
 
+  it("should not be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("//localhost?master=localhost&attributes=attributes&layers=tiles")
+    val provider = new HBaseLayerProvider
+
+    provider.canProcess(badURI) should be (false)
+  }
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerProvider.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerProvider.scala
@@ -29,7 +29,11 @@ import java.net.URI
  */
 class S3LayerProvider extends AttributeStoreProvider
     with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
-  def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "s3"
+
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => if (str.toLowerCase == "s3") true else false
+    case null => false
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val s3Uri = new AmazonS3URI(uri)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGLayerProvider.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGLayerProvider.scala
@@ -31,7 +31,11 @@ import java.net.URI
  */
 class S3COGLayerProvider extends AttributeStoreProvider
     with COGLayerReaderProvider with COGLayerWriterProvider with COGValueReaderProvider with COGCollectionLayerReaderProvider {
-  def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "s3"
+
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => if (str.toLowerCase == "s3") true else false
+    case null => false
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val s3Uri = new AmazonS3URI(uri)

--- a/s3/src/test/scala/geotrellis/spark/io/s3/S3LayerProviderSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/S3LayerProviderSpec.scala
@@ -48,4 +48,11 @@ class S3LayerProviderSpec extends FunSpec with TestEnvironment {
     val reader = ValueReader(uri)
     assert(reader.isInstanceOf[S3ValueReader])
   }
+
+  it("should not be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("//fake-bucket/some-prefix")
+    val provider = new S3LayerProvider
+
+    provider.canProcess(badURI) should be (false)
+  }
 }

--- a/s3/src/test/scala/geotrellis/spark/io/s3/cog/COGS3LayerProviderSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/cog/COGS3LayerProviderSpec.scala
@@ -38,4 +38,11 @@ class COGS3LayerProviderSpec extends FunSpec with TestEnvironment {
     val reader = COGValueReader(uri)
     assert(reader.isInstanceOf[S3COGValueReader])
   }
+
+  it("should not be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("//fake-bucket/some-prefix")
+    val provider = new S3COGLayerProvider
+
+    provider.canProcess(badURI) should be (false)
+  }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerProvider.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerProvider.scala
@@ -30,7 +30,10 @@ import java.io.File
 class FileLayerProvider extends AttributeStoreProvider
     with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
 
-  def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "file"
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => if (str.toLowerCase == "file") true else false
+    case null => true // assume that the user is passing in the path to the catalog
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val file = new File(uri)

--- a/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGLayerProvider.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGLayerProvider.scala
@@ -32,7 +32,10 @@ import java.io.File
 class FileCOGLayerProvider extends AttributeStoreProvider
     with COGLayerReaderProvider with COGLayerWriterProvider with COGValueReaderProvider with COGCollectionLayerReaderProvider {
 
-  def canProcess(uri: URI): Boolean = uri.getScheme.toLowerCase == "file"
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => if (str.toLowerCase == "file") true else false
+    case null => true // assume that the user is passing in the path to the catalog
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val file = new File(uri)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerProvider.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerProvider.scala
@@ -41,7 +41,10 @@ class HadoopLayerProvider extends AttributeStoreProvider
       new URI(uri.toString.stripPrefix("hdfs+"))
     else uri
 
-  def canProcess(uri: URI): Boolean = schemes contains uri.getScheme.toLowerCase
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => schemes contains str.toLowerCase
+    case null => false
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val path = new Path(trim(uri))

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGLayerProvider.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGLayerProvider.scala
@@ -43,7 +43,10 @@ class HadoopCOGLayerProvider extends AttributeStoreProvider
       new URI(uri.toString.stripPrefix("hdfs+"))
     else uri
 
-  def canProcess(uri: URI): Boolean = schemes contains uri.getScheme.toLowerCase
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => schemes contains str.toLowerCase
+    case null => false
+  }
 
   def attributeStore(uri: URI): AttributeStore = {
     val path = new Path(trim(uri))

--- a/spark/src/test/scala/geotrellis/spark/io/file/FileLayerProviderSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/file/FileLayerProviderSpec.scala
@@ -42,4 +42,10 @@ class FileLayerProviderSpec extends FunSpec with TestEnvironment {
     assert(reader.isInstanceOf[FileValueReader])
   }
 
+  it("should be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("/tmp/catalog")
+    val provider = new FileLayerProvider
+
+    provider.canProcess(badURI) should be (true)
+  }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/file/cog/COGFileLayerProviderSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/file/cog/COGFileLayerProviderSpec.scala
@@ -39,4 +39,11 @@ class FileCOGLayerProviderSpec extends FunSpec with TestEnvironment {
     val reader = COGValueReader(uri)
     assert(reader.isInstanceOf[FileCOGValueReader])
   }
+
+  it("should be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("/tmp/catalog")
+    val provider = new FileCOGLayerProvider
+
+    provider.canProcess(badURI) should be (true)
+  }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopLayerProviderSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopLayerProviderSpec.scala
@@ -42,4 +42,11 @@ class HadoopLayerProviderSpec extends FunSpec with TestEnvironment {
     assert(reader.isInstanceOf[HadoopValueReader])
   }
 
+  it("should not be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("/tmp/catalog")
+    val provider = new HadoopLayerProvider
+
+    provider.canProcess(badURI) should be (false)
+  }
+
 }

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/cog/COGHadoopLayerProviderSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/cog/COGHadoopLayerProviderSpec.scala
@@ -21,7 +21,7 @@ import geotrellis.spark.io.cog._
 import geotrellis.spark.testkit.TestEnvironment
 import org.scalatest._
 
-class HadoopLayerProviderSpec extends FunSpec with TestEnvironment {
+class COGHadoopLayerProviderSpec extends FunSpec with TestEnvironment {
   val uri = new java.net.URI("hdfs+file:/tmp/catalog")
 
   it("construct HadoopCOGLayerReader from URI") {
@@ -37,5 +37,12 @@ class HadoopLayerProviderSpec extends FunSpec with TestEnvironment {
   it("construct HadoopCOGValueReader from URI") {
     val reader = COGValueReader(uri)
     assert(reader.isInstanceOf[HadoopCOGValueReader])
+  }
+
+  it("should not be able to process a URI without a scheme") {
+    val badURI = new java.net.URI("/tmp/catalog")
+    val provider = new HadoopCOGLayerProvider
+
+    provider.canProcess(badURI) should be (false)
   }
 }


### PR DESCRIPTION
## Overview

This PR makes it so that a `RuntimeException` will be thrown when a user tries to pass in a `URI` to a `LayerProvider` instead of a `NullPointerException`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

Closes #2551 
