### PR TITLE
Specify maxTileSize When Writing a COGLayer

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -21,6 +21,8 @@ API Changes
   - **New:** ``ZoomResample`` can now be used on ``MultibandTileLayerRDD``\s.
   - **New:** A ``Partitioner`` can be specified in the ``reproject`` methods of ``TileLayerRDD``.
   - **New:** Compression ``level`` of GeoTiffs can be specified in the ``DeflateCompression`` constructor.
+  - **Change:** Specifying the ``maxTileSize`` for a COGLayer that's to be written is now done via ``COGLayerWriter.Options``
+    which can be passed directly to the ``write`` methods.
 
 Fixes
 ^^^^^

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
@@ -19,6 +19,7 @@ package geotrellis.spark.testkit.io.cog
 import geotrellis.raster.CellGrid
 import geotrellis.raster.crop.TileCropMethods
 import geotrellis.raster.merge.TileMergeMethods
+import geotrellis.raster.io.geotiff.compression.NoCompression
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.prototype.TilePrototypeMethods
@@ -138,6 +139,12 @@ abstract class COGPersistenceSpec[
         val readV: V = tileReader.read(key)
         val expectedV: V = sample.filter(_._1 == key).values.first()
         readV should be equals expectedV
+      }
+
+      it("should write a layer with maxTileSize set") {
+        val tileSize = 1024
+
+        writer.write[K, V](s"${layerId.name}-2", sample, layerId.zoom, keyIndexMethod, tileSize)
       }
 
       /*it("should delete a layer") {

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
@@ -186,6 +186,16 @@ trait COGLayerWriter extends LazyLogging with Serializable {
 
 object COGLayerWriter {
 
+  case class Options(maxTileSize: Int = DefaultMaxTileSize)
+
+  object Options {
+    def DEFAULT = Options()
+
+    implicit def maxTileSizeToOptions(maxTileSize: Int): Options = Options(maxTileSize = maxTileSize)
+  }
+
+  private val DefaultMaxTileSize = 4096
+
   /**
    * Produce COGLayerWriter instance based on URI description.
    * Find instances of [[COGLayerWriterProvider]] through Java SPI.

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
@@ -37,6 +37,8 @@ import java.util.ServiceLoader
 import scala.reflect._
 
 trait COGLayerWriter extends LazyLogging with Serializable {
+  import COGLayerWriter.Options
+
   val attributeStore: AttributeStore
 
   def writeCOGLayer[
@@ -57,7 +59,18 @@ trait COGLayerWriter extends LazyLogging with Serializable {
      tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
      tileZoom: Int,
      keyIndexMethod: KeyIndexMethod[K]
-   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndexMethod, NoCompression, None)
+   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndexMethod, NoCompression, None, Options.DEFAULT)
+
+  def write[
+    K: SpatialComponent: Ordering: JsonFormat: ClassTag,
+    V <: CellGrid: ClassTag: ? => TileMergeMethods[V]: ? => TilePrototypeMethods[V]: ? => TileCropMethods[V]: GeoTiffReader: GeoTiffBuilder
+  ](
+     layerName: String,
+     tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
+     tileZoom: Int,
+     keyIndexMethod: KeyIndexMethod[K],
+     options: Options
+   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndexMethod, NoCompression, None, options)
 
   def write[
     K: SpatialComponent: Ordering: JsonFormat: ClassTag,
@@ -68,11 +81,12 @@ trait COGLayerWriter extends LazyLogging with Serializable {
     tileZoom: Int,
     keyIndexMethod: KeyIndexMethod[K],
     compression: Compression,
-    mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]]
+    mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]],
+    options: Options
   ): Unit =
     tiles.metadata.bounds match {
       case keyBounds: KeyBounds[K] =>
-        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression)
+        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression, options = options)
         // println(cogLayer.metadata.toJson.prettyPrint)
         val keyIndexes: Map[ZoomRange, KeyIndex[K]] =
           cogLayer.metadata.zoomRangeInfos.
@@ -91,7 +105,18 @@ trait COGLayerWriter extends LazyLogging with Serializable {
      tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
      tileZoom: Int,
      keyIndex: KeyIndex[K]
-   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndex, NoCompression, None)
+   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndex, NoCompression, None, Options.DEFAULT)
+
+  def write[
+    K: SpatialComponent: Ordering: JsonFormat: ClassTag,
+    V <: CellGrid: ClassTag: ? => TileMergeMethods[V]: ? => TilePrototypeMethods[V]: ? => TileCropMethods[V]: GeoTiffReader: GeoTiffBuilder
+  ](
+     layerName: String,
+     tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
+     tileZoom: Int,
+     keyIndex: KeyIndex[K],
+     options: Options
+   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndex, NoCompression, None, options)
 
   def write[
     K: SpatialComponent: Ordering: JsonFormat: ClassTag,
@@ -102,12 +127,12 @@ trait COGLayerWriter extends LazyLogging with Serializable {
      tileZoom: Int,
      keyIndex: KeyIndex[K],
      compression: Compression,
-     mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]]
+     mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]],
+     options: Options
    ): Unit =
     tiles.metadata.bounds match {
       case keyBounds: KeyBounds[K] =>
-        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression)
-        // println(cogLayer.metadata.toJson.prettyPrint)
+        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression, options = options)
         val keyIndexes: Map[ZoomRange, KeyIndex[K]] =
           cogLayer.metadata.zoomRangeInfos.
             map { case (zr, _) => zr -> keyIndex }.
@@ -143,9 +168,10 @@ trait COGLayerWriter extends LazyLogging with Serializable {
     layerName: String,
     tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
     tileZoom: Int,
-    compression: Compression = NoCompression
+    compression: Compression = NoCompression,
+    options: Options = Options.DEFAULT
   ): Unit =
-    if(tiles.metadata.bounds.nonEmpty) update[K, V](layerName, tiles, tileZoom, compression, None)
+    if(tiles.metadata.bounds.nonEmpty) update[K, V](layerName, tiles, tileZoom, compression, None, options)
     else logger.info("Skipping layer update with empty bounds rdd.")
 
   def update[
@@ -156,7 +182,8 @@ trait COGLayerWriter extends LazyLogging with Serializable {
      tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
      tileZoom: Int,
      compression: Compression = NoCompression,
-     mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]]
+     mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]],
+     options: Options = Options.DEFAULT
    ): Unit = {
     (tiles.metadata.bounds, mergeFunc) match {
       case (keyBounds: KeyBounds[K], _) =>
@@ -174,7 +201,7 @@ trait COGLayerWriter extends LazyLogging with Serializable {
         if(!indexKeyBounds.contains(keyBounds) && !metadata.keyBoundsForZoom(tileZoom).contains(keyBounds))
           throw new LayerOutOfKeyBoundsError(LayerId(layerName, tileZoom), indexKeyBounds)
 
-        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression)
+        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression, options = options)
         val ucogLayer = cogLayer.copy(metadata = cogLayer.metadata.combine(metadata))
 
         writeCOGLayer(layerName, ucogLayer, keyIndexes, mergeFunc)


### PR DESCRIPTION
## Overview

This PR makes it so that a user can specify the `maxTileSize` of a COGLayer that is about to written in the `write` methods themselves. This is done via the newly created `COGLayerWrtier.Options` which can be passed in to the `write` methods.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Demo

```scala

val options = COGLayerWriter.Options(1024)

writer.write[K, V](layerId.name, tiles, layerId.zoom, keyIndexMethod, options)
```

Closes #2606 
