### PR TITLE
GeoTiff Band Interleave Construction

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -61,6 +61,7 @@ API Changes
   - **New:** Kryo serialization of geometry now uses a binary format to reduce shuffle block size.
   - **Change:** Scalaz streams were replaced by fs2 streams.
   - **New:** ``GeoTiffMultibandTile`` now has another ``crop`` method that takes a ``GridBounds`` and an ``Array[Int]`` that represents the band indices.
+  - **New:** ``GeoTiff[MultibandTile]`` can be written with ``BandInterleave``, only ``PixelInterleave`` previously supported.  <https://github.com/locationtech/geotrellis/pull/2767>
 
 - ``geotrellis.spark-etl``
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
@@ -273,67 +273,34 @@ object GeoTiffMultibandTile {
 
   def apply(tile: MultibandTile, options: GeoTiffOptions): GeoTiffMultibandTile = {
     val bandType = BandType.forCellType(tile.cellType)
-    val bandCount = tile.bandCount
+    val segmentLayout = GeoTiffSegmentLayout(
+      tile.cols, tile.rows, options.storageMethod, options.interleaveMethod, bandType)
 
-    // TODO: Handle band interleave construction.
-     val segmentLayout =
-       GeoTiffSegmentLayout(tile.cols, tile.rows, options.storageMethod, PixelInterleave, bandType)
+    val segmentPixelCols = segmentLayout.tileLayout.tileCols
+    val segmentPixelRows = segmentLayout.tileLayout.tileRows
 
-    val segmentCount = segmentLayout.tileLayout.layoutCols * segmentLayout.tileLayout.layoutRows
-    val compressor = options.compression.createCompressor(segmentCount)
+    val segments: Iterator[((Int, Int), MultibandTile)] = 
+      for {
+        windowRowMin <- Iterator.range(start = 0, end = tile.rows, step = segmentPixelRows)
+        windowColMin <- Iterator.range(start = 0, end = tile.cols, step = segmentPixelCols)
+      } yield {
+        val bounds = GridBounds(
+          colMin = windowColMin,
+          rowMin = windowRowMin,
+          colMax = windowColMin + segmentPixelCols - 1,
+          rowMax = windowRowMin + segmentPixelRows - 1)
 
-    val segmentBytes = Array.ofDim[Array[Byte]](segmentCount)
-    val segmentTiles = Array.ofDim[Array[Tile]](segmentCount)
+        val key = (bounds.colMin / segmentPixelCols, bounds.rowMin / segmentPixelRows)
+        val bands: Seq[Tile] =
+          for (bandIndex <- 0 until tile.bandCount)
+          yield CroppedTile(tile.band(bandIndex), bounds)
 
-    segmentLayout.interleaveMethod match {
-      case PixelInterleave => {
-        cfor(0)(_ < bandCount, _ + 1) { bandIndex =>
-          val bandTiles =
-            options.storageMethod match {
-              case _: Tiled => tile.band(bandIndex).split(segmentLayout.tileLayout)
-              case _: Striped => tile.band(bandIndex).split(segmentLayout.tileLayout, Split.Options(extend = false))
-            }
-
-          cfor(0)(_ < segmentCount, _ + 1) { segmentIndex =>
-            val bandTile = bandTiles(segmentIndex)
-            if(bandIndex == 0) { segmentTiles(segmentIndex) = Array.ofDim[Tile](bandCount) }
-            segmentTiles(segmentIndex)(bandIndex) = bandTile
-          }
-        }
-
-        val byteCount = tile.cellType.bytes
-
-        cfor(0)(_ < segmentCount, _ + 1) { i =>
-          val tiles = segmentTiles(i)
-          val cols = tiles(0).cols
-          val rows = tiles(0).rows
-          val segBytes = Array.ofDim[Byte](cols * rows * bandCount * byteCount)
-
-          val tileBytes = Array.ofDim[Array[Byte]](bandCount)
-          cfor(0)(_ < bandCount, _ + 1) { b =>
-            tileBytes(b) = tiles(b).toBytes
-          }
-
-          var segmentIndex = 0
-          cfor(0)(_ < cols * rows, _ + 1) { cellIndex =>
-            cfor(0)(_ < bandCount, _ + 1) { bandIndex =>
-              cfor(0)(_ < byteCount, _ + 1) { b =>
-                val bytes = tileBytes(bandIndex)
-                segBytes(segmentIndex) = bytes(cellIndex * byteCount + b)
-                segmentIndex += 1
-              }
-            }
-          }
-
-          segmentBytes(i) = compressor.compress(segBytes, i)
-        }
+        (key, ArrayMultibandTile(bands.toArray))
       }
 
-      case BandInterleave =>
-        throw new Exception("Band interleave construction is not supported yet.")
-    }
-
-    apply(new ArraySegmentBytes(segmentBytes), compressor.createDecompressor, segmentLayout, options.compression, bandCount, tile.cellType)
+    GeoTiffBuilder[MultibandTile]
+      .makeTile(segments, segmentLayout, tile.cellType, options.compression)
+      .asInstanceOf[GeoTiffMultibandTile] // This is always safe in current implementation
   }
 }
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegmentLayout.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegmentLayout.scala
@@ -32,7 +32,13 @@ import scala.collection.mutable
   * @param storageMethod      Storage method used for the segments (tiled or striped)
   * @param interleaveMethod   The interleave method used for segments (pixel or band)
   */
-case class GeoTiffSegmentLayout(totalCols: Int, totalRows: Int, tileLayout: TileLayout, storageMethod: StorageMethod, interleaveMethod: InterleaveMethod) {
+case class GeoTiffSegmentLayout(
+  totalCols: Int, 
+  totalRows: Int, 
+  tileLayout: TileLayout, 
+  storageMethod: StorageMethod, 
+  interleaveMethod: InterleaveMethod
+) {
   def isTiled: Boolean =
     storageMethod match {
       case _: Tiled => true

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -92,8 +92,14 @@ object TiffTagFieldValue {
     fieldValues += TiffTagFieldValue(PredictorTag, ShortsFieldType, 1, imageData.decompressor.predictorCode)
     fieldValues += TiffTagFieldValue(PhotometricInterpTag, ShortsFieldType, 1, geoTiff.options.colorSpace)
     fieldValues += TiffTagFieldValue(SamplesPerPixelTag, ShortsFieldType, 1, imageData.bandCount)
-    fieldValues += TiffTagFieldValue(PlanarConfigurationTag, ShortsFieldType, 1, PlanarConfigurations.PixelInterleave)
     fieldValues += TiffTagFieldValue(SampleFormatTag, ShortsFieldType, 1, imageData.bandType.sampleFormat)
+
+    imageData.segmentLayout.interleaveMethod match {
+      case PixelInterleave =>
+        fieldValues += TiffTagFieldValue(PlanarConfigurationTag, ShortsFieldType, 1, PlanarConfigurations.PixelInterleave)
+      case BandInterleave =>
+        fieldValues += TiffTagFieldValue(PlanarConfigurationTag, ShortsFieldType, 1, PlanarConfigurations.BandInterleave)
+    }
 
     geoTiff.options.subfileType.foreach { sft =>
       fieldValues += TiffTagFieldValue(NewSubfileTypeTag, IntsFieldType, 1, toBytes(sft.code))

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffBuilerSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffBuilerSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.io.geotiff
+
+import geotrellis.util._
+import geotrellis.raster.io.geotiff.reader._
+import geotrellis.raster.io.geotiff.compression.NoCompression
+import geotrellis.raster._
+import geotrellis.raster.testkit._
+import geotrellis.vector.Extent
+
+import org.scalatest._
+
+class GeoTiffBuilderSpec extends FunSpec with RasterMatchers with GeoTiffTestUtils {
+  describe("GeoTiffBuilder") {
+    val tileSize = 5
+    val ct = IntCellType
+    var expectedTile: MultibandTile = ArrayMultibandTile.empty(ct, 3, 15, 15)
+
+    val segments =
+      for {
+        row <- 0 until 3
+        col <- 0 until 3
+      } yield {
+        val tile = ArrayMultibandTile(
+          ArrayTile(Array.ofDim[Int](tileSize*tileSize).fill(100 + (col*10)+(row)), tileSize, tileSize),
+          ArrayTile(Array.ofDim[Int](tileSize*tileSize).fill(200 + (col*10)+(row)), tileSize, tileSize),
+          ArrayTile(Array.ofDim[Int](tileSize*tileSize).fill(300 + (col*10)+(row)), tileSize, tileSize)
+        )
+
+        expectedTile = expectedTile.merge(tile, col * tileSize, row * tileSize)
+
+        ((col, row), tile)
+      }
+
+    it("should build multiband tiffs with band interleave") {
+      val segmentLayout = GeoTiffSegmentLayout(
+        totalCols = 15,
+        totalRows = 15,
+        Tiled(tileSize, tileSize),
+        BandInterleave,
+        BandType.forCellType(ct))
+
+      val tiff = GeoTiffBuilder[MultibandTile].makeTile(segments.toIterator, segmentLayout, ct, NoCompression)
+      val actualTile = tiff.tile.toArrayTile
+
+      assertEqual(expectedTile, actualTile)
+    }
+
+    it("should build multiband tiffs with pixel interleave") {
+      val segmentLayout = GeoTiffSegmentLayout(
+        totalCols = 15,
+        totalRows = 15,
+        Tiled(tileSize, tileSize),
+        PixelInterleave,
+        BandType.forCellType(ct))
+
+      val tiff = GeoTiffBuilder[MultibandTile].makeTile(segments.toIterator, segmentLayout, ct, NoCompression)
+      val actualTile = tiff.tile.toArrayTile
+
+      assertEqual(expectedTile, actualTile)
+    }
+  }
+}

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
@@ -113,8 +113,9 @@ class GeoTiffMultibandTileSpec extends FunSpec
           band3
         )
 
-      val gtm = GeoTiffMultibandTile(original, GeoTiffOptions(Tiled(16, 16)))
-      val geoTiff = MultibandGeoTiff(gtm, Extent(100.0, 40.0, 120.0, 42.0), LatLng)
+      val options = GeoTiffOptions(Tiled(16, 16))
+      val gtm = GeoTiffMultibandTile(original, options)
+      val geoTiff = MultibandGeoTiff(gtm, Extent(100.0, 40.0, 120.0, 42.0), LatLng, options = options)
       geoTiff.write(path)
 
       addToPurge(path)


### PR DESCRIPTION
## Overview

Enables building multiband GeoTiffs with band interleave storage method.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [-] `docs` guides update, if necessary
- [-] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature
