### PR TITLE
readSubsetBands Performance Improvement

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -62,6 +62,8 @@ API Changes
   - **Change:** Scalaz streams were replaced by fs2 streams.
   - **New:** ``GeoTiffMultibandTile`` now has another ``crop`` method that takes a ``GridBounds`` and an ``Array[Int]`` that represents the band indices.
   - **New:** ``GeoTiff[MultibandTile]`` can be written with ``BandInterleave``, only ``PixelInterleave`` previously supported.  <https://github.com/locationtech/geotrellis/pull/2767>
+  - **New:** ``MultibandTile`` now has a new method, ``cropBands`` that takes an Array of band indices and returns a cropped ``MultibandTile`` with the chosen
+    bands.
 
 - ``geotrellis.spark-etl``
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -100,6 +100,9 @@ Fixes
 - Change aspect result to azimuth, i.e. start from due north and be clockwise.
 - COG overviews generated in the ``COGLayer.fromLayerRDD`` method will now use the passed in ``ResampleMethod``.
 - Reading a GeoTiff with ``streaming`` will now work with files that are larger than ``java.lang.Integer.MAX_VALUE``.
+- ``GeoTiffMultibandTile.crop`` will now work with GeoTiffs that have tiled segments and band interleave.
+- ``GeoTiffMultibandTile.crop`` will now return ``ArrayMultibandTile``\(s) with the correct number of bands.
+- Imroved performance of ``COGValueReader.readSubsetBands`` when reading from S3.
 
 1.2.1
 _____

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
@@ -551,7 +551,7 @@ abstract class GeoTiffMultibandTile(
         else
           getIntersectingSegments(window, bandIndices)
 
-      val bands = Array.fill(bandCount)(ArrayTile.empty(cellType, window.width, window.height))
+      val bands = Array.fill(bandSubsetLength)(ArrayTile.empty(cellType, window.width, window.height))
       val chip = Chip(window, bands, segments.length)
       for (segment <- segments.map(_._2)) {
         val tail = chipsBySegment.getOrElse(segment, Nil)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
@@ -599,10 +599,10 @@ abstract class GeoTiffMultibandTile(
     }
 
 
-    def burnBandInterleave(segmentId: Int, offsetId: Int, subsetBandIndex: Int, segment: GeoTiffSegment): List[Chip] = {
+    def burnBandInterleave(segmentId: Int, subsetBandIndex: Int, segment: GeoTiffSegment): List[Chip] = {
       var finished: List[Chip] = Nil
-      val segmentBounds = getGridBounds(offsetId)
-      val segmentTransform = getSegmentTransform(offsetId)
+      val segmentBounds = getGridBounds(segmentId)
+      val segmentTransform = getSegmentTransform(segmentId)
 
       for (chip <- chipsBySegment(segmentId)) {
         val gridBounds = chip.window
@@ -648,10 +648,8 @@ abstract class GeoTiffMultibandTile(
         getSegments(intersectingSegments.map(_._2)).flatMap { case (segmentId, segment) =>
           val bandIndex = segmentBandMap(segmentId)
           val subsetBandIndex = bandIndexToSubsetIndex(bandIndex)
-          val segmentOffset = bandSegmentCount * subsetBandIndex
-          val offsetId = segmentId - segmentOffset
 
-          burnBandInterleave(segmentId, offsetId, subsetBandIndex, segment)
+          burnBandInterleave(segmentId, subsetBandIndex, segment)
         }
       }
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
@@ -721,6 +721,57 @@ class GeoTiffMultibandTileSpec extends FunSpec
     }
   }
 
+  describe("GeoTiffMultibandTile crop") {
+    val pixelStripedGeoTiff = GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-pixel.tif"))
+    val pixelTiledGeoTiff = GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif"))
+
+    val bandStripedGeoTiff = GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-striped-band.tif"))
+    val bandTiledGeoTiff = GeoTiffReader.readMultiband(geoTiffPath("3bands/int32/3bands-tiled-band.tif"))
+
+    val pixelStripedRasterExtent = RasterExtent(pixelStripedGeoTiff.extent, pixelStripedGeoTiff.cols, pixelStripedGeoTiff.rows)
+    val bandStripedRasterExtent = RasterExtent(bandStripedGeoTiff.extent, bandStripedGeoTiff.cols, bandStripedGeoTiff.rows)
+
+    it("should have the correct number of subset bands - pixel") {
+      val cropped = pixelStripedGeoTiff.tile.cropBands(pixelStripedRasterExtent.gridBounds, Array(1, 0))
+
+      cropped.bands.size should be (2)
+    }
+
+    it("should have the correct number of subset bands - band") {
+      val cropped = bandStripedGeoTiff.tile.cropBands(bandStripedRasterExtent.gridBounds, Array(1))
+
+      cropped.bands.size should be (1)
+    }
+
+    it("should have the crop the correct area - pixel striped") {
+      val actual = pixelStripedGeoTiff.tile.cropBands(pixelStripedRasterExtent.gridBounds, Array(1, 0, 2))
+      val expected = pixelStripedGeoTiff.crop(pixelStripedRasterExtent.gridBounds).tile.subsetBands(1, 0, 2)
+
+      actual should be (expected)
+    }
+
+    it("should have the crop the correct area - pixel tiled") {
+      val actual = pixelTiledGeoTiff.tile.cropBands(pixelStripedRasterExtent.gridBounds, Array(1, 0, 2))
+      val expected = pixelTiledGeoTiff.crop(pixelStripedRasterExtent.gridBounds).tile.subsetBands(1, 0, 2)
+
+      actual should be (expected)
+    }
+
+    it("should have the crop the correct area - band striped") {
+      val actual = bandStripedGeoTiff.tile.cropBands(bandStripedRasterExtent.gridBounds, Array(1, 2, 0))
+      val expected = bandStripedGeoTiff.crop(bandStripedRasterExtent.gridBounds).tile.subsetBands(1, 2, 0)
+
+      actual should be (expected)
+    }
+
+    it("should have the crop the correct area - band tiled") {
+      val actual = bandTiledGeoTiff.tile.cropBands(bandStripedRasterExtent.gridBounds, Array(1, 2, 0))
+      val expected = bandTiledGeoTiff.crop(bandStripedRasterExtent.gridBounds).tile.subsetBands(1, 2, 0)
+
+      actual should be (expected)
+    }
+  }
+
   describe("GeoTiffMultibandTile streaming read") {
     it("reads over-buffered windows"){
       val path = geoTiffPath("3bands/int32/3bands-striped-pixel.tif")


### PR DESCRIPTION
## Overview

This PR improves the performance of the `readSubsetBands` method by changing how cropping operation is performed. Before, the input GeoTiff was converted to a `GeoTiffMultibandTile` and then cropped, but now it will be pattern matched instead and crop instead. This removes unneeded memory allocation which improves performance with certain backends, mainly S3.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

Closes #2761 
