### PR TITLE
Introduce unspecified options into Spark ETL package

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -46,16 +46,23 @@ API Changes
   - **New:** Alter `geotrellis.spark.stitch.StitchRDDMethods` to allow `RDD[(K, V)]` to be stitched when not all tiles are
     of the same dimension.
   - **Change:** Change `TilerMethods.tileToLayout` functions that accept `TileLayerMetadata` as an argument to return `RDD[(K, V)] with Metadata[M]`
-    instead of `RDD[(K, V)]`
-  - **New:** Introduce ``Pyramid`` class to provide a convenience wrapper for building raster pyramids
-  - **Change:** Expose ``attributeStore`` parameter to LayerReader interface
-  - **Change:** Added exponential backoffs in ``S3RDDReader``
+    instead of `RDD[(K, V)]`.
+  - **New:** Introduce ``Pyramid`` class to provide a convenience wrapper for building raster pyramids.
+  - **Change:** Expose ``attributeStore`` parameter to LayerReader interface.
+  - **Change:** Added exponential backoffs in ``S3RDDReader``.
 
 - ``geotrellis.raster``
 
   - **Change:** Removed ``decompress`` option from `GeoTiffReader` functions.
-  - **New:** Kryo serialization of geometry now uses a binary format to reduce shuffle block size
-  - **Change:** Scalaz streams were replaced by fs2 streams
+  - **New:** Kryo serialization of geometry now uses a binary format to reduce shuffle block size.
+  - **Change:** Scalaz streams were replaced by fs2 streams.
+
+- ``geotrellis.spark-etl``
+
+  - **Change**: Package is deprecated since GeoTrellis 2.0.
+  - **Change**: ``Input.maxTileSize`` is ``256`` by default to correspond ``HadoopGeoTiffRDD default behaviour``.
+                Added ``Input.partitionBytes`` and it is set to ``134217728`` by default to correspond ``HadoopGeoTiffRDD default behaviour``.
+                Added ``Output.bufferSize`` option to set up a custom buffer size for the buffered reprojection.
 
 Fixes
 ^^^^^

--- a/spark-etl/src/main/resources/input-schema.json
+++ b/spark-etl/src/main/resources/input-schema.json
@@ -25,6 +25,9 @@
       "numPartitions": {
         "type": "integer"
       },
+      "partitionBytes": {
+        "type": "integer"
+      },
       "clip": {
         "type": "object",
         "properties": {

--- a/spark-etl/src/main/resources/output-schema.json
+++ b/spark-etl/src/main/resources/output-schema.json
@@ -102,6 +102,9 @@
     "partitions": {
       "type": "integer"
     },
+    "bufferSize": {
+      "type": "integer"
+    },
     "crs": {
       "type": "string"
     },

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/Etl.scala
@@ -208,13 +208,22 @@ case class Etl(conf: EtlConf, @transient modules: Seq[TypedModule] = Etl.default
         scheme match {
           case Left(layoutScheme: ZoomedLayoutScheme) if output.maxZoom.isDefined =>
             val LayoutLevel(zoom, layoutDefinition) = layoutScheme.levelForZoom(output.maxZoom.get)
-            zoom -> tiled.reproject(destCrs, layoutDefinition, RasterReprojectOptions(method = method, targetCellSize = Some(layoutDefinition.cellSize)))._2
+            (zoom, output.bufferSize match {
+              case Some(bs) => tiled.reproject(destCrs, layoutDefinition, bs, RasterReprojectOptions(method = method, targetCellSize = Some(layoutDefinition.cellSize)))._2
+              case _ => tiled.reproject(destCrs, layoutDefinition, RasterReprojectOptions(method = method, targetCellSize = Some(layoutDefinition.cellSize)))._2
+            })
 
           case Left(layoutScheme) =>
-            tiled.reproject(destCrs, layoutScheme, method)
+            output.bufferSize match {
+              case Some(bs) => tiled.reproject(destCrs, layoutScheme, bs, method)
+              case _ => tiled.reproject(destCrs, layoutScheme, method)
+            }
 
           case Right(layoutDefinition) =>
-            tiled.reproject(destCrs, layoutDefinition, method)
+            output.bufferSize match {
+              case Some(bs) => tiled.reproject(destCrs, layoutDefinition, bs, method)
+              case _ => tiled.reproject(destCrs, layoutDefinition, method)
+            }
         }
     }
   }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/Input.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/Input.scala
@@ -17,6 +17,7 @@
 package geotrellis.spark.etl.config
 
 import geotrellis.proj4.CRS
+import geotrellis.spark.io.hadoop.HadoopGeoTiffRDD
 import geotrellis.vector.Extent
 
 import org.apache.spark.storage.StorageLevel
@@ -29,8 +30,9 @@ case class Input(
   noData: Option[Double] = None,
   clip: Option[Extent] = None,
   crs: Option[String] = None,
-  maxTileSize: Option[Int] = None,
-  numPartitions: Option[Int] = None
+  maxTileSize: Option[Int] = HadoopGeoTiffRDD.Options.DEFAULT.maxTileSize,
+  numPartitions: Option[Int] = None,
+  partitionBytes: Option[Long] = HadoopGeoTiffRDD.Options.DEFAULT.partitionBytes
 ) extends Serializable {
   def getCrs = crs.map(CRS.fromName)
 }

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/Output.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/Output.scala
@@ -44,10 +44,11 @@ case class Output(
   encoding: Option[String] = None,
   breaks: Option[String] = None,
   maxZoom: Option[Int] = None,
-  tileLayout: Option[TileLayout] = None
+  tileLayout: Option[TileLayout] = None,
+  bufferSize: Option[Int] = None
 ) extends Serializable {
 
-  require(maxZoom.isEmpty || layoutScheme == Some("zoomed"),
+  require(maxZoom.isEmpty || layoutScheme.contains("zoomed"),
     "maxZoom can only be used with 'zoomed' layoutScheme")
 
   def getCrs = crs.map(c => Try(CRS.fromName(c)) getOrElse CRS.fromString(c))

--- a/spark-etl/src/main/scala/geotrellis/spark/etl/config/json/ConfigFormats.scala
+++ b/spark-etl/src/main/scala/geotrellis/spark/etl/config/json/ConfigFormats.scala
@@ -204,7 +204,8 @@ trait ConfigFormats {
       "clip"    -> i.clip.toJson,
       "crs"   -> i.crs.toJson,
       "maxTileSize"   -> i.crs.toJson,
-      "numPartitions" -> i.numPartitions.toJson
+      "numPartitions" -> i.numPartitions.toJson,
+      "partitionBytes" -> i.partitionBytes.toJson
     )
     def read(value: JsValue): Input =
       value match {
@@ -218,7 +219,8 @@ trait ConfigFormats {
             clip    = fields.get("clip").map(_.convertTo[Extent]),
             crs     = fields.get("crs").map(_.convertTo[String]),
             maxTileSize = fields.get("maxTileSize").map(_.convertTo[Int]),
-            numPartitions = fields.get("numPartitions").map(_.convertTo[Int])
+            numPartitions = fields.get("numPartitions").map(_.convertTo[Int]),
+            partitionBytes = fields.get("partitionBytes").map(_.convertTo[Long])
           )
         case _ =>
           throw new DeserializationException("Input must be a valid json object.")
@@ -255,7 +257,8 @@ trait ConfigFormats {
       "encoding"            -> o.encoding.toJson,
       "breaks"              -> o.breaks.toJson,
       "maxZoom"             -> o.maxZoom.toJson,
-      "tileLayout"          -> o.tileLayout.toJson
+      "tileLayout"          -> o.tileLayout.toJson,
+      "bufferSize"          -> o.bufferSize.toJson
     )
 
     def read(value: JsValue): Output =
@@ -278,7 +281,8 @@ trait ConfigFormats {
             encoding            = fields.get("encoding").map(_.convertTo[String]),
             breaks              = fields.get("breaks").map(_.convertTo[String]),
             maxZoom             = fields.get("maxZoom").map(_.convertTo[Int]),
-            tileLayout          = fields.get("tileLayout").map(_.convertTo[TileLayout])
+            tileLayout          = fields.get("tileLayout").map(_.convertTo[TileLayout]),
+            bufferSize          = fields.get("bufferSize").map(_.convertTo[Int])
           )
         case _ =>
           throw new DeserializationException("Output must be a valid json object.")


### PR DESCRIPTION
## Overview

This PR adds a couple of `spark-etl` parameters, as we are still in process of moving to our `spark-pipeline` package.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

Docs would be done in a separate PR.

Related to #2681
