### PR TITLE
Change aspect result to azimuth

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -90,6 +90,7 @@ Fixes
 - Fixed a bug in incorrect metadata fetch by COGLayerReaders that could lead to an incorrect data querying.
 - Cropping RDDs with clamp=false now produces correct result.
 - Fixed tiff reads in case RowsPerStrip tiff tag is not defined.
+- Change aspect result to azimuth, i.e. start from due north and be clockwise.
 
 1.2.1
 _____

--- a/raster/data/data/aspect.json
+++ b/raster/data/data/aspect.json
@@ -1,1 +1,1 @@
-{ "layer": "aspect", "type": "arg", "datatype": "float32", "rows": 1400, "cols": 979, "xmin": 557815.0, "ymax": 5121985.0, "cellwidth": 10.0, "cellheight": 10.0, "xmax": 567605.0, "ymin": 5107985.0, "xskew": 0.0, "yskew": 0.0, "epsg": 26710 }
+{"layer":"aspect","type":"arg","datatype":"float32","rows":1400,"cols":979,"xmin":557815.000000,"ymax":5121985.000000,"cellwidth":10.000000,"cellheight":10.000000,"xmax":567605.000000,"ymin":5107985.000000,"xskew":0.000000,"yskew":0.000000,"epsg":26710}

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Aspect.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Aspect.scala
@@ -36,7 +36,7 @@ import geotrellis.raster.mapalgebra.focal.Angles._
   * Aspect is computed in degrees from due north, i.e. as an azimuth in degrees not radians.
   * The expression for aspect is:
   * {{{
-  * val aspect = 270 - 360 / (2 * Pi) * atan2(`dz / dy`, - `dz / dx`)
+  * val aspect = 360 / (2 * Pi) * atan2(`dz / dy`, `dz / dx`) - 90
   * }}}
   *
   */
@@ -47,7 +47,7 @@ object Aspect {
       with DoubleArrayTileResult
     {
       def setValue(x: Int, y: Int, s: SurfacePoint) {
-        resultTile.setDouble(x, y, degrees(s.aspect))
+        resultTile.setDouble(x, y, s.aspectAzimuth)
       }
     }
   }.execute()

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/Hillshade.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/Hillshade.scala
@@ -72,7 +72,7 @@ object Hillshade {
 
     val hr = aspect.combineDouble(slope) { (aspectValue, slopeValue) =>
       val slopeRads = radians(slopeValue)
-      val aspectRads = radians(aspectValue)
+      val aspectRads = radians(90.0 - aspectValue)
       val v = (cosZe * cos(slopeRads)) +
         (sinZe * sin(slopeRads) * cos(az - aspectRads))
       round(127.0 * max(0.0, v))

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/SurfacePointCalculation.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/SurfacePointCalculation.scala
@@ -36,6 +36,18 @@ class SurfacePoint() {
   /** Partial derivative of z with respect to y */
   var `dz/dy` = Double.NaN
 
+  def aspectAzimuth() = {
+    if (`dz/dx` == 0 && `dz/dy` == 0) {
+      /* Flat area */
+      -1.0
+    } else {
+      var aAzimuth = toDegrees(atan2(`dz/dy`, `dz/dx`) - Pi * 0.5)
+      if (aAzimuth < 0) { aAzimuth += 360.0 }
+      if (aAzimuth == 360.0) { aAzimuth = 0.0 }
+      aAzimuth
+    }
+  }
+
   def aspect() = {
     var a = atan2(`dz/dy`, -`dz/dx`)
 
@@ -208,7 +220,7 @@ abstract class SurfacePointCalculation[T](r: Tile, n: Neighborhood, analysisArea
     cellWidth = cellSize.width
     cellHeight = cellSize.height
 
-    if(colBorderMax < 3 || rowBorderMax < 3) {
+    if(colBorderMax < 2 || rowBorderMax < 2) {
       sys.error(s"Tile is too small to get surface values. ($colBorderMax, $rowBorderMax)")
     }
 

--- a/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/AspectSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/AspectSpec.scala
@@ -69,8 +69,9 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       var dx = ((0 - 1) + 2 * (2 - 1) + (2 - 1)) / 8.0
       var dy = ((1 - 1) + 2 * (1 - (-1)) + (2 - 0)) / 8.0
 
-      var aspect = atan2(dy, -dx) / (Pi / 180.0)
-      value should equal (aspect)
+      var aspect = atan2(dy, dx) / (Pi / 180.0) - 90.0
+      if(aspect < 0.0) { aspect += 360 }
+      (value - aspect) should be < 0.0000001
 
       //Check right edge
       value = aR.getDouble(4, 1)
@@ -78,7 +79,8 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       dx = ((2 - 1) + 2 * (2 - 2) + (2 - 2)) / 8.0
       dy = ((2 - 1) + 2 * (2 - 1) + (2 - 2)) / 8.0
 
-      aspect = atan2(dy, -dx) / (Pi / 180.0)
+      aspect = atan2(dy, dx) / (Pi / 180.0) - 90.0
+      if(aspect < 0.0) { aspect += 360 }
       (value - aspect) should be < 0.0000001
 
       //Check bottom edge
@@ -87,7 +89,8 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       dx = ((2 - 1) + 2 * (2 - 1) + (2 - 2)) / 8.0
       dy = ((2 - 1) + 2 * (2 - 2) + (2 - 2)) / 8.0
 
-      aspect = atan2(dy, -dx) / (Pi / 180.0)
+      aspect = atan2(dy, dx) / (Pi / 180.0) - 90.0
+      if(aspect < 0.0) { aspect += 360 }
       (value - aspect) should be < 0.0000001
 
       //Check top edge
@@ -96,7 +99,7 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       dx = ((1 - 1) + 2 * (1 - 1) + (2 - 2)) / 8.0
       dy = ((2 - 1) + 2 * (2 - 1) + (2 - 1)) / 8.0
 
-      aspect = atan2(dy, -dx) / (Pi / 180.0)
+      aspect = atan2(dy, dx) / (Pi / 180.0) - 90.0
       (value - aspect) should be < 0.0000001
 
       //Check top right corner 
@@ -105,7 +108,7 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       dx = ((1 - 1) + 2 * (1 - 1) + (1 - 2)) / 8.0
       dy = ((2 - 1) + 2 * (2 - 1) + (1 - 1)) / 8.0
 
-      aspect = atan2(dy, -dx) / (Pi / 180.0)
+      aspect = atan2(dy, dx) / (Pi / 180.0) - 90.0
       (value - aspect) should be < 0.0000001
 
       //Check top left corner
@@ -114,7 +117,8 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       dx = (((-1) - (-1)) + 2 * (0 - (-1)) + (2 - (-1))) / 8.0
       dy = (((-1) - (-1)) + 2 * (1 - (-1)) + (2 - (-1))) / 8.0
 
-      aspect = atan2(dy, -dx) / (Pi / 180.0)
+      aspect = atan2(dy, dx) / (Pi / 180.0) - 90.0
+      if(aspect < 0.0) { aspect += 360 }
       (value - aspect) should be < 0.0000001
 
       //Check bottom left corner
@@ -123,7 +127,7 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       dx = ((2 - 1) + 2 * (2 - 1) + (1 - 1)) / 8.0
       dy = ((1 - 1) + 2 * (1 - 1) + (1 - 2)) / 8.0
 
-      aspect = atan2(dy, -dx) / (Pi / 180.0)
+      aspect = atan2(dy, dx) / (Pi / 180.0) - 90.0
       if(aspect < 0.0) { aspect += 360 }
       (value - aspect) should be < 0.000001
 
@@ -131,11 +135,48 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       value = aR.getDouble(4, 4)
 
       dx = ((2 - 2) + 2 * (2 - 1) + (2 - 2)) / 8.0
-      dy = ((2 - 12) + 2 * (2 - 2) + (2 - 2)) / 8.0
+      dy = ((2 - 2) + 2 * (2 - 2) + (2 - 2)) / 8.0
 
-      aspect = atan2(dy, -dx) / (Pi / 180.0)
+      aspect = atan2(dy, dx) / (Pi / 180.0) - 90.0
       if(aspect < 0.0) { aspect += 360 }
       (value - aspect) should be < 0.0000001
+    }
+
+    it("should start from due north and be clockwise") {
+      val r = createTile(
+        Array[Int](
+          1, 2, 3, 2, 1,
+          2, 3, 4, 3, 2,
+          3, 4, 5, 4, 3,
+          2, 3, 4, 3, 2,
+          1, 2, 3, 2, 1), 5, 5)
+
+      val aR = r.aspect(CellSize(5, 5))
+
+      var value = aR.getDouble(3, 1)
+      (value - 45.0) should be < 0.000001
+
+      value = aR.getDouble(3, 3)
+      (value - 135.0) should be < 0.000001
+
+      value = aR.getDouble(1, 3)
+      (value - 225.0) should be < 0.000001
+
+      value = aR.getDouble(1, 1)
+      (value - 315.0) should be < 0.000001
+    }
+
+    it("should assign flat area to -1") {
+      val r = createTile(
+        Array[Int](
+          1, 1, 1,
+          1, 1, 1,
+          1, 1, 1), 3, 3)
+
+      val aR = r.aspect(CellSize(5, 5))
+
+      var value = aR.getDouble(1, 1)
+      (value - (-1.0)) should be < 0.000001
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/AspectSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/AspectSpec.scala
@@ -48,9 +48,9 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       val rgc = rg.convert(DoubleConstantNoDataCellType).crop(rasterExtent.extent, cropExtent)
       val rc = aspectComputed.crop(rasterExtentElevation.extent, cropExtent)
 
-      assertEqual(rgc, rc, 0.1)
+      // '1.1' is because gdal's flat area is 0, and our flat area is -1
+      assertEqual(rgc, rc, 1.1)
     }
-
 
     it("should calculate edge cases correctly") {
       val r = createTile(


### PR DESCRIPTION
## Overview

Change aspect result to azimuth, i.e. start from due north and be clockwise. So that it will match the API description in `raster.mapalgebra.focal.Aspect`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

Closes #2580
