### PR TITLE
Should handle a single striped case the same way as GDAL

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/BasicTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/BasicTags.scala
@@ -27,7 +27,7 @@ case class BasicTags(
   compression: Int = 1,
   photometricInterp: Int = -1,
   resolutionUnit: Option[Int] = None,
-  rowsPerStrip: Long = 1,
+  rowsPerStrip: Long = -1, // If it's undefined GDAL interprets the entire TIFF as a single strip
   samplesPerPixel: Int = 1,
   stripByteCounts: Option[Array[Long]] = None,
   stripOffsets: Option[Array[Long]] = None,


### PR DESCRIPTION
## Overview

If `RowsPerStrip` tag is not defined we should handle the entire tiff as a single strip. 

```
// GDAL warning for this tiff.
GDAL: Warning 1: RowsPerStrip not defined ... assuming all one strip.
```

The solution was to [replicate GDAL behaviour](https://github.com/OSGeo/gdal/blob/f6833aea93b09852c9e25fb54abbb6f019524d37/gdal/frmts/gtiff/gt_jpeg_copy.cpp#L883-L885).

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

Closes #2577
