### PR TITLE
FileCOGValueReader and HadoopCOGValueReader Will Now Throw a ValueNotFoundError

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGValueReader.scala
@@ -43,7 +43,12 @@ class FileCOGValueReader(
     def keyPath(key: K, maxWidth: Int, baseKeyIndex: KeyIndex[K], zoomRange: ZoomRange): String =
       (KeyPathGenerator(catalogPath, s"${layerId.name}/${zoomRange.slug}", baseKeyIndex, maxWidth) andThen (_ ++ s".$Extension"))(key)
 
-    baseReader[K, V](layerId, keyPath, new URI(_))
+    baseReader[K, V](
+      layerId,
+      keyPath,
+      new URI(_),
+      key => { case e: java.io.FileNotFoundException => throw new ValueNotFoundError(key, layerId) }
+    )
   }
 }
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGValueReader.scala
@@ -59,7 +59,8 @@ class HadoopCOGValueReader(
     baseReader[K, V](
       layerId,
       keyPath,
-      path => new URI(path)
+      path => new URI(path),
+      key => { case e: java.io.FileNotFoundException => throw new ValueNotFoundError(key, layerId) }
     )
   }
 }


### PR DESCRIPTION
## Overview

This PR makes it so that `FileCOGValueReader` and `HadoopCOGValueReader` will throw a `ValueNotFoundError` instead of a `java.io.FileNotFoundException` when trying to read a value that doesn't exist.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature


Closes #2607 