### PR TITLE
Add shapeless shading into GeoTrellis assembly

### DIFF
--- a/spark-etl/build.sbt
+++ b/spark-etl/build.sbt
@@ -19,7 +19,8 @@ assemblyShadeRules in assembly := {
     ShadeRule.rename("com.fasterxml.jackson.**" -> s"$shadePackage.com.fasterxml.jackson.@1")
       .inLibrary(jsonSchemaValidator).inAll,
     ShadeRule.rename("org.apache.avro.**" -> s"$shadePackage.org.apache.avro.@1")
-      .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll
+      .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll,
+    ShadeRule.rename("shapeless.**" -> s"$shadePackage.shapeless.@1").inAll
   )
 }
 

--- a/spark-pipeline/build.sbt
+++ b/spark-pipeline/build.sbt
@@ -22,7 +22,8 @@ assemblyShadeRules in assembly := {
     ShadeRule.rename("com.fasterxml.jackson.**" -> s"$shadePackage.com.fasterxml.jackson.@1")
       .inLibrary(jsonSchemaValidator).inAll,
     ShadeRule.rename("org.apache.avro.**" -> s"$shadePackage.org.apache.avro.@1")
-      .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll
+      .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll,
+    ShadeRule.rename("shapeless.**" -> s"$shadePackage.shapeless.@1").inAll
   )
 }
 


### PR DESCRIPTION
## Overview

We depend on shapeless at the moment (dep brought by `circe` and `pureconfig`)
This PR shows how to shade shapeless. Shading is necessary as `Spark` itself depends on some old shapeless version.
