### PR TITLE
Fix index calculation in RasterExample

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/raster/RasterExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/raster/RasterExamples.scala
@@ -28,7 +28,7 @@ object RasterExamples {
         val x = point.x
         val y = point.y
         if(rasterExtent.extent.intersects(x,y)) {
-          val index = rasterExtent.mapXToGrid(x) * cols + rasterExtent.mapYToGrid(y)
+          val index = rasterExtent.mapXToGrid(x) + rasterExtent.mapYToGrid(y) * cols
           array(index) = array(index) + 1
         }
       }


### PR DESCRIPTION
## Overview
Edited a single line to fix the index calculation in doc-examples/src/main/scala/geotrellis/doc/examples/raster/RasterExamples.scala/RasterExample.scala

### Checklist

- [ x] `docs/CHANGELOG.rst` updated, if necessary
- [ x] `docs` guides update, if necessary
- [ x] New user API has useful Scaladoc strings
- [ x] Unit tests added for bug-fix or new feature

### Demo

Optional. Screenshots/REPL

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #XXX
