### PR TITLE
Make all tests Java Serialization compatible

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/BandTypes.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/BandTypes.scala
@@ -19,7 +19,7 @@ package geotrellis.raster.io.geotiff
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.tags.codes.SampleFormat._
 
-sealed abstract trait BandType {
+sealed abstract trait BandType extends Serializable {
   def bytesPerSample: Int = (bitsPerSample + 7) / 8
   def bitsPerSample: Int
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SegmentBytes.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SegmentBytes.scala
@@ -22,7 +22,7 @@ package geotrellis.raster.io.geotiff
   * The base trait of SegmentBytes. It can be implemented either as
   * an Array[Array[Byte]] or as a ByteBuffer that is lazily read in.
   */
-trait SegmentBytes extends Seq[Array[Byte]] {
+trait SegmentBytes extends Seq[Array[Byte]] with Serializable {
   def getSegment(i: Int): Array[Byte]
 
   def getSegments(indices: Traversable[Int]): Iterator[(Int, Array[Byte])]

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Predictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Predictor.scala
@@ -46,7 +46,7 @@ object Predictor {
   }
 }
 
-trait Predictor {
+trait Predictor extends Serializable {
   /** True if this predictor needs to check if the endian requires flipping */
   def checkEndian: Boolean
   /** GeoTiff tag value for this predictor */

--- a/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
+++ b/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
@@ -112,7 +112,7 @@ object IterativeCostDistance {
     gs
       .flatMap({ g => geometryToKeys(md, g).map({ k => (k, g) }) })
       .groupBy(_._1)
-      .mapValues({ list => list.map({ case (_, v) => v }) })
+      .map({ case (key, list) => (key, list.map({ case (_, v) => v })) })
   }
 
   /**

--- a/spark/src/main/scala/geotrellis/spark/io/RasterReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/RasterReader.scala
@@ -64,13 +64,13 @@ object RasterReader {
     def readFully(byteReader: ByteReader, options: Options) = {
       val geotiff = SinglebandGeoTiff(byteReader)
       val raster: Raster[Tile] = geotiff.raster
-      (ProjectedExtent(raster.extent, options.crs.getOrElse(geotiff.crs)), raster.tile)
+      (ProjectedExtent(raster.extent, options.crs.getOrElse(geotiff.crs)), raster.tile.toArrayTile)
     }
 
     def readWindow(streamingByteReader: StreamingByteReader, pixelWindow: GridBounds, options: Options) = {
       val geotiff = SinglebandGeoTiff.streaming(streamingByteReader)
       val raster: Raster[Tile] = geotiff.raster.crop(pixelWindow)
-      (ProjectedExtent(raster.extent, options.crs.getOrElse(geotiff.crs)), raster.tile)
+      (ProjectedExtent(raster.extent, options.crs.getOrElse(geotiff.crs)), raster.tile.toArrayTile)
     }
 
     def readWindows(gbs: Array[GridBounds], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
@@ -86,13 +86,13 @@ object RasterReader {
     def readFully(byteReader: ByteReader, options: Options) = {
       val geotiff = MultibandGeoTiff(byteReader)
       val raster: Raster[MultibandTile] = geotiff.raster
-      (ProjectedExtent(raster.extent, options.crs.getOrElse(geotiff.crs)), raster.tile)
+      (ProjectedExtent(raster.extent, options.crs.getOrElse(geotiff.crs)), raster.tile.toArrayTile)
     }
 
     def readWindow(streamingByteReader: StreamingByteReader, pixelWindow: GridBounds, options: Options) = {
       val geotiff = MultibandGeoTiff.streaming(streamingByteReader)
       val raster: Raster[MultibandTile] = geotiff.raster.crop(pixelWindow)
-      (ProjectedExtent(raster.extent, options.crs.getOrElse(geotiff.crs)), raster.tile)
+      (ProjectedExtent(raster.extent, options.crs.getOrElse(geotiff.crs)), raster.tile.toArrayTile)
     }
 
     def readWindows(gbs: Array[GridBounds], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
@@ -110,7 +110,7 @@ object RasterReader {
       val raster: Raster[Tile] = geotiff.raster
       val time = options.parseTime(geotiff.tags)
       val crs = options.crs.getOrElse(geotiff.crs)
-      (TemporalProjectedExtent(raster.extent, crs, time), raster.tile)
+      (TemporalProjectedExtent(raster.extent, crs, time), raster.tile.toArrayTile)
     }
 
     def readWindow(streamingByteReader: StreamingByteReader, pixelWindow: GridBounds, options: Options) = {
@@ -118,7 +118,7 @@ object RasterReader {
       val raster: Raster[Tile] = geotiff.raster.crop(pixelWindow)
       val time = options.parseTime(geotiff.tags)
       val crs = options.crs.getOrElse(geotiff.crs)
-      (TemporalProjectedExtent(raster.extent, crs, time), raster.tile)
+      (TemporalProjectedExtent(raster.extent, crs, time), raster.tile.toArrayTile)
     }
 
     def readWindows(gbs: Array[GridBounds], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
@@ -128,8 +128,8 @@ object RasterReader {
         (TemporalProjectedExtent(
           extent = re.extentFor(gb, clamp = false),
           crs = options.crs.getOrElse(info.crs),
-          options.parseTime(info.tags)),
-        tile)
+          options.parseTime(info.tags)
+        ), tile)
       }
     }
   }
@@ -140,7 +140,7 @@ object RasterReader {
       val raster: Raster[MultibandTile] = geotiff.raster
       val time = options.parseTime(geotiff.tags)
       val crs = options.crs.getOrElse(geotiff.crs)
-      (TemporalProjectedExtent(raster.extent, crs, time), raster.tile)
+      (TemporalProjectedExtent(raster.extent, crs, time), raster.tile.toArrayTile)
     }
 
     def readWindow(streamingByteReader: StreamingByteReader, pixelWindow: GridBounds, options: Options) = {
@@ -148,7 +148,7 @@ object RasterReader {
       val raster: Raster[MultibandTile] = geotiff.raster.crop(pixelWindow)
       val time = options.parseTime(geotiff.tags)
       val crs = options.crs.getOrElse(geotiff.crs)
-      (TemporalProjectedExtent(raster.extent, crs, time), raster.tile)
+      (TemporalProjectedExtent(raster.extent, crs, time), raster.tile.toArrayTile)
     }
 
     def readWindows(gbs: Array[GridBounds], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
@@ -158,8 +158,8 @@ object RasterReader {
         (TemporalProjectedExtent(
           extent = re.extentFor(gb, clamp = false ),
           crs = options.crs.getOrElse(info.crs),
-          options.parseTime(info.tags)),
-        tile)
+          options.parseTime(info.tags)
+        ), tile)
       }
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriterSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/slippy/HadoopSlippyTileWriterSpec.scala
@@ -50,7 +50,7 @@ class HadoopSlippyTileWriterSpec
 
       val reader =
         new FileSlippyTileReader[Tile](testPath)({ (key, bytes) =>
-          SinglebandGeoTiff(bytes).tile
+          SinglebandGeoTiff(bytes).tile.toArrayTile
         })
 
       rastersEqual(reader.read(TestFiles.ZOOM_LEVEL), AllOnesTestFile)

--- a/spark/src/test/scala/geotrellis/spark/render/SpatialTileLayerRDDRenderMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/render/SpatialTileLayerRDDRenderMethodsSpec.scala
@@ -50,7 +50,7 @@ class SpatialTileRDDRenderMethodsSpec extends FunSpec
       import geotrellis.raster.io.geotiff._
       val tiff = SinglebandGeoTiff(new java.io.File(inputHomeLocalPath, "elevation.tif").getAbsolutePath)
 
-      val (raster, rdd) = createTileLayerRDD(tiff.raster, 100, 100, tiff.crs)
+      val (raster, rdd) = createTileLayerRDD(tiff.raster.mapTile(_.toArrayTile), 100, 100, tiff.crs)
 
       val colorMap =
         ColorMap(

--- a/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
@@ -244,7 +244,7 @@ class TileRDDReprojectSpec extends FunSpec with TestEnvironment {
   describe("Reprojected with the same scheme and CRS") {
     it("should tile with minimum number of tiles") {
       val tiff = SinglebandGeoTiff(new java.io.File(inputHomeLocalPath, "aspect.tif").getAbsolutePath)
-      val rdd = sc.parallelize(Seq( (tiff.projectedExtent, tiff.tile) ))
+      val rdd = sc.parallelize(Seq( (tiff.projectedExtent, tiff.tile.toArrayTile: Tile) ))
       val scheme = FloatingLayoutScheme(256)
       val extent = Extent(-31.4569758,  27.6350020, 40.2053192,  80.7984255)
       val cellSize = CellSize(0.083328250000000, 0.083328250000000)

--- a/vector/src/main/scala/geotrellis/vector/mesh/IndexedPointSet.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/IndexedPointSet.scala
@@ -24,7 +24,7 @@ import geotrellis.vector.Point
  * Provides an interface to a collection of Coordinates that have integer
  * indices.  The wrapped collection may be sparsely indexed.
  */
-trait IndexedPointSet {
+trait IndexedPointSet extends Serializable {
   /**
    * Returns the number of points in the collection.
    */


### PR DESCRIPTION
## Overview

The following tests were not passing with kryo serialization disabled. Only a part of them were related to a default tiff readers behavior change. 

- [x] geotrellis.spark.render.SpatialTileRDDRenderMethodsSpec (tiff reader change, explicit segments unpacking is required)
- [x] geotrellis.spark.reproject.TileRDDReprojectSpec (tiff reader change, explicit segments unpacking is required)
- [x] geotrellis.spark.io.slippy.HadoopSlippyTileWriterSpec (tiff reader change, explicit segments unpacking is required)
- [x] geotrellis.spark.costdistance.RDDCostDistanceMethodsSpec ([SI-7005](https://issues.scala-lang.org/browse/SI-7005))
- [x] geotrellis.spark.distance.EuclideanDistanceSpec (`IndexedPointSet` extends `Serializable`)
- [x] geotrellis.spark.costdistance.IterativeCostDistanceSpec ([SI-7005](https://issues.scala-lang.org/browse/SI-7005))
- [x] make GeoTiffTile types `Serializable`

Closes #2721
