### PR TITLE
Remove possible HTML special chars from GeoTiff tags

### DIFF
--- a/core/src/main/scala/geotrellis copy/Focal.scala
+++ b/core/src/main/scala/geotrellis copy/Focal.scala
@@ -1,0 +1,173 @@
+package geotrellis
+
+import scala.{specialized => sp}
+
+import cats.implicits._
+import simulacrum._
+import spire.algebra._
+import spire.syntax.field._
+
+// --- //
+
+/** A strategy for handling locations outside the usual legal range of [[Focal.get]]. */
+sealed trait Boundary[@sp(Int, Double) A]
+
+/* Reference:
+ http://hackage.haskell.org/package/repa-3.4.1.3/docs/Data-Array-Repa-Stencil.html#t:Boundary
+ */
+object Boundary {
+  /** Locations outside the legal range of [[Focal.get]] will be completely ignored.
+   * Any neighbourhood that involves them will simply have less values.
+   */
+  case object Ignore extends Boundary[Nothing]
+
+  /** Locations outside the legal range of [[Focal.get]] will all return the
+   * same [[value]].
+   */
+  case class Constant[@sp(Int, Double) A](value: A) extends Boundary[A]
+
+  /** Locations outside the legal range of [[Focal.get]] will be given the
+   * value of the nearest legal location.
+   */
+  // case object Edge extends Boundary[Nothing]
+}
+
+/** A description of deltas from the "current location" as occurs during
+  * [[Focal]] operations. [[boundary]] specifies how to handle locations
+  * outside the legal boundaries of [[Focal.get]].
+  */
+case class Stencil[@sp(Int, Double) A](deltas: List[(Int, Int)], boundary: Boundary[A]) {
+  /* Assumes symmetric stencil shapes. */
+  val topLeft: (Int, Int) = deltas.foldLeft((0,0)) {
+    case ((minx, miny), (x, y)) => (minx.min(x), miny.min(y))
+  }
+  val bottomRight: (Int, Int) = deltas.foldLeft((0,0)) {
+    case ((maxx, maxy), (x, y)) => (maxx.max(x), maxy.max(y))
+  }
+}
+
+object Stencil {
+  def square[@sp(Int, Double) A](boundary: Boundary[A]) =
+    Stencil(List((-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1,1)), boundary)
+}
+
+/**
+  * Types which can have ''Focal'' operations performed on them.
+  *
+  * '''LAW''': Existance
+  * {{{
+  *  `get(0,0)` must return a value.
+  * }}}
+  *
+  * '''LAW''': Solidity
+  * {{{
+  *   for (y > 0), if get(x,y) then get(x, y-1)
+  *   for (x > 0), if get(x,y) then get(x-1, y)
+  * }}}
+  *
+  * @groupname minimal Minimal Complete Definition
+  * @groupprio minimal 0
+  *
+  * @groupname focal Focal Operations
+  * @groupprio focal 1
+  * @groupdesc focal Operations over "neighbourhoods" of one `A`.
+  */
+@typeclass trait Focal[F[_]] {
+
+  def isBorder[@sp(Int, Double) A](self: F[A], s: Stencil[A], xy: (Int, Int)): Boolean
+
+  def isLegal[@sp(Int, Double) A](self: F[A], xy: (Int, Int)): Boolean
+
+  def get[@sp(Int, Double) A](self: F[A], xy: (Int, Int)): A
+
+  def imap[@sp(Int, Double) A](self: F[A], f: ((Int, Int), A) => A): F[A]
+
+  def focal[@sp(Int, Double) A](self: F[A], s: Stencil[A], f: List[A] => A): F[A] = {
+
+    // TODO Turn the `foldLeft` into a tail-recursive alg?
+
+    // TODO Yield the correct out-of-bounds values! (use `Boundary`)
+    def work(ix: (Int, Int), a: A): A = ix match {
+      /* Special checks must be done on each pixel in the neighbourhood */
+      case _ if isBorder(self, s, ix) =>
+        val ps: List[A] = s.deltas.foldLeft(Nil: List[A]) { (acc, d) =>
+          val p: (Int, Int) = d |+| ix
+          if (isLegal(self, p)) get(self, p) :: acc else acc
+        }
+        f(a :: ps)
+
+      /* By definition, each pixel in the neighbourhood is a legal location */
+      case _ => f(a :: s.deltas.map(d => get(self, d |+| ix)))
+    }
+
+    imap(self, work)
+  }
+
+  @inline def fsum[@sp(Int, Double) A: Ring](self: F[A], s: Stencil[A]): F[A] =
+    focal(self, s, { _.foldLeft(Ring[A].zero)(_ + _) })
+
+  @inline def fmean[@sp(Int, Double) A: Field](self: F[A], s: Stencil[A]): F[A] =
+    focal(self, s, { n => n.foldLeft(Field[A].zero)(_ + _) / n.length })
+
+  @inline def fold[@sp(Int, Double) A: cats.Monoid](self: F[A], s: Stencil[A]): F[A] =
+    focal(self, s, { _.combineAll })
+
+}
+
+private[geotrellis] trait FocalInstances {
+
+  /** Assumes a square Tile, which is not representative of reality. */
+  implicit val arrayFocal: Focal[Array] = new Focal[Array] {
+
+    // TODO Try passing that `dim` function around: `F[A] => (Int, Int)`
+    // `get` calls `oneD`, which happens for a /shit/ ton of pixels.
+
+    /** Convert 2D row-major coordinates into a 1D index. */
+    private[this] def oneD(size: Int, x: Int, y: Int): Int = {
+      val dim: Int = Math.sqrt(size).toInt
+
+      x + (y * dim)
+    }
+
+    def isBorder[@sp(Int, Double) A](self: Array[A], s: Stencil[A], xy: (Int, Int)): Boolean =
+      !isLegal(self, xy |+| s.topLeft) || !isLegal(self, xy |+| s.bottomRight)
+
+    def isLegal[@sp(Int, Double) A](self: Array[A], xy: (Int, Int)): Boolean = {
+      // TODO Fix. Assumes a square tile.
+      // This would be solved if this function also took the argument: F[A] => (Int, Int)
+      // where the two Ints are the xmax and ymax respectively.
+      val dim: Int = Math.sqrt(self.size).toInt
+
+      xy._1 >= 0 && xy._1 < dim && xy._2 >= 0 && xy._2 < dim
+    }
+
+    def get[@sp(Int, Double) A](self: Array[A], xy: (Int, Int)): A =
+      self(oneD(self.size, xy._1, xy._2))
+
+    def imap[@sp(Int, Double) A](self: Array[A], f: ((Int, Int), A) => A): Array[A] = {
+
+      // TODO Fix. This is evil, since it assumes a square tile.
+      // Giving accurate dimensions either requires a wrapper around `Array`
+      // (potentially killing the specialization) or passing it in as another
+      // argument to `imap`.
+      val res: Array[A] = self.clone
+      val dim: Int = Math.sqrt(self.size).toInt
+      var x: Int = 0
+      var y: Int = 0
+
+      while(y < dim) {
+        while(x < dim) {
+          val i: Int = oneD(self.size, x, y)
+          res(i) = f((x, y), self(i))
+
+          x += 1
+        }
+
+        x = 0
+        y += 1
+      }
+
+      res
+    }
+  }
+}

--- a/core/src/main/scala/geotrellis copy/Local.scala
+++ b/core/src/main/scala/geotrellis copy/Local.scala
@@ -1,0 +1,103 @@
+package geotrellis
+
+import scala.{specialized => sp}
+
+import cats.Functor
+import simulacrum._
+import spire.algebra._
+import spire.std.any._
+import spire.syntax.field._
+import spire.syntax.order._
+
+// --- //
+
+/**
+  * Types which can have ''Local'' map algebra operations performed on them.
+  *
+  * '''LAW''': Identity
+  * {{{
+  * a.lmap(identity) == identity(a)
+  * }}}
+  *
+  * '''LAW''': Composibility
+  * {{{
+  * a.lmap(f compose g) == a.lmap(g).lmap(f)
+  * }}}
+  *
+  * '''LAW''': Right-laziness
+  * {{{
+  * Array.empty.zipWith(throw new Exception) == Array.empty
+  * }}}
+  *
+  * @groupname minimal Minimal Complete Definition
+  * @groupprio minimal 0
+  *
+  * @groupname local Local Operations
+  * @groupprio local 1
+  * @groupdesc local Per-"location" operations between one or more `A`.
+  */
+@typeclass trait Local[F[_]] {
+
+  def lmap[@sp(Int, Double) A](self: F[A], f: A => A): F[A]
+
+  def zipWith[@sp(Int, Double) A](self: F[A], other: => F[A], f: (A, A) => A): F[A]
+
+  /** @group local */
+  // def classify(self: A, f: Int => Int): A = map(self, f)
+
+  @inline def +[@sp(Int, Double) A: Ring](self: F[A], other: => F[A]): F[A] =
+    zipWith(self, other, { _ + _ })
+
+  @inline def -[@sp(Int, Double) A: Ring](self: F[A], other: => F[A]): F[A] =
+    zipWith(self, other, { _ - _ })
+
+  @inline def *[@sp(Int, Double) A: Ring](self: F[A], other: => F[A]): F[A] =
+    zipWith(self, other, { _ * _ })
+
+  @inline def /[@sp(Int, Double) A: Field](self: F[A], other: => F[A]): F[A] =
+    zipWith(self, other, { _ / _ })
+
+  @inline def min[@sp(Int, Double) A: Order](self: F[A], other: => F[A]): F[A] =
+    zipWith(self, other, { _ min _ })
+
+  @inline def max[@sp(Int, Double) A: Order](self: F[A], other: => F[A]): F[A] =
+    zipWith(self, other, { _ max _ })
+
+}
+
+private[geotrellis] trait LocalInstances {
+
+  implicit val arrayLocal: Local[Array] = new Local[Array] {
+
+    def lmap[@sp(Int, Double) A](self: Array[A], f: A => A): Array[A] = {
+      val len: Int = self.size
+      val res: Array[A] = self.clone
+      var i: Int = 0
+
+      while (i < len) {
+        res(i) = f(self(i))
+        i += 1
+      }
+
+      res
+    }
+
+    def zipWith[@sp(Int, Double) A](self: Array[A], other: => Array[A], f: (A, A) => A): Array[A] = {
+
+      if (self.isEmpty) self else {
+        val len: Int = if (self.size < other.size) self.size else other.size
+        val res: Array[A] = if (self.size < other.size) self.clone else other.clone
+        var i: Int = 0
+
+        while(i < len) {
+          res(i) = f(self(i), other(i))
+
+          i += 1
+        }
+
+        res
+      }
+    }
+
+  }
+}

--- a/core/src/main/scala/geotrellis copy/package.scala
+++ b/core/src/main/scala/geotrellis copy/package.scala
@@ -1,0 +1,1 @@
+package object geotrellis extends Local.ToLocalOps with LocalInstances with FocalInstances

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
@@ -263,13 +263,13 @@ object COGLayerReader {
             else {
               val uri = fullPath(keyPath(index))
               val byteReader: ByteReader = uri
-              val baseKey =
-                TiffTagsReader
-                  .read(byteReader)
-                  .tags
-                  .headTags(GTKey)
-                  .parseJson
-                  .convertTo[K](keyFormat)
+              val baseKey = {
+                val keyTag = TiffTagsReader.read(byteReader).tags.headTags(GTKey)
+                val decoded = if (keyTag.contains('&')) {
+                  org.apache.commons.lang.StringEscapeUtils.unescapeHtml(keyTag)
+                } else keyTag
+                decoded.parseJson.convertTo[K](keyFormat)
+              }
 
               readDefinitions
                 .get(baseKey.getComponent[SpatialKey])


### PR DESCRIPTION
When `gdal_translate` is applied to a COGs written by GeoTrellis it will apparently encode tags with HTML special characters. 

This will change `GT_KEY` from `{ "col": 162, "row": 230 }`  to `{ &quot;col&quot;: 161, &quot;row&quot;: 229 }`. `gdalinfo`  will in turn decode the HTML special chars and the tag will display normally.

However when parsing these COGs with GeoTrellis `COGLayerReader` the following exception will be thrown

```scala
Caused by: spray.json.JsonParser$ParsingException: Unexpected character '&' at input index 2 (line 1, position 3), expected '"':
{ &quot;col&quot;: 161, &quot;row&quot;: 229 }
  ^
  at spray.json.JsonParser.fail(JsonParser.scala:213)
  at spray.json.JsonParser.string(JsonParser.scala:141)
  at spray.json.JsonParser.members$1(JsonParser.scala:77)
  at spray.json.JsonParser.object(JsonParser.scala:86)
  at spray.json.JsonParser.value(JsonParser.scala:60)
  at spray.json.JsonParser.parseJsValue(JsonParser.scala:43)
  at spray.json.JsonParser$.apply(JsonParser.scala:28)
  at spray.json.PimpedString.parseJson(package.scala:45)
  at geotrellis.spark.io.cog.COGLayerReader$$anonfun$7$$anonfun$apply$3$$anonfun$apply$4.apply(COGLayerReader.scala:271)
  at geotrellis.spark.io.cog.COGLayerReader$$anonfun$7$$anonfun$apply$3$$anonfun$apply$4.apply(COGLayerReader.scala:261)
  at geotrellis.spark.io.LayerReader$$anonfun$2$$anonfun$apply$3.apply(LayerReader.scala:123)
  at geotrellis.spark.io.LayerReader$$anonfun$2$$anonfun$apply$3.apply(LayerReader.scala:123)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:85)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:310)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:292)
  at cats.effect.IO$$anonfun$shift$1$$anon$8.run(IO.scala:817)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
```

Since re-encoding the COG layers is something that can legitimately happen we should account for this case.