### PR TITLE
Standardized the Spelling of GeoWave

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -51,6 +51,7 @@ API Changes
   - **Change:** Expose ``attributeStore`` parameter to LayerReader interface.
   - **Change:** Added exponential backoffs in ``S3RDDReader``.
   - **Change:** Changed SinglebandGeoTiff and MultibandGeoTiff crop function behaviour to work properly with cases when extent to crop by doesn't intersect tiff extent.
+  - **Change:** All classes and objects in the ``geowave`` package now use the spelling: ``GeoWave`` in their names.
 
 - ``geotrellis.raster``
 

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveAttributeStore.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveAttributeStore.scala
@@ -62,7 +62,7 @@ import spray.json.DefaultJsonProtocol._
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental object GeowaveAttributeStore {
+@experimental object GeoWaveAttributeStore {
 
   /** $experimental */
   @experimental def accumuloRequiredOptions(
@@ -121,7 +121,7 @@ import spray.json.DefaultJsonProtocol._
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeowaveAttributeStore(
+@experimental class GeoWaveAttributeStore(
   val zookeepers: String,
   val accumuloInstance: String,
   val accumuloUser: String,
@@ -136,14 +136,14 @@ import spray.json.DefaultJsonProtocol._
   val connector = zkInstance.getConnector(accumuloUser, token)
   val delegate = AccumuloAttributeStore(connector, s"${geowaveNamespace}_ATTR")
 
-  val basicAccumuloOperations = GeowaveAttributeStore.basicOperations(
+  val basicAccumuloOperations = GeoWaveAttributeStore.basicOperations(
     zookeepers,
     accumuloInstance,
     accumuloUser,
     accumuloPass,
     geowaveNamespace: String
   )
-  val accumuloRequiredOptions = GeowaveAttributeStore.accumuloRequiredOptions(
+  val accumuloRequiredOptions = GeoWaveAttributeStore.accumuloRequiredOptions(
     zookeepers,
     accumuloInstance,
     accumuloUser,
@@ -199,13 +199,13 @@ import spray.json.DefaultJsonProtocol._
   }
 
   /** $experimental */
-  @experimental def primaryIndex = GeowaveAttributeStore.primaryIndex
+  @experimental def primaryIndex = GeoWaveAttributeStore.primaryIndex
 
   /** $experimental */
-  @experimental def adapters = GeowaveAttributeStore.adapters(basicAccumuloOperations)
+  @experimental def adapters = GeoWaveAttributeStore.adapters(basicAccumuloOperations)
 
   /** $experimental */
-  @experimental def subStrategies = GeowaveAttributeStore.subStrategies(primaryIndex)
+  @experimental def subStrategies = GeoWaveAttributeStore.subStrategies(primaryIndex)
 
   /** $experimental */
   @experimental def delete(layerId: LayerId, attributeName: String): Unit =

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveLayerReader.scala
@@ -55,7 +55,7 @@ import scala.reflect._
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-object GeowaveLayerReader {
+object GeoWaveLayerReader {
   private val geometryFactory = new GeometryFactory
   private val tileClassTag = classTag[Tile]
   private val mbtClassTag = classTag[MultibandTile]
@@ -92,14 +92,14 @@ object GeowaveLayerReader {
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeowaveLayerReader(val attributeStore: AttributeStore)
+@experimental class GeoWaveLayerReader(val attributeStore: AttributeStore)
   (implicit sc: SparkContext) extends LazyLogging {
 
   logger.error("GeoWave support is experimental")
 
   val defaultNumPartitions = sc.defaultParallelism
 
-  val gas = attributeStore.asInstanceOf[GeowaveAttributeStore]
+  val gas = attributeStore.asInstanceOf[GeoWaveAttributeStore]
 
   @experimental private def adapters = gas.adapters
   @experimental private def basicOperations = gas.basicAccumuloOperations
@@ -207,7 +207,7 @@ object GeowaveLayerReader {
     V: TileOrMultibandTile: ClassTag,
     M: JsonFormat: GetComponent[?, Bounds[K]]
   ](id: LayerId, rasterQuery: LayerQuery[K, M]) = {
-    import GeowaveLayerReader._
+    import GeoWaveLayerReader._
 
     /* Perform checks */
     if (!attributeStore.layerExists(id))

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveLayerWriter.scala
@@ -70,7 +70,7 @@ import mil.nga.giat.geowave.core.store.data.VisibilityWriter
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental object GeowaveLayerWriter extends LazyLogging {
+@experimental object GeoWaveLayerWriter extends LazyLogging {
 
   /** $experimental */
   @experimental def write[
@@ -81,7 +81,7 @@ import mil.nga.giat.geowave.core.store.data.VisibilityWriter
     coverageName: String,
     bits: Int,
     rdd: RDD[(K, V)] with Metadata[M],
-    as: GeowaveAttributeStore,
+    as: GeoWaveAttributeStore,
     accumuloWriter: AccumuloWriteStrategy
   ): Unit = {
     val metadata = rdd.metadata.asInstanceOf[TileLayerMetadata[SpatialKey]]
@@ -92,7 +92,7 @@ import mil.nga.giat.geowave.core.store.data.VisibilityWriter
     val specimen = rdd.first
 
     /* Construct (Multiband|)Tile to GridCoverage2D conversion function */
-    val rectify = GeowaveUtil.rectify(bits)_
+    val rectify = GeoWaveUtil.rectify(bits)_
     val geotrellisKvToGeotools: ((K, V)) => GridCoverage2D = {
       case (k: SpatialKey, _tile: V) =>
         val Extent(minX, minY, maxX, maxY) = mt(k.asInstanceOf[SpatialKey]).reproject(crs, LatLng)
@@ -244,8 +244,8 @@ import mil.nga.giat.geowave.core.store.data.VisibilityWriter
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeowaveLayerWriter(
-  val attributeStore: GeowaveAttributeStore,
+@experimental class GeoWaveLayerWriter(
+  val attributeStore: GeoWaveAttributeStore,
   val accumuloWriter: AccumuloWriteStrategy
 )(implicit sc: SparkContext)
     extends LazyLogging {
@@ -284,7 +284,7 @@ import mil.nga.giat.geowave.core.store.data.VisibilityWriter
     if (bits <= 0)
       logger.warn("It is highly recommended that you specify a bit precision when writing into GeoWave")
 
-    GeowaveLayerWriter.write(
+    GeoWaveLayerWriter.write(
       coverageName,
       (if (bits <= 0) 0; else bits),
       rdd,

--- a/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveUtil.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/geowave/GeoWaveUtil.scala
@@ -24,7 +24,7 @@ import scala.math.{ abs, pow, round }
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental object GeowaveUtil {
+@experimental object GeoWaveUtil {
 
   /**
     * $experimental If an edge or corner of an extent is very close to a split in

--- a/geowave/src/main/scala/geotrellis/spark/io/kryo/GeoWaveKryoRegistrator.scala
+++ b/geowave/src/main/scala/geotrellis/spark/io/kryo/GeoWaveKryoRegistrator.scala
@@ -38,7 +38,7 @@ import java.io.{ ObjectInputStream, ObjectOutputStream }
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeowaveKryoRegistrator extends KryoRegistrator {
+@experimental class GeoWaveKryoRegistrator extends KryoRegistrator {
 
   /** $experimental */
   @experimental override def registerClasses(kryo: Kryo) = {

--- a/geowave/src/test/scala/geotrellis/spark/GeoWaveTestEnvironment.scala
+++ b/geowave/src/test/scala/geotrellis/spark/GeoWaveTestEnvironment.scala
@@ -14,28 +14,18 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.geowave
+package geotrellis.spark
 
-import geotrellis.spark.io.AttributeStoreSpec
-import org.scalatest.BeforeAndAfter
+import geotrellis.spark.io.kryo.GeoWaveKryoRegistrator
+import geotrellis.spark.testkit.TestEnvironment
 
-class GeowaveAttributeStoreSpec
-    extends AttributeStoreSpec {
+import org.apache.spark.SparkConf
+import org.scalatest._
 
-  private def clear: Unit =
-    attributeStore
-      .layerIds
-      .foreach(attributeStore.delete(_))
-
-  lazy val attributeStore = new GeowaveAttributeStore(
-    "leader:21810",
-    "instance",
-    "root",
-    "password",
-    "TEST"
-  )
-
-  it("should clean up after itself") {
-    clear
+trait GeoWaveTestEnvironment extends TestEnvironment { self: Suite =>
+  override def setKryoRegistrator(conf: SparkConf) = {
+    conf
+      .set("spark.kryo.registrator", classOf[GeoWaveKryoRegistrator].getName)
+      .set("spark.kryo.registrationRequired", "false")
   }
 }

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeoWaveAttributeStoreSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeoWaveAttributeStoreSpec.scala
@@ -14,18 +14,28 @@
  * limitations under the License.
  */
 
-package geotrellis.spark
+package geotrellis.spark.io.geowave
 
-import geotrellis.spark.io.kryo.GeowaveKryoRegistrator
-import geotrellis.spark.testkit.TestEnvironment
+import geotrellis.spark.io.AttributeStoreSpec
+import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.SparkConf
-import org.scalatest._
+class GeoWaveAttributeStoreSpec
+    extends AttributeStoreSpec {
 
-trait GeowaveTestEnvironment extends TestEnvironment { self: Suite =>
-  override def setKryoRegistrator(conf: SparkConf) = {
-    conf
-      .set("spark.kryo.registrator", classOf[GeowaveKryoRegistrator].getName)
-      .set("spark.kryo.registrationRequired", "false")
+  private def clear: Unit =
+    attributeStore
+      .layerIds
+      .foreach(attributeStore.delete(_))
+
+  lazy val attributeStore = new GeoWaveAttributeStore(
+    "leader:21810",
+    "instance",
+    "root",
+    "password",
+    "TEST"
+  )
+
+  it("should clean up after itself") {
+    clear
   }
 }

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeoWaveFeatureRDDReaderSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeoWaveFeatureRDDReaderSpec.scala
@@ -60,7 +60,7 @@ object GeoWaveFeatureRDDReaderSpec {
   */
 class GeoWaveFeatureRDDReaderSpec
     extends FunSpec
-    with GeowaveTestEnvironment
+    with GeoWaveTestEnvironment
 {
 
   import GeoWaveFeatureRDDReaderSpec.id

--- a/geowave/src/test/scala/geotrellis/spark/io/geowave/GeoWaveSpatialSpec.scala
+++ b/geowave/src/test/scala/geotrellis/spark/io/geowave/GeoWaveSpatialSpec.scala
@@ -34,16 +34,16 @@ import org.opengis.parameter.GeneralParameterValue
 
 import org.scalatest._
 
-class GeowaveSpatialSpec
+class GeoWaveSpatialSpec
     extends FunSpec
     with Matchers
     with BeforeAndAfterAll
-    with GeowaveTestEnvironment
+    with GeoWaveTestEnvironment
 {
 
   val gwNamespace = "TEST"
 
-  val attributeStore = new GeowaveAttributeStore(
+  val attributeStore = new GeoWaveAttributeStore(
     "leader:21810",
     "instance",
     "root",
@@ -51,8 +51,8 @@ class GeowaveSpatialSpec
     gwNamespace
   )
 
-  val reader = new GeowaveLayerReader(attributeStore)
-  val writer = new GeowaveLayerWriter(attributeStore, SocketWriteStrategy())
+  val reader = new GeoWaveLayerReader(attributeStore)
+  val writer = new GeoWaveLayerWriter(attributeStore, SocketWriteStrategy())
   val coverageName = "Sample Elevation 1"
   val id1 = LayerId(coverageName, 11)
   val id2 = LayerId("Sample Elevation 2", 11)


### PR DESCRIPTION
## Overview

This PR standardizes the spelling of `GeoWave` in the `geowave` package. Before, classes and objects in the project used either the `Geowave` or the `GeoWave` spelling in their names. Now will they all have the same spelling of: `GeoWave`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary