### PR TITLE
Use exponential backoff function in S3LayerReader

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -49,6 +49,7 @@ API Changes
     instead of `RDD[(K, V)]`
   - **New:** Introduce ``Pyramid`` class to provide a convenience wrapper for building raster pyramids
   - **Change:** Expose ``attributeStore`` parameter to LayerReader interface
+  - **Change:** Added exponential backoffs in ``S3RDDReader``
 
 - ``geotrellis.raster``
 


### PR DESCRIPTION
## Overview

Sometimes `S3` throws exceptions during reads. We already created a workaround for `S3` writes. This PR adds exponential backoffs for reads.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

Closes #2574
