### PR TITLE
TileLayerMetadata.fromRDD Name Fix

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -58,6 +58,7 @@ API Changes
     in the order they choose.
   - **Change:** ``COGLayerReader.baseRead`` has been removed and has been replaced with ``COGLayerReader.baseReadAllBands`` and ``COGLayerReader.baseReadSubsetBands``.
   - **New:** ``KeyBounds`` now has the ``rekey`` method that will rekey the bounds from a source layout to a target layout.
+  - **Change:** The ``TileLayerMetadata.fromRdd`` method has been renamed to ``TileLayerMetadata.fromRDD``.
 
 - ``geotrellis.raster``
 

--- a/spark/src/main/scala/geotrellis/spark/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/Implicits.scala
@@ -242,29 +242,29 @@ trait Implicits
     /** The `Int` is the zoom level if ingested with the produced Metadata. */
     def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, layoutScheme: LayoutScheme)
         (implicit ev: K1 => TilerKeyMethods[K1, K2]): (Int, TileLayerMetadata[K2]) = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, crs, layoutScheme)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, crs, layoutScheme)
     }
 
     def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, layout: LayoutDefinition)
         (implicit ev: K1 => TilerKeyMethods[K1, K2]): TileLayerMetadata[K2] = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, crs, layout)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, crs, layout)
     }
 
     /** The `Int` is the zoom level if ingested with the produced Metadata. */
     def collectMetadata[K2: Boundable: SpatialComponent](layoutScheme: LayoutScheme)
         (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): (Int, TileLayerMetadata[K2]) = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, layoutScheme)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, layoutScheme)
     }
 
     /** The `Int` is the zoom level if ingested with the produced Metadata. */
     def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, size: Int, zoom: Int)
         (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): (Int, TileLayerMetadata[K2]) = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, ZoomedLayoutScheme(crs, size), zoom)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, ZoomedLayoutScheme(crs, size), zoom)
     }
 
     def collectMetadata[K2: Boundable: SpatialComponent](layout: LayoutDefinition)
         (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): TileLayerMetadata[K2] = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, layout)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, layout)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
@@ -169,7 +169,7 @@ object TileLayerMetadata {
     * Compose Extents from given raster tiles and fit it on given
     * TileLayout.
     */
-  def fromRdd[
+  def fromRDD[
     K: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -183,7 +183,7 @@ object TileLayerMetadata {
     * Compose Extents from given raster tiles and use LayoutScheme to
     * create the LayoutDefinition.
     */
-  def fromRdd[
+  def fromRDD[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -199,28 +199,28 @@ object TileLayerMetadata {
     * [[geotrellis.spark.tiling.ZoomedLayoutScheme]] to create the
     * [[geotrellis.spark.tiling.LayoutDefinition]].
     */
-  def fromRdd[
+  def fromRDD[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme):
     (Int, TileLayerMetadata[K2]) =
-      _fromRdd[K, V, K2](rdd, crs, scheme, None)
+      _fromRDD[K, V, K2](rdd, crs, scheme, None)
 
   /**
     * Compose Extents from given raster tiles using
     * [[geotrellis.spark.tiling.ZoomedLayoutScheme]] and a maximum
     * zoom value.
     */
-  def fromRdd[
+  def fromRDD[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme, maxZoom: Int):
     (Int, TileLayerMetadata[K2]) =
-      _fromRdd[K, V, K2](rdd, crs, scheme, Some(maxZoom))
+      _fromRDD[K, V, K2](rdd, crs, scheme, Some(maxZoom))
 
-  private def _fromRdd[
+  private def _fromRDD[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -235,7 +235,7 @@ object TileLayerMetadata {
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
 
-  def fromRdd[
+  def fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -247,23 +247,23 @@ object TileLayerMetadata {
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
 
-  def fromRdd[
+  def fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)],  scheme: ZoomedLayoutScheme):
     (Int, TileLayerMetadata[K2]) =
-      _fromRdd[K, V, K2](rdd, scheme, None)
+      _fromRDD[K, V, K2](rdd, scheme, None)
 
-  def fromRdd[
+  def fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)], scheme: ZoomedLayoutScheme, maxZoom: Int):
     (Int, TileLayerMetadata[K2]) =
-      _fromRdd[K, V, K2](rdd, scheme, Some(maxZoom))
+      _fromRDD[K, V, K2](rdd, scheme, Some(maxZoom))
 
-  private def _fromRdd[
+  private def _fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -279,7 +279,7 @@ object TileLayerMetadata {
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
 
-  def fromRdd[
+  def fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable


### PR DESCRIPTION
## Overview

This PR changes the name of the `TileLayerMetadata.fromRdd` method to `TileLayerMetadata.fromRDD` in order to match the spelling patterns found throughout the rest of the library.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary