### PR TITLE
ResampleMethod for COGLayer.fromLayerRDD

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -91,6 +91,7 @@ Fixes
 - Cropping RDDs with clamp=false now produces correct result.
 - Fixed tiff reads in case RowsPerStrip tiff tag is not defined.
 - Change aspect result to azimuth, i.e. start from due north and be clockwise.
+- COG overviews generated in the ``COGLayer.fromLayerRDD`` method will now use the passed in ``ResampleMethod``.
 
 1.2.1
 _____


### PR DESCRIPTION
## Overview

This PR fixes a bug where the `ResampleMethod` passed into `COGLayer.fromLayerRDD` would be ignored when creating the COG overviews. Now, the COG overview creation will use the passed in `ResampleMethod`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

Closes #2718 