### PR TITLE
Fix error in S3AttributeStore::availableZoomLevels

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3AttributeStore.scala
@@ -143,9 +143,12 @@ class S3AttributeStore(val bucket: String, val prefix: String) extends BlobLayer
     s3Client
       .listObjectsIterator(bucket, path(prefix, s"_attributes/metadata${SEP}${layerName}"))
       .toList
-      .map { os =>
-        val List(zoomStr, _) = new java.io.File(os.getKey).getName.split(SEP).reverse.take(2).toList
-        zoomStr.replace(".json", "").toInt
+      .flatMap { os =>
+        val List(zoomStr, foundName) = new java.io.File(os.getKey).getName.split(SEP).reverse.take(2).toList
+        if (foundName == layerName)
+          Some(zoomStr.replace(".json", "").toInt)
+        else
+          None
       }
       .distinct
   }


### PR DESCRIPTION
## Overview

An error was introduced in #2640 in S3AttributeStore::availableZoomLevels wherein all layers with a name starting with the queried layer name will be treated as a single layer in that method.  This can lead to errors further upstream (as observed in OverzoomingalueReader, e.g.).  We thus filter explicitly for the name of the queried layer in this PR.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>

### Notes

NOTE: Due to the choice of "__" as a separator, any layer containing that sequence in the name will most likely fail to find any available zoom levels.