### PR TITLE
Added example of rasterizing polygons with count

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/raster/RasterExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/raster/RasterExamples.scala
@@ -35,4 +35,25 @@ object RasterExamples {
       IntArrayTile(array, cols, rows)
     }
   }
+
+  def `Counting polygon features in raster cells (rasterize operation)`: Unit = {
+    import geotrellis.raster._
+    import geotrellis.vector._
+
+    def countPolygon(features: Seq[PolygonFeature[Int]], rasterExtent: RasterExtent): MultibandTile = {
+      // Assumes the polygon features have 5 classes
+
+      val (cols, rows) = (rasterExtent.cols, rasterExtent.rows)
+      val bands = Array.fill(5) { IntArrayTile.ofDim(cols, rows) }
+      for(Feature(polygon, classId) <- features) {
+        val targetBand = bands(classId)
+        // Use the 'foreach' method exension to rasterize the polygon over the raster extent.
+        rasterExtent.foreach(polygon) { (col, row) =>
+          targetBand.set(col, row, targetBand.get(col, row) + 1)
+        }
+      }
+
+      MultibandTile(bands)
+    }
+  }
 }


### PR DESCRIPTION
## Overview

This adds an example of rasterizing a set of polygon features, where the feature data represents a set of class IDs from 0 - 4. The resulting multiband raster  has 5 bands, each for class 0 - 4, and contains counts of how many polygons of that class overlapped that cell.