### PR TITLE
Split TravisCI tests and make them more consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: false
+# See https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
+sudo: required
+dist: trusty
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
     - secure: "UwH3B4k5Nqt2THYYTY7uRxTPaJXZbK1hHrVsyJjZp/H2uFTYtQTxXpNb9aR7wuHuhLjXwKkq3gEXxEqhfy6V8+ZPbee6MUNvoYe/HhaPjsmTzcVihTBbO9e7g0bIQFc9bzwY15Y1ImshLcDAYvaXwXapy4Z/KadLiBheyqMk8Cs="
     # Scaladocs
     - secure: "FPfJbtXmhyMTh/eh9B/f6JZIv6aw+XZMipYlJsdgMEv+XKzL1tdYbKQv8G4C13lhyBZmOlQAbOhl4mRUBmq0FqG3361Y9SS4o5KfDRkZNErBTb8tveoRgKLkdLPwooAOUmRUeygKmhO4ehdQsMXCZmCk33nDq/ZrNallfnCRdm8="
+  matrix:
+    - RUN_SET=1
+    - RUN_SET=2
+    - RUN_SET=3
 
 language: scala
 
@@ -23,6 +27,7 @@ before_script:
   - docker run -d --restart=always --net=host -m 1G --memory-swap -1 --env="MAX_HEAP_SIZE=500M" --env="HEAP_NEWSIZE=100M" --env="CASSANDRA_LISTEN_ADDRESS=127.0.0.1" cassandra:latest
   - docker run -d --restart=always -p 8081:80 -v $(pwd)/spark/src/test/resources:/usr/share/nginx/html:ro nginx:stable
   - .travis/hbase-install.sh
+  - .travis/unzip-rasters.sh
 
 jdk:
   - openjdk8
@@ -33,9 +38,9 @@ scala:
 
 cache:
   directories:
-  - "$HOME/.ivy2"
-  - "$HOME/.sbt"
-  - "$HOME/downloads"
+  - $HOME/.ivy2
+  - $HOME/.sbt
+  - $HOME/downloads
 
 script:
   - .travis/build-and-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ cache:
   - $HOME/downloads
 
 script:
-  - .travis/build-and-test.sh
+  - travis_wait 60 .travis/build-and-test.sh
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ cache:
   - $HOME/downloads
 
 script:
-  - travis_wait 60 .travis/build-and-test.sh
+  - .travis/build-and-test.sh
 
 notifications:
   email:

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -9,4 +9,5 @@
   "project slick" test \
   "project vectortile" test \
   "project geowave" compile test:compile \
-  "project hbase" test || { exit 1; }
+  "project hbase" test \
+  "project geomesa" test || { exit 1; }

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -10,4 +10,5 @@
   "project vectortile" test \
   "project geowave" compile test:compile \
   "project hbase" test \
-  "project geomesa" test || { exit 1; }
+  "project geomesa" test \
+  "project cassandra" test || { exit 1; }

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -5,5 +5,8 @@
   "project geotools" test \
   "project shapefile" test \
   "project doc-examples" compile \
-  "project spark" test || { exit 1; }
-./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project cassandra" test || { exit 1; }
+  "project vector" test \
+  "project slick" test \
+  "project vectortile" test \
+  "project geowave" compile test:compile \
+  "project hbase" test || { exit 1; }

--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
-  "project vector" test \
   "project raster" test \
-  "project slick" test \
-  "project vectortile" test \
-  "project spark-pipeline" test \
-  "project spark-etl" test \
-  "project geowave" compile test:compile \
-  "project hbase" test \
   "project accumulo" test \
   "project s3" test \
   "project s3-testkit" test \

--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -4,5 +4,4 @@
   "project raster" test \
   "project accumulo" test \
   "project s3" test \
-  "project s3-testkit" test \
-  "project geomesa" test || { exit 1; }
+  "project s3-testkit" test || { exit 1; }

--- a/.travis/build-and-test-set-3.sh
+++ b/.travis/build-and-test-set-3.sh
@@ -2,6 +2,5 @@
 
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
   "project spark" test \
-  "project cassandra" test \
   "project spark-pipeline" test \
   "project spark-etl" test || { exit 1; }

--- a/.travis/build-and-test-set-3.sh
+++ b/.travis/build-and-test-set-3.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
+  "project spark" test \
+  "project cassandra" test \
+  "project spark-pipeline" test \
+  "project spark-etl" test || { exit 1; }

--- a/.travis/build-and-test.sh
+++ b/.travis/build-and-test.sh
@@ -1,24 +1,12 @@
 #!/bin/bash
 
-COMMIT_HASH_NUMBER=`printf %i "'${TRAVIS_COMMIT: -1}"`
-SCALA_MINOR_VERSION_NUMBER=`echo $TRAVIS_SCALA_VERSION | cut -d . -f2`
-JAVA_VERSION_NUMBER=`echo ${TRAVIS_JDK_VERSION: -1}`
-JDK_VERSION_NUMBER=`printf %i "'${TRAVIS_JDK_VERSION:3:3}"` # The 3rd letter in "openjdk" or "oracle", translates to 110 or 99
-
-# Since the whole test suite runs too long for travis,
-# we run a subset of the tests based on the mod 2 of
-# a number derived from the hash, the scala version and the java jdk version.
-
-RUN_SET=$((($COMMIT_HASH_NUMBER + $SCALA_MINOR_VERSION_NUMBER + $JAVA_VERSION_NUMBER + $JDK_VERSION_NUMBER) % 2))
-
-echo "USING SCALA VERSION: $TRAVIS_SCALA_VERSION";
-echo "USING JDK VERSION: $TRAVIS_JDK_VERSION";
-echo "RUN SET CALC: ($COMMIT_HASH_NUMBER + $SCALA_MINOR_VERSION_NUMBER + $JAVA_VERSION_NUMBER + $JDK_VERSION_NUMBER) % 2 == $RUN_SET";
-
 if [ $RUN_SET = "1" ]; then
     echo "RUNNING SET 1";
     .travis/build-and-test-set-1.sh;
-else
+elif [ $RUN_SET = "2" ]; then
     echo "RUNNING SET 2";
     .travis/build-and-test-set-2.sh;
+else
+    echo "RUNNING SET 3";
+    .travis/build-and-test-set-3.sh;
 fi

--- a/.travis/unzip-rasters.sh
+++ b/.travis/unzip-rasters.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+cd ./raster/data/ && unzip ./geotiff-test-files.zip


### PR DESCRIPTION
## Overview

This PR splits GeoTrellis tests into three parts and launches everything on both oracle and open jdk.
