### PR TITLE
Add TMS reader for raster case [WIP] / [Blocked]

### DIFF
--- a/raster/build.sbt
+++ b/raster/build.sbt
@@ -3,6 +3,7 @@ import Dependencies._
 name := "geotrellis-raster"
 
 libraryDependencies ++= Seq(
+  "org.scalaj" %% "scalaj-http" % "2.4.0",
   typesafeConfig,
   jts,
   spire,

--- a/raster/src/main/scala/geotrellis/raster/io/tms/TMSReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/tms/TMSReader.scala
@@ -1,0 +1,76 @@
+package geotrellis.raster.io
+
+import geotrellis.raster._
+import geotrellis.vector.{Point, Extent}
+import geotrellis.spark.tiling.ZoomedLayoutScheme
+
+import spire.syntax.cfor._
+import scalaj.http._
+
+import scala.collection.mutable._
+import java.net.{URI, URL}
+import javax.imageio._
+
+class TMSReader[T](
+  uriTemplate: String,
+  f: URI => T = TMSReader.decodeTile _,
+  tileSize: Int = ZoomedLayoutScheme.DEFAULT_TILE_SIZE
+) extends Serializable {
+  def uri(z: Int, x: Int, y: Int): URI = new URI(
+    uriTemplate.replace("{z}", z.toString)
+      .replace("{x}", x.toString)
+      .replace("{y}", y.toString)
+  )
+
+  def read(zoom: Int, extent: Extent): Iterator[((Int, Int), T)] = {
+    val layoutDefinition = ZoomedLayoutScheme.layoutForZoom(zoom, extent, tileSize)
+    val bounds = layoutDefinition.mapTransform.extentToBounds(extent)
+    // construct bounds from zoom + extent
+    for ((x, y) <- bounds.coordsIter)
+    yield (x, y) -> f(uri(zoom, x, y))
+  }
+
+  def read(zoom: Int, x: Int, y: Int): T = f(uri(zoom, x, y))
+}
+
+object TMSReader {
+  import geotrellis.raster.render._
+
+  // ImageIO use here to deal with different decoding behaviors (png vs jpg)
+  def decodeTile(uri: URI): Tile = {
+    val img = ImageIO.read(uri.toURL)
+    val height = img.getHeight()
+    val width = img.getWidth()
+    val rgbArr = img.getRGB(0, 0, width, height, null, 0, width)
+    IntArrayTile(rgbArr, width, height, None)
+  }
+
+  // ImageIO use here to deal with different decoding behaviors (png vs jpg)
+  def decodeMultibandTile(uri: URI): MultibandTile = {
+    val img = ImageIO.read(uri.toURL)
+    val height = img.getHeight()
+    val width = img.getWidth()
+    val length = width * height
+
+    val rgbArr = img.getRGB(0, 0, width, height, null, 0, width)
+    val reds = new ArrayBuffer[Byte](length)
+    val greens = new ArrayBuffer[Byte](length)
+    val blues = new ArrayBuffer[Byte](length)
+    val alphas = new ArrayBuffer[Byte](length)
+    cfor(0)(_ < length, _ + 1) { cellIdx =>
+      val cell = rgbArr(cellIdx)
+      reds :+ cell.red.toByte
+      greens :+ cell.green.toByte
+      blues :+ cell.blue.toByte
+      alphas :+ cell.alpha.toByte
+    }
+
+    val redTile = ByteArrayTile(reds.toArray, width, height, None)
+    val greenTile = ByteArrayTile(greens.toArray, width, height, None)
+    val blueTile = ByteArrayTile(blues.toArray, width, height, None)
+    val alphaTile = ByteArrayTile(alphas.toArray, width, height, None)
+    MultibandTile(redTile, greenTile, blueTile, alphaTile)
+  }
+
+}
+

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
   sparkCore % Provided,
   hadoopClient % Provided,
   "com.google.uzaygezen" % "uzaygezen-core" % "0.2",
-  "org.scalaj" %% "scalaj-http" % "2.3.0",
+  "org.scalaj" %% "scalaj-http" % "2.4.0",
   avro,
   spire,
   monocleCore, monocleMacro,

--- a/spark/src/main/scala/geotrellis/spark/io/tms/SparkTMSReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/tms/SparkTMSReader.scala
@@ -1,0 +1,36 @@
+package geotrellis.spark
+
+import geotrellis.raster._
+import geotrellis.raster.io.tms._
+import geotrellis.vector.{Point, Extent}
+import geotrellis.spark.tiling.ZoomedLayoutScheme
+
+import spire.syntax.cfor._
+import scalaj.http._
+
+import scala.collection.mutable._
+import java.net.{URI, URL}
+import javax.imageio._
+
+
+import org.apache.spark.rdd._
+import geotrellis.spark._
+
+
+class SparkTMSReader[T](
+  uriTemplate: String,
+  f: URI => T = TMSReader.decodeTile _,
+  tileSize = ZoomedLayoutScheme.DEFAULT_TILE_SIZE
+) extends TMSReader(uriTemplate, f) {
+  /** Read a region from a ZXY source into RDD
+   * @param zoom Level of zoom to read from
+   * @param bounds Query bounds to read
+   * @param window Window that will cover partitions, offset from (0,0) of bounds
+   */
+  def rdd(zoom: Int, bounds: GridBounds, window: GridBounds = GridBounds(0,0,10,10)): RDD[(SpatialKey, T)] = {
+    // - divide bound into num "rectangular" partitions
+    // - make rdd of bounds
+    // - map from bounds to records using f
+    ???
+  }
+}


### PR DESCRIPTION
## Overview

This PR adds the ability to read TMS layers to the raster and the spark packages. Compilation won't work until we break tiling out of `Spark` (`ZoomedLayoutScheme` needs to be accessible from within `Raster`)

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [x] Raster case
- [ ] Spark case


Closes #2143