### PR TITLE
Fix issues with simple feature building

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -48,6 +48,8 @@ Fixes
 - The regex used to match files for the ``HadoopLayerAttributeStore`` and ``FileLayerAttributeStore`` has been
   expanded to include more characters.
 - ``HadoopAttributeStore.availableAttributes`` has been fixed so that it'll now list all attribute files.
+- Allow for simple features to be generated with a specified or random id with geometry stored in the standard
+  field, "the_geom"
 
 1.2.1
 _____

--- a/geomesa/src/main/scala/geotrellis/geomesa/geotools/GeometryToGeoMesaSimpleFeature.scala
+++ b/geomesa/src/main/scala/geotrellis/geomesa/geotools/GeometryToGeoMesaSimpleFeature.scala
@@ -35,7 +35,7 @@ import com.typesafe.config.ConfigFactory
 object GeometryToGeoMesaSimpleFeature {
 
   val whenField  = "when"
-  val whereField = "where"
+  val whereField = "the_geom"
 
   lazy val featureTypeCache =
     Scaffeine()

--- a/geotools/src/main/scala/geotrellis/geotools/FeatureToSimpleFeatureMethods.scala
+++ b/geotools/src/main/scala/geotrellis/geotools/FeatureToSimpleFeatureMethods.scala
@@ -30,4 +30,10 @@ trait FeatureToSimpleFeatureMethods[G <: Geometry, T] extends MethodExtensions[F
 
   def toSimpleFeature(crs: CRS)(implicit transmute: T => Seq[(String, Any)]): SimpleFeature =
     GeometryToSimpleFeature(self.geom, Some(crs), self.data)
+
+  def toSimpleFeature(featureId: String)(implicit transmute: T => Seq[(String, Any)]): SimpleFeature =
+    GeometryToSimpleFeature(self.geom, None, self.data, featureId)
+
+  def toSimpleFeature(crs: CRS, featureId: String)(implicit transmute: T => Seq[(String, Any)]): SimpleFeature =
+    GeometryToSimpleFeature(self.geom, Some(crs), self.data, featureId)
 }

--- a/geotools/src/main/scala/geotrellis/geotools/GeometryToSimpleFeature.scala
+++ b/geotools/src/main/scala/geotrellis/geotools/GeometryToSimpleFeature.scala
@@ -27,17 +27,18 @@ import scala.collection.JavaConverters._
 
 
 object GeometryToSimpleFeature {
-  val geometryField = "geometry"
+  val geometryField = "the_geom"
 
   /**
     * Given a Geotrellis geometry, a CRS, and a sequence of ancillary
     * data, produce a GeoTools SimpleFeature.
     *
-    * @param  geom  The Geotrellis geometry
-    * @param  crs   The CRS of the geometry
-    * @param  data  A sequence of (String, Any) pairs
+    * @param  geom       The Geotrellis geometry
+    * @param  crs        The CRS of the geometry
+    * @param  data       A sequence of (String, Any) pairs
+    * @param  featureId  A identifier for the output simple feature (null for a randomly generated id)
     */
-  def apply(geom: Geometry, crs: Option[CRS], data: Seq[(String, Any)]): SimpleFeature = {
+  def apply(geom: Geometry, crs: Option[CRS], data: Seq[(String, Any)], featureId: String = null): SimpleFeature = {
     val sftb = (new SimpleFeatureTypeBuilder).minOccurs(1).maxOccurs(1).nillable(false)
 
     sftb.setName("Bespoke Type")
@@ -74,6 +75,6 @@ object GeometryToSimpleFeature {
     }
     data.foreach({ case (key, value) => sfb.add(value) })
 
-    sfb.buildFeature("SimpleFeature")
+    sfb.buildFeature(featureId)
   }
 }

--- a/geotools/src/main/scala/geotrellis/geotools/GeometryToSimpleFeatureMethods.scala
+++ b/geotools/src/main/scala/geotrellis/geotools/GeometryToSimpleFeatureMethods.scala
@@ -36,4 +36,16 @@ trait GeometryToSimpleFeatureMethods[G <: Geometry] extends MethodExtensions[G] 
 
   def toSimpleFeature(crs: CRS, map: Map[String, Any]): SimpleFeature =
     GeometryToSimpleFeature(self, Some(crs), map.toList)
+
+  def toSimpleFeature(featureId: String): SimpleFeature =
+    GeometryToSimpleFeature(self, None, Seq.empty[(String, Any)], featureId)
+
+  def toSimpleFeature(crs: CRS, featureId: String): SimpleFeature =
+    GeometryToSimpleFeature(self, Some(crs), Seq.empty[(String, Any)], featureId)
+
+  def toSimpleFeature(map: Map[String, Any], featureId: String): SimpleFeature =
+    GeometryToSimpleFeature(self, None, map.toList, featureId)
+
+  def toSimpleFeature(crs: CRS, map: Map[String, Any], featureId: String): SimpleFeature =
+    GeometryToSimpleFeature(self, Some(crs), map.toList, featureId)
 }

--- a/geotools/src/test/scala/geotrellis/geotools/FeatureToSimpleFeatureMethodsSpec.scala
+++ b/geotools/src/test/scala/geotrellis/geotools/FeatureToSimpleFeatureMethodsSpec.scala
@@ -47,50 +47,50 @@ class FeatureToSimpleFeatureMethodsSpec
 
     it("should work with Points") {
       val feature = Feature(point, Foo(42, "72"))
-      val actual = feature.toSimpleFeature
-      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList)
+      val actual = feature.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work with Lines") {
       val feature = Feature(line, Foo(42, "72"))
-      val actual = feature.toSimpleFeature
-      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList)
+      val actual = feature.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work with Polygons") {
       val feature = Feature(polygon, Foo(42, "72"))
-      val actual = feature.toSimpleFeature
-      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList)
+      val actual = feature.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work with MultiPoints") {
       val feature = Feature(multiPoint, Foo(42, "72"))
-      val actual = feature.toSimpleFeature
-      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList)
+      val actual = feature.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work with MultiLines") {
       val feature = Feature(multiLine, Foo(42, "72"))
-      val actual = feature.toSimpleFeature
-      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList)
+      val actual = feature.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work with MultiPolygons") {
       val feature = Feature(multiPolygon, Foo(42, "72"))
-      val actual = feature.toSimpleFeature
-      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList)
+      val actual = feature.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(feature.geom, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work with supplied CRS") {
       val feature = Feature(multiPolygon, Foo(42, "72"))
-      val actual = feature.toSimpleFeature(crs)
-      val expected = GeometryToSimpleFeature(feature.geom, Some(crs), nonEmptyList)
+      val actual = feature.toSimpleFeature(crs, "test_id")
+      val expected = GeometryToSimpleFeature(feature.geom, Some(crs), nonEmptyList, "test_id")
       actual should be (expected)
     }
 

--- a/geotools/src/test/scala/geotrellis/geotools/GeometryToSimpleFeatureMethodsSpec.scala
+++ b/geotools/src/test/scala/geotrellis/geotools/GeometryToSimpleFeatureMethodsSpec.scala
@@ -44,156 +44,156 @@ class GeometryToSimpleFeatureMethodsSpec
     val map = nonEmptyList.toMap
 
     it("should work on Points w/ no arguments") {
-      val actual = point.toSimpleFeature
-      val expected = GeometryToSimpleFeature(point, None, emptyList)
+      val actual = point.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(point, None, emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Points w/ CRS") {
-      val actual = point.toSimpleFeature(crs)
-      val expected = GeometryToSimpleFeature(point, Some(crs), emptyList)
+      val actual = point.toSimpleFeature(crs, "test_id")
+      val expected = GeometryToSimpleFeature(point, Some(crs), emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Points w/ Map") {
-      val actual = point.toSimpleFeature(map)
-      val expected = GeometryToSimpleFeature(point, None, nonEmptyList)
+      val actual = point.toSimpleFeature(map, "test_id")
+      val expected = GeometryToSimpleFeature(point, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Points w/ CRS and Map") {
-      val actual = point.toSimpleFeature(crs, map)
-      val expected = GeometryToSimpleFeature(point, Some(crs), nonEmptyList)
+      val actual = point.toSimpleFeature(crs, map, "test_id")
+      val expected = GeometryToSimpleFeature(point, Some(crs), nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     /* --------------------------------- */
 
     it("should work on Lines w/ no arguments") {
-      val actual = line.toSimpleFeature
-      val expected = GeometryToSimpleFeature(line, None, emptyList)
+      val actual = line.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(line, None, emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Lines w/ CRS") {
-      val actual = line.toSimpleFeature(crs)
-      val expected = GeometryToSimpleFeature(line, Some(crs), emptyList)
+      val actual = line.toSimpleFeature(crs, "test_id")
+      val expected = GeometryToSimpleFeature(line, Some(crs), emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Lines w/ Map") {
-      val actual = line.toSimpleFeature(map)
-      val expected = GeometryToSimpleFeature(line, None, nonEmptyList)
+      val actual = line.toSimpleFeature(map, "test_id")
+      val expected = GeometryToSimpleFeature(line, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Lines w/ CRS and Map") {
-      val actual = line.toSimpleFeature(crs, map)
-      val expected = GeometryToSimpleFeature(line, Some(crs), nonEmptyList)
+      val actual = line.toSimpleFeature(crs, map, "test_id")
+      val expected = GeometryToSimpleFeature(line, Some(crs), nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     /* --------------------------------- */
 
     it("should work on Polygons w/ no arguments") {
-      val actual = polygon.toSimpleFeature
-      val expected = GeometryToSimpleFeature(polygon, None, emptyList)
+      val actual = polygon.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(polygon, None, emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Polygons w/ CRS") {
-      val actual = polygon.toSimpleFeature(crs)
-      val expected = GeometryToSimpleFeature(polygon, Some(crs), emptyList)
+      val actual = polygon.toSimpleFeature(crs, "test_id")
+      val expected = GeometryToSimpleFeature(polygon, Some(crs), emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Polygons w/ Map") {
-      val actual = polygon.toSimpleFeature(map)
-      val expected = GeometryToSimpleFeature(polygon, None, nonEmptyList)
+      val actual = polygon.toSimpleFeature(map, "test_id")
+      val expected = GeometryToSimpleFeature(polygon, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on Polygons w/ CRS and Map") {
-      val actual = polygon.toSimpleFeature(crs, map)
-      val expected = GeometryToSimpleFeature(polygon, Some(crs), nonEmptyList)
+      val actual = polygon.toSimpleFeature(crs, map, "test_id")
+      val expected = GeometryToSimpleFeature(polygon, Some(crs), nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     /* --------------------------------- */
 
     it("should work on MultiPoints w/ no arguments") {
-      val actual = multiPoint.toSimpleFeature
-      val expected = GeometryToSimpleFeature(multiPoint, None, emptyList)
+      val actual = multiPoint.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(multiPoint, None, emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiPoints w/ CRS") {
-      val actual = multiPoint.toSimpleFeature(crs)
-      val expected = GeometryToSimpleFeature(multiPoint, Some(crs), emptyList)
+      val actual = multiPoint.toSimpleFeature(crs, "test_id")
+      val expected = GeometryToSimpleFeature(multiPoint, Some(crs), emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiPoints w/ Map") {
-      val actual = multiPoint.toSimpleFeature(map)
-      val expected = GeometryToSimpleFeature(multiPoint, None, nonEmptyList)
+      val actual = multiPoint.toSimpleFeature(map, "test_id")
+      val expected = GeometryToSimpleFeature(multiPoint, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiPoints w/ CRS and Map") {
-      val actual = multiPoint.toSimpleFeature(crs, map)
-      val expected = GeometryToSimpleFeature(multiPoint, Some(crs), nonEmptyList)
+      val actual = multiPoint.toSimpleFeature(crs, map, "test_id")
+      val expected = GeometryToSimpleFeature(multiPoint, Some(crs), nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     /* --------------------------------- */
 
     it("should work on MultiLines w/ no arguments") {
-      val actual = multiLine.toSimpleFeature
-      val expected = GeometryToSimpleFeature(multiLine, None, emptyList)
+      val actual = multiLine.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(multiLine, None, emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiLines w/ CRS") {
-      val actual = multiLine.toSimpleFeature(crs)
-      val expected = GeometryToSimpleFeature(multiLine, Some(crs), emptyList)
+      val actual = multiLine.toSimpleFeature(crs, "test_id")
+      val expected = GeometryToSimpleFeature(multiLine, Some(crs), emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiLines w/ Map") {
-      val actual = multiLine.toSimpleFeature(map)
-      val expected = GeometryToSimpleFeature(multiLine, None, nonEmptyList)
+      val actual = multiLine.toSimpleFeature(map, "test_id")
+      val expected = GeometryToSimpleFeature(multiLine, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiLines w/ CRS and Map") {
-      val actual = multiLine.toSimpleFeature(crs, map)
-      val expected = GeometryToSimpleFeature(multiLine, Some(crs), nonEmptyList)
+      val actual = multiLine.toSimpleFeature(crs, map, "test_id")
+      val expected = GeometryToSimpleFeature(multiLine, Some(crs), nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     /* --------------------------------- */
 
     it("should work on MultiPolygons w/ no arguments") {
-      val actual = multiPolygon.toSimpleFeature
-      val expected = GeometryToSimpleFeature(multiPolygon, None, emptyList)
+      val actual = multiPolygon.toSimpleFeature("test_id")
+      val expected = GeometryToSimpleFeature(multiPolygon, None, emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiPolygons w/ CRS") {
-      val actual = multiPolygon.toSimpleFeature(crs)
-      val expected = GeometryToSimpleFeature(multiPolygon, Some(crs), emptyList)
+      val actual = multiPolygon.toSimpleFeature(crs, "test_id")
+      val expected = GeometryToSimpleFeature(multiPolygon, Some(crs), emptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiPolygons w/ Map") {
-      val actual = multiPolygon.toSimpleFeature(map)
-      val expected = GeometryToSimpleFeature(multiPolygon, None, nonEmptyList)
+      val actual = multiPolygon.toSimpleFeature(map, "test_id")
+      val expected = GeometryToSimpleFeature(multiPolygon, None, nonEmptyList, "test_id")
       actual should be (expected)
     }
 
     it("should work on MultiPolygons w/ CRS and Map") {
-      val actual = multiPolygon.toSimpleFeature(crs, map)
-      val expected = GeometryToSimpleFeature(multiPolygon, Some(crs), nonEmptyList)
+      val actual = multiPolygon.toSimpleFeature(crs, map, "test_id")
+      val expected = GeometryToSimpleFeature(multiPolygon, Some(crs), nonEmptyList, "test_id")
       actual should be (expected)
     }
   }


### PR DESCRIPTION
## Overview

Simple features were being built with a constant ID field.  This PR allows the user to specify that ID or to accept a randomly generated ID.  We were also storing geometry into the nonstandard field "geometry".  This has been updated to store geometry in the standard "the_geom" field.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

### Notes

Closes #2575 
