### PR TITLE
Query Results Will Now Have the Correct KeyBounds and Extent

### DIFF
--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloCollectionLayerReader.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloCollectionLayerReader.scala
@@ -32,7 +32,7 @@ class AccumuloCollectionLayerReader(val attributeStore: AttributeStore)(implicit
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rasterQuery: LayerQuery[K, M], filterIndexOnly: Boolean) = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -43,6 +43,7 @@ class AccumuloCollectionLayerReader(val attributeStore: AttributeStore)(implicit
     }
 
     val queryKeyBounds = rasterQuery(metadata)
+    val layerMetadata = metadata.setComponent[Bounds[K]](queryKeyBounds.foldLeft(EmptyBounds: Bounds[K])(_ combine _))
 
     val decompose = (bounds: KeyBounds[K]) =>
       keyIndex.indexRanges(bounds).map { case (min, max) =>
@@ -50,7 +51,7 @@ class AccumuloCollectionLayerReader(val attributeStore: AttributeStore)(implicit
       }
 
     val seq = AccumuloCollectionReader.read[K, V](header.tileTable, columnFamily(id), queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
-    new ContextCollection(seq, metadata)
+    new ContextCollection(seq, layerMetadata)
   }
 }
 

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerCopier.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerCopier.scala
@@ -39,7 +39,7 @@ class AccumuloLayerCopier(
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerManager.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerManager.scala
@@ -38,28 +38,28 @@ class AccumuloLayerManager(attributeStore: AccumuloAttributeStore, instance: Acc
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     AccumuloLayerCopier(instance).copy[K, V, M](from, to)
 
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     AccumuloLayerMover(instance).move[K, V, M](from, to)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     AccumuloLayerReindexer(instance).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     AccumuloLayerReindexer(instance).reindex[K, V, M](id, keyIndex)
 }

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReindexer.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReindexer.scala
@@ -61,7 +61,7 @@ class AccumuloLayerReindexer(
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)
@@ -83,7 +83,7 @@ class AccumuloLayerReindexer(
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerUpdater.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerUpdater.scala
@@ -41,7 +41,7 @@ class AccumuloLayerUpdater(
   protected def _update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyBounds: KeyBounds[K], mergeFunc: (V, V) => V): Unit = {
     val LayerAttributes(header, metadata, keyIndex, writerSchema) = try {
       attributeStore.readLayerAttributes[AccumuloLayerHeader, M, K](id)
@@ -55,7 +55,7 @@ class AccumuloLayerUpdater(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
     val LayerAttributes(header, metadata, keyIndex, writerSchema) = try {
       attributeStore.readLayerAttributes[AccumuloLayerHeader, M, K](id)

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerWriter.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerWriter.scala
@@ -42,7 +42,7 @@ class AccumuloLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -53,7 +53,7 @@ class AccumuloLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -65,7 +65,7 @@ class AccumuloLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -98,7 +98,7 @@ class AccumuloLayerWriter(
   protected def _write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyIndex: KeyIndex[K]): Unit = {
     val codec  = KeyValueRecordCodec[K, V]
     val schema = codec.schema

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerCopier.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerCopier.scala
@@ -34,7 +34,7 @@ class CassandraLayerCopier(
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerManager.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerManager.scala
@@ -35,28 +35,28 @@ class CassandraLayerManager(attributeStore: CassandraAttributeStore, instance: C
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     CassandraLayerCopier(instance).copy[K, V, M](from, to)
 
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     CassandraLayerMover(instance).move[K, V, M](from, to)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     CassandraLayerReindexer(instance).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     CassandraLayerReindexer(instance).reindex[K, V, M](id, keyIndex)
 }

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerReindexer.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerReindexer.scala
@@ -64,7 +64,7 @@ class CassandraLayerReindexer(
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)
@@ -86,7 +86,7 @@ class CassandraLayerReindexer(
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerUpdater.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerUpdater.scala
@@ -38,7 +38,7 @@ class CassandraLayerUpdater(
   protected def _update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyBounds: KeyBounds[K], mergeFunc: (V, V) => V): Unit = {
     val CassandraLayerHeader(_, _, keyspace, table) = attributeStore.readHeader[CassandraLayerHeader](id)
     val layerWriter = new CassandraLayerWriter(attributeStore, instance, keyspace, table)
@@ -48,7 +48,7 @@ class CassandraLayerUpdater(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
     val CassandraLayerHeader(_, _, keyspace, table) = attributeStore.readHeader[CassandraLayerHeader](id)
     val layerWriter = new CassandraLayerWriter(attributeStore, instance, keyspace, table)

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerWriter.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerWriter.scala
@@ -42,7 +42,7 @@ class CassandraLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -53,7 +53,7 @@ class CassandraLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -65,7 +65,7 @@ class CassandraLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -90,7 +90,7 @@ class CassandraLayerWriter(
   protected def _write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyIndex: KeyIndex[K]): Unit = {
     val codec  = KeyValueRecordCodec[K, V]
     val schema = codec.schema

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -89,6 +89,8 @@ API Changes
     folding of 3D tile layers into 2D tile layers.
   - The often-used ``apply`` method overloads in ``MapKeyTransform`` have been given
     more descriptive aliases.
+  - **Change:** Querying a layer will now produce a result whose metadata will have an ``Extent`` and
+    ``KeyBounds`` of the queried region and not of the whole layer.
 
 - ``geotrellis.vectortile`` (experimental)
 

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseCollectionLayerReader.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseCollectionLayerReader.scala
@@ -31,7 +31,7 @@ class HBaseCollectionLayerReader(val attributeStore: AttributeStore, instance: H
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rasterQuery: LayerQuery[K, M], filterIndexOnly: Boolean) = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -42,11 +42,12 @@ class HBaseCollectionLayerReader(val attributeStore: AttributeStore, instance: H
     }
 
     val queryKeyBounds = rasterQuery(metadata)
+    val layerMetadata = metadata.setComponent[Bounds[K]](queryKeyBounds.foldLeft(EmptyBounds: Bounds[K])(_ combine _))
 
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
 
     val seq = HBaseCollectionReader.read[K, V](instance, header.tileTable, id, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
-    new ContextCollection(seq, metadata)
+    new ContextCollection(seq, layerMetadata)
   }
 }
 

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerCopier.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerCopier.scala
@@ -34,7 +34,7 @@ class HBaseLayerCopier(
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerManager.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerManager.scala
@@ -35,28 +35,28 @@ class HBaseLayerManager(attributeStore: HBaseAttributeStore, instance: HBaseInst
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     HBaseLayerCopier(instance).copy[K, V, M](from, to)
 
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     HBaseLayerMover(instance).move[K, V, M](from, to)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     HBaseLayerReindexer(instance).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     HBaseLayerReindexer(instance).reindex[K, V, M](id, keyIndex)
 }

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerReader.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerReader.scala
@@ -34,7 +34,7 @@ class HBaseLayerReader(val attributeStore: AttributeStore, instance: HBaseInstan
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, tileQuery: LayerQuery[K, M], numPartitions: Int, filterIndexOnly: Boolean) = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -45,11 +45,12 @@ class HBaseLayerReader(val attributeStore: AttributeStore, instance: HBaseInstan
     }
 
     val queryKeyBounds = tileQuery(metadata)
+    val layerMetadata = metadata.setComponent[Bounds[K]](queryKeyBounds.foldLeft(EmptyBounds: Bounds[K])(_ combine _))
 
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
 
     val rdd = HBaseRDDReader.read[K, V](instance, header.tileTable, id, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
-    new ContextRDD(rdd, metadata)
+    new ContextRDD(rdd, layerMetadata)
   }
 }
 

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerReindexer.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerReindexer.scala
@@ -64,7 +64,7 @@ class HBaseLayerReindexer(
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)
@@ -85,7 +85,7 @@ class HBaseLayerReindexer(
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerUpdater.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerUpdater.scala
@@ -39,7 +39,7 @@ class HBaseLayerUpdater(
   protected def _update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyBounds: KeyBounds[K], mergeFunc: (V, V) => V): Unit = {
     val table = attributeStore.readHeader[HBaseLayerHeader](id).tileTable
     val layerWriter = new HBaseLayerWriter(attributeStore, instance, table)
@@ -49,7 +49,7 @@ class HBaseLayerUpdater(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
     val table = attributeStore.readHeader[HBaseLayerHeader](id).tileTable
     val layerWriter = new HBaseLayerWriter(attributeStore, instance, table)

--- a/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerWriter.scala
+++ b/hbase/src/main/scala/geotrellis/spark/io/hbase/HBaseLayerWriter.scala
@@ -41,7 +41,7 @@ class HBaseLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -52,7 +52,7 @@ class HBaseLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -64,7 +64,7 @@ class HBaseLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -87,7 +87,7 @@ class HBaseLayerWriter(
   protected def _write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyIndex: KeyIndex[K]): Unit = {
     val codec  = KeyValueRecordCodec[K, V]
     val schema = codec.schema

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3CollectionLayerReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3CollectionLayerReader.scala
@@ -41,7 +41,7 @@ class S3CollectionLayerReader(val attributeStore: AttributeStore) extends Collec
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rasterQuery: LayerQuery[K, M], filterIndexOnly: Boolean) = {
     if(!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -55,12 +55,13 @@ class S3CollectionLayerReader(val attributeStore: AttributeStore) extends Collec
     val prefix = header.key
 
     val queryKeyBounds = rasterQuery(metadata)
+    val layerMetadata = metadata.setComponent[Bounds[K]](queryKeyBounds.foldLeft(EmptyBounds: Bounds[K])(_ combine _))
     val maxWidth = Index.digits(keyIndex.toIndex(keyIndex.keyBounds.maxKey))
     val keyPath = (index: BigInt) => makePath(prefix, Index.encode(index, maxWidth))
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
     val seq = collectionReader.read[K, V](bucket, keyPath, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
 
-    new ContextCollection(seq, metadata)
+    new ContextCollection(seq, layerMetadata)
   }
 }
 

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerCopier.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerCopier.scala
@@ -52,7 +52,7 @@ class S3LayerCopier(
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerManager.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerManager.scala
@@ -38,28 +38,28 @@ class S3LayerManager(attributeStore: S3AttributeStore)(implicit sc: SparkContext
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     S3LayerCopier(attributeStore).copy[K, V, M](from, to)
 
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     S3LayerMover(attributeStore).move[K, V, M](from, to)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     S3LayerReindexer(attributeStore).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     S3LayerReindexer(attributeStore).reindex[K, V, M](id, keyIndex)
 }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerReader.scala
@@ -45,7 +45,7 @@ class S3LayerReader(val attributeStore: AttributeStore)(implicit sc: SparkContex
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, tileQuery: LayerQuery[K, M], numPartitions: Int, filterIndexOnly: Boolean) = {
     if(!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -59,12 +59,13 @@ class S3LayerReader(val attributeStore: AttributeStore)(implicit sc: SparkContex
     val prefix = header.key
 
     val queryKeyBounds = tileQuery(metadata)
+    val layerMetadata = metadata.setComponent[Bounds[K]](queryKeyBounds.foldLeft(EmptyBounds: Bounds[K])(_ combine _))
     val maxWidth = Index.digits(keyIndex.toIndex(keyIndex.keyBounds.maxKey))
     val keyPath = (index: BigInt) => makePath(prefix, Index.encode(index, maxWidth))
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
     val rdd = rddReader.read[K, V](bucket, keyPath, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema), Some(numPartitions))
 
-    new ContextRDD(rdd, metadata)
+    new ContextRDD(rdd, layerMetadata)
   }
 }
 

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerUpdater.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerUpdater.scala
@@ -41,7 +41,7 @@ class S3LayerUpdater(
 
   private def layerWriterFor[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, bounds: Bounds[K]): LayerWriter[LayerId] = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -66,7 +66,7 @@ class S3LayerUpdater(
   protected def _update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyBounds: KeyBounds[K], mergeFunc: (V, V) => V): Unit = {
     val layerWriter = layerWriterFor[K, M](id, keyBounds)
     layerWriter.update(id, rdd, mergeFunc)
@@ -75,7 +75,7 @@ class S3LayerUpdater(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
     val layerWriter = layerWriterFor[K, M](id, rdd.metadata.getComponent[Bounds[K]])
     layerWriter.overwrite(id, rdd)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerWriter.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3LayerWriter.scala
@@ -59,7 +59,7 @@ class S3LayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -70,7 +70,7 @@ class S3LayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], mergeFunc: (V, V) => V): Unit = {
     update(id, rdd, Some(mergeFunc))
   }
@@ -78,7 +78,7 @@ class S3LayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -104,7 +104,7 @@ class S3LayerWriter(
   protected def _write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyIndex: KeyIndex[K]): Unit = {
     require(!attributeStore.layerExists(id), s"$id already exists")
     implicit val sc = rdd.sparkContext

--- a/spark/src/main/scala/geotrellis/spark/io/CollectionLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/CollectionLayerReader.scala
@@ -32,13 +32,13 @@ abstract class CollectionLayerReader[ID] { self =>
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, rasterQuery: LayerQuery[K, M], indexFilterOnly: Boolean): Seq[(K, V)] with Metadata[M]
 
   def reader[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ]: Reader[ID, Seq[(K, V)] with Metadata[M]] =
     new Reader[ID, Seq[(K, V)] with Metadata[M]] {
       def read(id: ID): Seq[(K, V)] with Metadata[M] =
@@ -48,21 +48,21 @@ abstract class CollectionLayerReader[ID] { self =>
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, rasterQuery: LayerQuery[K, M]): Seq[(K, V)] with Metadata[M] =
     read[K, V, M](id, rasterQuery, false)
 
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID): Seq[(K, V)] with Metadata[M] =
     read[K, V, M](id, new LayerQuery[K, M])
 
   def query[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](layerId: ID): BoundLayerQuery[K, M, Seq[(K, V)] with Metadata[M]] =
     new BoundLayerQuery(new LayerQuery, read[K, V, M](layerId, _))
 }

--- a/spark/src/main/scala/geotrellis/spark/io/FilteringLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/FilteringLayerReader.scala
@@ -46,41 +46,41 @@ abstract class FilteringLayerReader[ID] extends LayerReader[ID] {
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, rasterQuery: LayerQuery[K, M], numPartitions: Int, indexFilterOnly: Boolean): RDD[(K, V)] with Metadata[M]
 
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, rasterQuery: LayerQuery[K, M], numPartitions: Int): RDD[(K, V)] with Metadata[M] =
     read(id, rasterQuery, numPartitions, false)
 
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, rasterQuery: LayerQuery[K, M]): RDD[(K, V)] with Metadata[M] =
     read(id, rasterQuery, defaultNumPartitions)
 
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, numPartitions: Int): RDD[(K, V)] with Metadata[M] =
     read(id, new LayerQuery[K, M], numPartitions)
 
   def query[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](layerId: ID): BoundLayerQuery[K, M, RDD[(K, V)] with Metadata[M]] =
     new BoundLayerQuery(new LayerQuery, read(layerId, _))
 
   def query[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](layerId: ID, numPartitions: Int): BoundLayerQuery[K, M, RDD[(K, V)] with Metadata[M]] =
     new BoundLayerQuery(new LayerQuery, read(layerId, _, numPartitions))
 }

--- a/spark/src/main/scala/geotrellis/spark/io/GenericLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GenericLayerCopier.scala
@@ -37,7 +37,7 @@ class GenericLayerCopier[Header: JsonFormat](
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/GenericLayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GenericLayerMover.scala
@@ -29,7 +29,7 @@ class GenericLayerMover[ID](layerCopier: LayerCopier[ID], layerDeleter: LayerDel
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: ID, to: ID): Unit = {
     layerCopier.copy[K, V, M](from, to)
     layerDeleter.delete(from)

--- a/spark/src/main/scala/geotrellis/spark/io/GenericLayerReindexer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GenericLayerReindexer.scala
@@ -41,7 +41,7 @@ abstract class GenericLayerReindexer[Header:JsonFormat](
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)
@@ -55,7 +55,7 @@ abstract class GenericLayerReindexer[Header:JsonFormat](
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
     val tmpId = getTmpId(id)

--- a/spark/src/main/scala/geotrellis/spark/io/LayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerCopier.scala
@@ -29,6 +29,6 @@ trait LayerCopier[ID] {
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: ID, to: ID): Unit
 }

--- a/spark/src/main/scala/geotrellis/spark/io/LayerManager.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerManager.scala
@@ -34,25 +34,25 @@ trait LayerManager[ID] {
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: ID, to: ID): Unit
 
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: ID, to: ID): Unit
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, keyIndexMethod: KeyIndexMethod[K]): Unit
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, keyIndex: KeyIndex[K]): Unit
 
 }

--- a/spark/src/main/scala/geotrellis/spark/io/LayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerMover.scala
@@ -29,6 +29,6 @@ trait LayerMover[ID] {
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: ID, to: ID): Unit
 }

--- a/spark/src/main/scala/geotrellis/spark/io/LayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerReader.scala
@@ -40,20 +40,20 @@ trait LayerReader[ID] {
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, numPartitions: Int): RDD[(K, V)] with Metadata[M]
 
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID): RDD[(K, V)] with Metadata[M] =
     read(id, defaultNumPartitions)
 
   def reader[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ]: Reader[ID, RDD[(K, V)] with Metadata[M]] =
     new Reader[ID, RDD[(K, V)] with Metadata[M]] {
       def read(id: ID): RDD[(K, V)] with Metadata[M] =

--- a/spark/src/main/scala/geotrellis/spark/io/LayerReindexer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerReindexer.scala
@@ -30,12 +30,12 @@ trait LayerReindexer[ID] {
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, keyIndex: KeyIndex[K]): Unit
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, keyIndexMethod: KeyIndexMethod[K]): Unit
 }

--- a/spark/src/main/scala/geotrellis/spark/io/LayerUpdater.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerUpdater.scala
@@ -36,13 +36,13 @@ abstract class LayerUpdater[ID] {
   protected def _update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: ID, rdd: RDD[(K, V)] with Metadata[M], keyBounds: KeyBounds[K], mergeFunc: (V, V) => V): Unit
 
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: ID, rdd: RDD[(K, V)] with Metadata[M]): Unit
 
 
@@ -56,7 +56,7 @@ abstract class LayerUpdater[ID] {
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: ID, rdd: RDD[(K, V)] with Metadata[M], mergeFunc: (V, V) => V): Unit =
     rdd.metadata.getComponent[Bounds[K]] match {
       case keyBounds: KeyBounds[K] =>
@@ -69,7 +69,7 @@ abstract class LayerUpdater[ID] {
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: ID, rdd: RDD[(K, V)] with Metadata[M]): Unit =
     rdd.metadata.getComponent[Bounds[K]] match {
       case keyBounds: KeyBounds[K] =>

--- a/spark/src/main/scala/geotrellis/spark/io/LayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerWriter.scala
@@ -50,7 +50,7 @@ trait LayerWriter[ID] {
     H: JsonFormat,
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec,
-    M: GetComponent[?, Bounds[K]]: Mergable: JsonFormat
+    M: Component[?, Bounds[K]]: Mergable: JsonFormat
   ](id: LayerId, updateMetadata: M): Option[LayerAttributes[H, M, K]] = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -95,7 +95,7 @@ trait LayerWriter[ID] {
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: ID, rdd: RDD[(K, V)] with Metadata[M], mergeFunc: (V, V) => V): Unit
 
   /** Update persisted layer without checking for possible.
@@ -120,20 +120,20 @@ trait LayerWriter[ID] {
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: ID, rdd: RDD[(K, V)] with Metadata[M]): Unit
 
   // Layer Writing
   protected def _write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, layer: RDD[(K, V)] with Metadata[M], keyIndex: KeyIndex[K]): Unit
 
   def write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, layer: RDD[(K, V)] with Metadata[M], keyIndex: KeyIndex[K]): Unit =
     layer.metadata.getComponent[Bounds[K]] match {
       case keyBounds: KeyBounds[K] =>
@@ -145,7 +145,7 @@ trait LayerWriter[ID] {
   def write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: ID, layer: RDD[(K, V)] with Metadata[M], keyIndexMethod: KeyIndexMethod[K]): Unit =
     layer.metadata.getComponent[Bounds[K]] match {
       case keyBounds: KeyBounds[K] =>
@@ -158,7 +158,7 @@ trait LayerWriter[ID] {
   def writer[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](keyIndexMethod: KeyIndexMethod[K]):  Writer[ID, RDD[(K, V)] with Metadata[M]] =
     new Writer[ID, RDD[(K, V)] with Metadata[M]] {
       def write(id: ID, layer: RDD[(K, V)] with Metadata[M]) =
@@ -168,7 +168,7 @@ trait LayerWriter[ID] {
   def writer[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](keyIndex: KeyIndex[K]):  Writer[ID, RDD[(K, V)] with Metadata[M]] =
     new Writer[ID, RDD[(K, V)] with Metadata[M]] {
       def write(id: ID, layer: RDD[(K, V)] with Metadata[M]) =

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileCollectionLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileCollectionLayerReader.scala
@@ -42,7 +42,7 @@ class FileCollectionLayerReader(
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rasterQuery: LayerQuery[K, M], filterIndexOnly: Boolean) = {
     if(!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -55,12 +55,13 @@ class FileCollectionLayerReader(
     val layerPath = header.path
 
     val queryKeyBounds = rasterQuery(metadata)
+    val layerMetadata = metadata.setComponent[Bounds[K]](queryKeyBounds.foldLeft(EmptyBounds: Bounds[K])(_ combine _))
     val maxWidth = Index.digits(keyIndex.toIndex(keyIndex.keyBounds.maxKey))
     val keyPath = KeyPathGenerator(catalogPath, layerPath, maxWidth)
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
     val seq = FileCollectionReader.read[K, V](keyPath, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema))
 
-    new ContextCollection(seq, metadata)
+    new ContextCollection(seq, layerMetadata)
   }
 }
 

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerCopier.scala
@@ -35,7 +35,7 @@ object FileLayerCopier {
       def copy[
         K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
         V: AvroRecordCodec: ClassTag,
-        M: JsonFormat: GetComponent[?, Bounds[K]]
+        M: JsonFormat: Component[?, Bounds[K]]
       ](from: LayerId, to: LayerId): Unit = {
         if(targetAttributeStore.layerExists(to))
           throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerManager.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerManager.scala
@@ -38,28 +38,28 @@ class FileLayerManager(attributeStore: FileAttributeStore)(implicit sc: SparkCon
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     FileLayerCopier(attributeStore).copy[K, V, M](from, to)
 
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     FileLayerMover(attributeStore).move[K, V, M](from, to)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     FileLayerReindexer(attributeStore).reindex[K, V, M](id, keyIndexMethod)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     FileLayerReindexer(attributeStore).reindex[K, V, M](id, keyIndex)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerMover.scala
@@ -35,7 +35,7 @@ object FileLayerMover {
       def move[
         K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
         V: AvroRecordCodec: ClassTag,
-        M: JsonFormat: GetComponent[?, Bounds[K]]
+        M: JsonFormat: Component[?, Bounds[K]]
       ](from: LayerId, to: LayerId): Unit = {
         if(targetAttributeStore.layerExists(to))
           throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerReader.scala
@@ -45,7 +45,7 @@ class FileLayerReader(
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, tileQuery: LayerQuery[K, M], numPartitions: Int, filterIndexOnly: Boolean) = {
     if(!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -58,12 +58,13 @@ class FileLayerReader(
     val layerPath = header.path
 
     val queryKeyBounds = tileQuery(metadata)
+    val layerMetadata = metadata.setComponent[Bounds[K]](queryKeyBounds.foldLeft(EmptyBounds: Bounds[K])(_ combine _))
     val maxWidth = Index.digits(keyIndex.toIndex(keyIndex.keyBounds.maxKey))
     val keyPath = KeyPathGenerator(catalogPath, layerPath, maxWidth)
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
     val rdd = FileRDDReader.read[K, V](keyPath, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema), Some(numPartitions))
 
-    new ContextRDD(rdd, metadata)
+    new ContextRDD(rdd, layerMetadata)
   }
 }
 

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerUpdater.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerUpdater.scala
@@ -44,7 +44,7 @@ class FileLayerUpdater(
   protected def _update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyBounds: KeyBounds[K], mergeFunc: (V, V) => V): Unit = {
     layerWriter.update(id, rdd, mergeFunc)
   }
@@ -52,7 +52,7 @@ class FileLayerUpdater(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
     layerWriter.overwrite(id, rdd)
   }

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerWriter.scala
@@ -55,7 +55,7 @@ class FileLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -66,7 +66,7 @@ class FileLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -78,7 +78,7 @@ class FileLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -105,7 +105,7 @@ class FileLayerWriter(
   protected def _write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](layerId: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyIndex: KeyIndex[K]): Unit = {
     val catalogPathFile = new File(catalogPath)
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerCopier.scala
@@ -41,7 +41,7 @@ class HadoopLayerCopier(
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerManager.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerManager.scala
@@ -38,28 +38,28 @@ class HadoopLayerManager(attributeStore: HadoopAttributeStore)(implicit sc: Spar
   def copy[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     HadoopLayerCopier(attributeStore).copy[K, V, M](from, to)
 
   def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit =
     HadoopLayerMover(attributeStore).move[K, V, M](from, to)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndex: KeyIndex[K]): Unit =
     HadoopLayerReindexer(attributeStore).reindex[K, V, M](id, keyIndex)
 
   def reindex[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, keyIndexMethod: KeyIndexMethod[K]): Unit =
     HadoopLayerReindexer(attributeStore).reindex[K, V, M](id, keyIndexMethod)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerMover.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerMover.scala
@@ -42,7 +42,7 @@ class HadoopLayerMover(
   override def move[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](from: LayerId, to: LayerId): Unit = {
     if (!attributeStore.layerExists(from)) throw new LayerNotFoundError(from)
     if (attributeStore.layerExists(to)) throw new LayerExistsError(to)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerUpdater.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerUpdater.scala
@@ -42,7 +42,7 @@ class HadoopLayerUpdater(
   protected def _update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyBounds: KeyBounds[K], mergeFunc: (V, V) => V): Unit = {
     layerWriter.update(id, rdd, mergeFunc)
   }
@@ -50,7 +50,7 @@ class HadoopLayerUpdater(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
     layerWriter.overwrite(id, rdd)
   }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerWriter.scala
@@ -46,7 +46,7 @@ class HadoopLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
     update(id, rdd, None)
   }
@@ -54,7 +54,7 @@ class HadoopLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], mergeFunc: (V, V) => V): Unit = {
     update(id, rdd, Some(mergeFunc))
   }
@@ -62,7 +62,7 @@ class HadoopLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]: Mergable
+    M: JsonFormat: Component[?, Bounds[K]]: Mergable
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -97,7 +97,7 @@ class HadoopLayerWriter(
   protected def _write[
     K: AvroRecordCodec: JsonFormat: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: JsonFormat: GetComponent[?, Bounds[K]]
+    M: JsonFormat: Component[?, Bounds[K]]
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], keyIndex: KeyIndex[K]): Unit = {
     val layerPath =
       try {

--- a/spark/src/test/scala/geotrellis/spark/io/AllOnesTestTileSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/AllOnesTestTileSpec.scala
@@ -73,6 +73,12 @@ trait AllOnesTestTileSpec { self: PersistenceSpec[SpatialKey, Tile, TileLayerMet
           for ((col, row) <- GridBounds(3, 3, 4, 4).coordsIter.toSeq) yield SpatialKey(col, row)
         }
       }
+
+      it("layer should have a proper extent after query") {
+        val extent = Extent(-10, -10, 10, 10) // this should intersect the four central tiles in 8x8 layout
+        val metadata = query.where(Intersects(extent)).result.metadata
+        metadata.extent should be (metadata.mapTransform(GridBounds(3, 3, 4, 4)))
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

This PR makes it so that the resulting TileLayerMetadata of a query will contain the correct KeyBounds and Extent of the queried region. This is opposed to the current output which will have the KeyBounds and Extent for the whole layer.

This PR is an updated version of https://github.com/locationtech/geotrellis/pull/2582

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

Closes #2543 