### PR TITLE
Spark Version 2.3.0

### DIFF
--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -21,6 +21,6 @@ object Environment {
     Properties.envOrElse(environmentVariable, default)
 
   lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.8.0")
-  lazy val sparkVersion   = either("SPARK_VERSION", "2.2.0")
+  lazy val sparkVersion   = either("SPARK_VERSION", "2.3.0")
   lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
 }

--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -20,7 +20,7 @@ object Environment {
   def either(environmentVariable: String, default: String): String =
     Properties.envOrElse(environmentVariable, default)
 
-  lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.8.0")
+  lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.8.3")
   lazy val sparkVersion   = either("SPARK_VERSION", "2.3.0")
   lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
 }


### PR DESCRIPTION
Upgrades the spark dependency to 2.3.0.
Driving reason aside from keeping current is to use improved ORC file support from Spark 2.3.0 in https://github.com/geotrellis/vectorpipe/pull/54