### PR TITLE
Specify a resampleMethod and maxTileSize when writing a COGLayer

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -26,6 +26,8 @@ API Changes
   - **Change:** Specifying the ``maxTileSize`` for a COGLayer that's to be written is now done via ``COGLayerWriter.Options``
     which can be passed directly to the ``write`` methods.
   - **New:** The ``resampleMethod`` parameter has been added to ``COGLayerWriter.Options``.
+  - **Change:** Specifying the ``compression`` for a COGLayer that's to be written is now done via ``COGLayerWriter.Options``
+    which can be passed directly to the ``write`` methods.
 
 Fixes
 ^^^^^

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,7 @@ API Changes
   - **Change:** Replace `geotrellis.util.Functor` with `cats.Functor`
   - **Change:** Specifying the ``maxTileSize`` for a COGLayer that's to be written is now done via ``COGLayerWriter.Options``
     which can be passed directly to the ``write`` methods.
+  - **New:** The ``resampleMethod`` parameter has been added to ``COGLayerWriter.Options``.
 
 Fixes
 ^^^^^

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,8 @@ API Changes
   - **New:** Compression ``level`` of GeoTiffs can be specified in the ``DeflateCompression`` constructor.
   - **Change:**: The Ascii draw methods are now method extensions of ``Tile``.
   - **Change:** Replace `geotrellis.util.Functor` with `cats.Functor`
+  - **Change:** Specifying the ``maxTileSize`` for a COGLayer that's to be written is now done via ``COGLayerWriter.Options``
+    which can be passed directly to the ``write`` methods.
 
 Fixes
 ^^^^^

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
@@ -149,7 +149,11 @@ abstract class COGPersistenceSpec[
       }
 
       it("should create a COGLayer with the resample method set") {
-        COGLayer.fromLayerRDD(sample, layerId.zoom, NoCompression, options = Sum)
+        COGLayer.fromLayerRDD(sample, layerId.zoom, options = Sum)
+      }
+
+      it("should create a COGLayer with the compression set") {
+        COGLayer.fromLayerRDD(sample, layerId.zoom, options = NoCompression)
       }
 
       /*it("should delete a layer") {

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
@@ -19,6 +19,7 @@ package geotrellis.spark.testkit.io.cog
 import geotrellis.raster.CellGrid
 import geotrellis.raster.crop.TileCropMethods
 import geotrellis.raster.merge.TileMergeMethods
+import geotrellis.raster.resample._
 import geotrellis.raster.io.geotiff.compression.NoCompression
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
@@ -145,6 +146,10 @@ abstract class COGPersistenceSpec[
         val tileSize = 1024
 
         writer.write[K, V](s"${layerId.name}-2", sample, layerId.zoom, keyIndexMethod, tileSize)
+      }
+
+      it("should create a COGLayer with the resample method set") {
+        COGLayer.fromLayerRDD(sample, layerId.zoom, NoCompression, options = Sum)
       }
 
       /*it("should delete a layer") {

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
@@ -19,6 +19,7 @@ package geotrellis.spark.testkit.io.cog
 import geotrellis.raster.CellGrid
 import geotrellis.raster.crop.TileCropMethods
 import geotrellis.raster.merge.TileMergeMethods
+import geotrellis.raster.io.geotiff.compression.NoCompression
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.prototype.TilePrototypeMethods
@@ -138,6 +139,12 @@ abstract class COGPersistenceSpec[
         val readV: V = tileReader.read(key)
         val expectedV: V = sample.filter(_._1 == key).values.first()
         readV should be equals expectedV
+      }
+
+      it("should write a layer with maxTileSize set") {
+        val tileSize = 1024
+
+        writer.write[K, V](s"${layerId.name}-2", sample, layerId.zoom, keyIndexMethod, tileSize)
       }
 
       /*it("should delete a layer") {

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayer.scala
@@ -92,6 +92,8 @@ object COGLayer {
         options.maxTileSize
       )
 
+    val pyramidOptions = Pyramid.Options(resampleMethod = options.resampleMethod)
+
     val layers: Map[ZoomRange, RDD[(K, GeoTiff[V])]] =
       cogLayerMetadata.zoomRanges.
         sorted(Ordering[ZoomRange].reverse).
@@ -106,7 +108,7 @@ object COGLayer {
 
             val tmd: TileLayerMetadata[K] = cogLayerMetadata.tileLayerMetadata(range.maxZoom + 1)
             val upsampledPreviousLayer =
-              Pyramid.up(ContextRDD(previousLayer, tmd), layoutScheme, range.maxZoom + 1)._2
+              Pyramid.up(ContextRDD(previousLayer, tmd), layoutScheme, range.maxZoom + 1, pyramidOptions)._2
 
             val rzz = generateGeoTiffRDD(upsampledPreviousLayer, range, layoutScheme, cogLayerMetadata.cellType, compression)
 

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayer.scala
@@ -41,9 +41,9 @@ object COGLayer {
     *
     * @param rdd             Layer layer, at highest resolution
     * @param baseZoom        Zoom level of the base layer, assumes [[ZoomedLayoutScheme]]
-    * @param compression     Compression method for GeoTiff tiles
     * @param minZoom         Zoom level at which to stop the pyramiding.
-    * @param options         [[COGLayerWriter.Options]] that contains information on the maxTileSize of the layer.
+    * @param options         [[COGLayerWriter.Options]] that contains information on the maxTileSize,
+    *                        resampleMethod, and compression of the written layer.
     */
   def fromLayerRDD[
     K: SpatialComponent: Ordering: JsonFormat: ClassTag,
@@ -51,9 +51,8 @@ object COGLayer {
   ](
      rdd: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
      baseZoom: Int,
-     compression: Compression = Deflate,
      minZoom: Option[Int] = None,
-     options: COGLayerWriter.Options
+     options: COGLayerWriter.Options = COGLayerWriter.Options.DEFAULT
    ): COGLayer[K, V] = {
     // TODO: Clean up conditional checks, figure out how to bake into type system, or report errors better.
 
@@ -66,6 +65,8 @@ object COGLayer {
         sys.error("Cannot create Pyramided COG layer for tile sizes that are not power-of-two.")
       }
     }
+
+    val compression = options.compression
 
     val layoutScheme =
       ZoomedLayoutScheme(rdd.metadata.crs, rdd.metadata.layout.tileCols)

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
@@ -20,6 +20,7 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.merge._
 import geotrellis.raster.prototype._
+import geotrellis.raster.resample._
 import geotrellis.raster.crop._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.compression.{Compression, NoCompression}
@@ -213,12 +214,16 @@ trait COGLayerWriter extends LazyLogging with Serializable {
 
 object COGLayerWriter {
 
-  case class Options(maxTileSize: Int = DefaultMaxTileSize)
+  case class Options(
+    maxTileSize: Int = DefaultMaxTileSize,
+    resampleMethod: ResampleMethod = NearestNeighbor
+  )
 
   object Options {
     def DEFAULT = Options()
 
     implicit def maxTileSizeToOptions(maxTileSize: Int): Options = Options(maxTileSize = maxTileSize)
+    implicit def resampleMethodToOptions(resampleMethod: ResampleMethod): Options = Options(resampleMethod = resampleMethod)
   }
 
   private val DefaultMaxTileSize = 4096

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
@@ -186,6 +186,16 @@ trait COGLayerWriter extends LazyLogging with Serializable {
 
 object COGLayerWriter {
 
+  case class Options(maxTileSize: Int = DefaultMaxTileSize)
+
+  object Options {
+    def DEFAULT = Options()
+
+    implicit def maxTileSizeToOptions(maxTileSize: Int): Options = Options(maxTileSize = maxTileSize)
+  }
+
+  private val DefaultMaxTileSize = 4096
+
   /**
    * Produce COGLayerWriter instance based on URI description.
    * Find instances of [[COGLayerWriterProvider]] through Java SPI.

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
@@ -37,6 +37,8 @@ import java.util.ServiceLoader
 import scala.reflect._
 
 trait COGLayerWriter extends LazyLogging with Serializable {
+  import COGLayerWriter.Options
+
   val attributeStore: AttributeStore
 
   def writeCOGLayer[
@@ -57,7 +59,18 @@ trait COGLayerWriter extends LazyLogging with Serializable {
      tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
      tileZoom: Int,
      keyIndexMethod: KeyIndexMethod[K]
-   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndexMethod, NoCompression, None)
+   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndexMethod, NoCompression, None, Options.DEFAULT)
+
+  def write[
+    K: SpatialComponent: Ordering: JsonFormat: ClassTag,
+    V <: CellGrid: ClassTag: ? => TileMergeMethods[V]: ? => TilePrototypeMethods[V]: ? => TileCropMethods[V]: GeoTiffReader: GeoTiffBuilder
+  ](
+     layerName: String,
+     tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
+     tileZoom: Int,
+     keyIndexMethod: KeyIndexMethod[K],
+     options: Options
+   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndexMethod, NoCompression, None, options)
 
   def write[
     K: SpatialComponent: Ordering: JsonFormat: ClassTag,
@@ -68,11 +81,12 @@ trait COGLayerWriter extends LazyLogging with Serializable {
     tileZoom: Int,
     keyIndexMethod: KeyIndexMethod[K],
     compression: Compression,
-    mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]]
+    mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]],
+    options: Options
   ): Unit =
     tiles.metadata.bounds match {
       case keyBounds: KeyBounds[K] =>
-        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression)
+        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression, options = options)
         // println(cogLayer.metadata.toJson.prettyPrint)
         val keyIndexes: Map[ZoomRange, KeyIndex[K]] =
           cogLayer.metadata.zoomRangeInfos.
@@ -91,7 +105,18 @@ trait COGLayerWriter extends LazyLogging with Serializable {
      tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
      tileZoom: Int,
      keyIndex: KeyIndex[K]
-   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndex, NoCompression, None)
+   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndex, NoCompression, None, Options.DEFAULT)
+
+  def write[
+    K: SpatialComponent: Ordering: JsonFormat: ClassTag,
+    V <: CellGrid: ClassTag: ? => TileMergeMethods[V]: ? => TilePrototypeMethods[V]: ? => TileCropMethods[V]: GeoTiffReader: GeoTiffBuilder
+  ](
+     layerName: String,
+     tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
+     tileZoom: Int,
+     keyIndex: KeyIndex[K],
+     options: Options
+   ): Unit = write[K, V](layerName, tiles, tileZoom, keyIndex, NoCompression, None, options)
 
   def write[
     K: SpatialComponent: Ordering: JsonFormat: ClassTag,
@@ -102,12 +127,12 @@ trait COGLayerWriter extends LazyLogging with Serializable {
      tileZoom: Int,
      keyIndex: KeyIndex[K],
      compression: Compression,
-     mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]]
+     mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]],
+     options: Options
    ): Unit =
     tiles.metadata.bounds match {
       case keyBounds: KeyBounds[K] =>
-        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression)
-        // println(cogLayer.metadata.toJson.prettyPrint)
+        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression, options = options)
         val keyIndexes: Map[ZoomRange, KeyIndex[K]] =
           cogLayer.metadata.zoomRangeInfos.
             map { case (zr, _) => zr -> keyIndex }.
@@ -143,9 +168,10 @@ trait COGLayerWriter extends LazyLogging with Serializable {
     layerName: String,
     tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
     tileZoom: Int,
-    compression: Compression = NoCompression
+    compression: Compression = NoCompression,
+    options: Options = Options.DEFAULT
   ): Unit =
-    if(tiles.metadata.bounds.nonEmpty) update[K, V](layerName, tiles, tileZoom, compression, None)
+    if(tiles.metadata.bounds.nonEmpty) update[K, V](layerName, tiles, tileZoom, compression, None, options)
     else logger.info("Skipping layer update with empty bounds rdd.")
 
   def update[
@@ -156,7 +182,8 @@ trait COGLayerWriter extends LazyLogging with Serializable {
      tiles: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
      tileZoom: Int,
      compression: Compression = NoCompression,
-     mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]]
+     mergeFunc: Option[(GeoTiff[V], GeoTiff[V]) => GeoTiff[V]],
+     options: Options = Options.DEFAULT
    ): Unit = {
     (tiles.metadata.bounds, mergeFunc) match {
       case (keyBounds: KeyBounds[K], _) =>
@@ -174,7 +201,7 @@ trait COGLayerWriter extends LazyLogging with Serializable {
         if(!indexKeyBounds.contains(keyBounds) && !metadata.keyBoundsForZoom(tileZoom).contains(keyBounds))
           throw new LayerOutOfKeyBoundsError(LayerId(layerName, tileZoom), indexKeyBounds)
 
-        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression)
+        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, compression = compression, options = options)
         val ucogLayer = cogLayer.copy(metadata = cogLayer.metadata.combine(metadata))
 
         writeCOGLayer(layerName, ucogLayer, keyIndexes, mergeFunc)


### PR DESCRIPTION
## Overview

This PR adds the `resampleMethod`, `maxTileSize` and moves `compression` parameter to `COGLayerWriter.Options`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Demo

```scala
COGLayer.fromLayerRDD(layerRDD, zoom, options = Bilinear)
```

```scala
val options = COGLayerWriter.Options(1024)

writer.write[K, V](layerId.name, tiles, layerId.zoom, keyIndexMethod, options)
```

### Notes

This PR is based on another, open PR #2628 which should be merged before this one.

Closes #2605 and #2606
