### PR TITLE
Move GeoTrellis GeoMesa to use pureconfig

### DIFF
--- a/geomesa/src/main/scala/geotrellis/geomesa/geotools/GeometryToGeoMesaSimpleFeature.scala
+++ b/geomesa/src/main/scala/geotrellis/geomesa/geotools/GeometryToGeoMesaSimpleFeature.scala
@@ -16,16 +16,15 @@
 
 package geotrellis.geomesa.geotools
 
+import geotrellis.spark.io.geomesa.conf.GeoMesaConfig
 import geotrellis.proj4.{CRS => GCRS}
 import geotrellis.util.annotations.experimental
 import geotrellis.vector.{Geometry, Line, MultiLine, MultiPoint, MultiPolygon, Point, Polygon}
-
-import com.github.blemale.scaffeine.Scaffeine
+import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import com.vividsolutions.jts.{geom => jts}
 import org.geotools.feature.simple.{SimpleFeatureBuilder, SimpleFeatureTypeBuilder}
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.locationtech.geomesa.accumulo.index.Constants
-import com.typesafe.config.ConfigFactory
 
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
@@ -33,13 +32,13 @@ import com.typesafe.config.ConfigFactory
 @experimental
 object GeometryToGeoMesaSimpleFeature {
 
-  val whenField  = "when"
-  val whereField = "the_geom"
+  val whenField: String = "when"
+  val whereField: String = "the_geom"
 
-  lazy val featureTypeCache =
+  lazy val featureTypeCache: Cache[String, SimpleFeatureType] =
     Scaffeine()
       .recordStats()
-      .maximumSize(ConfigFactory.load().getInt("geotrellis.geomesa.featureTypeCacheSize"))
+      .maximumSize(GeoMesaConfig.featureTypeCacheSize)
       .build[String, SimpleFeatureType]()
 
   /** $experimental */

--- a/geomesa/src/main/scala/geotrellis/spark/io/geomesa/conf/GeoMesaConfig.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/io/geomesa/conf/GeoMesaConfig.scala
@@ -1,0 +1,8 @@
+package geotrellis.spark.io.geomesa.conf
+
+case class GeoMesaConfig(featureTypeCacheSize: Int = 16)
+
+object GeoMesaConfig {
+  lazy val conf: GeoMesaConfig = pureconfig.loadConfigOrThrow[GeoMesaConfig]("geotrellis.geomesa")
+  implicit def geoMesaConfigToClass(obj: GeoMesaConfig.type): GeoMesaConfig = conf
+}

--- a/geomesa/src/test/scala/geotrellis/geomesa/geotools/GeoMesaSimpleFeatureType.scala
+++ b/geomesa/src/test/scala/geotrellis/geomesa/geotools/GeoMesaSimpleFeatureType.scala
@@ -16,27 +16,26 @@
 
 package geotrellis.geomesa.geotools
 
+import geotrellis.spark.io.geomesa.conf.GeoMesaConfig
 import geotrellis.vector.Geometry
 import geotrellis.proj4.{WebMercator, CRS => GCRS}
-
-import com.github.blemale.scaffeine.Scaffeine
+import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import com.vividsolutions.jts.{geom => jts}
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder
 import org.locationtech.geomesa.accumulo.index.Constants
 import org.opengis.feature.simple.SimpleFeatureType
-import com.typesafe.config.ConfigFactory
 
 import scala.reflect._
 
 object GeoMesaSimpleFeatureType {
 
-  val whenField  = GeometryToGeoMesaSimpleFeature.whenField
-  val whereField = GeometryToGeoMesaSimpleFeature.whereField
+  val whenField: String = GeometryToGeoMesaSimpleFeature.whenField
+  val whereField: String = GeometryToGeoMesaSimpleFeature.whereField
 
-  lazy val featureTypeCache =
+  lazy val featureTypeCache: Cache[String, SimpleFeatureType] =
     Scaffeine()
       .recordStats()
-      .maximumSize(ConfigFactory.load().getInt("geotrellis.geomesa.featureTypeCacheSize"))
+      .maximumSize(GeoMesaConfig.featureTypeCacheSize)
       .build[String, SimpleFeatureType]()
 
   def apply[G <: Geometry: ClassTag](featureName: String, crs: Option[GCRS] = Some(WebMercator), temporal: Boolean = false): SimpleFeatureType = {


### PR DESCRIPTION
## Overview

We depend on `pureconfig`, so we can standardize over the method to access params.
Update for the vector package is in #2619.
