### PR TITLE
Reading Big GeoTiffs With streaming Fix

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -93,6 +93,7 @@ Fixes
 - Fixed tiff reads in case RowsPerStrip tiff tag is not defined.
 - Change aspect result to azimuth, i.e. start from due north and be clockwise.
 - COG overviews generated in the ``COGLayer.fromLayerRDD`` method will now use the passed in ``ResampleMethod``.
+- Reading a GeoTiff with ``streaming`` will now work with files that are larger than ``java.lang.Integer.MAX_VALUE``.
 
 1.2.1
 _____

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReader.scala
@@ -25,7 +25,7 @@ import geotrellis.raster.io.geotiff.tags._
 import geotrellis.raster.io.geotiff.util._
 import geotrellis.vector.Extent
 import geotrellis.proj4.CRS
-import geotrellis.util.{ByteReader, Filesystem}
+import geotrellis.util.{ByteReader, Filesystem, FileRangeReader, StreamingByteReader}
 import geotrellis.raster.io.geotiff.tags.codes.ColorSpace
 import geotrellis.raster.render.IndexedColorMap
 import monocle.syntax.apply._
@@ -68,9 +68,9 @@ object GeoTiffReader {
     val ovrPathExists = new File(ovrPath).isFile
     if (streaming)
       readSingleband(
-        Filesystem.toMappedByteBuffer(path),
+        StreamingByteReader(FileRangeReader(path)),
         streaming, true,
-        if(ovrPathExists) Some(Filesystem.toMappedByteBuffer(ovrPath)) else None
+        if(ovrPathExists) Some(StreamingByteReader(FileRangeReader(ovrPath))) else None
       )
     else
       readSingleband(
@@ -170,9 +170,9 @@ object GeoTiffReader {
     val ovrPathExists = new File(ovrPath).isFile
     if (streaming)
       readMultiband(
-        Filesystem.toMappedByteBuffer(path),
+        StreamingByteReader(FileRangeReader(path)),
         streaming, true,
-        if(ovrPathExists) Some(Filesystem.toMappedByteBuffer(ovrPath)) else None
+        if(ovrPathExists) Some(StreamingByteReader(FileRangeReader(ovrPath))) else None
       )
     else
       readMultiband(


### PR DESCRIPTION
## Overview

This PR fixes a bug where reading large GeoTiffs (>= 25 GB) with `streaming` would fail. The cause of this bug was because we were using a `FileInputStream` when streaming in GeoTiffs which has a max size of `Int.MAX_VALUE`. This was resolved by using a `StreamingByteReader` instead.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

Closes #2711 