### PR TITLE
Tile.slope(cellSize, target = TargetCell.Data) Fix

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixes
   - **Note:** Existing spatial layers using Hilbert index will need to be updated, see PR for directions.
 - Fixed ``CastException`` that sometimes occured when reading cached attributes.
 - Uncompressed GeoTiffMultibandTiles will now convert to the correct CellType
+- Calculating the Slope of a ``Tile`` when ``targetCell`` is ``Data`` will now produce the correct result.
 
 
 1.2.1

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/SurfacePointCalculation.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/SurfacePointCalculation.scala
@@ -282,6 +282,7 @@ abstract class SurfacePointCalculation[T](r: Tile, n: Neighborhood, analysisArea
       col = colMin + 1
       while (col < colMax) {
         moveRight()
+        focalValue = r.getDouble(col, row)
         east(0) = r.getDouble(col+1, row-1)
         east(1) = r.getDouble(col+1, row)
         east(2) = r.getDouble(col+1, row+1)

--- a/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/SlopeSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/SlopeSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.mapalgebra.focal
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.focal.Angles._
+import org.scalatest._
+
+import scala.math._
+
+class SlopeSpec extends FunSpec with Matchers {
+  describe("Slope") {
+    it("should calculate Slope when the targetCell is set to Data") {
+      val noData = byteNODATA
+      val arr = Array[Byte](
+        -1,         0, 1, 1, 1,
+        noData,     2, 2, 2, 2,
+        1,          2, 2, 2, 2,
+        1,          2, 2, 2, 2,
+        1,          2, 2, 2, 2)
+
+      val tile = ByteArrayTile(arr, 5, 5, ByteConstantNoDataCellType)
+      val size = CellSize(5, 5)
+
+      val slope = tile.slope(size, target = TargetCell.Data)
+
+      def calculateSlope(dx: Double, dy: Double): Double =
+        degrees(atan(sqrt(pow(dx, 2) + pow(dy, 2))))
+
+      // Calculating the slope value for the (1, 1) cell
+
+      var dx = ((1 + 4 + 2) - (-1 + 4 + 1)) / (8.0 * size.width)
+      var dy = ((1 + 4 + 2) - (-1 + 1)) / (8.0 * size.height)
+
+      calculateSlope(dx, dy) should be (slope.getDouble(1, 1))
+
+      // Calculating the slope value for the (2, 1) cell
+
+      dx = ((1 + 4 + 2) - (0 + 4 + 2)) / (8.0 * size.width)
+      dy = ((2 + 4 + 2) - (0 + 2 + 1)) / (8.0 * size.height)
+
+      calculateSlope(dx, dy) should be (slope.getDouble(2, 1))
+
+      // Calculating the slope value for the (3, 1) cell
+
+      dx = ((1 + 4 + 2) - (1 + 4 + 2)) / (8.0 * size.width)
+      dy = ((2 + 4 + 2) - (1 + 2 + 1)) / (8.0 * size.height)
+
+      calculateSlope(dx, dy) should be (slope.getDouble(3, 1))
+
+      // Calculating the slope value for the (4, 1) cell
+
+      dx = ((2 + 4 + 2) - (1 + 4 + 2)) / (8.0 * size.width)
+      dy = ((2 + 4 + 2) - (1 + 2 + 2)) / (8.0 * size.height)
+
+      calculateSlope(dx, dy) should be (slope.getDouble(4, 1))
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR fixes a bug in the `Tile.slope(cellSize, target = TargetCell.Data)` method call where if the first value of a column was `NoData` then all of the values in that row would be set to `NoData`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

Closes #2563 
