### PR TITLE
Removed InterleaveType

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/codes/InterleaveType
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/codes/InterleaveType
@@ -1,8 +1,0 @@
-package geotrellis.raster.io.geotiff.tags.codes
-
-object InterleaveType {
-
-  val Pixel = 1
-  val Band = 2
-
-}


### PR DESCRIPTION
## Overview

Currently, the `InterleaveType` file in GeoTrellis isn't a `.scala`, and thus, is not used at all. Because it's not being used, it'd be best to remove it from the library.