### PR TITLE
Remove possible HTML special chars from GeoTiff tags

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
@@ -263,13 +263,13 @@ object COGLayerReader {
             else {
               val uri = fullPath(keyPath(index))
               val byteReader: ByteReader = uri
-              val baseKey =
-                TiffTagsReader
-                  .read(byteReader)
-                  .tags
-                  .headTags(GTKey)
-                  .parseJson
-                  .convertTo[K](keyFormat)
+              val baseKey = {
+                val keyTag = TiffTagsReader.read(byteReader).tags.headTags(GTKey)
+                val decoded = if (keyTag.contains('&')) {
+                  org.apache.commons.lang.StringEscapeUtils.unescapeHtml(keyTag)
+                } else keyTag
+                decoded.parseJson.convertTo[K](keyFormat)
+              }
 
               readDefinitions
                 .get(baseKey.getComponent[SpatialKey])


### PR DESCRIPTION
When `gdal_translate` is applied to a COGs written by GeoTrellis it will apparently encode tags with HTML special characters. 

This will change `GT_KEY` from `{ "col": 162, "row": 230 }`  to `{ &quot;col&quot;: 161, &quot;row&quot;: 229 }`. `gdalinfo`  will in turn decode the HTML special chars and the tag will display normally.

However when parsing these COGs with GeoTrellis `COGLayerReader` the following exception will be thrown

```scala
Caused by: spray.json.JsonParser$ParsingException: Unexpected character '&' at input index 2 (line 1, position 3), expected '"':
{ &quot;col&quot;: 161, &quot;row&quot;: 229 }
  ^
  at spray.json.JsonParser.fail(JsonParser.scala:213)
  at spray.json.JsonParser.string(JsonParser.scala:141)
  at spray.json.JsonParser.members$1(JsonParser.scala:77)
  at spray.json.JsonParser.object(JsonParser.scala:86)
  at spray.json.JsonParser.value(JsonParser.scala:60)
  at spray.json.JsonParser.parseJsValue(JsonParser.scala:43)
  at spray.json.JsonParser$.apply(JsonParser.scala:28)
  at spray.json.PimpedString.parseJson(package.scala:45)
  at geotrellis.spark.io.cog.COGLayerReader$$anonfun$7$$anonfun$apply$3$$anonfun$apply$4.apply(COGLayerReader.scala:271)
  at geotrellis.spark.io.cog.COGLayerReader$$anonfun$7$$anonfun$apply$3$$anonfun$apply$4.apply(COGLayerReader.scala:261)
  at geotrellis.spark.io.LayerReader$$anonfun$2$$anonfun$apply$3.apply(LayerReader.scala:123)
  at geotrellis.spark.io.LayerReader$$anonfun$2$$anonfun$apply$3.apply(LayerReader.scala:123)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:85)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:310)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:292)
  at cats.effect.IO$$anonfun$shift$1$$anon$8.run(IO.scala:817)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
```

Since re-encoding the COG layers is something that can legitimately happen we should account for this case.