### PR TITLE
Fix deployment script launch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,4 +59,4 @@ deploy:
       repo: locationtech/geotrellis
       branch: master
       jdk: oraclejdk8
-      scala: "2.11.8"
+      scala: "2.11.12"


### PR DESCRIPTION
## Overview

Right now travis doesn't publish scaladocs and snapshots because of a typo in a `.travis.yml`.
