### PR TITLE
Revert "Deprecate Slick and move Projected"

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,9 +9,6 @@ API Changes
 
 - ``geotrellis.spark``
 
-
-  - **Deprecation:**  ``geotrellis.slick`` is being deprecated and will likely be moved to an external repo
-  - **Change:**  ``geotrellis.slick.Projected`` has been moved to ``geotrellis.vector.Projected``
   - **Change:**  The length of the key (the space-filling curve index or address) used for layer reading and writing has
     been extended from a fixed length of 8 bytes to an arbitrary length.  This change affects not only the
     ``geotrellis.spark`` package, but all backends (excluding ``geotrellis.geowave`` and ``geotrellis.geomesa``).

--- a/slick/src/main/scala/geotrellis/slick/PostGisProjectionSupport.scala
+++ b/slick/src/main/scala/geotrellis/slick/PostGisProjectionSupport.scala
@@ -47,7 +47,6 @@ import scala.reflect.ClassTag
  *
  * based on [[package com.github.tminglei.slickpg.PgPostGISSupport]]
  */
-@deprecated("We no longer recommend the use of Slick for scala JDBC access: try Doobie instead", "2.0.0")
 trait PostGisProjectionSupport extends PgPostGISExtensions { driver: PostgresDriver =>
   import PostGisProjectionSupportUtils._
   import driver.api._
@@ -101,7 +100,6 @@ trait PostGISProjectionImplicits {
   }
 }
 
-@deprecated("We no longer recommend the use of Slick for scala JDBC access: try Doobie instead", "2.0.0")
 object PostGisProjectionSupportUtils {
   lazy val WITH_SRID = """^SRID=([\d]+);(.*)""".r
 

--- a/slick/src/main/scala/geotrellis/slick/PostGisSupport.scala
+++ b/slick/src/main/scala/geotrellis/slick/PostGisSupport.scala
@@ -46,7 +46,6 @@ import java.sql.{PreparedStatement, ResultSet}
  *
  * based on [[package com.github.tminglei.slickpg.PgPostGISSupport]]
  */
-@deprecated("We no longer recommend the use of Slick for scala JDBC access: try Doobie instead", "2.0.0")
 trait PostGisSupport extends PgPostGISExtensions { driver: PostgresDriver =>
   import PostGisSupportUtils._
   import driver.api._

--- a/slick/src/main/scala/geotrellis/slick/Projected.scala
+++ b/slick/src/main/scala/geotrellis/slick/Projected.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package geotrellis.vector
+package geotrellis.slick
 
 import geotrellis.proj4.CRS
+import geotrellis.vector._
 import geotrellis.vector.reproject.Reproject
 
 

--- a/slick/src/main/scala/geotrellis/slick/package.scala
+++ b/slick/src/main/scala/geotrellis/slick/package.scala
@@ -14,8 +14,24 @@
  * limitations under the License.
  */
 
-package geotrellis.vector
+package geotrellis
 
-package object io extends io.json.Implicits
-    with io.wkb.Implicits
-    with io.wkt.Implicits
+import geotrellis.vector._
+
+/**
+  * Implicit conversion for geotrellis.vector.Geometry instances.
+  *
+  * @example {{{
+  * import geotrellis.vector._
+  * import geotrellis.slick._
+  *
+  * // create a web mercator projected point with the ExtendGeometry implicit class
+  * val projectedPoint = Point(1.0, 2.0).withSRID(3274)
+  * }}}
+  */
+package object slick {
+  implicit class ExtendGeometry[G <: Geometry](g: G) {
+    /** Upgrade Geometry to Projected[Geometry] */
+    def withSRID(srid: Int) = Projected(g, srid)
+  }
+}

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -132,9 +132,4 @@ package object vector extends SeqMethods
 
   implicit def seqGeometryToGeometryCollection(gs: Seq[Geometry]): GeometryCollection =
     GeometryCollection(gs)
-
-  implicit class ProjectGeometry[G <: Geometry](g: G) {
-    /** Upgrade Geometry to Projected[Geometry] */
-    def withSRID(srid: Int) = Projected(g, srid)
-  }
 }


### PR DESCRIPTION
Reverts locationtech/geotrellis#2639

I think it can cause problems in the future merges into 2.0 branch. Reverting to merge this PR into master.