### PR TITLE
Introduce Pyramid class

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -47,10 +47,14 @@ API Changes
     of the same dimension.
   - **Change:** Change `TilerMethods.tileToLayout` functions that accept `TileLayerMetadata` as an argument to return `RDD[(K, V)] with Metadata[M]`
     instead of `RDD[(K, V)]`
+  - **New:** Introduce ``Pyramid`` class to provide a convenience wrapper for building raster pyramids
+  - **Change:** Expose ``attributeStore`` parameter to LayerReader interface
 
 - ``geotrellis.raster``
 
   - **Change:** Removed ``decompress`` option from `GeoTiffReader` functions.
+  - **New:** Kryo serialization of geometry now uses a binary format to reduce shuffle block size
+  - **Change:** Scalaz streams were replaced by fs2 streams
 
 Fixes
 ^^^^^

--- a/spark/src/main/scala/geotrellis/spark/io/LayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerReader.scala
@@ -35,6 +35,7 @@ import java.net.URI
 
 trait LayerReader[ID] {
   def defaultNumPartitions: Int
+  val attributeStore: AttributeStore
 
   def read[
     K: AvroRecordCodec: Boundable: JsonFormat: ClassTag,

--- a/spark/src/main/scala/geotrellis/spark/pyramid/Pyramid.scala
+++ b/spark/src/main/scala/geotrellis/spark/pyramid/Pyramid.scala
@@ -103,7 +103,10 @@ object Pyramid extends LazyLogging {
     partitioner: Option[Partitioner] = None
   ): Pyramid[K, V, M] = {
     val opts = Options(resampleMethod, partitioner)
-    val gridBounds = rdd.metadata.getComponent[Bounds[K]].asInstanceOf[KeyBounds[K]].toGridBounds
+    val gridBounds = rdd.metadata.getComponent[Bounds[K]] match {
+      case kb: KeyBounds[K] => kb.toGridBounds
+      case _ => throw new IllegalArgumentException("Cannot construct a pyramid for an empty layer")
+    }
     val maxDim = math.max(gridBounds.width, gridBounds.height).toDouble
     val levels = math.ceil(math.log(maxDim)/math.log(2)).toInt
 


### PR DESCRIPTION
## Overview

GeoTrellis creates, as one of its core functions, multi-resolution, hierarchical level-of-detail structures that we commonly call pyramids.  Despite their frequent appearance in our workflows, we have been representing them as `List[(Int, RDD[(K, V)] with Metadata[M])]`.  This PR aims to grant pyramids first-class citizenship by creating a wrapper class that streamlines common operations on those structures.

Closes #2654 

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>

### Checklist

- [x] ~`docs/CHANGELOG.rst` updated, if necessary~
- [x] ~`docs` guides update, if necessary~
- [x] ~New user API has useful Scaladoc strings~
- [x] Unit tests added for bug-fix or new feature

