### PR TITLE
Remove Raster[T] to T implicit conversion

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/COGSparkExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/COGSparkExamples.scala
@@ -78,8 +78,7 @@ object COGSparkExamples {
     val layer: TileLayerRDD[SpatialKey] = reader.read[SpatialKey, Tile](LayerId("example_cog_layer", zoom))
 
     // Let's stitch the layer into tile
-    val tile: Tile = layer.stitch
-    val raster: Raster[Tile] = Raster(tile, layer.metadata.mapTransform(layer.metadata.gridBounds))
+    val raster: Raster[Tile] = layer.stitch
 
     // Create a tiff
     val tiff = GeoTiff(raster.reproject(layer.metadata.crs, WebMercator), WebMercator)

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -61,6 +61,7 @@ API Changes
   - **New:** Kryo serialization of geometry now uses a binary format to reduce shuffle block size.
   - **Change:** Scalaz streams were replaced by fs2 streams.
   - **New:** ``GeoTiffMultibandTile`` now has another ``crop`` method that takes a ``GridBounds`` and an ``Array[Int]`` that represents the band indices.
+  - **Change:** Removed implicit conversion from ``Raster[T]`` to ``T`` <https://github.com/locationtech/geotrellis/pull/2771>__ .
 
 - ``geotrellis.spark-etl``
 

--- a/raster-testkit/src/main/scala/geotrellis/raster/testkit/RasterMatchers.scala
+++ b/raster-testkit/src/main/scala/geotrellis/raster/testkit/RasterMatchers.scala
@@ -63,6 +63,16 @@ trait RasterMatchers extends Matchers {
     }
   }
 
+  def assertEqual(r1: Raster[Tile], r2: Raster[Tile])(implicit di: DummyImplicit): Unit = {
+    assertEqual(r1.tile, r2.tile)
+    assert(r1.extent == r2.extent, s"${r1.extent} != ${r2.extent}")
+  }
+
+  def assertEqual(r1: Raster[MultibandTile], r2: Raster[MultibandTile]): Unit = {
+    assertEqual(r1.tile, r2.tile)
+    assert(r1.extent == r2.extent, s"${r1.extent} != ${r2.extent}")
+  }
+
   def assertEqual(ta: Tile, tb: Tile): Unit = tilesEqual(ta, tb)
 
   def assertEqual(ta: Tile, tb: Tile, threshold: Double): Unit = tilesEqual(ta, tb, threshold)

--- a/raster/src/main/scala/geotrellis/raster/Raster.scala
+++ b/raster/src/main/scala/geotrellis/raster/Raster.scala
@@ -44,12 +44,6 @@ object Raster {
     Raster(tup._2, tup._1)
 
   /**
-    * Implicit conversion from a [[Raster]] to a [[CellGrid]].
-    */
-  implicit def rasterToTile[T <: CellGrid](r: Raster[T]): T =
-    r.tile
-
-  /**
     * Implicit conversion from a [[Raster]] to a PolygonFeature.
     */
   implicit def rasterToFeature[T <: CellGrid](r: Raster[T]): PolygonFeature[T] =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
@@ -52,7 +52,7 @@ case class MultibandGeoTiff(
     extent.intersection(subExtent) match {
       case Some(ext) =>
         val raster: Raster[MultibandTile] = this.raster.crop(ext, options)
-        MultibandGeoTiff(raster, ext, this.crs, this.tags, this.options, this.overviews)
+        MultibandGeoTiff(raster.tile, ext, this.crs, this.tags, this.options, this.overviews)
       case _ => throw GeoAttrsError(s"Extent to crop by ($subExtent) should intersect the imagery extent ($extent).")
     }
   }
@@ -64,7 +64,7 @@ case class MultibandGeoTiff(
     val raster: Raster[MultibandTile] =
       this.raster.crop(colMin, rowMin, colMax, rowMax)
 
-    MultibandGeoTiff(raster, raster._2, this.crs, this.tags, this.options, this.overviews)
+    MultibandGeoTiff(raster.tile, raster.extent, this.crs, this.tags, this.options, this.overviews)
   }
 
   def crop(gridBounds: GridBounds): MultibandGeoTiff =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
@@ -52,7 +52,7 @@ case class MultibandGeoTiff(
     extent.intersection(subExtent) match {
       case Some(ext) =>
         val raster: Raster[MultibandTile] = this.raster.crop(ext, options)
-        MultibandGeoTiff(raster.tile, ext, this.crs, this.tags, this.options, this.overviews)
+        MultibandGeoTiff(raster.tile, raster.extent, this.crs, this.tags, this.options, this.overviews)
       case _ => throw GeoAttrsError(s"Extent to crop by ($subExtent) should intersect the imagery extent ($extent).")
     }
   }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
@@ -53,7 +53,7 @@ case class SinglebandGeoTiff(
     extent.intersection(subExtent) match {
       case Some(ext) =>
         val raster: Raster[Tile] = this.raster.crop(ext, options)
-        SinglebandGeoTiff(raster.tile, ext, this.crs, this.tags, this.options, this.overviews)
+        SinglebandGeoTiff(raster.tile, raster.extent, this.crs, this.tags, this.options, this.overviews)
       case _ => throw GeoAttrsError(s"Extent to crop by ($subExtent) should intersect the imagery extent ($extent).")
     }
   }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
@@ -53,7 +53,7 @@ case class SinglebandGeoTiff(
     extent.intersection(subExtent) match {
       case Some(ext) =>
         val raster: Raster[Tile] = this.raster.crop(ext, options)
-        SinglebandGeoTiff(raster, ext, this.crs, this.tags, this.options, this.overviews)
+        SinglebandGeoTiff(raster.tile, ext, this.crs, this.tags, this.options, this.overviews)
       case _ => throw GeoAttrsError(s"Extent to crop by ($subExtent) should intersect the imagery extent ($extent).")
     }
   }
@@ -65,7 +65,7 @@ case class SinglebandGeoTiff(
     val raster: Raster[Tile] =
       this.raster.crop(colMin, rowMin, colMax, rowMax)
 
-    SinglebandGeoTiff(raster, raster._2, this.crs, this.tags, this.options, this.overviews)
+    SinglebandGeoTiff(raster.tile, raster.extent, this.crs, this.tags, this.options, this.overviews)
   }
 
   def crop(gridBounds: GridBounds): SinglebandGeoTiff =

--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
@@ -140,7 +140,7 @@ object RasterRegionReproject {
     def regionReproject(raster: Raster[MultibandTile], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Raster[MultibandTile] = {
       val bands = Array.ofDim[MutableArrayTile](raster.tile.bandCount)
       cfor(0)(_ < bands.length, _ + 1) { i =>
-        bands(i) = raster.band(i).prototype(rasterExtent.cols, rasterExtent.rows).mutable
+        bands(i) = raster.tile.band(i).prototype(rasterExtent.cols, rasterExtent.rows).mutable
       }
       mutableRegionReproject(MultibandTile(bands), raster, src, dest, rasterExtent, region, resampleMethod)
       Raster(MultibandTile(bands), rasterExtent.extent)
@@ -154,8 +154,8 @@ object RasterRegionReproject {
         bands(i) = target.band(i).mutable
       }
 
-      val resampler = (0 until raster.bandCount).map { i =>
-        Resample(resampleMethod, raster.band(i), raster.extent, raster.rasterExtent.cellSize)
+      val resampler = (0 until raster.tile.bandCount).map { i =>
+        Resample(resampleMethod, raster.tile.band(i), raster.extent, raster.rasterExtent.cellSize)
       }
 
       if (raster.cellType.isFloatingPoint) {

--- a/raster/src/test/scala/geotrellis/raster/CompositeTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/CompositeTileSpec.scala
@@ -79,7 +79,7 @@ class CompositeTileSpec extends FunSpec
           256,
           256
         )
-      val tiled = CompositeTile.wrap(r, tileLayout, cropped = true)
+      val tiled = CompositeTile.wrap(r.tile, tileLayout, cropped = true)
       tiled.tiles.map( t => t.asInstanceOf[CroppedTile])
     }
 
@@ -91,7 +91,7 @@ class CompositeTileSpec extends FunSpec
           256,
           256
         )
-      val tiled = CompositeTile.wrap(r, tileLayout, cropped = false)
+      val tiled = CompositeTile.wrap(r.tile, tileLayout, cropped = false)
       tiled.tiles.map( t => t.asInstanceOf[ArrayTile])
     }
 
@@ -103,7 +103,7 @@ class CompositeTileSpec extends FunSpec
           256,
           256
         )
-      val tiled = CompositeTile.wrap(r, tileLayout, cropped = false)
+      val tiled = CompositeTile.wrap(r.tile, tileLayout, cropped = false)
       val backToArray = tiled.toArrayTile
 
       cfor(0)(_ < backToArray.rows, _ + 1) { row =>
@@ -114,7 +114,7 @@ class CompositeTileSpec extends FunSpec
             }
           } else {
             withClue (s"Value different at $col, $row: ") {
-              backToArray.get(col, row) should be (r.get(col, row))
+              backToArray.get(col, row) should be (r.tile.get(col, row))
             }
           }
         }

--- a/raster/src/test/scala/geotrellis/raster/interpolation/InverseDistanceWieghtedSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/interpolation/InverseDistanceWieghtedSpec.scala
@@ -47,7 +47,7 @@ class InverseDistanceWeightedSpec extends FunSpec
 
       for(col <- 0 until re.cols) {
         for(row <- 0 until re.rows) {
-          val actual = result.get(col,row)
+          val actual = result.tile.get(col,row)
           val expected = r.get(col,row)
 
           actual should be (expected +- 1)
@@ -65,7 +65,7 @@ class InverseDistanceWeightedSpec extends FunSpec
       )
       val result = points.inverseDistanceWeighted(re)
 
-      assert(result.get(0, 0) === value)
+      assert(result.tile.get(0, 0) === value)
     }
 
     it("keeps sampled values closer than sample radius") {
@@ -79,7 +79,7 @@ class InverseDistanceWeightedSpec extends FunSpec
       )
       val result = points.inverseDistanceWeighted(re, InverseDistanceWeighted.Options(equalWeightRadius = 3, onSet = x => Math.round(x)))
 
-      assert(result.get(0, 0) === Math.round((sampleValue1+sampleValue2)/2.0))
+      assert(result.tile.get(0, 0) === Math.round((sampleValue1+sampleValue2)/2.0))
     }
 
     it("uses points closer than radius in raster units") {
@@ -93,8 +93,8 @@ class InverseDistanceWeightedSpec extends FunSpec
 
       val result = points.inverseDistanceWeighted(re, InverseDistanceWeighted.Options(radiusX = 0.05, radiusY = 0.05))
 
-      assert(result.get(0, 0) === 15)
-      assert(result.get(3, 0) === 500)
+      assert(result.tile.get(0, 0) === 15)
+      assert(result.tile.get(3, 0) === 500)
     }
   }
 
@@ -108,7 +108,7 @@ class InverseDistanceWeightedSpec extends FunSpec
       )
       val result = points.inverseDistanceWeighted(re, InverseDistanceWeighted.Options(cellType = DoubleConstantNoDataCellType))
 
-      value should be (result.getDouble(0, 0) +- 0.001)
+      value should be (result.tile.getDouble(0, 0) +- 0.001)
     }
 
     it("keeps sampled values closer than sample radius") {
@@ -122,7 +122,7 @@ class InverseDistanceWeightedSpec extends FunSpec
       )
       val result = points.inverseDistanceWeighted(re, InverseDistanceWeighted.Options(equalWeightRadius = 3, cellType = DoubleConstantNoDataCellType))
 
-      assert(result.getDouble(0, 0) === (sampleValue1+sampleValue2)/2.0)
+      assert(result.tile.getDouble(0, 0) === (sampleValue1+sampleValue2)/2.0)
     }
 
     it("uses points closer than radius in raster units") {
@@ -141,8 +141,8 @@ class InverseDistanceWeightedSpec extends FunSpec
 
       val result = points.inverseDistanceWeighted(re, InverseDistanceWeighted.Options(radiusX = 0.05, radiusY = 0.05, cellType = DoubleConstantNoDataCellType))
 
-      expected should be (result.getDouble(0, 0) +- 0.001)
-      c should be (result.getDouble(3, 0) +- 0.001)
+      expected should be (result.tile.getDouble(0, 0) +- 0.001)
+      c should be (result.tile.getDouble(3, 0) +- 0.001)
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/arg/ArgTest.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/arg/ArgTest.scala
@@ -53,26 +53,26 @@ class ArgTest extends FunSuite
   }
 
   test("check int8") {
-    assert(loadRaster("/tmp/foo-int8.json").toArray === array)
+    assert(loadRaster("/tmp/foo-int8.json").tile.toArray === array)
   }
 
   test("check int16") {
-    assert(loadRaster("/tmp/foo-int16.json").toArray === array)
+    assert(loadRaster("/tmp/foo-int16.json").tile.toArray === array)
   }
 
   test("check int32") {
-    assert(loadRaster("/tmp/foo-int32.json").toArray === array)
+    assert(loadRaster("/tmp/foo-int32.json").tile.toArray === array)
   }
 
   test("check float32") {
-    val d = loadRaster("/tmp/foo-float32.json").toArrayTile
+    val d = loadRaster("/tmp/foo-float32.json").tile.toArrayTile
     assert(isNoData(d.applyDouble(0)))
     assert(d.applyDouble(1) === -1.0)
     assert(d.applyDouble(2) === 2.0)
   }
 
   test("check float64") {
-    val d = loadRaster("/tmp/foo-float64.json").toArrayTile
+    val d = loadRaster("/tmp/foo-float64.json").tile.toArrayTile
     assert(isNoData(d.applyDouble(0)))
     assert(d.applyDouble(1) === -1.0)
     assert(d.applyDouble(2) === 2.0)
@@ -101,7 +101,7 @@ class ArgTest extends FunSuite
     ArgWriter(ByteConstantNoDataCellType).write("/tmp/fooc-int8.arg", tile, extent, "fooc-int8")
     val r2 = loadRaster("/tmp/fooc-int8.json")
 
-    assert(r2.toArrayTile === tile.toArrayTile)
+    assert(r2.tile.toArrayTile === tile.toArrayTile)
   }
 
   test("make sure it contains 100 cells") {

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/MultibandCropIteratorSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/MultibandCropIteratorSpec.scala
@@ -64,14 +64,14 @@ class MultibandCropIteratorSpec extends FunSpec
         MultibandCropIterator(geoTiff, windowedCols, windowedRows)
 
       val expected: Array[MultibandTile] =
-        Array(geoTiff.raster.crop(0, 0, 10, 10),
-          geoTiff.raster.crop(10, 0, 20, 10),
-          geoTiff.raster.crop(0, 10, 10, 20),
-          geoTiff.raster.crop(10, 10, 20, 20),
-          geoTiff.raster.crop(0, 20, 10, 30),
-          geoTiff.raster.crop(10, 20, 20, 30),
-          geoTiff.raster.crop(0, 30, 10, 40),
-          geoTiff.raster.crop(10, 30, 20, 40))
+        Array(geoTiff.raster.tile.crop(0, 0, 10, 10),
+          geoTiff.raster.tile.crop(10, 0, 20, 10),
+          geoTiff.raster.tile.crop(0, 10, 10, 20),
+          geoTiff.raster.tile.crop(10, 10, 20, 20),
+          geoTiff.raster.tile.crop(0, 20, 10, 30),
+          geoTiff.raster.tile.crop(10, 20, 20, 30),
+          geoTiff.raster.tile.crop(0, 30, 10, 40),
+          geoTiff.raster.tile.crop(10, 30, 20, 40))
 
       val actual: Array[MultibandTile] =
         Array(multibandIterator.next.tile,
@@ -106,10 +106,10 @@ class MultibandCropIteratorSpec extends FunSpec
         new MultibandCropIterator(geoTiff, windowedCols, windowedRows)
 
       val expected: Array[MultibandTile] =
-        Array(geoTiff.raster.crop(0, 0, 15, 25),
-          geoTiff.raster.crop(15, 0, 20, 25),
-          geoTiff.raster.crop(0, 25, 15, 40),
-          geoTiff.raster.crop(15, 25, 20, 40))
+        Array(geoTiff.raster.tile.crop(0, 0, 15, 25),
+          geoTiff.raster.tile.crop(15, 0, 20, 25),
+          geoTiff.raster.tile.crop(0, 25, 15, 40),
+          geoTiff.raster.tile.crop(15, 25, 20, 40))
 
       val actual: Array[MultibandTile] =
         Array(multibandIterator.next.tile,

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandCropIteratorSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/SinglebandCropIteratorSpec.scala
@@ -64,10 +64,10 @@ class SinglebandCropIteratorSpec extends FunSpec
         new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
 
       val expected: Array[Tile] =
-        Array(geoTiff.raster.crop(0, 0, 256, 256),
-          geoTiff.raster.crop(256, 0, 512, 256),
-          geoTiff.raster.crop(0, 256, 256, 512),
-          geoTiff.raster.crop(256, 256, 512, 512))
+        Array(geoTiff.raster.tile.crop(0, 0, 256, 256),
+          geoTiff.raster.tile.crop(256, 0, 512, 256),
+          geoTiff.raster.tile.crop(0, 256, 256, 512),
+          geoTiff.raster.tile.crop(256, 256, 512, 512))
 
       val actual: Array[Tile] =
         Array(singlebandIterator.next.tile,
@@ -99,12 +99,12 @@ class SinglebandCropIteratorSpec extends FunSpec
         new SinglebandCropIterator(geoTiff, windowedCols, windowedRows)
 
       val expected: Array[Tile] =
-        Array(geoTiff.raster.crop(0, 0, 250, 450),
-          geoTiff.raster.crop(250, 0, 500, 450),
-          geoTiff.raster.crop(500, 0, 512, 450),
-          geoTiff.raster.crop(0, 450, 250, 512),
-          geoTiff.raster.crop(250, 450, 500, 512),
-          geoTiff.raster.crop(500, 450, 512, 512))
+        Array(geoTiff.raster.tile.crop(0, 0, 250, 450),
+          geoTiff.raster.tile.crop(250, 0, 500, 450),
+          geoTiff.raster.tile.crop(500, 0, 512, 450),
+          geoTiff.raster.tile.crop(0, 450, 250, 512),
+          geoTiff.raster.tile.crop(250, 450, 500, 512),
+          geoTiff.raster.tile.crop(500, 450, 512, 512))
 
       val actual: Array[Tile] =
         Array(singlebandIterator.next.tile,

--- a/raster/src/test/scala/geotrellis/raster/rasterize/RasterizeMethodsSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/rasterize/RasterizeMethodsSpec.scala
@@ -54,9 +54,9 @@ class RasterizeMethodsSpec extends FunSpec
   describe("The rasterize methods on the Feature class") {
     it("should agree with Rasterizer.rasterizeWithValue for a point") {
       val actual1 = Feature[Point, Int](point, magicNumber).rasterize(re)
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = Feature[Point, Double](point, magicNumber).rasterize(re)
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
 
       assert(actual1 == pointExpected)
       assert(actual2 == pointExpected)
@@ -64,9 +64,9 @@ class RasterizeMethodsSpec extends FunSpec
 
     it("should agree with Rasterizer.rasterizeWithValue for a line") {
       val actual1 = Feature[Line, Int](line, magicNumber).rasterize(re)
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = Feature[Line, Double](line, magicNumber).rasterize(re)
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
 
       assert(actual1 == lineExpected)
       assert(actual2 == lineExpected)
@@ -74,9 +74,9 @@ class RasterizeMethodsSpec extends FunSpec
 
     it("should agree with Rasterizer.rasterizeWithValue for a polygon") {
       val actual1 = Feature[Polygon, Int](square, magicNumber).rasterize(re)
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = Feature[Polygon, Double](square, magicNumber).rasterize(re)
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
 
       assert(actual1 == squareExpected)
       assert(actual2 == squareExpected)
@@ -89,9 +89,9 @@ class RasterizeMethodsSpec extends FunSpec
   describe("The rasterize methods on the Geometry class") {
     it("should agree with Rasterizer.rasterizeWithValue for a point") {
       val actual1 = point.rasterize(re)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = point.rasterizeDouble(re)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
 
       assert(actual1 == pointExpected)
       assert(actual2 == pointExpected)
@@ -99,9 +99,9 @@ class RasterizeMethodsSpec extends FunSpec
 
     it("should agree with Rasterizer.rasterizeWithValue for a line") {
       val actual1 = line.rasterize(re)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = line.rasterizeDouble(re)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
 
       assert(actual1 == lineExpected)
       assert(actual2 == lineExpected)
@@ -109,9 +109,9 @@ class RasterizeMethodsSpec extends FunSpec
 
     it("should agree with Rasterizer.rasterizeWithValue for a polygon") {
       val actual1 = square.rasterize(re)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = square.rasterizeDouble(re)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
 
       assert(actual1 == squareExpected)
       assert(actual2 == squareExpected)
@@ -124,9 +124,9 @@ class RasterizeMethodsSpec extends FunSpec
   describe("The rasterize and foreach methods on the RasterExtent class") {
     it("should agree with Rasterizer.rasterizeWithValue for a square") {
       val actual1 = re.rasterize(square)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = re.rasterizeDouble(square)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
 
       assert(actual1 == squareExpected)
       assert(actual2 == squareExpected)
@@ -134,9 +134,9 @@ class RasterizeMethodsSpec extends FunSpec
 
     it("should agree with Rasterizer.rasterizeWithValue for a diamond") {
       val actual1 = re.rasterize(diamond)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = re.rasterizeDouble(diamond)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val expected = Rasterizer.rasterizeWithValue(diamond, re, magicNumber)
         .toArray.filter(_ == magicNumber).length
 
@@ -146,9 +146,9 @@ class RasterizeMethodsSpec extends FunSpec
 
     it("should agree with Rasterizer.rasterizeWithValue for a triangle") {
       val actual1 = re.rasterize(triangle)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val actual2 = re.rasterizeDouble(triangle)({ (x: Int, y: Int) => magicNumber })
-        .toArray.filter(_ == magicNumber).length
+        .tile.toArray.filter(_ == magicNumber).length
       val expected = Rasterizer.rasterizeWithValue(triangle, re, magicNumber)
         .toArray.filter(_ == magicNumber).length
 

--- a/raster/src/test/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizerSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizerSpec.scala
@@ -140,7 +140,7 @@ class PolygonRasterizerSpec extends FunSuite
     // 390, 332
     // 390, 333
 
-    val r1 = p1.rasterizeWithValue(rasterExtent, 0x55)
+    val r1 = p1.rasterizeWithValue(rasterExtent, 0x55).tile
     var sum = 0
     r1.foreach(f => if (isData(f)) sum = sum + 1 )
     assert(sum === 3)

--- a/raster/src/test/scala/geotrellis/raster/split/RasterSplitMethodsSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/split/RasterSplitMethodsSpec.scala
@@ -49,7 +49,7 @@ class RasterSplitMethodsSpec extends FunSpec with Matchers with TileBuilders {
         for(b <- 0 until 3) {
           val Raster(resultTile, resultExtent) = result(i)
           resultTile.bandCount should be (3)
-          val band = result(i).band(b)
+          val band = result(i).tile.band(b)
           (band.cols, band.rows) should be ((3,2))
           band.foreach { z =>
             z should be ((i + 1) * math.pow(10, b))

--- a/raster/src/test/scala/geotrellis/raster/viewshed/ApproxViewshedSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/viewshed/ApproxViewshedSpec.scala
@@ -105,7 +105,7 @@ class ApproxViewshedSpec extends FunSpec
 
       val (x, y) = (-93.63300872055451407, 30.54649743277299123) // create overload
       val (col, row) = re.mapToGrid(x, y)
-      val actual = ApproxViewshed(elevation, col, row)
+      val actual = ApproxViewshed(elevation.tile, col, row)
 
       def countDiff(a: Tile, b: Tile): Int = {
         var ans = 0

--- a/raster/src/test/scala/geotrellis/raster/viewshed/R2ViewshedSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/viewshed/R2ViewshedSpec.scala
@@ -479,7 +479,7 @@ class R2ViewshedSpec extends FunSpec
       val rs = loadTestArg("data/viewshed-elevation")
       val elevation = rs.tile
       val rasterExtent = rs.rasterExtent
-      val expected = loadTestArg("data/viewshed-expected")
+      val expected = loadTestArg("data/viewshed-expected").tile
 
       val (x, y) = (-93.63300872055451407, 30.54649743277299123) // create overload
       val (col, row) = rasterExtent.mapToGrid(x, y)
@@ -507,7 +507,7 @@ class R2ViewshedSpec extends FunSpec
       val rs = loadTestArg("data/viewshed-elevation")
       val elevation = rs.tile
       val rasterExtent = rs.rasterExtent
-      val expected = loadTestArg("data/viewshed-expected")
+      val expected = loadTestArg("data/viewshed-expected").tile
 
       val (x, y) = (-93.63300872055451407, 30.54649743277299123) // create overload
       val (col, row) = rasterExtent.mapToGrid(x, y)

--- a/raster/src/test/scala/geotrellis/raster/viewshed/ViewshedSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/viewshed/ViewshedSpec.scala
@@ -114,7 +114,7 @@ class ViewshedSpec extends FunSpec
       val rs = loadTestArg("data/viewshed-elevation")
       val elevation = rs.tile
       val rasterExtent = rs.rasterExtent
-      val expected = loadTestArg("data/viewshed-expected")
+      val expected = loadTestArg("data/viewshed-expected").tile
 
       val (x, y) = (-93.63300872055451407, 30.54649743277299123) // create overload
       val (col, row) = rasterExtent.mapToGrid(x, y)

--- a/s3/src/test/scala/geotrellis/spark/io/s3/S3GeoTiffRDDSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/S3GeoTiffRDDSpec.scala
@@ -88,8 +88,8 @@ class S3GeoTiffRDDSpec
 
       val (_, md) = source1.collectMetadata[SpatialKey](FloatingLayoutScheme(256))
 
-      val stitched1: Tile = source1.tileToLayout(md).stitch
-      val stitched2: Tile = source2.tileToLayout(md).stitch
+      val stitched1: Tile = source1.tileToLayout(md).stitch.tile
+      val stitched2: Tile = source2.tileToLayout(md).stitch.tile
 
       assertEqual(stitched1, stitched2)
     }

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/OpAsserter.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/OpAsserter.scala
@@ -80,7 +80,7 @@ trait OpAsserter { self: TestEnvironment =>
     val rasterResult = rasterOp(tile, rasterRDD.metadata.layout.toRasterExtent)
     val sparkResult = sparkOp(rasterRDD).stitch
 
-    asserter(rasterResult, sparkResult)
+    asserter(rasterResult, sparkResult.tile)
   }
 
   def testTileCollection(sc: SparkContext,
@@ -104,6 +104,6 @@ trait OpAsserter { self: TestEnvironment =>
     val rasterResult = rasterOp(tile, rasterCollection.metadata.layout.toRasterExtent)
     val sparkResult = sparkOp(rasterCollection).stitch
 
-    asserter(rasterResult, sparkResult)
+    asserter(rasterResult, sparkResult.tile)
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/buffer/BufferTilesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/buffer/BufferTilesSpec.scala
@@ -99,7 +99,7 @@ class BufferTilesSpec extends FunSpec with TestEnvironment with RasterMatchers {
       val buffers = BufferTiles(ContextRDD(wholeRdd, metadata), { _: SpatialKey => BufferSizes(2,2,2,2) }).collect
       val tile11 = buffers.find{ case (key, _) => key == SpatialKey(1, 1) }.get._2.tile
       val baseline = originalRaster.crop(98, 98, 201, 201, Crop.Options.DEFAULT)
-      assertEqual(baseline, tile11)
+      assertEqual(baseline.tile, tile11)
     }
 
     it("the lightweight RDD version should work with the main diagonal missing") {

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/MaxSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/MaxSpec.scala
@@ -42,7 +42,7 @@ class MaxSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMax(Square(1)).stitch.toArray
+      val res = rasterRDD.focalMax(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         9, 9, 7,    2, 2, 2,    3, 3, 3,
@@ -68,7 +68,7 @@ class MaxSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMax(Square(2)).stitch.toArray
+      val res = rasterRDD.focalMax(Square(2)).stitch.tile.toArray
 
       val expected = Array(
         9, 9, 9,    8, 3, 3,    3, 3, 3,
@@ -94,7 +94,7 @@ class MaxSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMax(Circle(1)).stitch.toArray
+      val res = rasterRDD.focalMax(Circle(1)).stitch.tile.toArray
 
       val expected = Array(
         9, 7, 7,    2, 2, 2,    1, 3, 1,
@@ -120,7 +120,7 @@ class MaxSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMax(Square(1)).stitch.toArray
+      val res = rasterCollection.focalMax(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         9, 9, 7,    2, 2, 2,    3, 3, 3,
@@ -146,7 +146,7 @@ class MaxSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMax(Square(2)).stitch.toArray
+      val res = rasterCollection.focalMax(Square(2)).stitch.tile.toArray
 
       val expected = Array(
         9, 9, 9,    8, 3, 3,    3, 3, 3,
@@ -172,7 +172,7 @@ class MaxSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMax(Circle(1)).stitch.toArray
+      val res = rasterCollection.focalMax(Circle(1)).stitch.tile.toArray
 
       val expected = Array(
         9, 7, 7,    2, 2, 2,    1, 3, 1,

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/MeanSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/MeanSpec.scala
@@ -43,7 +43,7 @@ class MeanSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMean(Square(1)).stitch.toArrayDouble
+      val res = rasterRDD.focalMean(Square(1)).stitch.tile.toArrayDouble
 
       val expected = Array(
         5.666, 3.8, 2.166,   1.666,   2.5, 4.166,    5.166, 5.166,   4.5,
@@ -69,7 +69,7 @@ class MeanSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMean(Square(1), TargetCell.NoData).stitch.toArrayDouble
+      val res = rasterRDD.focalMean(Square(1), TargetCell.NoData).stitch.tile.toArrayDouble
 
       val expected = Array(
         5.666,7, 1,   1, 3, 5,   9, 8, 2,
@@ -95,7 +95,7 @@ class MeanSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMean(Square(1), TargetCell.NoData).stitch.toArrayDouble
+      val res = rasterRDD.focalMean(Square(1), TargetCell.NoData).stitch.tile.toArrayDouble
 
       val expected = Array(
         5.666,7, 1,   1, 3, 5,   9.5, 8.5, 2.5,
@@ -121,7 +121,7 @@ class MeanSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMean(Circle(1)).stitch.toArrayDouble
+      val res = rasterRDD.focalMean(Circle(1)).stitch.tile.toArrayDouble
 
       val expected = Array(
         5.022,3.876,2.602,    2.054, 2.749, 3.846,    4.652, 4.708, 4.444,
@@ -147,7 +147,7 @@ class MeanSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMean(Square(1)).stitch.toArrayDouble
+      val res = rasterCollection.focalMean(Square(1)).stitch.tile.toArrayDouble
 
       val expected = Array(
         5.666, 3.8, 2.166,   1.666,   2.5, 4.166,    5.166, 5.166,   4.5,
@@ -173,7 +173,7 @@ class MeanSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMean(Circle(1)).stitch.toArrayDouble
+      val res = rasterCollection.focalMean(Circle(1)).stitch.tile.toArrayDouble
 
       val expected = Array(
         5.022,3.876,2.602,    2.054, 2.749, 3.846,    4.652, 4.708, 4.444,

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/MedianSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/MedianSpec.scala
@@ -43,7 +43,7 @@ class MedianSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMedian(Square(1)).stitch.toArray
+      val res = rasterRDD.focalMedian(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         7, 1, 1,    1, 2, 3,    4, 4, 4,
@@ -69,7 +69,7 @@ class MedianSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMedian(Square(1)).stitch.toArray
+      val res = rasterCollection.focalMedian(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         7, 1, 1,    1, 2, 3,    4, 4, 4,
@@ -95,7 +95,7 @@ class MedianSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMedian(Square(1), TargetCell.Data).stitch.toArray
+      val res = rasterRDD.focalMedian(Square(1), TargetCell.Data).stitch.tile.toArray
 
       val expected = Array(
         nd, 1, 1,    1, 2, 3,    4, 4, 4,

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/MinSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/MinSpec.scala
@@ -44,7 +44,7 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMin(Square(1)).stitch.toArray
+      val res = rasterRDD.focalMin(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         1, 1, 1,    1, 1, 2,    2, 2, 2,
@@ -70,8 +70,8 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMin(Square(1), TargetCell.NoData).stitch.toArray
-      val res2 = rasterRDD.focalMin(Square(1), TargetCell.Data).stitch.toArray
+      val res = rasterRDD.focalMin(Square(1), TargetCell.NoData).stitch.tile.toArray
+      val res2 = rasterRDD.focalMin(Square(1), TargetCell.Data).stitch.tile.toArray
       println(res2.toSeq)
 
       val expected = Array(
@@ -98,7 +98,7 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMin(Square(1)).stitch.toArrayDouble
+      val res = rasterRDD.focalMin(Square(1)).stitch.tile.toArrayDouble
 
       val expected = Array(
         1.1, 1.1, 1.1,    1.2, 1.4, 2.2,    2.9, 2.2, 2.2,
@@ -124,7 +124,7 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMin(Square(2)).stitch.toArray
+      val res = rasterRDD.focalMin(Square(2)).stitch.tile.toArray
 
       val expected = Array(
         3, 2, 2,    2, 2, 2,    2, 2, 2,
@@ -150,7 +150,7 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMin(Circle(1)).stitch.toArray
+      val res = rasterRDD.focalMin(Circle(1)).stitch.tile.toArray
 
       val expected = Array(
         7, 4, 2,    2, 2, 2,    2, 3, nd,
@@ -176,7 +176,7 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMin(Square(1)).stitch.toArray
+      val res = rasterCollection.focalMin(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         1, 1, 1,    1, 1, 2,    2, 2, 2,
@@ -202,7 +202,7 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMin(Square(1)).stitch.toArrayDouble
+      val res = rasterCollection.focalMin(Square(1)).stitch.tile.toArrayDouble
 
       val expected = Array(
         1.1, 1.1, 1.1,    1.2, 1.4, 2.2,    2.9, 2.2, 2.2,
@@ -228,7 +228,7 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMin(Square(2)).stitch.toArray
+      val res = rasterCollection.focalMin(Square(2)).stitch.tile.toArray
 
       val expected = Array(
         3, 2, 2,    2, 2, 2,    2, 2, 2,
@@ -254,7 +254,7 @@ class MinSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMin(Circle(1)).stitch.toArray
+      val res = rasterCollection.focalMin(Circle(1)).stitch.tile.toArray
 
       val expected = Array(
         7, 4, 2,    2, 2, 2,    2, 3, nd,

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/ModeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/ModeSpec.scala
@@ -43,7 +43,7 @@ class ModeSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMode(Square(1)).stitch.toArray
+      val res = rasterRDD.focalMode(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         nd, 1, 1,    1, 2, 2,   nd,nd,nd,
@@ -69,7 +69,7 @@ class ModeSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalMode(Square(1)).stitch.toArray
+      val res = rasterCollection.focalMode(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         nd, 1, 1,    1, 2, 2,   nd,nd,nd,
@@ -95,7 +95,7 @@ class ModeSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalMode(Square(1), TargetCell.NoData).stitch.toArray
+      val res = rasterRDD.focalMode(Square(1), TargetCell.NoData).stitch.tile.toArray
 
       val expected = Array(
         nd,7, 1,   1, 3, 5,   9, 8, 2,

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/SumSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/focal/SumSpec.scala
@@ -45,7 +45,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalSum(Square(1)).stitch.toArray
+      val res = rasterRDD.focalSum(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         3, 5, 7,    8, 9, 8,    7, 6, 4,
@@ -71,7 +71,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalSum(Square(2)).stitch.toArray
+      val res = rasterRDD.focalSum(Square(2)).stitch.tile.toArray
 
       val expected = Array(
         8, 14, 20,   24,24,24,    21,15, 9,
@@ -97,7 +97,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalSum(Square(2), TargetCell.NoData).stitch.toArray
+      val res = rasterRDD.focalSum(Square(2), TargetCell.NoData).stitch.tile.toArray
 
       val expected = Array(
         8,1, 1,   1, 1, 1,   1, 1, 1,
@@ -123,7 +123,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalSum(Circle(1)).stitch.toArray
+      val res = rasterRDD.focalSum(Circle(1)).stitch.tile.toArray
 
       val expected = Array(
         2, 3, 4,    5, 5, 5,    4, 4, 3,
@@ -149,7 +149,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalSum(Square(1)).stitch.toArray
+      val res = rasterCollection.focalSum(Square(1)).stitch.tile.toArray
 
       val expected = Array(
         3, 5, 7,    8, 9, 8,    7, 6, 4,
@@ -175,7 +175,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalSum(Square(2)).stitch.toArray
+      val res = rasterCollection.focalSum(Square(2)).stitch.tile.toArray
 
       val expected = Array(
         8, 14, 20,   24,24,24,    21,15, 9,
@@ -201,7 +201,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       ).toCollection
 
-      val res = rasterCollection.focalSum(Circle(1)).stitch.toArray
+      val res = rasterCollection.focalSum(Circle(1)).stitch.tile.toArray
 
       val expected = Array(
         2, 3, 4,    5, 5, 5,    4, 4, 3,
@@ -227,7 +227,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalSum(Square(1), TargetCell.NoData).stitch.toArray
+      val res = rasterRDD.focalSum(Square(1), TargetCell.NoData).stitch.tile.toArray
 
       val expected = Array(
         11,12, 13,   21, 22, 23,   31, 32, 33,
@@ -253,7 +253,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalSum(Square(1), TargetCell.NoData).stitch.toArray
+      val res = rasterRDD.focalSum(Square(1), TargetCell.NoData).stitch.tile.toArray
 
       val expected = Array(
         3,1, 1,   1, 1, 1,   1, 1, 1,
@@ -279,7 +279,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalSum(Square(1), TargetCell.Data).stitch.toArray
+      val res = rasterRDD.focalSum(Square(1), TargetCell.Data).stitch.tile.toArray
 
       val expected = Array(
         nd, 5, 7,    8, 9, 8,    7, 6, 4,
@@ -305,7 +305,7 @@ class SumSpec extends FunSpec with TestEnvironment {
         TileLayout(3, 2, 3, 2)
       )
 
-      val res = rasterRDD.focalSum(Circle(1), TargetCell.Data).stitch.toArray
+      val res = rasterRDD.focalSum(Circle(1), TargetCell.Data).stitch.tile.toArray
 
       val expected = Array(
         nd, 3, 4,    5, 5, 5,    4, 4, 3,

--- a/spark/src/test/scala/geotrellis/spark/mapalgebra/zonal/HistogramSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mapalgebra/zonal/HistogramSpec.scala
@@ -76,9 +76,9 @@ class HistogramSpec extends FunSpec with TestEnvironment with TestFiles {
 
       for(row <- 0 until rows) {
         for(col <- 0 until cols) {
-          val z = zones.get(col, row)
+          val z = zones.tile.get(col, row)
           if(!zoneValues.contains(z)) zoneValues(z) = mutable.ListBuffer[Int]()
-          zoneValues(z) += r.get(col, row)
+          zoneValues(z) += r.tile.get(col, row)
         }
       }
 

--- a/spark/src/test/scala/geotrellis/spark/mask/TileRDDMaskMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/mask/TileRDDMaskMethodsSpec.scala
@@ -158,7 +158,7 @@ class TileRDDMaskMethodsSpec extends FunSpec
         if(poly.isValid) {
           val masked = rdd.mask(poly, options = opts).stitch
           val expected = tile.mask(worldExt, poly)
-          masked.toArray() shouldEqual expected.toArray()
+          masked.tile.toArray() shouldEqual expected.toArray()
         }
       }
     }
@@ -172,7 +172,7 @@ class TileRDDMaskMethodsSpec extends FunSpec
       cases foreach { poly =>
         val masked = rdd.mask(poly, options = opts).stitch
         val expected = tile.mask(worldExt, poly)
-        masked.toArray() shouldEqual expected.toArray()
+        masked.tile.toArray() shouldEqual expected.toArray()
       }
     }
 
@@ -185,7 +185,7 @@ class TileRDDMaskMethodsSpec extends FunSpec
         if(multipoly.isValid) {
           val masked = rdd.mask(multipoly, options = opts).stitch
           val expected = tile.mask(worldExt, multipoly)
-          masked.toArray() shouldEqual expected.toArray()
+          masked.tile.toArray() shouldEqual expected.toArray()
         }
       }
     }
@@ -200,7 +200,7 @@ class TileRDDMaskMethodsSpec extends FunSpec
       cases foreach { multipoly =>
         val masked = rdd.mask(multipoly, options = opts).stitch
         val expected = tile.mask(worldExt, multipoly)
-        masked.toArray() shouldEqual expected.toArray()
+        masked.tile.toArray() shouldEqual expected.toArray()
       }
     }
 
@@ -209,7 +209,7 @@ class TileRDDMaskMethodsSpec extends FunSpec
       extents foreach { extent =>
         val masked = rdd.mask(extent, options = opts).stitch
         val expected = tile.mask(worldExt, extent)
-        masked.toArray() shouldEqual expected.toArray()
+        masked.tile.toArray() shouldEqual expected.toArray()
       }
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/pyramid/PyramidSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/pyramid/PyramidSpec.scala
@@ -229,7 +229,7 @@ class PyramidSpec extends FunSpec with Matchers with TestEnvironment {
       assert(pyramid.minZoom == 0)
       assert(pyramid.maxZoom == 2)
 
-      val tile2x2 = pyramid(0).stitch
+      val tile2x2 = pyramid(0).stitch.tile
 
       // should end up with the proper top-level tile
       assert(tile2x2.dimensions == (2, 2))

--- a/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
@@ -29,7 +29,7 @@ import org.scalatest._
 class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
 
   val simpleLayer = {
-    val tiles = 
+    val tiles =
       for ( x <- 0 to 3 ;
             y <- 0 to 2
       ) yield {
@@ -48,7 +48,7 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
   }
 
   val temporalLayer = {
-    val tiles = 
+    val tiles =
       for ( x <- 0 to 3 ;
             y <- 0 to 2
       ) yield {
@@ -79,21 +79,21 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
       val newLayer = simpleLayer.regrid(64)
 
       assert(newLayer.stitch.dimensions == (128, 128))
-      assertEqual(simpleLayer.stitch, newLayer.stitch.tile.crop(0,0,127,95))
+      assertEqual(simpleLayer.stitch.tile, newLayer.stitch.tile.crop(0,0,127,95))
     }
 
     it("should allow breaking into non-square tiles") {
       val newLayer = simpleLayer.regrid(50, 25)
 
       assert(newLayer.stitch.dimensions == (150, 100))
-      assertEqual(simpleLayer.stitch, newLayer.stitch.tile.crop(0,0,127,95))
+      assertEqual(simpleLayer.stitch.tile, newLayer.stitch.tile.crop(0,0,127,95))
     }
 
     it("should work for spatiotemporal data") {
       val newLayer = temporalLayer.regrid(50, 25)
 
       assert(newLayer.toSpatial(0L).stitch.dimensions == (150, 100))
-      assertEqual(temporalLayer.toSpatial(0L).stitch, newLayer.toSpatial(0L).stitch.tile.crop(0,0,127,95))
+      assertEqual(temporalLayer.toSpatial(0L).stitch.tile, newLayer.toSpatial(0L).stitch.tile.crop(0,0,127,95))
     }
   }
 


### PR DESCRIPTION
In particular this conversion results in data loss and surprising behavior.

Other remaining implicit conversion, from `Raster[T]` to `PolygonFeature[T]` at least preserve the extent information.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [-] `docs` guides update, if necessary
- [-] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Demo

Optional. Screenshots/REPL

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Resolves #2768