### PR TITLE
Fix problems with tile layer cropping when `clamp=false`

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -73,6 +73,7 @@ Fixes
   field, "the_geom"
 - Use a new Amazon SDK API to remove deprecation warnings.
 - Fixed a bug in incorrect metadata fetch by COGLayerReaders that could lead to an incorrect data querying.
+- Cropping RDDs with clamp=false now produces correct result
 
 1.2.1
 _____

--- a/raster/src/main/scala/geotrellis/raster/crop/RasterCropMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/crop/RasterCropMethods.scala
@@ -31,7 +31,7 @@ class RasterCropMethods[T <: CellGrid: (? => CropMethods[T])](val self: Raster[T
     * [[Raster]].
     */
   def crop(extent: Extent, options: Options): Raster[T] = {
-    val re = RasterExtent(self._2, self._1)
+    val re = RasterExtent(self.tile, self.extent)
     val gridBounds = re.gridBoundsFor(extent, clamp = options.clamp)
     val croppedExtent = re.extentFor(gridBounds, clamp = options.clamp)
     val croppedTile = self._1.crop(gridBounds, options)

--- a/spark/src/main/scala/geotrellis/spark/crop/Crop.scala
+++ b/spark/src/main/scala/geotrellis/spark/crop/Crop.scala
@@ -47,7 +47,7 @@ object Crop {
                     if (extent.contains(srcExtent)) {
                       Some((key, tile))
                     } else if (extent.interiorIntersects(srcExtent)) {
-                      val newTile = tile.crop(srcExtent, extent, options)
+                      val newTile = tile.crop(srcExtent, extent.intersection(srcExtent).get, options)
                       Some((key, newTile))
                     } else {
                       None


### PR DESCRIPTION
## Overview

Cropping of RDD tile layers with `clamp=false` caused problems because the cropping region wasn't restricted to the current spatial key, resulting in tiles that have a partial intersection with the crop region producing tiles that span the entire crop region.

Note: This PR is based on #2662 and also resolves part of the problem from issue #2549 

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

