### PR TITLE
Avoid casting file position offsets to Int when reading byte ranges

### DIFF
--- a/util/src/main/scala/geotrellis/util/StreamingByteReader.scala
+++ b/util/src/main/scala/geotrellis/util/StreamingByteReader.scala
@@ -104,9 +104,9 @@ class StreamingByteReader(rangeReader: RangeReader, chunkSize: Int = 45876) exte
 
   /** Ensure we can read given number of bytes from current filePosition */
   private def ensureChunk(length: Int): Unit = {
-    val trimmed = math.min(length, (rangeReader.totalLength - filePosition).toInt)
+    val trimmed: Long = math.min(length.toLong, rangeReader.totalLength - filePosition)
     if (!chunkRange.contains(filePosition) || !chunkRange.contains(filePosition + trimmed - 1)) {
-      val len = math.min(math.max(length, chunkSize), (rangeReader.totalLength - filePosition).toInt)
+      val len: Long = math.min(math.max(length, chunkSize), rangeReader.totalLength - filePosition)
       readChunk(filePosition to (filePosition + len - 1))
     }
 


### PR DESCRIPTION
This results in overflow in Integer math for files larger than 2G

Resulting offsets would attempt to read at negative buffer position producing traces like: 
```scala
[info]   java.nio.BufferUnderflowException:
[info]   at java.nio.Buffer.nextGetIndex(Buffer.java:500)
[info]   at java.nio.HeapByteBuffer.get(HeapByteBuffer.java:135)
[info]   at geotrellis.util.StreamingByteReader.get(StreamingByteReader.scala:130)
[info]   at geotrellis.raster.io.geotiff.reader.GeoTiffReader$.readGeoTiffInfo(GeoTiffReader.scala:343)
[info]   at geotrellis.spark.io.file.cog.COGSpec$$anonfun$1.apply(COGSpec.scala:39)
[info]   at geotrellis.spark.io.file.cog.COGSpec$$anonfun$1.apply(COGSpec.scala:35)
```