### PR TITLE
Fix conflicting GeoTiff reader flags

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -38,6 +38,11 @@ API Changes
     and ``writeCOGLayerAttributes``.
   - **New:** Kryo serialization of geometry now uses a binary format to reduce shuffle block size
   - **Change:** Scalaz streams were replaced by fs2 streams
+  - **Change:** Replace `geotrellis.util.Functor` with `cats.Functor`.
+
+- ``geotrellis.raster``
+
+  - **Change:** Removed ``decompress`` option from `GeoTiffReader` functions.
 
 Fixes
 ^^^^^

--- a/geotools/src/test/scala/geotrellis/geotools/GridCoverage2DConvertersSpec.scala
+++ b/geotools/src/test/scala/geotrellis/geotools/GridCoverage2DConvertersSpec.scala
@@ -35,11 +35,15 @@ class GridCoverage2DConvertersSpec extends FunSpec with Matchers with GeoTiffTes
     def gridCoverage2D: GridCoverage2D =
       new GeoTiffReader(new java.io.File(path)).read(null)
 
-    def singlebandRaster: ProjectedRaster[Tile] =
-      SinglebandGeoTiff(path).projectedRaster
+    def singlebandRaster: ProjectedRaster[Tile] = {
+      val tiff = SinglebandGeoTiff(path)
+      tiff.projectedRaster.copy(raster = Raster(tiff.tile.toArrayTile, tiff.extent))
+    }
 
-    def multibandRaster: ProjectedRaster[MultibandTile] =
-      MultibandGeoTiff(path).projectedRaster
+    def multibandRaster: ProjectedRaster[MultibandTile] = {
+      val tiff = MultibandGeoTiff(path)
+      tiff.projectedRaster.copy(raster = Raster(tiff.tile.toArrayTile, tiff.extent))
+    }
   }
 
   val testFilesWithProjections: List[TestFile] =

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -105,6 +105,13 @@ class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMu
   }
 
   /**
+    * Return the [[ArrayMultibandTile]] equivalent of this ArrayMultibandTile.
+    *
+    * @return  The object on which the method was invoked
+    */
+  def toArrayTile = this
+
+  /**
     * Retrieve one band of an [[ArrayMultibandTile]].
     *
     * @param   bandIndex  The index of the band to be retrieved

--- a/raster/src/main/scala/geotrellis/raster/DelayedConversionMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DelayedConversionMultibandTile.scala
@@ -326,4 +326,6 @@ class DelayedConversionMultibandTile(inner: MultibandTile, override val targetCe
     }
     result
   }
+
+  def toArrayTile: ArrayMultibandTile = inner.toArrayTile
 }

--- a/raster/src/main/scala/geotrellis/raster/DelayedConversionTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DelayedConversionTile.scala
@@ -52,9 +52,9 @@ class DelayedConversionTile(inner: Tile, targetCellType: CellType)
   def interpretAs(newCellType: CellType): Tile =
     withNoData(None).convert(newCellType)
 
-  override def toArray = inner.toArray
+  def toArray = inner.toArray
 
-  override def toArrayDouble = inner.toArrayDouble
+  def toArrayDouble = inner.toArrayDouble
 
   def toArrayTile: ArrayTile = mutable
 

--- a/raster/src/main/scala/geotrellis/raster/MultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/MultibandTile.scala
@@ -279,4 +279,8 @@ trait MultibandTile extends CellGrid with MacroCombinableMultibandTile[Tile] wit
     */
   def combineDouble(b0: Int, b1: Int)(f: (Double, Double) => Double): Tile
 
+  /**
+    * Convert the present [[MultibandTile]] to an [[MultibandTile]] of [[ArrayTile]]s.
+    */
+  def toArrayTile(): ArrayMultibandTile
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
@@ -38,7 +38,7 @@ case class MultibandGeoTiff(
     MultibandGeoTiff(f(tile), extent, crs, tags, options, overviews)
 
   def withStorageMethod(storageMethod: StorageMethod): MultibandGeoTiff =
-    new MultibandGeoTiff(tile, extent, crs, tags, options.copy(storageMethod = storageMethod), overviews.map(_.withStorageMethod(storageMethod)))
+    new MultibandGeoTiff(tile.toArrayTile, extent, crs, tags, options.copy(storageMethod = storageMethod), overviews.map(_.withStorageMethod(storageMethod)))
 
   def imageData: GeoTiffImageData =
     tile match {
@@ -151,9 +151,8 @@ case class MultibandGeoTiff(
     }
   }
 
-  def copy(tile: MultibandTile, extent: Extent, crs: CRS, tags: Tags, options: GeoTiffOptions, overviews: List[GeoTiff[MultibandTile]]): MultibandGeoTiff =
+  def copy(tile: MultibandTile = tile, extent: Extent = extent, crs: CRS = crs, tags: Tags = tags, options: GeoTiffOptions = options, overviews: List[GeoTiff[MultibandTile]] = overviews): MultibandGeoTiff =
     MultibandGeoTiff(tile, extent, crs, tags, options, overviews)
-
 }
 
 object MultibandGeoTiff {
@@ -166,8 +165,8 @@ object MultibandGeoTiff {
   /** Read a multi-band GeoTIFF file from a byte array.
     * If decompress = true, the GeoTIFF will be fully uncompressed and held in memory.
     */
-  def apply(bytes: Array[Byte], decompress: Boolean, streaming: Boolean): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(bytes, decompress, streaming)
+  def apply(bytes: Array[Byte], streaming: Boolean): MultibandGeoTiff =
+    GeoTiffReader.readMultiband(bytes, streaming)
 
   /** Read a multi-band GeoTIFF file from the file at the given path.
     * GeoTIFF will be fully decompressed and held in memory.
@@ -184,8 +183,8 @@ object MultibandGeoTiff {
   /** Read a multi-band GeoTIFF file from the file at the given path.
     * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
-  def apply(path: String, decompress: Boolean, streaming: Boolean): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(path, decompress, streaming)
+  def apply(path: String, streaming: Boolean): MultibandGeoTiff =
+    GeoTiffReader.readMultiband(path, streaming)
 
   def apply(byteReader: ByteReader): MultibandGeoTiff =
     GeoTiffReader.readMultiband(byteReader)
@@ -196,26 +195,14 @@ object MultibandGeoTiff {
   def apply(byteReader: ByteReader, e: Option[Extent]): MultibandGeoTiff =
     GeoTiffReader.readMultiband(byteReader, e)
 
-  def apply(byteReader: ByteReader, decompress: Boolean, streaming: Boolean): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(byteReader, decompress, streaming)
-
-  /** Read a multi-band GeoTIFF file from the file at a given path.
-    * The tile data will remain tiled/striped and compressed in the TIFF format.
-    */
-  def compressed(path: String): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(path, false, false)
-
-  /** Read a multi-band GeoTIFF file from a byte array.
-    * The tile data will remain tiled/striped and compressed in the TIFF format.
-    */
-  def compressed(bytes: Array[Byte]): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(bytes, false, false)
+  def apply(byteReader: ByteReader, streaming: Boolean): MultibandGeoTiff =
+    GeoTiffReader.readMultiband(byteReader, streaming)
 
   def streaming(path: String): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(path, false, true)
+    GeoTiffReader.readMultiband(path, true)
 
   def streaming(byteReader: ByteReader): MultibandGeoTiff =
-    GeoTiffReader.readMultiband(byteReader, false, true)
+    GeoTiffReader.readMultiband(byteReader, true)
 
   def apply(
     tile: MultibandTile,

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
@@ -25,6 +25,8 @@ import geotrellis.raster.crop.Crop
 import geotrellis.raster.resample.ResampleMethod
 import spire.syntax.cfor._
 
+import java.nio.ByteBuffer
+
 case class SinglebandGeoTiff(
   tile: Tile,
   extent: Extent,
@@ -39,7 +41,7 @@ case class SinglebandGeoTiff(
     SinglebandGeoTiff(f(tile), extent, crs, tags, options, overviews)
 
   def withStorageMethod(storageMethod: StorageMethod): SinglebandGeoTiff =
-    SinglebandGeoTiff(tile, extent, crs, tags, options.copy(storageMethod = storageMethod), overviews)
+    SinglebandGeoTiff(tile.toArrayTile, extent, crs, tags, options.copy(storageMethod = storageMethod), overviews)
 
   def imageData: GeoTiffImageData =
     tile match {
@@ -140,7 +142,7 @@ case class SinglebandGeoTiff(
     }
   }
 
-  def copy(tile: Tile, extent: Extent, crs: CRS, tags: Tags, options: GeoTiffOptions, overviews: List[GeoTiff[Tile]]): SinglebandGeoTiff =
+  def copy(tile: Tile = tile, extent: Extent = extent, crs: CRS = crs, tags: Tags = tags, options: GeoTiffOptions = options, overviews: List[GeoTiff[Tile]] = overviews): SinglebandGeoTiff =
     SinglebandGeoTiff(tile, extent, crs, tags, options, overviews)
 }
 
@@ -154,16 +156,14 @@ object SinglebandGeoTiff {
     SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT)
 
   /** Read a single-band GeoTIFF file from a byte array.
-    * The GeoTIFF will be fully decompressed and held in memory.
     */
   def apply(bytes: Array[Byte]): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(bytes)
 
   /** Read a single-band GeoTIFF file from a byte array.
-    * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
-  def apply(bytes: Array[Byte], decompress: Boolean, streaming: Boolean): SinglebandGeoTiff =
-    GeoTiffReader.readSingleband(bytes, decompress, streaming)
+  def apply(bytes: Array[Byte], streaming: Boolean): SinglebandGeoTiff =
+    GeoTiffReader.readSingleband(bytes, streaming)
 
   /** Read a single-band GeoTIFF file from the file at the given path.
     * The GeoTIFF will be fully decompressed and held in memory.
@@ -178,10 +178,9 @@ object SinglebandGeoTiff {
     GeoTiffReader.readSingleband(path, e)
 
   /** Read a single-band GeoTIFF file from the file at the given path.
-    * If decompress = true, the GeoTIFF will be fully decompressed and held in memory.
     */
-  def apply(path: String, decompress: Boolean, streaming: Boolean): SinglebandGeoTiff =
-    GeoTiffReader.readSingleband(path, decompress, streaming)
+  def apply(path: String, streaming: Boolean): SinglebandGeoTiff =
+    GeoTiffReader.readSingleband(path, streaming)
 
   def apply(byteReader: ByteReader): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(byteReader)
@@ -192,21 +191,9 @@ object SinglebandGeoTiff {
   def apply(byteReader: ByteReader, e: Option[Extent]): SinglebandGeoTiff =
     GeoTiffReader.readSingleband(byteReader, e)
 
-  /** Read a single-band GeoTIFF file from the file at the given path.
-    * The tile data will remain tiled/striped and compressed in the TIFF format.
-    */
-  def compressed(path: String): SinglebandGeoTiff =
-    GeoTiffReader.readSingleband(path, false, false)
-
-  /** Read a single-band GeoTIFF file from a byte array.
-    * The tile data will remain tiled/striped and compressed in the TIFF format.
-    */
-  def compressed(bytes: Array[Byte]): SinglebandGeoTiff =
-    GeoTiffReader.readSingleband(bytes, false, false)
-
   def streaming(path: String): SinglebandGeoTiff =
-    GeoTiffReader.readSingleband(path, false, true)
+    GeoTiffReader.readSingleband(path, true)
 
   def streaming(byteReader: ByteReader): SinglebandGeoTiff =
-    GeoTiffReader.readSingleband(byteReader, false, true)
+    GeoTiffReader.readSingleband(byteReader, true)
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
@@ -43,7 +43,7 @@ object GeoTiffReader {
    * If there is more than one band in the GeoTiff, read the first band only.
    */
   def readSingleband(path: String): SinglebandGeoTiff =
-    readSingleband(path, true, false)
+    readSingleband(path, false)
 
   /* Read in only the extent of a single band GeoTIFF file.
    * If there is more than one band in the GeoTiff, read the first band only.
@@ -56,65 +56,58 @@ object GeoTiffReader {
    */
   def readSingleband(path: String, e: Option[Extent]): SinglebandGeoTiff =
     e match {
-      case Some(x) => readSingleband(path, false, true).crop(x)
+      case Some(x) => readSingleband(path, true).crop(x)
       case None => readSingleband(path)
     }
 
   /* Read a single band GeoTIFF file.
    * If there is more than one band in the GeoTiff, read the first band only.
    */
-  def readSingleband(path: String, decompress: Boolean, streaming: Boolean): SinglebandGeoTiff = {
+  def readSingleband(path: String, streaming: Boolean): SinglebandGeoTiff = {
     val ovrPath = s"${path}.ovr"
     val ovrPathExists = new File(ovrPath).isFile
     if (streaming)
       readSingleband(
         Filesystem.toMappedByteBuffer(path),
-        decompress, streaming, true,
+        streaming, true,
         if(ovrPathExists) Some(Filesystem.toMappedByteBuffer(ovrPath)) else None
       )
     else
       readSingleband(
         ByteBuffer.wrap(Filesystem.slurp(path)),
-        decompress, streaming, true,
+        streaming, true,
         if(ovrPathExists) Some(ByteBuffer.wrap(Filesystem.slurp(ovrPath))) else None
       )
   }
 
-  /* Read a single band GeoTIFF file.
-   * If there is more than one band in the GeoTiff, read the first band only.
-   */
   def readSingleband(bytes: Array[Byte]): SinglebandGeoTiff =
-    readSingleband(ByteBuffer.wrap(bytes), true, false)
+    readSingleband(ByteBuffer.wrap(bytes), false)
 
-  /* Read a single band GeoTIFF file.
-   * If there is more than one band in the GeoTiff, read the first band only.
-   */
-  def readSingleband(bytes: Array[Byte], decompress: Boolean, streaming: Boolean = false): SinglebandGeoTiff =
-    readSingleband(ByteBuffer.wrap(bytes), decompress, streaming)
+  def readSingleband(bytes: Array[Byte], streaming: Boolean): SinglebandGeoTiff =
+    readSingleband(ByteBuffer.wrap(bytes), streaming)
 
   def readSingleband(byteReader: ByteReader): SinglebandGeoTiff =
-    readSingleband(byteReader, true, false)
+    readSingleband(byteReader, false)
 
   def readSingleband(byteReader: ByteReader, e: Extent): SinglebandGeoTiff =
     readSingleband(byteReader, Some(e))
 
   def readSingleband(byteReader: ByteReader, e: Option[Extent]): SinglebandGeoTiff =
     e match {
-      case Some(x) => readSingleband(byteReader, false, true).crop(x)
+      case Some(x) => readSingleband(byteReader, true).crop(x)
       case None => readSingleband(byteReader)
     }
 
   /* Read a single band GeoTIFF file.
    * If there is more than one band in the GeoTiff, read the first band only.
    */
-  def readSingleband(byteReader: ByteReader, decompress: Boolean, streaming: Boolean): SinglebandGeoTiff =
-    readSingleband(byteReader, decompress, streaming, true, None)
+  def readSingleband(byteReader: ByteReader, streaming: Boolean): SinglebandGeoTiff =
+    readSingleband(byteReader, streaming, true, None)
 
-  def readSingleband(byteReader: ByteReader, decompress: Boolean, streaming: Boolean, withOverviews: Boolean, byteReaderExternal: Option[ByteReader]): SinglebandGeoTiff = {
+  def readSingleband(byteReader: ByteReader, streaming: Boolean, withOverviews: Boolean, byteReaderExternal: Option[ByteReader]): SinglebandGeoTiff = {
     def getSingleband(geoTiffTile: GeoTiffTile, info: GeoTiffInfo): SinglebandGeoTiff =
       SinglebandGeoTiff(
-        // it's not possible to decompress and still perform a streaming read
-        if (decompress && !streaming) geoTiffTile.toArrayTile else geoTiffTile,
+        geoTiffTile,
         info.extent,
         info.crs,
         info.tags,
@@ -155,7 +148,7 @@ object GeoTiffReader {
   /* Read a multi band GeoTIFF file.
    */
   def readMultiband(path: String): MultibandGeoTiff =
-    readMultiband(path, true, false)
+    readMultiband(path, false)
 
   /* Read in only the extent for each band in a multi ban GeoTIFF file.
    */
@@ -166,59 +159,56 @@ object GeoTiffReader {
    */
   def readMultiband(path: String, e: Option[Extent]): MultibandGeoTiff =
     e match {
-      case Some(x) => readMultiband(path, false, true).crop(x)
+      case Some(x) => readMultiband(path, true).crop(x)
       case None => readMultiband(path)
     }
 
   /* Read a multi band GeoTIFF file.
    */
-  def readMultiband(path: String, decompress: Boolean, streaming: Boolean): MultibandGeoTiff = {
+  def readMultiband(path: String, streaming: Boolean): MultibandGeoTiff = {
     val ovrPath = s"${path}.ovr"
     val ovrPathExists = new File(ovrPath).isFile
     if (streaming)
       readMultiband(
         Filesystem.toMappedByteBuffer(path),
-        decompress, streaming, true,
+        streaming, true,
         if(ovrPathExists) Some(Filesystem.toMappedByteBuffer(ovrPath)) else None
       )
     else
       readMultiband(
         ByteBuffer.wrap(Filesystem.slurp(path)),
-        decompress, streaming, true,
+        streaming, true,
         if(ovrPathExists) Some(ByteBuffer.wrap(Filesystem.slurp(ovrPath))) else None
       )
   }
-
-  def readMultiband(byteReader: ByteReader): MultibandGeoTiff =
-    readMultiband(byteReader, true, false)
 
   def readMultiband(byteReader: ByteReader, e: Extent): MultibandGeoTiff =
     readMultiband(byteReader, Some(e))
 
   def readMultiband(byteReader: ByteReader, e: Option[Extent]): MultibandGeoTiff =
     e match {
-      case Some(x) => readMultiband(byteReader, false, true).crop(x)
+      case Some(x) => readMultiband(byteReader, true).crop(x)
       case None => readMultiband(byteReader)
     }
 
   /* Read a multi band GeoTIFF file.
    */
   def readMultiband(bytes: Array[Byte]): MultibandGeoTiff =
-    readMultiband(ByteBuffer.wrap(bytes), true, false)
+    readMultiband(bytes, false)
 
-  /* Read a multi band GeoTIFF file.
-   */
-  def readMultiband(bytes: Array[Byte], decompress: Boolean, streaming: Boolean = false): MultibandGeoTiff =
-    readMultiband(ByteBuffer.wrap(bytes), decompress, streaming)
+  def readMultiband(bytes: Array[Byte], streaming: Boolean): MultibandGeoTiff =
+    readMultiband(ByteBuffer.wrap(bytes), streaming)
 
-  def readMultiband(byteReader: ByteReader, decompress: Boolean, streaming: Boolean): MultibandGeoTiff =
-    readMultiband(byteReader, decompress, streaming, true, None)
+  def readMultiband(byteReader: ByteReader): MultibandGeoTiff =
+    readMultiband(byteReader, false)
 
-  def readMultiband(byteReader: ByteReader, decompress: Boolean, streaming: Boolean, withOverviews: Boolean, byteReaderExternal: Option[ByteReader]): MultibandGeoTiff = {
+  def readMultiband(byteReader: ByteReader, streaming: Boolean): MultibandGeoTiff =
+    readMultiband(byteReader, streaming, true, None)
+
+  def readMultiband(byteReader: ByteReader, streaming: Boolean, withOverviews: Boolean, byteReaderExternal: Option[ByteReader]): MultibandGeoTiff = {
     def getMultiband(geoTiffTile: GeoTiffMultibandTile, info: GeoTiffInfo): MultibandGeoTiff =
       new MultibandGeoTiff(
-        // it's not possible to decompress and still perform a streaming read
-        if (decompress && !streaming) geoTiffTile.toArrayTile else geoTiffTile,
+        geoTiffTile,
         info.extent,
         info.crs,
         info.tags,
@@ -492,21 +482,21 @@ object GeoTiffReader {
   }
 
   implicit val singlebandGeoTiffReader: GeoTiffReader[Tile] = new GeoTiffReader[Tile]{
-    def read(byteReader: ByteReader, decompress: Boolean, streaming: Boolean): GeoTiff[Tile] =
-      GeoTiffReader.readSingleband(byteReader, decompress, streaming)
+    def read(byteReader: ByteReader, streaming: Boolean): GeoTiff[Tile] =
+      GeoTiffReader.readSingleband(byteReader, streaming)
   }
 
   implicit val multibandGeoTiffReader: GeoTiffReader[MultibandTile] = new GeoTiffReader[MultibandTile]{
-    def read(byteReader: ByteReader, decompress: Boolean, streaming: Boolean): GeoTiff[MultibandTile] =
-      GeoTiffReader.readMultiband(byteReader, decompress, streaming)
+    def read(byteReader: ByteReader, streaming: Boolean): GeoTiff[MultibandTile] =
+      GeoTiffReader.readMultiband(byteReader, streaming)
   }
 
   def apply[V <: CellGrid](implicit ev: GeoTiffReader[V]): GeoTiffReader[V] = ev
 }
 
 trait GeoTiffReader[V <: CellGrid] extends Serializable {
-  def read(byteReader: ByteReader, decompress: Boolean, streaming: Boolean): GeoTiff[V]
+  def read(byteReader: ByteReader, streaming: Boolean): GeoTiff[V]
 
-  def read(bytes: Array[Byte], decompress: Boolean): GeoTiff[V] =
-    read(ByteBuffer.wrap(bytes), decompress, streaming = false)
+  def read(bytes: Array[Byte]): GeoTiff[V] =
+    read(ByteBuffer.wrap(bytes), streaming = false)
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -40,7 +40,7 @@ class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
       val actual = SinglebandGeoTiff(reader)
       val expected = SinglebandGeoTiff(smallPath)
 
-      assertEqual(actual.tile, expected.tile)
+      assertEqual(actual.tile.toArrayTile, expected.tile.toArrayTile)
     }
 
     it("should read in a cropped SinlebandGeoTiff from the edge") {
@@ -53,7 +53,7 @@ class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
       val actual = SinglebandGeoTiff(reader, e)
       val expected = SinglebandGeoTiff(smallPath, e)
 
-      assertEqual(actual.tile, expected.tile)
+      assertEqual(actual.tile.toArrayTile, expected.tile.toArrayTile)
     }
 
     it("should read in a cropped SinglebandGeoTiff in the middle") {
@@ -66,7 +66,7 @@ class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
       val actual = SinglebandGeoTiff(reader, e)
       val expected = SinglebandGeoTiff(smallPath, e)
 
-      assertEqual(actual.tile, expected.tile)
+      assertEqual(actual.tile.toArrayTile, expected.tile.toArrayTile)
     }
 
     it("should read in the entire MultibandGeoTiff") {
@@ -75,7 +75,7 @@ class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
       val actual = MultibandGeoTiff(reader)
       val expected = MultibandGeoTiff(smallPathMulti)
 
-      assertEqual(actual.tile, expected.tile)
+      assertEqual(actual.tile.toArrayTile, expected.tile.toArrayTile)
     }
 
     it("should read in a cropped MultibandGeoTiff from the edge") {
@@ -88,7 +88,7 @@ class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
       val actual = MultibandGeoTiff(reader, e)
       val expected = MultibandGeoTiff(smallPathMulti, e)
 
-      assertEqual(actual.tile, expected.tile)
+      assertEqual(actual.tile.toArrayTile, expected.tile.toArrayTile)
     }
 
     it("should read in a cropped MultibandGeoTiff in the middle") {
@@ -101,7 +101,7 @@ class BigTiffSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
       val actual = MultibandGeoTiff(reader, e)
       val expected = MultibandGeoTiff(smallPathMulti, e)
 
-      assertEqual(actual.tile, expected.tile)
+      assertEqual(actual.tile.toArrayTile, expected.tile.toArrayTile)
     }
 
     it("should read a previously problematic big tiff") {

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BitGeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BitGeoTiffMultibandTileSpec.scala
@@ -43,50 +43,6 @@ class BitGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "pixel")).tile
-
-      val actual = tile.combine(_.sum % 2)
-      val expected = BitConstantTile(0, tile.cols, tile.rows)
-
-      assertEqual(actual, expected)
-    }
-
-    it("should combine all bands with pixel interleave, tiled") {
-      val tile =
-        MultibandGeoTiff.compressed(p("tiled", "pixel")).tile
-
-      val actual = tile.combine(_.sum % 2)
-      val expected = BitConstantTile(0, tile.cols, tile.rows)
-
-      assertEqual(actual, expected)
-    }
-
-    it("should combine all bands with band interleave, striped") {
-      val tile =
-        MultibandGeoTiff.compressed(p("striped", "band")).tile
-
-      val actual = tile.combine(_.sum % 2)
-      val expected = BitConstantTile(0, tile.cols, tile.rows)
-
-      assertEqual(actual, expected)
-    }
-
-    it("should combine all bands with band interleave, tiled") {
-      val tile =
-        MultibandGeoTiff.compressed(p("tiled", "band")).tile
-
-      val actual = tile.combine(_.sum % 2)
-      val expected = BitConstantTile(0, tile.cols, tile.rows)
-
-      assertEqual(actual, expected)
-    }
-
-  }
-
-  describe("BitGeoTiffMultibandTile, decompressed") {
-
-    it("should combine all bands with pixel interleave, striped") {
-      val tile =
         MultibandGeoTiff(p("striped", "pixel")).tile
 
       val actual = tile.combine(_.sum % 2)
@@ -118,6 +74,50 @@ class BitGeoTiffMultibandTileSpec extends FunSpec
     it("should combine all bands with band interleave, tiled") {
       val tile =
         MultibandGeoTiff(p("tiled", "band")).tile
+
+      val actual = tile.combine(_.sum % 2)
+      val expected = BitConstantTile(0, tile.cols, tile.rows)
+
+      assertEqual(actual, expected)
+    }
+
+  }
+
+  describe("BitGeoTiffMultibandTile, decompressed") {
+
+    it("should combine all bands with pixel interleave, striped") {
+      val tile =
+        MultibandGeoTiff(p("striped", "pixel")).tile.toArrayTile
+
+      val actual = tile.combine(_.sum % 2)
+      val expected = BitConstantTile(0, tile.cols, tile.rows)
+
+      assertEqual(actual, expected)
+    }
+
+    it("should combine all bands with pixel interleave, tiled") {
+      val tile =
+        MultibandGeoTiff(p("tiled", "pixel")).tile.toArrayTile
+
+      val actual = tile.combine(_.sum % 2)
+      val expected = BitConstantTile(0, tile.cols, tile.rows)
+
+      assertEqual(actual, expected)
+    }
+
+    it("should combine all bands with band interleave, striped") {
+      val tile =
+        MultibandGeoTiff(p("striped", "band")).tile.toArrayTile
+
+      val actual = tile.combine(_.sum % 2)
+      val expected = BitConstantTile(0, tile.cols, tile.rows)
+
+      assertEqual(actual, expected)
+    }
+
+    it("should combine all bands with band interleave, tiled") {
+      val tile =
+        MultibandGeoTiff(p("tiled", "band")).tile.toArrayTile
 
       val actual = tile.combine(_.sum % 2)
       val expected = BitConstantTile(0, tile.cols, tile.rows)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BitGeoTiffTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BitGeoTiffTileSpec.scala
@@ -36,7 +36,7 @@ class BitGeoTiffTileSpec extends FunSpec
     with TileBuilders {
   describe("BitGeoTiffTile") {
     it("should map same") {
-      val tile = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).tile
+      val tile = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile
 
       val res = tile.map { z => z }
 
@@ -44,7 +44,7 @@ class BitGeoTiffTileSpec extends FunSpec
     }
 
     it("should map inverse") {
-      val tile = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).tile
+      val tile = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile
 
       val res = tile.map { z => z ^ 1 }.map { z => z ^ 1 }
 
@@ -52,7 +52,7 @@ class BitGeoTiffTileSpec extends FunSpec
     }
 
     it("should map with index") {
-      val tile = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).tile
+      val tile = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile
 
       val res = tile.map { (col, row, z) => z }
 
@@ -60,7 +60,7 @@ class BitGeoTiffTileSpec extends FunSpec
     }
 
     it("should map with index double") {
-      val tile = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).tile
+      val tile = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile
 
       val res = tile.mapDouble { (col, row, z) => z }
 
@@ -68,7 +68,7 @@ class BitGeoTiffTileSpec extends FunSpec
     }
 
     it("should map with index - tiled") {
-      val tile = SinglebandGeoTiff.compressed(geoTiffPath("bilevel_tiled.tif")).tile
+      val tile = SinglebandGeoTiff(geoTiffPath("bilevel_tiled.tif")).tile
 
       val res = tile.map { (col, row, z) => z }
 
@@ -76,7 +76,7 @@ class BitGeoTiffTileSpec extends FunSpec
     }
 
     it("should map with index double - tiled") {
-      val tile = SinglebandGeoTiff.compressed(geoTiffPath("bilevel_tiled.tif")).tile
+      val tile = SinglebandGeoTiff(geoTiffPath("bilevel_tiled.tif")).tile
 
       val res = tile.mapDouble { (col, row, z) => z }
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/CroppedWindowedGeoTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/CroppedWindowedGeoTiffSpec.scala
@@ -31,8 +31,15 @@ import monocle.syntax.apply._
 
 object Reader {
   def singleBand(path: String, extent: Extent): (Raster[Tile], Raster[Tile]) = {
-    val expected = SinglebandGeoTiff(path, extent).raster
-    val actual = SinglebandGeoTiff(path).raster.crop(extent)
+    val expected = {
+      val tiff = SinglebandGeoTiff(path, extent)
+      tiff.copy(tile = tiff.tile.toArrayTile)
+    }.raster
+
+    val actual = {
+      val tiff = SinglebandGeoTiff(path)
+      tiff.copy(tile = tiff.tile.toArrayTile)
+    }.raster.crop(extent)
     (expected, actual)
   }
   def multiBand(path: String, extent: Extent): (Raster[MultibandTile], Raster[MultibandTile]) = {

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/Float32GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/Float32GeoTiffMultibandTileSpec.scala
@@ -43,7 +43,7 @@ class Float32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile
 
       val actual = tile.combine(_.sum)
       val expected = RawArrayTile(Array.ofDim[Float](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -53,7 +53,7 @@ class Float32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile
 
       val actual = tile.combine(_.sum)
       val expected = RawArrayTile(Array.ofDim[Float](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -63,7 +63,7 @@ class Float32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile
 
       val actual = tile.combine(_.sum)
       val expected = RawArrayTile(Array.ofDim[Float](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -73,7 +73,7 @@ class Float32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile
 
       val actual = tile.combine(_.sum)
       val expected = RawArrayTile(Array.ofDim[Float](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/Float64GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/Float64GeoTiffMultibandTileSpec.scala
@@ -43,7 +43,7 @@ class Float64GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile
 
       val actual = tile.combineDouble(_.sum)
       val expected = RawArrayTile(Array.ofDim[Double](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -53,7 +53,7 @@ class Float64GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile
 
       val actual = tile.combineDouble(_.sum)
       val expected = RawArrayTile(Array.ofDim[Double](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -63,7 +63,7 @@ class Float64GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile
 
       val actual = tile.combineDouble(_.sum)
       val expected = RawArrayTile(Array.ofDim[Double](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -73,7 +73,7 @@ class Float64GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile
 
       val actual = tile.combineDouble(_.sum)
       val expected = RawArrayTile(Array.ofDim[Double](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
@@ -133,7 +133,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
         MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(UShortCellType)
 
       val expected =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(UShortCellType)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile.convert(UShortCellType)
 
       assertEqual(expected, actual)
     }
@@ -156,7 +156,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
         tiles.combine(List(0,2))({ seq: Seq[Int] => seq.sum })
       }
       val expected = {
-        val tiles = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+        val tiles = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
         tiles.combine(List(0,2))({ seq: Seq[Int] => seq.sum })
       }
 
@@ -164,7 +164,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     }
 
     it("should work correctly on integer-valued tiles") {
-      val tiles = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+      val tiles = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
       val band0 = tiles.band(0)
       val band2 = tiles.band(2)
       val actual = tiles.combine(List(0,2))({ seq: Seq[Int] => seq.sum })
@@ -194,7 +194,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
   describe("Multiband subset map methods") {
 
     it("should work correctly on integer-valued tiles") {
-      val tiles = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+      val tiles = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
       val actual = tiles.map(List(0,2))({ (band,z) => z + band + 3 })
       val expectedBand0 = tiles.band(0).map({ z => z + 0 + 3 }).toArray
       val expectedBand1 = tiles.band(1).toArray
@@ -251,7 +251,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     }
 
     it("result should have correct bandCount") {
-      val tile0 = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+      val tile0 = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
       val tile1 = tile0.subsetBands(List(1, 2, 0))
       val tile2 = tile0.subsetBands(List(1, 2))
 
@@ -260,7 +260,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     }
 
     it("result should work properly with foreach") {
-      val tile0 = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+      val tile0 = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
       val tile1 = tile0.subsetBands(List(1, 2, 0))
       val tile2 = tile1.subsetBands(List(1, 2, 0))
 
@@ -288,7 +288,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should map a single band, striped, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.map(1)(_ + 3)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile.map(1)(_ + 3)
 
       tile.band(0).foreach { z => z should be (1) }
       tile.band(1).foreach { z => z should be (5) }
@@ -298,7 +298,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should map a single band, tiled, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile.map(1)(_ + 3)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile.toArrayTile.map(1)(_ + 3)
 
       tile.band(0).foreach { z => z should be (1) }
       tile.band(1).foreach { z => z should be (5) }
@@ -308,7 +308,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should map a single band, striped, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile.map(1)(_ + 3)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile.toArrayTile.map(1)(_ + 3)
 
       tile.band(0).foreach { z => z should be (1) }
       tile.band(1).foreach { z => z should be (5) }
@@ -318,7 +318,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should map a single band, tiled, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile.map(1)(_ + 3)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile.toArrayTile.map(1)(_ + 3)
 
       tile.band(0).foreach { z => z should be (1) }
       tile.band(1).foreach { z => z should be (5) }
@@ -328,7 +328,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should map over all bands, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.map { (b, z) => b * 10 + z }
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile.map { (b, z) => b * 10 + z }
 
       tile.band(0).foreach { z => z should be (1) }
       tile.band(1).foreach { z => z should be (12) }
@@ -338,7 +338,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should map over all bands, tiled") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile.map { (b, z) => ((b+1) * 10) + z }
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile.toArrayTile.map { (b, z) => ((b+1) * 10) + z }
 
       tile.band(0).foreach { z => z should be (11) }
       tile.band(1).foreach { z => z should be (22) }
@@ -348,7 +348,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should mapDouble a single band, striped, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(DoubleConstantNoDataCellType).mapDouble(1)(_ + 3.3)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile.convert(DoubleConstantNoDataCellType).mapDouble(1)(_ + 3.3)
 
       tile.band(0).foreach { z => z should be (1) }
       tile.band(1).foreach { z => z should be (5) }
@@ -358,7 +358,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should mapDouble a single band, tiled, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile.convert(DoubleConstantNoDataCellType).mapDouble(1)(_ + 3.3)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile.toArrayTile.convert(DoubleConstantNoDataCellType).mapDouble(1)(_ + 3.3)
 
       tile.band(0).foreach { z => z should be (1) }
       tile.band(1).foreach { z => z should be (5) }
@@ -372,7 +372,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should foreach a single band, striped, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
 
       val cellCount = tile.band(1).toArray.size
 
@@ -387,7 +387,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should foreach a single band, tiled, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile.toArrayTile
 
       val cellCount = tile.band(1).toArray.size
 
@@ -402,7 +402,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should foreach a single band, striped, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile.toArrayTile
 
       val cellCount = tile.band(1).toArray.size
 
@@ -417,7 +417,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should foreach a single band, tiled, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile.toArrayTile
 
       val cellCount = tile.band(1).toArray.size
 
@@ -432,7 +432,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should foreachDouble all bands, striped, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
 
       val cellCount = tile.band(1).toArray.size
 
@@ -450,7 +450,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should foreachDouble all bands, tiled, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile.toArrayTile
 
       val cellCount = tile.band(1).toArray.size
 
@@ -468,7 +468,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should foreachDouble all bands, striped, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile.toArrayTile
 
       val cellCount = tile.band(1).toArray.size
 
@@ -486,7 +486,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should foreachDouble all bands, tiled, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile.toArrayTile
 
       val cellCount = tile.band(1).toArray.size
 
@@ -506,7 +506,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should multiband foreach all values, striped, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
 
       val bandCount = tile.bandCount
       val cellCount = tile.rows * tile.cols
@@ -523,7 +523,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should multiband foreach all values, tiled, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile.toArrayTile
 
       val bandCount = tile.bandCount
       val cellCount = tile.rows * tile.cols
@@ -540,7 +540,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should multiband foreach all values, striped, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile.toArrayTile
 
       val bandCount = tile.bandCount
       val cellCount = tile.rows * tile.cols
@@ -557,7 +557,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should multiband foreach all values, tiled, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile.toArrayTile
 
       val bandCount = tile.bandCount
       val cellCount = tile.rows * tile.cols
@@ -574,7 +574,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should multiband foreachDouble all values, striped, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
 
       val bandCount = tile.bandCount
       val cellCount = tile.rows * tile.cols
@@ -591,7 +591,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should multiband foreachDouble all values, tiled, pixel interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif")).tile.toArrayTile
 
       val bandCount = tile.bandCount
       val cellCount = tile.rows * tile.cols
@@ -608,7 +608,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should multiband foreachDouble all values, striped, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-band.tif")).tile.toArrayTile
 
       val bandCount = tile.bandCount
       val cellCount = tile.rows * tile.cols
@@ -625,7 +625,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     it("should multiband foreachDouble all values, tiled, band interleave") {
 
       val tile =
-        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-band.tif")).tile.toArrayTile
 
       val bandCount = tile.bandCount
       val cellCount = tile.rows * tile.cols

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
@@ -130,7 +130,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
   describe("Multiband cellType conversion") {
     it("should convert the cellType with convert") {
       val actual =
-        MultibandGeoTiff.compressed(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(UShortCellType)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(UShortCellType)
 
       val expected =
         MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(UShortCellType)
@@ -140,7 +140,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
 
     it("should convert the cellType with interpretAs") {
       val actual =
-        MultibandGeoTiff.compressed(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.interpretAs(UShortCellType)
+        MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.interpretAs(UShortCellType)
 
       val expected =
         MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.interpretAs(UShortCellType)
@@ -152,7 +152,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
   describe("Multiband subset combine methods") {
     it("should work the same on integer-valued GeoTiff tiles as Array tiles") {
       val actual = {
-        val tiles = MultibandGeoTiff.compressed(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+        val tiles = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
         tiles.combine(List(0,2))({ seq: Seq[Int] => seq.sum })
       }
       val expected = {
@@ -164,7 +164,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     }
 
     it("should work correctly on integer-valued tiles") {
-      val tiles = MultibandGeoTiff.compressed(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+      val tiles = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
       val band0 = tiles.band(0)
       val band2 = tiles.band(2)
       val actual = tiles.combine(List(0,2))({ seq: Seq[Int] => seq.sum })
@@ -242,7 +242,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
   describe("Multiband bands (reorder) method") {
 
     it("should be inexpensive") {
-      val tile0 = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+      val tile0 = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
       val tile1 = tile0.subsetBands(List(1, 2, 0))
 
       tile0.band(0) should be theSameInstanceAs tile1.band(2)
@@ -276,7 +276,7 @@ class GeoTiffMultibandTileSpec extends FunSpec
     }
 
     it("should disallow \"invalid\" bandSequences") {
-      val tile0 = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile
+      val tile0 = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile
       an [IllegalArgumentException] should be thrownBy {
         tile0.subsetBands(0,1,2,3) // There are only 3 bands
       }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
@@ -723,8 +723,11 @@ class GeoTiffMultibandTileSpec extends FunSpec
   describe("GeoTiffMultibandTile streaming read") {
     it("reads over-buffered windows"){
       val path = geoTiffPath("3bands/int32/3bands-striped-pixel.tif")
-      val info = GeoTiffReader.readGeoTiffInfo(ByteBuffer.wrap(Filesystem.slurp(path)),
-        decompress = false, streaming = true, withOverviews = false, byteReaderExternal = None)
+      val info = GeoTiffReader.readGeoTiffInfo(
+        ByteBuffer.wrap(Filesystem.slurp(path)),
+        streaming = true, withOverviews = false,
+        byteReaderExternal = None
+      )
       val tiff = GeoTiffReader.geoTiffMultibandTile(info)
 
       val windows: Array[GridBounds] = info

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/Int16GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/Int16GeoTiffMultibandTileSpec.scala
@@ -43,7 +43,7 @@ class Int16GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile.toArrayTile
 
       val actual = tile.combine(_.sum)
       val expected = ShortRawArrayTile(Array.ofDim[Short](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -53,7 +53,7 @@ class Int16GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile.toArrayTile
 
       val actual = tile.combine(_.sum)
       val expected = ShortRawArrayTile(Array.ofDim[Short](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -63,7 +63,7 @@ class Int16GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile.toArrayTile
 
       val actual = tile.combine(_.sum)
       val expected = ShortRawArrayTile(Array.ofDim[Short](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -73,7 +73,7 @@ class Int16GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile.toArrayTile
 
       val actual = tile.combine(_.sum)
       val expected = ShortRawArrayTile(Array.ofDim[Short](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/Int32GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/Int32GeoTiffMultibandTileSpec.scala
@@ -43,7 +43,7 @@ class Int32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = IntRawArrayTile(Array.ofDim[Int](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -53,7 +53,7 @@ class Int32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = IntRawArrayTile(Array.ofDim[Int](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -63,7 +63,7 @@ class Int32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = IntRawArrayTile(Array.ofDim[Int](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -73,7 +73,7 @@ class Int32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = IntRawArrayTile(Array.ofDim[Int](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/MultibandCropIteratorSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/MultibandCropIteratorSpec.scala
@@ -30,7 +30,10 @@ class MultibandCropIteratorSpec extends FunSpec
 
   describe("Doing a crop iteration on a MultibandGeoTiff") {
     val path = geoTiffPath("3bands/3bands-striped-band.tif")
-    val geoTiff = MultibandGeoTiff(path)
+    val geoTiff = {
+      val tiff = MultibandGeoTiff(path)
+      tiff.copy(tile = tiff.tile.toArrayTile)
+    }
     val cols = geoTiff.imageData.cols
     val rows = geoTiff.imageData.rows
 
@@ -88,7 +91,7 @@ class MultibandCropIteratorSpec extends FunSpec
     it("should return the whole thing if the inputted dimensions are larger than the cols and rows") {
       val windowedCols = 25
       val windowedRows = 50
-      val multibandIterator = MultibandCropIterator(geoTiff.copy(tile = geoTiff.tile.toArrayTile), windowedCols, windowedRows)
+      val multibandIterator = MultibandCropIterator(geoTiff, windowedCols, windowedRows)
 
       val expected = geoTiff.tile
       val actual = multibandIterator.next.tile
@@ -100,7 +103,7 @@ class MultibandCropIteratorSpec extends FunSpec
       val windowedCols = 15
       val windowedRows = 25
       val multibandIterator =
-        new MultibandCropIterator(geoTiff.copy(tile = geoTiff.tile.toArrayTile), windowedCols, windowedRows)
+        new MultibandCropIterator(geoTiff, windowedCols, windowedRows)
 
       val expected: Array[MultibandTile] =
         Array(geoTiff.raster.crop(0, 0, 15, 25),

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/MultibandCropIteratorSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/MultibandCropIteratorSpec.scala
@@ -88,7 +88,7 @@ class MultibandCropIteratorSpec extends FunSpec
     it("should return the whole thing if the inputted dimensions are larger than the cols and rows") {
       val windowedCols = 25
       val windowedRows = 50
-      val multibandIterator = MultibandCropIterator(geoTiff, windowedCols, windowedRows)
+      val multibandIterator = MultibandCropIterator(geoTiff.copy(tile = geoTiff.tile.toArrayTile), windowedCols, windowedRows)
 
       val expected = geoTiff.tile
       val actual = multibandIterator.next.tile
@@ -100,7 +100,7 @@ class MultibandCropIteratorSpec extends FunSpec
       val windowedCols = 15
       val windowedRows = 25
       val multibandIterator =
-        new MultibandCropIterator(geoTiff, windowedCols, windowedRows)
+        new MultibandCropIterator(geoTiff.copy(tile = geoTiff.tile.toArrayTile), windowedCols, windowedRows)
 
       val expected: Array[MultibandTile] =
         Array(geoTiff.raster.crop(0, 0, 15, 25),

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/MultibandGeoTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/MultibandGeoTiffSpec.scala
@@ -26,7 +26,10 @@ import org.scalatest._
 
 class MultibandGeoTiffSpec extends FunSpec with Matchers with RasterMatchers with GeoTiffTestUtils {
   describe("Building Overviews") {
-    val tiff = MultibandGeoTiff(geoTiffPath("overviews/multiband.tif"))
+    val tiff = {
+      val t = MultibandGeoTiff(geoTiffPath("overviews/multiband.tif"))
+      t.copy(tile = t.tile.toArrayTile)
+    }
     val ovr = tiff.buildOverview(NearestNeighbor, 3, 128)
 
     it("should reduce pixels by decimation factor") {

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/SegmentBytesSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/SegmentBytesSpec.scala
@@ -36,10 +36,13 @@ trait Tester {
       LazySegmentBytes(byteBuffer, tiffTags)
 
     val geoTiff =
-      if (tiffTags.bandCount == 1)
-        SinglebandGeoTiff(path)
-      else
-        MultibandGeoTiff(path)
+      if (tiffTags.bandCount == 1) {
+        val tiff = SinglebandGeoTiff(path)
+        tiff.copy(tile = tiff.tile.toArrayTile)
+      } else {
+        val tiff = MultibandGeoTiff(path)
+        tiff.copy(tile = tiff.tile.toArrayTile)
+      }
 
     val actual = geoTiff.imageData.segmentBytes
   }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandCropIteratorSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandCropIteratorSpec.scala
@@ -67,10 +67,12 @@ class SinglebandCropIteratorSpec extends FunSpec
           geoTiff.raster.crop(256, 256, 512, 512))
 
       val actual: Array[Tile] =
-        Array(singlebandIterator.next.tile,
-          singlebandIterator.next.tile,
-          singlebandIterator.next.tile,
-          singlebandIterator.next.tile)
+        Array(
+          singlebandIterator.next.tile.toArrayTile,
+          singlebandIterator.next.tile.toArrayTile,
+          singlebandIterator.next.tile.toArrayTile,
+          singlebandIterator.next.tile.toArrayTile
+        )
 
       cfor(0)(_ < actual.length, _ + 1) { i =>
         assertEqual(expected(i), actual(i))
@@ -81,10 +83,10 @@ class SinglebandCropIteratorSpec extends FunSpec
       val windowedCols = 950
       val windowedRows = 1300
       val singlebandIterator =
-        new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
+        new SinglebandCropIterator(geoTiff.copy(tile = geoTiff.tile.toArrayTile), windowedCols, windowedRows)
 
-      val expected = geoTiff.tile
-      val actual = singlebandIterator.next.tile
+      val expected = geoTiff.tile.toArrayTile
+      val actual = singlebandIterator.next.tile.toArrayTile
 
       assertEqual(expected, actual)
     }
@@ -104,12 +106,14 @@ class SinglebandCropIteratorSpec extends FunSpec
           geoTiff.raster.crop(500, 450, 512, 512))
 
       val actual: Array[Tile] =
-        Array(singlebandIterator.next.tile,
-          singlebandIterator.next.tile,
-          singlebandIterator.next.tile,
-          singlebandIterator.next.tile,
-          singlebandIterator.next.tile,
-          singlebandIterator.next.tile)
+        Array(
+          singlebandIterator.next.tile.toArrayTile,
+          singlebandIterator.next.tile.toArrayTile,
+          singlebandIterator.next.tile.toArrayTile,
+          singlebandIterator.next.tile.toArrayTile,
+          singlebandIterator.next.tile.toArrayTile,
+          singlebandIterator.next.tile.toArrayTile
+        )
 
       cfor(0)(_ < actual.length, _ + 1) { i =>
         assertEqual(expected(i), actual(i))

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandCropIteratorSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandCropIteratorSpec.scala
@@ -30,7 +30,10 @@ class SinglebandCropIteratorSpec extends FunSpec
 
   describe("Doing a crop iteration on a SinglebandGeoTiff") {
     val path = geoTiffPath("ls8_int32.tif")
-    val geoTiff = SinglebandGeoTiff(path)
+    val geoTiff = {
+      val tiff = SinglebandGeoTiff(path)
+      tiff.copy(tile = tiff.tile.toArrayTile)
+    }
     val cols = geoTiff.imageData.cols
     val rows = geoTiff.imageData.rows
 
@@ -67,12 +70,10 @@ class SinglebandCropIteratorSpec extends FunSpec
           geoTiff.raster.crop(256, 256, 512, 512))
 
       val actual: Array[Tile] =
-        Array(
-          singlebandIterator.next.tile.toArrayTile,
-          singlebandIterator.next.tile.toArrayTile,
-          singlebandIterator.next.tile.toArrayTile,
-          singlebandIterator.next.tile.toArrayTile
-        )
+        Array(singlebandIterator.next.tile,
+          singlebandIterator.next.tile,
+          singlebandIterator.next.tile,
+          singlebandIterator.next.tile)
 
       cfor(0)(_ < actual.length, _ + 1) { i =>
         assertEqual(expected(i), actual(i))
@@ -83,10 +84,10 @@ class SinglebandCropIteratorSpec extends FunSpec
       val windowedCols = 950
       val windowedRows = 1300
       val singlebandIterator =
-        new SinglebandCropIterator(geoTiff.copy(tile = geoTiff.tile.toArrayTile), windowedCols, windowedRows)
+        new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
 
-      val expected = geoTiff.tile.toArrayTile
-      val actual = singlebandIterator.next.tile.toArrayTile
+      val expected = geoTiff.tile
+      val actual = singlebandIterator.next.tile
 
       assertEqual(expected, actual)
     }
@@ -106,14 +107,12 @@ class SinglebandCropIteratorSpec extends FunSpec
           geoTiff.raster.crop(500, 450, 512, 512))
 
       val actual: Array[Tile] =
-        Array(
-          singlebandIterator.next.tile.toArrayTile,
-          singlebandIterator.next.tile.toArrayTile,
-          singlebandIterator.next.tile.toArrayTile,
-          singlebandIterator.next.tile.toArrayTile,
-          singlebandIterator.next.tile.toArrayTile,
-          singlebandIterator.next.tile.toArrayTile
-        )
+        Array(singlebandIterator.next.tile,
+          singlebandIterator.next.tile,
+          singlebandIterator.next.tile,
+          singlebandIterator.next.tile,
+          singlebandIterator.next.tile,
+          singlebandIterator.next.tile)
 
       cfor(0)(_ < actual.length, _ + 1) { i =>
         assertEqual(expected(i), actual(i))

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiffSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest._
 
 class SinglebandGeoTiffSpec extends FunSpec with Matchers with RasterMatchers with GeoTiffTestUtils {
   describe("Building Overviews") {
-    val tiff = SinglebandGeoTiff(geoTiffPath("overviews/singleband.tif"), false, true)
+    val tiff = SinglebandGeoTiff(geoTiffPath("overviews/singleband.tif"), true)
 
     it("should reduce pixels by decimation factor") {
       val ovr = tiff.buildOverview(NearestNeighbor, 2)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/UByteGeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/UByteGeoTiffMultibandTileSpec.scala
@@ -44,7 +44,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile
 
       val actual = tile.combine(_.sum)
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(6), tile.cols, tile.rows, UByteCellType)
@@ -54,7 +54,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile
 
       val actual = tile.combine(_.sum)
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(6), tile.cols, tile.rows, UByteCellType)
@@ -64,7 +64,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile
 
       val actual = tile.combine(_.sum)
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(6), tile.cols, tile.rows, UByteCellType)
@@ -74,7 +74,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile
 
       val actual = tile.combine(_.sum)
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(6), tile.cols, tile.rows, UByteCellType)
@@ -86,7 +86,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combineDouble all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile
 
       val actual = tile.combineDouble(_.sum)
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(6), tile.cols, tile.rows, UByteCellType)
@@ -96,7 +96,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combineDouble all bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile
 
       val actual = tile.combineDouble(_.sum)
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(6), tile.cols, tile.rows, UByteCellType)
@@ -106,7 +106,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combineDouble all bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile
 
       val actual = tile.combineDouble(_.sum)
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(6), tile.cols, tile.rows, UByteCellType)
@@ -116,7 +116,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combineDouble all bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile
 
       val actual = tile.combineDouble(_.sum)
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(6), tile.cols, tile.rows, UByteCellType)
@@ -128,7 +128,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 2 bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile
 
       val actual = tile.combine(2, 1) { (z1, z2) => z1 + z2 }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(5), tile.cols, tile.rows, UByteCellType)
@@ -138,7 +138,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 2 bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile
 
       val actual = tile.combine(1, 2) { (z1, z2) => z1 + z2 }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(5), tile.cols, tile.rows, UByteCellType)
@@ -148,7 +148,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 2 bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile
 
       val actual = tile.combine(1, 2) { (z1, z2) => z1 + z2 }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(5), tile.cols, tile.rows, UByteCellType)
@@ -158,7 +158,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 2 bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile
 
       val actual = tile.combine(1, 2) { (z1, z2) => z1 + z2 }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(5), tile.cols, tile.rows, UByteCellType)
@@ -170,7 +170,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 3 bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile
 
       val actual = tile.combineDouble(2, 1, 0) { (z1, z2, z3) => z1 + z2 - z3 }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(4), tile.cols, tile.rows, UByteCellType)
@@ -180,7 +180,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 3 bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile
 
       val actual = tile.combineDouble(0, 1, 2) { (z1, z2, z3) => z1 + z2 - z3 }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(0), tile.cols, tile.rows, UByteCellType)
@@ -190,7 +190,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 3 bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile
 
       val actual = tile.combineDouble(0, 1, 2) { (z1, z2, z3) => z1 * z2 - z3 }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(-1), tile.cols, tile.rows, UByteCellType)
@@ -200,7 +200,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 3 bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile
 
       val actual = tile.combineDouble(0, 1, 2) { (z1, z2, z3) => z1 + (z2 * z3) }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(7), tile.cols, tile.rows, UByteCellType)
@@ -212,7 +212,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 4 bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile
 
       val actual = tile.combineDouble(2, 1, 0, 2) { (z1, z2, z3, z4) => z1 + z2 - z3 + z4}
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(7), tile.cols, tile.rows, UByteCellType)
@@ -222,7 +222,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 4 bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile
 
       val actual = tile.combineDouble(0, 1, 2, 0) { (z1, z2, z3, z4) => z1 + z2 - z3 + z4 }
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(1), tile.cols, tile.rows, UByteCellType)
@@ -232,7 +232,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 4 bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff.compressed(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile
 
       val actual = tile.combineDouble(0, 1, 2, 0) { (z1, z2, z3, z4) => z1 * z2 - z3 - z4}
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(-2), tile.cols, tile.rows, UByteCellType)
@@ -242,7 +242,7 @@ class ByteGeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine 4 bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff.compressed(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile
 
       val actual = tile.combineDouble(0, 1, 2, 2) { (z1, z2, z3, z4) => z1 + (z2 * z3) + z4}
       val expected = UByteArrayTile(Array.ofDim[Byte](tile.cols * tile.rows).fill(10), tile.cols, tile.rows, UByteCellType)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffMultibandTileSpec.scala
@@ -29,12 +29,12 @@ import geotrellis.raster.testkit._
 import org.scalatest._
 
 class UInt16GeoTiffMultibandTileSpec extends FunSpec
-    with Matchers
-    with BeforeAndAfterAll
-    with RasterMatchers
-    with GeoTiffTestUtils 
-    with TileBuilders {
-  def p(s: String, i: String): String = 
+  with Matchers
+  with BeforeAndAfterAll
+  with RasterMatchers
+  with GeoTiffTestUtils
+  with TileBuilders {
+  def p(s: String, i: String): String =
     geoTiffPath(s"3bands/uint16/3bands-${s}-${i}.tif")
 
   describe("UInt16GeoTiffMultibandTile") {
@@ -43,7 +43,7 @@ class UInt16GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = new UShortRawArrayTile(Array.ofDim[Short](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -53,7 +53,7 @@ class UInt16GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = new UShortRawArrayTile(Array.ofDim[Short](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -63,7 +63,7 @@ class UInt16GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = new UShortRawArrayTile(Array.ofDim[Short](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -73,7 +73,7 @@ class UInt16GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = new UShortRawArrayTile(Array.ofDim[Short](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTileSpec.scala
@@ -28,8 +28,8 @@ with GeoTiffTestUtils
 with TileBuilders {
   describe("UInt16GeoTiffTile") {
    it("should read landsat 8 data correctly") {
-     val actualImage = SinglebandGeoTiff(geoTiffPath(s"ls8_uint16.tif")).tile.convert(IntCellType)
-     val expectedImage = SinglebandGeoTiff(geoTiffPath(s"ls8_int32.tif")).tile
+     val actualImage = SinglebandGeoTiff(geoTiffPath(s"ls8_uint16.tif")).tile.toArrayTile.convert(IntCellType)
+     val expectedImage = SinglebandGeoTiff(geoTiffPath(s"ls8_int32.tif")).tile.toArrayTile
 
      assertEqual(actualImage, expectedImage)
    }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt32GeoTiffMultibandTileSpec.scala
@@ -43,7 +43,7 @@ class UInt32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, striped") {
       val tile =
-        MultibandGeoTiff(p("striped", "pixel")).tile
+        MultibandGeoTiff(p("striped", "pixel")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = FloatRawArrayTile(Array.ofDim[Float](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -53,7 +53,7 @@ class UInt32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with pixel interleave, tiled") {
       val tile =
-        MultibandGeoTiff(p("tiled", "pixel")).tile
+        MultibandGeoTiff(p("tiled", "pixel")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = FloatRawArrayTile(Array.ofDim[Float](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -63,7 +63,7 @@ class UInt32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, striped") {
       val tile =
-        MultibandGeoTiff(p("striped", "band")).tile
+        MultibandGeoTiff(p("striped", "band")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = FloatRawArrayTile(Array.ofDim[Float](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)
@@ -73,7 +73,7 @@ class UInt32GeoTiffMultibandTileSpec extends FunSpec
 
     it("should combine all bands with band interleave, tiled") {
       val tile =
-        MultibandGeoTiff(p("tiled", "band")).tile
+        MultibandGeoTiff(p("tiled", "band")).tile.toArrayTile
 
       val actual = tile.combineDouble(_.sum)
       val expected = FloatRawArrayTile(Array.ofDim[Float](tile.cols * tile.rows).fill(6), tile.cols, tile.rows)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -82,7 +82,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   }
 
-  ignore("reading compressed file must yield same image array as uncompressed file") {
+  describe("reading compressed file must yield same image array as uncompressed file") {
 
     it("must read econic_lzw.tif and match uncompressed file") {
       val decomp = SinglebandGeoTiff(geoTiffPath("econic_lzw.tif"))
@@ -131,7 +131,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   }
 
-  ignore("reading bit rasters") {
+  describe("reading bit rasters") {
     it("should match bit tile the ArrayTile pulled out of the resulting GeoTiffTile") {
       val expected = SinglebandGeoTiff(geoTiffPath("uncompressed/tiled/bit.tif")).tile
       val actual = SinglebandGeoTiff(geoTiffPath("uncompressed/tiled/bit.tif")).tile.toArrayTile
@@ -255,7 +255,7 @@ class GeoTiffReaderSpec extends FunSpec
    The listgeo command sometimes drops precision compared to our generator,
    therefore we sometimes increase the epsilon double comparison value.
    */
-  ignore("reads GeoTiff CRS correctly") {
+  describe("reads GeoTiff CRS correctly") {
 
     it("should read slope.tif CS correctly") {
       val crs = SinglebandGeoTiff(s"$baseDataPath/slope.tif", streaming = true).crs
@@ -343,7 +343,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   }
 
-  ignore("reads file data correctly") {
+  describe("reads file data correctly") {
 
     val MeanEpsilon = 1e-8
 
@@ -502,7 +502,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
   }
 
-  ignore("Reading and writing special metadata tags ") {
+  describe("Reading and writing special metadata tags ") {
     val temp = java.io.File.createTempFile("geotiff-writer", ".tif");
     val path = temp.getPath()
 
@@ -545,7 +545,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
   }
 
-  ignore("handling special CRS cases") {
+  describe("handling special CRS cases") {
     it("can handle an ESRI written GeoTiff in WebMercator") {
       val tif = SinglebandGeoTiff(s"$baseDataPath/propval_bg_01_01.tif")
       tif.crs should be (WebMercator)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -39,7 +39,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading an ESRI generated Float32 geotiff with 0 NoData value") {
     it("matches an arg produced from geotrellis.gdal reader of that tif") {
-      val tile = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif")).tile.convert(FloatConstantNoDataCellType)
+      val tile = SinglebandGeoTiff(geoTiffPath("us_ext_clip_esri.tif")).tile.convert(FloatConstantNoDataCellType)
 
       val expectedTile =
         ArgReader.read(geoTiffPath("us_ext_clip_esri.json")).tile
@@ -55,7 +55,7 @@ class GeoTiffReaderSpec extends FunSpec
       val path = "slope.tif"
       val argPath = s"$baseDataPath/data/slope.json"
 
-      val tile = SinglebandGeoTiff.compressed(s"$baseDataPath/$path").tile.convert(FloatConstantNoDataCellType)
+      val tile = SinglebandGeoTiff(s"$baseDataPath/$path").tile.convert(FloatConstantNoDataCellType)
 
       val expectedTile =
         ArgReader.read(argPath).tile
@@ -67,7 +67,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading modelTransformation.tiff") {
     val path = "modelTransformation.tiff"
-    val compressed: SinglebandGeoTiff = SinglebandGeoTiff.compressed(geoTiffPath(path))
+    val compressed: SinglebandGeoTiff = SinglebandGeoTiff(geoTiffPath(path))
     val tile = compressed.tile
     val bounds = tile.gridBounds
     bounds.width should be (1121)
@@ -85,36 +85,36 @@ class GeoTiffReaderSpec extends FunSpec
   describe("reading compressed file must yield same image array as uncompressed file") {
 
     it("must read econic_lzw.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_lzw.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
+      val decomp = SinglebandGeoTiff(geoTiffPath("econic_lzw.tif"))
+      val uncomp = SinglebandGeoTiff(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
     it("must read econic_zlib.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
+      val decomp = SinglebandGeoTiff(geoTiffPath("econic_zlib.tif"))
+      val uncomp = SinglebandGeoTiff(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
     it("must read econic_zlib_tiled.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib_tiled.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
+      val decomp = SinglebandGeoTiff(geoTiffPath("econic_zlib_tiled.tif"))
+      val uncomp = SinglebandGeoTiff(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
     it("must read econic_zlib_tiled_bandint.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib_tiled_bandint.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif")
+      val decomp = SinglebandGeoTiff(geoTiffPath("econic_zlib_tiled_bandint.tif"))
+      val uncomp = SinglebandGeoTiff(s"$baseDataPath/econic.tif")
 
       assertEqual(decomp.tile, uncomp.tile)
     }
 
     it("must read all-ones.tif and match uncompressed file") {
-      val decomp = SinglebandGeoTiff.compressed(geoTiffPath("all-ones.tif"))
-      val uncomp = SinglebandGeoTiff.compressed(geoTiffPath("all-ones-no-comp.tif"))
+      val decomp = SinglebandGeoTiff(geoTiffPath("all-ones.tif"))
+      val uncomp = SinglebandGeoTiff(geoTiffPath("all-ones-no-comp.tif"))
 
       assertEqual(decomp.tile, uncomp.tile)
     }
@@ -123,8 +123,8 @@ class GeoTiffReaderSpec extends FunSpec
   describe("reading tiled file must yield same image as strip files") {
 
     it("must read us_ext_clip_esri.tif and match strip file") {
-      val tiled = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif"))
-      val striped = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri_stripes.tif"))
+      val tiled = SinglebandGeoTiff(geoTiffPath("us_ext_clip_esri.tif"))
+      val striped = SinglebandGeoTiff(geoTiffPath("us_ext_clip_esri_stripes.tif"))
 
       assertEqual(tiled.tile, striped.tile)
     }
@@ -133,23 +133,23 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("reading bit rasters") {
     it("should match bit tile the ArrayTile pulled out of the resulting GeoTiffTile") {
-      val expected = SinglebandGeoTiff.compressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("uncompressed/tiled/bit.tif")).tile.toArrayTile
+      val expected = SinglebandGeoTiff(geoTiffPath("uncompressed/tiled/bit.tif")).tile
+      val actual = SinglebandGeoTiff(geoTiffPath("uncompressed/tiled/bit.tif")).tile.toArrayTile
 
       assertEqual(actual, expected)
       assertEqual(expected, actual)
     }
 
     it("must read bilevel_tiled.tif and match strip file") {
-      val tiled = SinglebandGeoTiff.compressed(geoTiffPath("bilevel_tiled.tif"))
-      val striped = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif"))
+      val tiled = SinglebandGeoTiff(geoTiffPath("bilevel_tiled.tif"))
+      val striped = SinglebandGeoTiff(geoTiffPath("bilevel.tif"))
 
       assertEqual(tiled.tile, striped.tile)
     }
 
     it("should match bit and byte-converted rasters") {
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).tile
-      val expected = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile.tile.convert(BitCellType)
+      val actual = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile.toArrayTile()
+      val expected = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile.toArrayTile()convert(BitCellType)
 
       assertEqual(actual, expected)
     }
@@ -260,7 +260,7 @@ class GeoTiffReaderSpec extends FunSpec
   describe("reads GeoTiff CRS correctly") {
 
     it("should read slope.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/slope.tif")crs
+      val crs = SinglebandGeoTiff(s"$baseDataPath/slope.tif")crs
 
       val correctCRS = CRS.fromString("+proj=utm +zone=10 +datum=NAD27 +units=m +no_defs")
 
@@ -268,7 +268,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read aspect.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/aspect.tif").crs
+      val crs = SinglebandGeoTiff(s"$baseDataPath/aspect.tif").crs
 
       val correctProj4String = "+proj=lcc +lat_1=36.16666666666666 +lat_2=34.33333333333334 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +datum=NAD83 +units=m +no_defs"
 
@@ -278,7 +278,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read econic.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif").crs
+      val crs = SinglebandGeoTiff(s"$baseDataPath/econic.tif").crs
 
       val correctProj4String = "+proj=eqdc +lat_0=33.76446202777777 +lon_0=-117.4745428888889 +lat_1=33.90363402777778 +lat_2=33.62529002777778 +x_0=0 +y_0=0 +datum=NAD27 +units=m +no_defs"
 
@@ -288,7 +288,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read bilevel.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("bilevel.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).crs
 
       val correctProj4String = "+proj=tmerc +lat_0=0 +lon_0=-3.45233333 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +units=m +no_defs"
 
@@ -298,7 +298,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read all-ones.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("all-ones.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("all-ones.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
 
@@ -306,14 +306,14 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read colormap.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("colormap.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("colormap.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
       crs should equal(correctCRS)
     }
 
     it("should read us_ext_clip_esri.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("us_ext_clip_esri.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("us_ext_clip_esri.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
 
@@ -321,7 +321,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read ndvi-web-mercator.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("ndvi-web-mercator.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("ndvi-web-mercator.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
 
@@ -329,7 +329,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read ny-state-plane.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("ny-state-plane.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("ny-state-plane.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=tmerc +lat_0=40 +lon_0=-74.33333333333333 +k=0.999966667 +x_0=152400.3048006096 +y_0=0 +datum=NAD27 +units=us-ft +no_defs ")
 
@@ -337,7 +337,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read alaska-polar-3572.tif CS correctly") {
-      val crs = SinglebandGeoTiff.compressed(geoTiffPath("alaska-polar-3572.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("alaska-polar-3572.tif")).crs
 
       val correctCRS = CRS.fromString("+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ")
       crs.toProj4String should equal(correctCRS.toProj4String)
@@ -350,7 +350,7 @@ class GeoTiffReaderSpec extends FunSpec
     val MeanEpsilon = 1e-8
 
     def testMinMaxAndMean(min: Double, max: Double, mean: Double, file: String) {
-      val SinglebandGeoTiff(tile, extent, _, _, _, _) = SinglebandGeoTiff.compressed(file)
+      val SinglebandGeoTiff(tile, extent, _, _, _, _) = SinglebandGeoTiff(file)
 
       tile.polygonalMax(extent, extent.toPolygon) should be (max)
       tile.polygonalMin(extent, extent.toPolygon) should be (min)
@@ -376,7 +376,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff without GeoKey Directory correctly") {
-      val SinglebandGeoTiff(tile, extent, crs, _, _, _) = SinglebandGeoTiff.compressed(geoTiffPath("no-geokey-dir.tif"))
+      val SinglebandGeoTiff(tile, extent, crs, _, _, _) = SinglebandGeoTiff(geoTiffPath("no-geokey-dir.tif"))
 
       crs should be (LatLng)
       extent should be (Extent(307485, 3911490, 332505, 3936510))
@@ -395,7 +395,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with tags") {
-      val tags = SinglebandGeoTiff.compressed(geoTiffPath("tags.tif")).tags.headTags
+      val tags = SinglebandGeoTiff(geoTiffPath("tags.tif")).tags.headTags
 
       tags("TILE_COL") should be ("6")
       tags("units") should be ("kg m-2 s-1")
@@ -405,7 +405,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with no extent data correctly") {
-      val Raster(tile, extent) = SinglebandGeoTiff.compressed(geoTiffPath("tags.tif")).raster
+      val Raster(tile, extent) = SinglebandGeoTiff(geoTiffPath("tags.tif")).raster
 
       extent should be (Extent(0, 0, tile.cols, tile.rows))
     }
@@ -446,7 +446,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read GeoTiff with ZLIB compression and needs exact segment sizes") {
-      val geoTiff = SinglebandGeoTiff.compressed(geoTiffPath("nex-pr-tile.tif"))
+      val geoTiff = SinglebandGeoTiff(geoTiffPath("nex-pr-tile.tif"))
 
       val tile = geoTiff.tile
       cfor(0)(_ < tile.rows, _ + 1) { row =>
@@ -458,13 +458,13 @@ class GeoTiffReaderSpec extends FunSpec
 
     it("should read clipped GeoTiff with byte NODATA value") {
       // Conversions carried out for both of these; first for byte -> float, second for user defined no data to constant
-      val geoTiff = SinglebandGeoTiff.compressed(geoTiffPath("nodata-tag-byte.tif")).tile.convert(FloatConstantNoDataCellType)
-      val geoTiff2 = SinglebandGeoTiff.compressed(geoTiffPath("nodata-tag-float.tif")).tile.convert(FloatConstantNoDataCellType)
+      val geoTiff = SinglebandGeoTiff(geoTiffPath("nodata-tag-byte.tif")).tile.convert(FloatConstantNoDataCellType)
+      val geoTiff2 = SinglebandGeoTiff(geoTiffPath("nodata-tag-float.tif")).tile.convert(FloatConstantNoDataCellType)
       assertEqual(geoTiff.toArrayTile, geoTiff2)
     }
 
     it("should read NODATA string with length = 4") {
-      val geoTiff = SinglebandGeoTiff.compressed(s"$baseDataPath/sbn/SBN_inc_percap-nodata-clip.tif")
+      val geoTiff = SinglebandGeoTiff(s"$baseDataPath/sbn/SBN_inc_percap-nodata-clip.tif")
       geoTiff.tile.cellType should be (ByteConstantNoDataCellType)
     }
 
@@ -483,7 +483,7 @@ class GeoTiffReaderSpec extends FunSpec
 
 
     it("should read and convert color table") {
-      val geoTiff = SinglebandGeoTiff.compressed(geoTiffPath("colormap.tif"))
+      val geoTiff = SinglebandGeoTiff(geoTiffPath("colormap.tif"))
 
       geoTiff.options.colorMap should be ('defined)
 
@@ -509,7 +509,7 @@ class GeoTiffReaderSpec extends FunSpec
     val path = temp.getPath()
 
     it("must read a tif, change the pixel sample type, write it out, and then read the correct in") {
-      val gt = SinglebandGeoTiff.compressed(s"$baseDataPath/slope.tif")
+      val gt = SinglebandGeoTiff(s"$baseDataPath/slope.tif")
       var headTags = gt.tags.headTags
       assert(headTags(Tags.AREA_OR_POINT) == "AREA")
       headTags -= Tags.AREA_OR_POINT
@@ -518,20 +518,20 @@ class GeoTiffReaderSpec extends FunSpec
       val gt2 = gt.copy(tags = tags)
       writer.GeoTiffWriter.write(gt2, path)
       addToPurge(path)
-      val gt3 = SinglebandGeoTiff.compressed(path)
+      val gt3 = SinglebandGeoTiff(path)
 
       gt3.tags.headTags.get(Tags.AREA_OR_POINT) should be (Some("POINT"))
     }
 
     it("must read a tif, set a datetime, write it out, and then read the correct in") {
-      val gt = SinglebandGeoTiff.compressed(geoTiffPath("reproject/nlcd_tile_wsg84.tif"))
+      val gt = SinglebandGeoTiff(geoTiffPath("reproject/nlcd_tile_wsg84.tif"))
       var headTags = gt.tags.headTags
       headTags += ((Tags.TIFFTAG_DATETIME, "1988:02:18 13:59:59"))
       val tags = Tags(headTags, gt.tags.bandTags)
       val gt2 = gt.copy(tags = tags)
       writer.GeoTiffWriter.write(gt2, path)
       addToPurge(path)
-      val gt3 = SinglebandGeoTiff.compressed(path)
+      val gt3 = SinglebandGeoTiff(path)
       assert(gt3.crs == LatLng)
 
       gt3.tags.headTags.get(Tags.TIFFTAG_DATETIME) should be (Some("1988:02:18 13:59:59"))
@@ -549,7 +549,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   describe("handling special CRS cases") {
     it("can handle an ESRI written GeoTiff in WebMercator") {
-      val tif = SinglebandGeoTiff.compressed(s"$baseDataPath/propval_bg_01_01.tif")
+      val tif = SinglebandGeoTiff(s"$baseDataPath/propval_bg_01_01.tif")
       tif.crs should be (WebMercator)
     }
   }
@@ -567,15 +567,15 @@ class PackBitsGeoTiffReaderSpec extends FunSpec
     }
 
     it("must read econic_packbits.tif and match uncompressed file") {
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("econic_packbits.tif")).tile
-      val expected = SinglebandGeoTiff.compressed(s"$baseDataPath/econic.tif").tile
+      val actual = SinglebandGeoTiff(geoTiffPath("econic_packbits.tif")).tile
+      val expected = SinglebandGeoTiff(s"$baseDataPath/econic.tif").tile
 
       assertEqual(actual, expected)
     }
 
     it("must read previously erroring packbits compression .tif and match uncompressed file") {
-      val expected = SinglebandGeoTiff.compressed(geoTiffPath("packbits-error-uncompressed.tif")).tile
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("packbits-error.tif")).tile
+      val expected = SinglebandGeoTiff(geoTiffPath("packbits-error-uncompressed.tif")).tile
+      val actual = SinglebandGeoTiff(geoTiffPath("packbits-error.tif")).tile
 
       assertEqual(actual, expected)
     }
@@ -587,7 +587,7 @@ class TiePointsTests extends FunSuite
     with GeoTiffTestUtils {
 
   test("Reads correct extent for tie points and PixelIsPoint") {
-    val actual = SinglebandGeoTiff.compressed(geoTiffPath("tie-points.tif")).extent
+    val actual = SinglebandGeoTiff(geoTiffPath("tie-points.tif")).extent
     // The expected Extent is read in from gdalinfo
     val expected = Extent( 0.5000000,   0.5000000,
       10.5000000,  10.5000000)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -55,7 +55,7 @@ class GeoTiffReaderSpec extends FunSpec
       val path = "slope.tif"
       val argPath = s"$baseDataPath/data/slope.json"
 
-      val tile = SinglebandGeoTiff(s"$baseDataPath/$path").tile.convert(FloatConstantNoDataCellType)
+      val tile = SinglebandGeoTiff(s"$baseDataPath/$path").tile.toArrayTile.convert(FloatConstantNoDataCellType)
 
       val expectedTile =
         ArgReader.read(argPath).tile
@@ -82,7 +82,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   }
 
-  describe("reading compressed file must yield same image array as uncompressed file") {
+  ignore("reading compressed file must yield same image array as uncompressed file") {
 
     it("must read econic_lzw.tif and match uncompressed file") {
       val decomp = SinglebandGeoTiff(geoTiffPath("econic_lzw.tif"))
@@ -131,7 +131,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   }
 
-  describe("reading bit rasters") {
+  ignore("reading bit rasters") {
     it("should match bit tile the ArrayTile pulled out of the resulting GeoTiffTile") {
       val expected = SinglebandGeoTiff(geoTiffPath("uncompressed/tiled/bit.tif")).tile
       val actual = SinglebandGeoTiff(geoTiffPath("uncompressed/tiled/bit.tif")).tile.toArrayTile
@@ -148,13 +148,11 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should match bit and byte-converted rasters") {
-      val actual = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile.toArrayTile()
-      val expected = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile.toArrayTile()convert(BitCellType)
+      val actual = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile
+      val expected = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).tile.toArrayTile.convert(BitCellType)
 
       assertEqual(actual, expected)
     }
-
-
   }
 
   describe("match tiff tags and geokeys correctly") {
@@ -257,10 +255,10 @@ class GeoTiffReaderSpec extends FunSpec
    The listgeo command sometimes drops precision compared to our generator,
    therefore we sometimes increase the epsilon double comparison value.
    */
-  describe("reads GeoTiff CRS correctly") {
+  ignore("reads GeoTiff CRS correctly") {
 
     it("should read slope.tif CS correctly") {
-      val crs = SinglebandGeoTiff(s"$baseDataPath/slope.tif")crs
+      val crs = SinglebandGeoTiff(s"$baseDataPath/slope.tif", streaming = true).crs
 
       val correctCRS = CRS.fromString("+proj=utm +zone=10 +datum=NAD27 +units=m +no_defs")
 
@@ -268,7 +266,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read aspect.tif CS correctly") {
-      val crs = SinglebandGeoTiff(s"$baseDataPath/aspect.tif").crs
+      val crs = SinglebandGeoTiff(s"$baseDataPath/aspect.tif", streaming = true).crs
 
       val correctProj4String = "+proj=lcc +lat_1=36.16666666666666 +lat_2=34.33333333333334 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +datum=NAD83 +units=m +no_defs"
 
@@ -278,7 +276,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read econic.tif CS correctly") {
-      val crs = SinglebandGeoTiff(s"$baseDataPath/econic.tif").crs
+      val crs = SinglebandGeoTiff(s"$baseDataPath/econic.tif", streaming = true).crs
 
       val correctProj4String = "+proj=eqdc +lat_0=33.76446202777777 +lon_0=-117.4745428888889 +lat_1=33.90363402777778 +lat_2=33.62529002777778 +x_0=0 +y_0=0 +datum=NAD27 +units=m +no_defs"
 
@@ -288,7 +286,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read bilevel.tif CS correctly") {
-      val crs = SinglebandGeoTiff(geoTiffPath("bilevel.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("bilevel.tif"), streaming = true).crs
 
       val correctProj4String = "+proj=tmerc +lat_0=0 +lon_0=-3.45233333 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +units=m +no_defs"
 
@@ -298,7 +296,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read all-ones.tif CS correctly") {
-      val crs = SinglebandGeoTiff(geoTiffPath("all-ones.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("all-ones.tif"), streaming = true).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
 
@@ -306,7 +304,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read colormap.tif CS correctly") {
-      val crs = SinglebandGeoTiff(geoTiffPath("colormap.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("colormap.tif"), streaming = true).crs
 
       val correctCRS = CRS.fromString("+proj=longlat +datum=WGS84 +no_defs")
       crs should equal(correctCRS)
@@ -321,7 +319,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read ndvi-web-mercator.tif CS correctly") {
-      val crs = SinglebandGeoTiff(geoTiffPath("ndvi-web-mercator.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("ndvi-web-mercator.tif"), streaming = true).crs
 
       val correctCRS = CRS.fromString("+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
 
@@ -329,7 +327,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read ny-state-plane.tif CS correctly") {
-      val crs = SinglebandGeoTiff(geoTiffPath("ny-state-plane.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("ny-state-plane.tif"), streaming = true).crs
 
       val correctCRS = CRS.fromString("+proj=tmerc +lat_0=40 +lon_0=-74.33333333333333 +k=0.999966667 +x_0=152400.3048006096 +y_0=0 +datum=NAD27 +units=us-ft +no_defs ")
 
@@ -337,7 +335,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
 
     it("should read alaska-polar-3572.tif CS correctly") {
-      val crs = SinglebandGeoTiff(geoTiffPath("alaska-polar-3572.tif")).crs
+      val crs = SinglebandGeoTiff(geoTiffPath("alaska-polar-3572.tif"), streaming =true).crs
 
       val correctCRS = CRS.fromString("+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ")
       crs.toProj4String should equal(correctCRS.toProj4String)
@@ -345,7 +343,7 @@ class GeoTiffReaderSpec extends FunSpec
 
   }
 
-  describe("reads file data correctly") {
+  ignore("reads file data correctly") {
 
     val MeanEpsilon = 1e-8
 
@@ -504,7 +502,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
   }
 
-  describe("Reading and writing special metadata tags ") {
+  ignore("Reading and writing special metadata tags ") {
     val temp = java.io.File.createTempFile("geotiff-writer", ".tif");
     val path = temp.getPath()
 
@@ -547,7 +545,7 @@ class GeoTiffReaderSpec extends FunSpec
     }
   }
 
-  describe("handling special CRS cases") {
+  ignore("handling special CRS cases") {
     it("can handle an ESRI written GeoTiff in WebMercator") {
       val tif = SinglebandGeoTiff(s"$baseDataPath/propval_bg_01_01.tif")
       tif.crs should be (WebMercator)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/MultibandGeoTiffReaderSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/MultibandGeoTiffReaderSpec.scala
@@ -245,7 +245,6 @@ class MultibandGeoTiffReaderSpec extends FunSpec
       val tile: GeoTiffMultibandTile =
         MultibandGeoTiff(
           path = p("striped", "pixel"),
-          decompress = false,
           streaming = false
         ).tile.asInstanceOf[GeoTiffMultibandTile]
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/SinglebandGeoTiffReaderSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/SinglebandGeoTiffReaderSpec.scala
@@ -29,10 +29,10 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
     with GeoTiffTestUtils {
 
   def geoTiff(storage: String, cellType: String): SinglebandGeoTiff =
-    SinglebandGeoTiff.compressed(geoTiffPath(s"uncompressed/$storage/${cellType}.tif"))
+    SinglebandGeoTiff(geoTiffPath(s"uncompressed/$storage/${cellType}.tif"))
 
   def geoTiff(compression: String, storage: String, cellType: String): SinglebandGeoTiff =
-    SinglebandGeoTiff.compressed(geoTiffPath(s"$compression/$storage/${cellType}.tif"))
+    SinglebandGeoTiff(geoTiffPath(s"$compression/$storage/${cellType}.tif"))
 
   def expectedTile(t: CellType, f: (Int, Int) => Double): Tile = {
     val cols = 500
@@ -66,9 +66,9 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
 
   describe("Reading a single band geotiff") {
     it("must read Striped Bit aspect and match tiled byte converted to bitfile") {
-      val actual = SinglebandGeoTiff.compressed(geoTiffPath("1band/aspect_bit_uncompressed_striped.tif")).tile
+      val actual = SinglebandGeoTiff(geoTiffPath("1band/aspect_bit_uncompressed_striped.tif")).tile
       val expected =
-        SinglebandGeoTiff.compressed(geoTiffPath("1band/aspect_byte_uncompressed_tiled.tif"))
+        SinglebandGeoTiff(geoTiffPath("1band/aspect_byte_uncompressed_tiled.tif"))
           .tile
           .toArrayTile
           .map { b => if(b == 0) 0 else 1 }
@@ -91,7 +91,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
 
       val n = "large-sparse-compressed.tif"
       val path = geoTiffPath(s"$n")
-      val raster = SinglebandGeoTiff.compressed(path).raster
+      val raster = SinglebandGeoTiff(path).raster
 
       val points = mutable.ListBuffer[Point]()
       val re = raster.rasterExtent
@@ -106,7 +106,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
     it("should find min and max of a large sparse raster, lzw compressed") {
       val n = "wm_depth.tif"
       val path = geoTiffPath(s"$n")
-      val tile = SinglebandGeoTiff.compressed(path).tile
+      val tile = SinglebandGeoTiff(path).tile
 
       val (min, max) = tile.findMinMaxDouble
 
@@ -217,7 +217,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -246,7 +246,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile
+          val tile = SinglebandGeoTiff(geoTiffPath(s"$c/$s/$t.tif")).tile
           assertEqual(tile, expected)
           //if(s == "striped") assertEqual(tile, expectedRaw) else assertEqual(tile, expected)
         }
@@ -272,7 +272,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
           println(s"     Testing $c $s:")
           withClue(s"Failed for Compression $c, storage $s") {
-            val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+            val tile = SinglebandGeoTiff(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
             assertEqual(tile, expected)
           }
@@ -298,7 +298,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -324,7 +324,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -350,7 +350,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -376,7 +376,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }
@@ -400,7 +400,7 @@ class SinglebandGeoTiffReaderSpec extends FunSpec
       ) {
         println(s"     Testing $c $s:")
         withClue(s"Failed for Compression $c, storage $s") {
-          val tile = SinglebandGeoTiff.compressed(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
+          val tile = SinglebandGeoTiff(geoTiffPath(s"$c/$s/$t.tif")).tile.toArrayTile
 
           assertEqual(tile, expected)
         }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -223,7 +223,7 @@ class GeoTiffWriterSpec extends FunSpec
         val actualBand = gt.tile.band(i)
         val expectedBand = geoTiff.tile.band(i)
 
-        assertEqual(actualBand.toArrayTile, expectedBand)
+        assertEqual(actualBand, expectedBand)
       }
     }
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -165,7 +165,7 @@ class GeoTiffWriterSpec extends FunSpec
     }
 
     it ("should read write raster correctly") {
-      val geoTiff = SinglebandGeoTiff.compressed(geoTiffPath("econic_zlib_tiled_bandint_wm.tif"))
+      val geoTiff = SinglebandGeoTiff(geoTiffPath("econic_zlib_tiled_bandint_wm.tif"))
       val projectedRaster = geoTiff.projectedRaster
       val ProjectedRaster(Raster(tile, extent), crs) = projectedRaster.reproject(LatLng)
       val reprojGeoTiff = SinglebandGeoTiff(tile, extent, crs, geoTiff.tags, geoTiff.options)
@@ -204,7 +204,7 @@ class GeoTiffWriterSpec extends FunSpec
     it ("should read write multibandraster with compression correctly") {
       val geoTiff = {
         val gt = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
-        MultibandGeoTiff(gt.raster, gt.crs, options = GeoTiffOptions(compression.DeflateCompression))
+        MultibandGeoTiff(Raster(gt.raster.tile.toArrayTile, gt.raster.extent), gt.crs, options = GeoTiffOptions(compression.DeflateCompression))
       }
 
       GeoTiffWriter.write(geoTiff, path)
@@ -223,7 +223,7 @@ class GeoTiffWriterSpec extends FunSpec
         val actualBand = gt.tile.band(i)
         val expectedBand = geoTiff.tile.band(i)
 
-        assertEqual(actualBand, expectedBand)
+        assertEqual(actualBand.toArrayTile, expectedBand)
       }
     }
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterTests.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterTests.scala
@@ -49,9 +49,12 @@ class GeoTiffWriterTests extends FunSuite
     val rr = FileRangeReader(p)
     val reader = StreamingByteReader(rr)
 
-    val gt1 = MultibandGeoTiff(reader)
+    val gt1 = {
+      val t = MultibandGeoTiff(reader)
+      t.copy(tile = t.tile.toArrayTile)
+    }
     val gt2 = MultibandGeoTiff.streaming(reader)
-    val gt3 = MultibandGeoTiff.compressed(p)
+    val gt3 = MultibandGeoTiff(p)
 
     withClue("Assumption failed: Reading GeoTiff two ways didn't match") {
       assertEqual(gt2.tile, gt1.tile)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterTests.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterTests.scala
@@ -49,33 +49,30 @@ class GeoTiffWriterTests extends FunSuite
     val rr = FileRangeReader(p)
     val reader = StreamingByteReader(rr)
 
-    val gt1 = {
-      val t = MultibandGeoTiff(reader)
-      t.copy(tile = t.tile.toArrayTile)
-    }
     val gt2 = MultibandGeoTiff.streaming(reader)
     val gt3 = MultibandGeoTiff(p)
+    val gt1 = gt3.tile.toArrayTile
 
-    withClue("Assumption failed: Reading GeoTiff two ways didn't match") {
-      assertEqual(gt2.tile, gt1.tile)
+      withClue("Assumption failed: Reading GeoTiff two ways didn't match") {
+      assertEqual(gt2.tile, gt1)
     }
 
     withClue("Assumption failed: Reading GeoTiff compressed doesn't work") {
-      assertEqual(gt3.tile, gt1.tile)
+      assertEqual(gt3.tile, gt1)
     }
 
     gt3.write(path)
 
     val resultComp = MultibandGeoTiff(path)
     withClue("Writing from a compressed read produced incorrect GeoTiff.") {
-      assertEqual(resultComp.tile, gt1.tile)
+      assertEqual(resultComp.tile, gt1)
     }
 
     gt2.write(path)
 
     val result = MultibandGeoTiff(path)
     withClue("Writing from a streaming read produced incorrect GeoTiff.") {
-      assertEqual(result.tile, gt1.tile)
+      assertEqual(result.tile, gt1)
     }
   }
 

--- a/raster/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
@@ -40,7 +40,7 @@ class ReprojectRasterExtentSpec extends FunSpec
     }
 
     it("should (approximately) match a GDAL for EPSG:4326 to EPSG:3857") {
-      val sourceGt = SinglebandGeoTiff.compressed(geoTiffPath("reproject/nlcd_tile_wsg84.tif"))
+      val sourceGt = SinglebandGeoTiff(geoTiffPath("reproject/nlcd_tile_wsg84.tif"))
       val sourceRaster = sourceGt.raster
 
       val rea @ RasterExtent(actualExtent, actualCellWidth, actualCellHeight, actualCols, actualRows) =

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffInfoReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffInfoReader.scala
@@ -33,7 +33,6 @@ case class S3GeoTiffInfoReader(
   prefix: String,
   getS3Client: () => S3Client = () => S3Client.DEFAULT,
   delimiter: Option[String] = None,
-  decompress: Boolean = false,
   streaming: Boolean = true,
   tiffExtensions: Seq[String] = S3GeoTiffRDD.Options.DEFAULT.tiffExtensions
 ) extends GeoTiffInfoReader {
@@ -54,7 +53,7 @@ case class S3GeoTiffInfoReader(
     val ovrReader: Option[ByteReader] =
       if (getS3Client().doesObjectExist(bucket, ovrKey)) Some(S3RangeReader(bucket, ovrKey, getS3Client())) else None
 
-    GeoTiffReader.readGeoTiffInfo(S3RangeReader(s3Uri.getBucket, s3Uri.getKey, getS3Client()), decompress, streaming, true, ovrReader)
+    GeoTiffReader.readGeoTiffInfo(S3RangeReader(s3Uri.getBucket, s3Uri.getKey, getS3Client()), streaming, true, ovrReader)
   }
 
   def getGeoTiffTags(uri: String): TiffTags = {

--- a/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGLayerWriter.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/cog/S3COGLayerWriter.scala
@@ -124,7 +124,7 @@ class S3COGAsyncWriter[V <: CellGrid: GeoTiffReader](
   ): Try[GeoTiff[V]] = Try {
     val is = client.getObject(bucket, key).getObjectContent
     val bytes = sun.misc.IOUtils.readFully(is, Int.MaxValue, true)
-    GeoTiffReader[V].read(bytes, decompress = false)
+    GeoTiffReader[V].read(bytes)
   }
 
   def encodeRecord(key: String, value: GeoTiff[V]): PutObjectRequest = {

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGCollectionLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGCollectionLayerReader.scala
@@ -232,7 +232,7 @@ object COGCollectionLayerReader {
           .flatten
           .flatMap { case (spatialKey, overviewIndex, _, seq) =>
             val key = baseKey.setComponent(spatialKey)
-            val tiff = GeoTiffReader[V].read(uri, decompress = false, streaming = true).getOverview(overviewIndex)
+            val tiff = GeoTiffReader[V].read(uri, streaming = true).getOverview(overviewIndex)
             val map = seq.map { case (gb, sk) => gb -> key.setComponent(sk) }.toMap
 
             tiff

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
@@ -277,7 +277,7 @@ object COGLayerReader {
                 .flatten
                 .flatMap { case (spatialKey, overviewIndex, _, seq) =>
                   val key = baseKey.setComponent(spatialKey)
-                  val tiff = GeoTiffReader[V].read(uri, decompress = false, streaming = true).getOverview(overviewIndex)
+                  val tiff = GeoTiffReader[V].read(uri, streaming = true).getOverview(overviewIndex)
                   val map = seq.map { case (gb, sk) => gb -> key.setComponent(sk) }.toMap
 
                   tiff

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGValueReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGValueReader.scala
@@ -64,7 +64,7 @@ trait COGValueReader[ID] {
       val uri = fullPath(keyPath(key.setComponent(spatialKey), maxWidth, baseKeyIndex, zoomRange))
 
       try {
-        GeoTiffReader[V].read(uri, decompress = false, streaming = true)
+        GeoTiffReader[V].read(uri, streaming = true)
           .getOverview(overviewIndex)
           .crop(gridBounds)
           .tile

--- a/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/cog/FileCOGLayerWriter.scala
@@ -84,7 +84,7 @@ class FileCOGLayerWriter(
               .foreach(samplesAccumulator.add)
 
           case Some(merge) if uriExists(path) =>
-            val old = GeoTiffReader[V].read(path, decompress = false, streaming = true)
+            val old = GeoTiffReader[V].read(path, streaming = true)
             val merged = merge(cog, old)
             merged.write(path, true)
             // collect VRT metadata

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffInfoReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffInfoReader.scala
@@ -31,7 +31,6 @@ case class HadoopGeoTiffInfoReader(
   path: String,
   config: SerializableConfiguration,
   tiffExtensions: Seq[String] = HadoopGeoTiffRDD.Options.DEFAULT.tiffExtensions,
-  decompress: Boolean = false,
   streaming: Boolean = true
 ) extends GeoTiffInfoReader {
 
@@ -51,7 +50,7 @@ case class HadoopGeoTiffInfoReader(
     val ovrReader: Option[ByteReader] =
       if (HdfsUtils.pathExists(ovrPath, config.value)) Some(HdfsRangeReader(ovrPath, config.value)) else None
 
-    GeoTiffReader.readGeoTiffInfo(rr, decompress, streaming, true, ovrReader) 
+    GeoTiffReader.readGeoTiffInfo(rr, streaming, true, ovrReader)
   }
 
   def getGeoTiffTags(uri: String): TiffTags = {

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffReader.scala
@@ -26,20 +26,20 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 
 object HadoopGeoTiffReader {
-  def readSingleband(path: Path)(implicit sc: SparkContext): SinglebandGeoTiff = readSingleband(path, decompress = true, streaming = false, None, sc.hadoopConfiguration)
-  def readSingleband(path: Path, decompress: Boolean, streaming: Boolean, extent: Option[Extent], conf: Configuration): SinglebandGeoTiff =
+  def readSingleband(path: Path)(implicit sc: SparkContext): SinglebandGeoTiff = readSingleband(path, streaming = false, None, sc.hadoopConfiguration)
+  def readSingleband(path: Path, streaming: Boolean, extent: Option[Extent], conf: Configuration): SinglebandGeoTiff =
     HdfsUtils.read(path, conf) { is =>
-      val geoTiff = GeoTiffReader.readSingleband(IOUtils.toByteArray(is), decompress, streaming)
+      val geoTiff = GeoTiffReader.readSingleband(IOUtils.toByteArray(is), streaming)
       extent match {
         case Some(e) => geoTiff.crop(e)
         case _ => geoTiff
       }
     }
 
-  def readMultiband(path: Path)(implicit sc: SparkContext): MultibandGeoTiff = readMultiband(path, decompress = true, streaming = false, None, sc.hadoopConfiguration)
-  def readMultiband(path: Path, decompress: Boolean, streaming: Boolean, extent: Option[Extent], conf: Configuration): MultibandGeoTiff =
+  def readMultiband(path: Path)(implicit sc: SparkContext): MultibandGeoTiff = readMultiband(path, streaming = false, None, sc.hadoopConfiguration)
+  def readMultiband(path: Path, streaming: Boolean, extent: Option[Extent], conf: Configuration): MultibandGeoTiff =
     HdfsUtils.read(path, conf) { is =>
-      val geoTiff = GeoTiffReader.readMultiband(IOUtils.toByteArray(is), decompress, streaming)
+      val geoTiff = GeoTiffReader.readMultiband(IOUtils.toByteArray(is), streaming)
       extent match {
         case Some(e) => geoTiff.crop(e)
         case _ => geoTiff

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/cog/HadoopCOGLayerWriter.scala
@@ -93,7 +93,7 @@ class HadoopCOGLayerWriter(
               .foreach(samplesAccumulator.add)
 
           case Some(merge) if HdfsUtils.pathExists(path, config.value) =>
-            val old = GeoTiffReader[V].read(path.toUri(), decompress = false, streaming = true)
+            val old = GeoTiffReader[V].read(path.toUri(), streaming = true)
             val merged = merge(cog, old)
             HdfsUtils.write(path, config.value) { new GeoTiffWriter(merged, _).write(true) }
             // collect VRT metadata

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/geotiff/GeoTiffLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/geotiff/GeoTiffLayerReader.scala
@@ -53,7 +53,7 @@ trait GeoTiffLayerReader[M[T] <: Traversable[T]] {
 
     val readRecord: (GeoTiffMetadata => fs2.Stream[IO, Option[Raster[V]]]) = { md =>
       fs2.Stream eval IO.shift(ec) *> IO {
-        val tiff = GeoTiffReader[V].read(md.uri, decompress = false, streaming = true)
+        val tiff = GeoTiffReader[V].read(md.uri, streaming = true)
         val reprojectedKeyExtent = keyExtent.reproject(layoutScheme.crs, tiff.crs)
 
         // crop is unsafe, let's double check that we have a correct extent
@@ -92,7 +92,7 @@ trait GeoTiffLayerReader[M[T] <: Traversable[T]] {
 
     val readRecord: (GeoTiffMetadata => fs2.Stream[IO, Raster[V]]) = { md =>
       fs2.Stream eval IO.shift(ec) *> IO {
-        val tiff = GeoTiffReader[V].read(md.uri, decompress = false, streaming = true)
+        val tiff = GeoTiffReader[V].read(md.uri, streaming = true)
         tiff
           .crop(tiff.extent, layout.cellSize)
           .reproject(tiff.crs, layoutScheme.crs)

--- a/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopRasterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/hadoop/HadoopRasterMethodsSpec.scala
@@ -68,7 +68,7 @@ class HadoopRasterMethodsSpec extends FunSpec
       val actual = actualTiff.tile
       val actualTags = actualTiff.tags
 
-      actual should be (expected)
+      actual.toArrayTile should be (expected.toArrayTile)
       actualTags should be (expectedTags)
     }
 
@@ -84,7 +84,7 @@ class HadoopRasterMethodsSpec extends FunSpec
       val actual = actualTiff.tile
       val actualTags = actualTiff.tags
 
-      actual should be (expected)
+      actual.toArrayTile should be (expected.toArrayTile)
       actualTags should be (expectedTags)
     }
 


### PR DESCRIPTION
## Overview

The thing is that the decompression flag is conflicting with a streaming flag. The solution is to allow "decompression" only in case of not streaming read.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

Closes #2086
