### PR TITLE
Scala 2.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jdk:
 
 scala:
   - "2.11.12"
+  - "2.12.6"
 
 cache:
   directories:

--- a/.travis/build-and-test.sh
+++ b/.travis/build-and-test.sh
@@ -17,8 +17,16 @@ echo "RUN SET CALC: ($COMMIT_HASH_NUMBER + $SCALA_MINOR_VERSION_NUMBER + $JAVA_V
 
 if [ $RUN_SET = "1" ]; then
     echo "RUNNING SET 1";
-    .travis/build-and-test-set-1.sh;
+    if [ `echo $TRAVIS_SCALA_VERSION | cut -f1-2 -d "."` = "2.11" ]; then
+        .travis/build-and-test-set-1.sh;
+    else
+        .travis/build-set-1.sh;
+    fi
 else
     echo "RUNNING SET 2";
-    .travis/build-and-test-set-2.sh;
+    if [ `echo $TRAVIS_SCALA_VERSION | cut -f1-2 -d "."` = "2.11" ]; then
+        .travis/build-and-test-set-2.sh;
+    else
+        .travis/build-set-2.sh;
+    fi
 fi

--- a/.travis/build-set-1.sh
+++ b/.travis/build-set-1.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
+  "project proj4" test \
+  "project geotools" test \
+  "project shapefile" test \
+  "project doc-examples" test:compile \
+  "project spark" test:compile \
+  "project cassandra" test:compile || { exit 1; }

--- a/.travis/build-set-2.sh
+++ b/.travis/build-set-2.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
+  "project vector" test \
+  "project raster" test \
+  "project slick" test:compile \
+  "project vectortile" test \
+  "project spark-pipeline" test:compile \
+  "project spark-etl" test:compile \
+  "project hbase" test:compile \
+  "project accumulo" test:compile \
+  "project s3" test:compile \
+  "project s3-testkit" test:compile || { exit 1; }
+  # "project geowave" test:compile \
+  # "project geomesa" test:compile || { exit 1; }

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ scalaVersion in ThisBuild := Version.scala
 lazy val commonSettings = Seq(
   version := Version.geotrellis,
   scalaVersion := Version.scala,
+  crossScalaVersions := Version.crossScala,
   description := Info.description,
   organization := "org.locationtech.geotrellis",
   licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
   val fs2Core             = "co.fs2"                     %% "fs2-core"                 % "0.10.4"
   val fs2Io               = "co.fs2"                     %% "fs2-io"                   % "0.10.4"
 
-  val sparkCore           = "org.apache.spark"           %% "spark-core"               % Version.spark
+  val sparkCore           = "org.apache.spark"            % "spark-core_2.11"          % Version.spark
   val hadoopClient        = "org.apache.hadoop"           % "hadoop-client"            % Version.hadoop
 
   val avro                = "org.apache.avro"             % "avro"                     % "1.8.2"

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -17,6 +17,7 @@
 object Version {
   val geotrellis  = "2.0.0" + Environment.versionSuffix
   val scala       = "2.11.12"
+  val crossScala  = Seq(scala, "2.12.6")
   val geotools    = "17.1"
   val sprayJson   = "1.3.3"
   val monocle     = "1.5.1-cats"

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -28,13 +28,13 @@ package object vector extends SeqMethods
     with triangulation.Implicits
     with voronoi.Implicits {
 
-  type PointFeature[D] = Feature[Point, D]
-  type LineFeature[D] = Feature[Line, D]
-  type PolygonFeature[D] = Feature[Polygon, D]
-  type MultiPointFeature[D] = Feature[MultiPoint, D]
-  type MultiLineFeature[D] = Feature[MultiLine, D]
-  type MultiPolygonFeature[D] = Feature[MultiPolygon, D]
-  type GeometryCollectionFeature[D] = Feature[GeometryCollection, D]
+  type PointFeature[+D] = Feature[Point, D]
+  type LineFeature[+D] = Feature[Line, D]
+  type PolygonFeature[+D] = Feature[Polygon, D]
+  type MultiPointFeature[+D] = Feature[MultiPoint, D]
+  type MultiLineFeature[+D] = Feature[MultiLine, D]
+  type MultiPolygonFeature[+D] = Feature[MultiPolygon, D]
+  type GeometryCollectionFeature[+D] = Feature[GeometryCollection, D]
 
   // MethodExtensions
 


### PR DESCRIPTION
## Overview

This PR introduces a cross compilation Scala 2.12 support. Note, that it won't work on Spark, however would allow to use GeoTrellis in 2.12 libraries without having spark calls in the code. 

A better approach would be to have `spark-core` published against scala 2.12.

@jisantuc can you check, would it work for you?