### PR TITLE
Document cogs + add `withOverviews` overload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: false
+# See https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
+sudo: required
+dist: trusty
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
     - secure: "UwH3B4k5Nqt2THYYTY7uRxTPaJXZbK1hHrVsyJjZp/H2uFTYtQTxXpNb9aR7wuHuhLjXwKkq3gEXxEqhfy6V8+ZPbee6MUNvoYe/HhaPjsmTzcVihTBbO9e7g0bIQFc9bzwY15Y1ImshLcDAYvaXwXapy4Z/KadLiBheyqMk8Cs="
     # Scaladocs
     - secure: "FPfJbtXmhyMTh/eh9B/f6JZIv6aw+XZMipYlJsdgMEv+XKzL1tdYbKQv8G4C13lhyBZmOlQAbOhl4mRUBmq0FqG3361Y9SS4o5KfDRkZNErBTb8tveoRgKLkdLPwooAOUmRUeygKmhO4ehdQsMXCZmCk33nDq/ZrNallfnCRdm8="
+  matrix:
+    - RUN_SET=1
+    - RUN_SET=2
+    - RUN_SET=3
 
 language: scala
 
@@ -23,6 +27,7 @@ before_script:
   - docker run -d --restart=always --net=host -m 1G --memory-swap -1 --env="MAX_HEAP_SIZE=500M" --env="HEAP_NEWSIZE=100M" --env="CASSANDRA_LISTEN_ADDRESS=127.0.0.1" cassandra:latest
   - docker run -d --restart=always -p 8081:80 -v $(pwd)/spark/src/test/resources:/usr/share/nginx/html:ro nginx:stable
   - .travis/hbase-install.sh
+  - .travis/unzip-rasters.sh
 
 jdk:
   - openjdk8
@@ -33,9 +38,9 @@ scala:
 
 cache:
   directories:
-  - "$HOME/.ivy2"
-  - "$HOME/.sbt"
-  - "$HOME/downloads"
+  - $HOME/.ivy2
+  - $HOME/.sbt
+  - $HOME/downloads
 
 script:
   - .travis/build-and-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ cache:
   - $HOME/downloads
 
 script:
-  - .travis/build-and-test.sh
+  - travis_wait 60 .travis/build-and-test.sh
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ cache:
   - $HOME/downloads
 
 script:
-  - travis_wait 60 .travis/build-and-test.sh
+  - .travis/build-and-test.sh
 
 notifications:
   email:

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -9,4 +9,5 @@
   "project slick" test \
   "project vectortile" test \
   "project geowave" compile test:compile \
-  "project hbase" test || { exit 1; }
+  "project hbase" test \
+  "project geomesa" test || { exit 1; }

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -10,4 +10,5 @@
   "project vectortile" test \
   "project geowave" compile test:compile \
   "project hbase" test \
-  "project geomesa" test || { exit 1; }
+  "project geomesa" test \
+  "project cassandra" test || { exit 1; }

--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -5,5 +5,8 @@
   "project geotools" test \
   "project shapefile" test \
   "project doc-examples" compile \
-  "project spark" test || { exit 1; }
-./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" "project cassandra" test || { exit 1; }
+  "project vector" test \
+  "project slick" test \
+  "project vectortile" test \
+  "project geowave" compile test:compile \
+  "project hbase" test || { exit 1; }

--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
-  "project vector" test \
   "project raster" test \
-  "project slick" test \
-  "project vectortile" test \
-  "project spark-pipeline" test \
-  "project spark-etl" test \
-  "project geowave" compile test:compile \
-  "project hbase" test \
   "project accumulo" test \
   "project s3" test \
   "project s3-testkit" test \

--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -4,5 +4,4 @@
   "project raster" test \
   "project accumulo" test \
   "project s3" test \
-  "project s3-testkit" test \
-  "project geomesa" test || { exit 1; }
+  "project s3-testkit" test || { exit 1; }

--- a/.travis/build-and-test-set-3.sh
+++ b/.travis/build-and-test-set-3.sh
@@ -2,6 +2,5 @@
 
 ./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
   "project spark" test \
-  "project cassandra" test \
   "project spark-pipeline" test \
   "project spark-etl" test || { exit 1; }

--- a/.travis/build-and-test-set-3.sh
+++ b/.travis/build-and-test-set-3.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
+  "project spark" test \
+  "project cassandra" test \
+  "project spark-pipeline" test \
+  "project spark-etl" test || { exit 1; }

--- a/.travis/build-and-test.sh
+++ b/.travis/build-and-test.sh
@@ -1,24 +1,12 @@
 #!/bin/bash
 
-COMMIT_HASH_NUMBER=`printf %i "'${TRAVIS_COMMIT: -1}"`
-SCALA_MINOR_VERSION_NUMBER=`echo $TRAVIS_SCALA_VERSION | cut -d . -f2`
-JAVA_VERSION_NUMBER=`echo ${TRAVIS_JDK_VERSION: -1}`
-JDK_VERSION_NUMBER=`printf %i "'${TRAVIS_JDK_VERSION:3:3}"` # The 3rd letter in "openjdk" or "oracle", translates to 110 or 99
-
-# Since the whole test suite runs too long for travis,
-# we run a subset of the tests based on the mod 2 of
-# a number derived from the hash, the scala version and the java jdk version.
-
-RUN_SET=$((($COMMIT_HASH_NUMBER + $SCALA_MINOR_VERSION_NUMBER + $JAVA_VERSION_NUMBER + $JDK_VERSION_NUMBER) % 2))
-
-echo "USING SCALA VERSION: $TRAVIS_SCALA_VERSION";
-echo "USING JDK VERSION: $TRAVIS_JDK_VERSION";
-echo "RUN SET CALC: ($COMMIT_HASH_NUMBER + $SCALA_MINOR_VERSION_NUMBER + $JAVA_VERSION_NUMBER + $JDK_VERSION_NUMBER) % 2 == $RUN_SET";
-
 if [ $RUN_SET = "1" ]; then
     echo "RUNNING SET 1";
     .travis/build-and-test-set-1.sh;
-else
+elif [ $RUN_SET = "2" ]; then
     echo "RUNNING SET 2";
     .travis/build-and-test-set-2.sh;
+else
+    echo "RUNNING SET 3";
+    .travis/build-and-test-set-3.sh;
 fi

--- a/.travis/unzip-rasters.sh
+++ b/.travis/unzip-rasters.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+cd ./raster/data/ && unzip ./geotiff-test-files.zip

--- a/docs/guide/core-concepts.rst
+++ b/docs/guide/core-concepts.rst
@@ -1657,14 +1657,14 @@ the specified tile. As with striped, ``TileOffsets`` and
 ``TileByteCounts`` are arrays that contain the begining offset and the
 byte count of each tile in the image, respectively.
 
-Layout of Columns and Rows
+Layout: Columns and Rows
 --------------------------
 
-There exists two ways in which to describe a location in GeoTiffs. One
-is in Map coordinates which use X and Y values. X's are oriented along
-the horizontal axis and run from west to east while Y's are on the
+At a high level, there exist two ways to refer to a location within GeoTiffs.
+One is to use Map coordinates which are X and Y values. X's are oriented
+along the horizontal axis and run from west to east while Y's are on the
 vertical axis and run from south to north. Thus the further east you
-are, the larger your X value ; and the more north you are the larger
+are, the larger your X value; and the more north you are the larger
 your Y value.
 
 The other method is to use the grid coordinate system. This technique of
@@ -1673,18 +1673,65 @@ things. Cols run east to west whereas Rows run north to south. This then
 means that Cols increase as you go east to west, and rows increase as
 you go north to south.
 
+Each (X, Y) pair corresponds to some real location on the planet. Cols and
+rows, on the other hand, are ways of specifying location *within the image*
+rather than by reference to any actual location. For more on coordinate
+systems supported by GeoTiffs, check out the relevant parts of the
+`spec <http://geotiff.maptools.org/spec/geotiff2.5.html#2.5/>`_.
+
 Big Tiffs
 ---------
 
-In some instances, your GeoTiff may contain an amount of data so large
-that it can no longer be described as a Tiff, but rather by a new name,
-BigTiff. In order to qualify as a BigTiff, your file needs to be **at
-least 4gb in size or larger**. At this point, the methods used to store
-and find data need to be changed. The accommodation that is made is to
+In order to qualify as a BigTiff, your file needs to be **at least 4gb
+in size or larger**. At this size, the methods used to store
+and find data are different. The accommodation that is made is to
 change the size of the various offsets and byte counts of each segment.
 For a normal Tiff, this size is 32-bits, but BigTiffs have these sizes
-at 64-bit. GeoTrellis supports BigTiffs without any issue, so one need
-not worry about size when working with their files.
+at 64-bit. GeoTrellis transparently supports BigTiffs, so
+so you shouldn't need to worry about size.
+
+Cloud Optimized GeoTiffs
+------------------------
+
+Just as the GeoTiff is a subset of Tiff meant to convey information not
+only about image values but also the spatial extent of that imagery,
+Cloud Optimized GeoTiffs are a nascent subset of GeoTiff meant to increase
+their expressiveness, ease of use, and portability through further
+standardization. We call these GeoTiff "cloud optimized" because the
+features they add allow for remote access to GeoTiff that, with the help
+of HTTP GET range requests, access the parts of a tiff you're interested
+without consuming large portions of the image which are irrelevant to your
+computation.
+
+COGs are thus capable of serving as a self-describing backing for raster
+layers. The only cost associated with the use of COGs over GeoTrellis'
+Avro-based layers layers is the extra effort related to metadata retrieval
+and munging (metadata for each individual GeoTiff will need to be collected
+as opposed to the monolithic metadata of Avro layers, which is read and
+handled once for the entire layer).
+
+Structured vs Unstructured
+--------------------------
+
+Historically, Geotrellis layers have been backed by specially encoded Avro
+layers which are were designed to maximize the performance of distributed
+reading and querying. With the advent of the COG and the development of
+tooling to support this subset of the GeoTiff spec, however, the advantages
+of depending upon a bespoke raster format are less obvious than they once were.
+Avro support is likely to continue, but support for applications backed by
+COGs are a priority for continued GeoTrellis development.
+
+To this end, GeoTrellis is introducing the notion of a 'structured' COG layer.
+Structured COG layers are actually a collection of COGs tiled out in a
+consistent manner and described through common (GeoTrellis-specific) metadata
+which is designed to enhance query performance for larger layers by allowing
+GeoTrellis programs to infer information about underlying, individual COG files
+without having to read multiple of them.
+
+
+
+
+
 
 Further Readings
 ----------------
@@ -1693,6 +1740,8 @@ Further Readings
    format <http://www.fileformat.info/format/tiff/egff.htm>`__
 -  `For more information on the GeoTiff file
    format <http://www.gdal.org/frmt_gtiff.html>`__
+-  `For more information on the Cloud Optimized GeoTiff file
+   format <http://www.cogeo.org/>`__
 
 .. raw:: html
 

--- a/docs/guide/core-concepts.rst
+++ b/docs/guide/core-concepts.rst
@@ -1695,10 +1695,10 @@ Cloud Optimized GeoTiffs
 
 Just as the GeoTiff is a subset of Tiff meant to convey information not
 only about image values but also the spatial extent of that imagery,
-Cloud Optimized GeoTiffs are a nascent subset of GeoTiff meant to increase
-their expressiveness, ease of use, and portability through further
-standardization. We call these GeoTiffs "cloud optimized" because the
-features they add allow for remote access to GeoTiff that, with the help
+Cloud Optimized GeoTiffs (COGs for short) are a nascent subset of GeoTiff
+meant to increase their expressiveness, ease of use, and portability through
+further standardization. We call these GeoTiffs "cloud optimized" because
+the features they add allow for remote access to GeoTiff that, with the help
 of HTTP GET range requests, access the parts of a tiff you're interested
 without consuming large portions of the image which are irrelevant to your
 computation.

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
@@ -84,6 +84,7 @@ trait GeoTiff[T <: CellGrid] extends GeoTiffData {
   def getOverview(idx: Int): GeoTiff[T] = if(idx < 0) this else overviews(idx)
   def buildOverview(resampleMethod: ResampleMethod, decimationFactor: Int, blockSize: Int = GeoTiff.DefaultBlockSize): GeoTiff[T]
   def withOverviews(resampleMethod: ResampleMethod, decimations: List[Int] = Nil, blockSize: Int = GeoTiff.DefaultBlockSize): GeoTiff[T]
+  def withOverviews(overviews: Seq[GeoTiff[T]]): GeoTiff[T] = copy(overviews = overviews.toList)
 
   /** Chooses the best matching overviews and makes resample */
   def resample(rasterExtent: RasterExtent, resampleMethod: ResampleMethod, strategy: OverviewStrategy): Raster[T]

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
@@ -70,7 +70,7 @@ case class SinglebandGeoTiff(
 
   def crop(gridBounds: GridBounds): SinglebandGeoTiff =
     crop(gridBounds.colMin, gridBounds.rowMin, gridBounds.colMax, gridBounds.rowMax)
-  
+
   def crop(subExtent: Extent): SinglebandGeoTiff = crop(subExtent, Crop.Options.DEFAULT)
 
   def crop(subExtent: Extent, cellSize: CellSize, resampleMethod: ResampleMethod, strategy: OverviewStrategy): SinglebandRaster =

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiffSpec.scala
@@ -42,6 +42,12 @@ class SinglebandGeoTiffSpec extends FunSpec with Matchers with RasterMatchers wi
       assert(wit.overviews.last.tile.rows <= GeoTiff.DefaultBlockSize)
     }
 
+    it("should be able to attach overviews manually") {
+      val ovr = tiff.buildOverview(NearestNeighbor, 2)
+      val withOvr = tiff.withOverviews(Seq(ovr))
+      withOvr.overviews should be (List(ovr))
+    }
+
     it("should default to power of 2 overviews") {
       val blockSize = 64
       val pixels = 512


### PR DESCRIPTION
## Overview

Add a short description of COGs and their support in GeoTrellis as well as a helper method to combine overviews with their origin Tiffs (useful for sidecar-based COGs)

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Notes

We probably can't merge this in without some more work being done to make the GT COG API consistent. We also can't support sidecar metadata, which seems to be necessary
