### PR TITLE
Expose Deflate compression level into user API

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -20,6 +20,7 @@ API Changes
   - **New:** CollectionLayerReader now has an SPI interface.
   - **New:** ``ZoomResample`` can now be used on ``MultibandTileLayerRDD``\s.
   - **New:** A ``Partitioner`` can be specified in the ``reproject`` methods of ``TileLayerRDD``.
+  - **New:** Compression ``level`` of GeoTiffs can be specified in the ``DeflateCompression`` constructor.
 
 Fixes
 ^^^^^

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/DeflateCompression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/DeflateCompression.scala
@@ -29,7 +29,8 @@ case class DeflateCompression(level: Int = Deflater.DEFAULT_COMPRESSION) extends
         segmentSizes(segmentIndex) = segment.size
 
         val deflater = new Deflater(level)
-        val tmp = segment.clone
+        // take into account extra 10 leading bytes header, in case of 0 compression level it is important
+        val tmp = Array.ofDim[Byte](segment.length + 10)
         deflater.setInput(segment, 0, segment.length)
         deflater.finish()
         val compressedSize = deflater.deflate(tmp)
@@ -53,7 +54,8 @@ class DeflateDecompressor(segmentSizes: Array[Int]) extends Decompressor {
 
   def compress(segment: Array[Byte], level: Int = Deflater.DEFAULT_COMPRESSION): Array[Byte] = {
     val deflater = new Deflater(level)
-    val tmp = segment.clone
+    // take into account extra 10 leading bytes header, in case of 0 compression level it is important
+    val tmp = Array.ofDim[Byte](segment.length + 10)
     deflater.setInput(segment, 0, segment.length)
     val compressedDataLength = deflater.deflate(tmp)
     java.util.Arrays.copyOf(tmp, compressedDataLength)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/compression/CompressionSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/compression/CompressionSpec.scala
@@ -20,26 +20,28 @@ import org.scalatest._
 
 class CompressionSpec extends FunSpec with Matchers {
   describe("DeflateCompression") {
-    it("should decompress and compress to the same things") {
-      val segment = """
-the human machine only moves when the tide of every one of us pushes to the outside
-and we realize that from the time you wake until the time you shake it up
-you're nothing more than a ghost echo
-it burns brighter when the pieces move the best way,
-whatever best may mean,
-it's so subjective. but when enough agree we can finally move it.
-when the pieces understand what they're doing they can chose a direction
-and run a little hotter.
-against inertia,
-it goes.
-whole lives change
-only the moment remains here
-""".getBytes("UTF-8")
-      val compressor = DeflateCompression.createCompressor(1)
-      val compressed = compressor.compress(segment, 0)
-      val decompressor = compressor.createDecompressor()
-      val decompressed = decompressor.decompress(compressed, 0)
-      decompressed should be (segment)
+    (-1 to 9).foreach { level =>
+      it(s"should decompress and compress to the same things at the ${if(level == -1) "default compression level" else s"zoom level $level"}") {
+        val segment =
+          """
+            | the human machine only moves when the tide of every one of us pushes to the outside
+            | and we realize that from the time you wake until the time you shake it up
+            | you're nothing more than a ghost echo
+            | it burns brighter when the pieces move the best way,
+            | whatever best may mean,
+            | it's so subjective. but when enough agree we can finally move it.
+            | when the pieces understand what they're doing they can chose a direction
+            | and run a little hotter.
+            | against inertia,
+            | it goes.
+            | whole lives change
+            | only the moment remains here""".getBytes("UTF-8")
+        val compressor = new DeflateCompression(level).createCompressor(1)
+        val compressed = compressor.compress(segment, 0)
+        val decompressor = compressor.createDecompressor()
+        val decompressed = decompressor.decompress(compressed, 0)
+        decompressed should be(segment)
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

We had concerns about Deflate compression speed. The truth is that it's at least 2 times slower than lzw (gdal numbers). This PR exposes levels of compression into user API

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Demo

Both things would work:

```scala
COGLayer.fromLayerRDD(
  reprojected,
  zoom,
  compression = DeflateCompression,
  maxTileSize = 4096
)

COGLayer.fromLayerRDD(
  reprojected,
  zoom,
  compression = new DeflateCompression(1),
  maxTileSize = 4096
)
```
