### PR TITLE
COGLayerReader readSubsetBands and querySubsetBands

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -54,6 +54,9 @@ API Changes
   - **Change:** All classes and objects in the ``geowave`` package now use the spelling: ``GeoWave`` in their names.
   - **New:** Both ``COGValueReader`` and ``OverzoomingCOGValueReader`` now have the ``readSubsetBands`` method which allows users to read in a select number
     of bands in any order they choose.
+  - **New:** ``COGLayerReader`` now has the ``readSubsetBands`` and ``querySubsetBands`` methods which allow users to read in layers with the desired bands
+    in the order they choose.
+  - **Change:** ``COGLayerReader.baseRead`` has been removed and has been replaced with ``COGLayerReader.baseReadAllBands`` and ``COGLayerReader.baseReadSubsetBands`.
 
 - ``geotrellis.raster``
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -56,7 +56,8 @@ API Changes
     of bands in any order they choose.
   - **New:** ``COGLayerReader`` now has the ``readSubsetBands`` and ``querySubsetBands`` methods which allow users to read in layers with the desired bands
     in the order they choose.
-  - **Change:** ``COGLayerReader.baseRead`` has been removed and has been replaced with ``COGLayerReader.baseReadAllBands`` and ``COGLayerReader.baseReadSubsetBands`.
+  - **Change:** ``COGLayerReader.baseRead`` has been removed and has been replaced with ``COGLayerReader.baseReadAllBands`` and ``COGLayerReader.baseReadSubsetBands``.
+  - **New:** ``KeyBounds`` now has the ``rekey`` method that will rekey the bounds from a source layout to a target layout.
 
 - ``geotrellis.raster``
 

--- a/raster/src/main/scala/geotrellis/raster/crop/MultibandTileCropMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/crop/MultibandTileCropMethods.scala
@@ -48,6 +48,22 @@ trait MultibandTileCropMethods extends TileCropMethods[MultibandTile] {
     }
   }
 
+  def cropBands(gridBounds: Seq[GridBounds], targetBands: Seq[Int], options: Options): Iterator[(GridBounds, MultibandTile)] =
+    self match {
+      case geotiffTile: GeoTiffMultibandTile =>
+        val cropBounds: Seq[GridBounds] = gridBounds.map { gb =>
+            if (!gb.intersects(self.gridBounds))
+              throw GeoAttrsError(s"Grid bounds do not intersect: ${self.gridBounds} crop $gb")
+
+            if (options.clamp) gb.intersection(self).get
+            else gb
+        }
+        geotiffTile.crop(cropBounds, targetBands.toArray)
+    }
+
+  def cropBands(gridBounds: Seq[GridBounds], targetBands: Seq[Int]): Iterator[(GridBounds, MultibandTile)] =
+    cropBands(gridBounds, targetBands, Options.DEFAULT)
+
   /**
    * Crops this [[MultibandTile]] to the given region using methods
    * specified in the cropping options.

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/io/cog/COGPersistenceSpec.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.spark.testkit.io.cog
 
-import geotrellis.raster.CellGrid
+import geotrellis.raster.{CellGrid, MultibandTile}
 import geotrellis.raster.crop.TileCropMethods
 import geotrellis.raster.merge.TileMergeMethods
 import geotrellis.raster.resample._
@@ -119,6 +119,19 @@ abstract class COGPersistenceSpec[
           info(s"unwanted: ${(actual diff expected).toList}")
 
         actual should contain theSameElementsAs expected
+      }
+
+      it("should read a subset of bands from the layer") {
+        val result =
+          reader
+            .readSubsetBands[K](layerId, Seq(12, 0, -1))
+            .mapValues { v => MultibandTile(v.flatten) }
+            .values
+            .collect()
+
+        for (band <- result) {
+          band.bandCount should be (1)
+        }
       }
 
       it("should read a layer back (collections api)") {

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
@@ -16,12 +16,15 @@
 
 package geotrellis.spark.io.cog
 
-import geotrellis.raster.{CellGrid, RasterExtent}
+import geotrellis.raster.{CellGrid, RasterExtent, GridBounds, MultibandTile, Tile}
+import geotrellis.raster.crop._
+import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.io.geotiff.reader.TiffTagsReader
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.index.{Index, IndexRanges, MergeQueue}
+import geotrellis.spark.io.index.{Index, KeyIndex, IndexRanges, MergeQueue}
+import geotrellis.spark.tiling.LayoutDefinition
 import geotrellis.util._
 import geotrellis.spark.util.KryoWrapper
 import org.apache.spark.rdd._
@@ -37,6 +40,14 @@ abstract class COGLayerReader[ID] extends Serializable {
   val attributeStore: AttributeStore
 
   def defaultNumPartitions: Int
+
+  protected def pathExists(path: String): Boolean
+
+  protected def fullPath(path: String): URI
+
+  protected def getHeader(id: LayerId): LayerHeader
+
+  protected def produceGetKeyPath(id: LayerId): (ZoomRange, Int) => BigInt => String
 
   /** read
     *
@@ -54,16 +65,154 @@ abstract class COGLayerReader[ID] extends Serializable {
     V <: CellGrid: GeoTiffReader: ClassTag
   ](id: ID, rasterQuery: LayerQuery[K, TileLayerMetadata[K]], numPartitions: Int): RDD[(K, V)] with Metadata[TileLayerMetadata[K]]
 
-  def baseRead[
+  def read[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
+    V <: CellGrid: GeoTiffReader: ClassTag
+  ](id: ID, rasterQuery: LayerQuery[K, TileLayerMetadata[K]]): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] =
+    read(id, rasterQuery, defaultNumPartitions)
+
+  def read[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
+    V <: CellGrid: GeoTiffReader: ClassTag
+  ](id: ID, numPartitions: Int): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] =
+    read(id, new LayerQuery[K, TileLayerMetadata[K]], numPartitions)
+
+  def read[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
+    V <: CellGrid: GeoTiffReader: ClassTag
+  ](id: ID): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] =
+    read(id, defaultNumPartitions)
+
+  /**
+    *
+    * This method will read in an RDD layer whose value will only contain the
+    * desired bands in their given order. This value is represented as an: Array[Option[Tile]].
+    * Where Some(tile) represents a single band and None represents a band that could not
+    * be accessed.
+    *
+    * @param id              The ID of the layer to be read
+    * @param targetBands     The desired set of bands the output layer should have.
+    * @param rasterQuery     The query that will specify the filter for this read.
+    * @param numPartitions   The desired number of partitions in the resulting RDD.
+    *
+    * @tparam K              Type of RDD Key (ex: SpatialKey)
+    */
+  def readSubsetBands[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag
+  ](
+    id: ID,
+    targetBands: Seq[Int],
+    rasterQuery: LayerQuery[K, TileLayerMetadata[K]],
+    numPartitions: Int
+  ): RDD[(K, Array[Option[Tile]])] with Metadata[TileLayerMetadata[K]]
+
+  def readSubsetBands[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag
+  ](
+    id: ID,
+    targetBands: Seq[Int],
+    rasterQuery: LayerQuery[K, TileLayerMetadata[K]]
+  ): RDD[(K, Array[Option[Tile]])] with Metadata[TileLayerMetadata[K]] =
+    readSubsetBands(id, targetBands, rasterQuery, defaultNumPartitions)
+
+  def readSubsetBands[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag
+  ](id: ID, targetBands: Seq[Int], numPartitions: Int): RDD[(K, Array[Option[Tile]])] with Metadata[TileLayerMetadata[K]] =
+    readSubsetBands(id, targetBands, new LayerQuery[K, TileLayerMetadata[K]], numPartitions)
+
+  def readSubsetBands[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag
+  ](id: ID, targetBands: Seq[Int]): RDD[(K, Array[Option[Tile]])] with Metadata[TileLayerMetadata[K]] =
+    readSubsetBands(id, targetBands, defaultNumPartitions)
+
+  // TODO: Have this return a COGLayerReader
+  def reader[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
+    V <: CellGrid: GeoTiffReader: ClassTag
+  ]: Reader[ID, RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] =
+    new Reader[ID, RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] {
+      def read(id: ID): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] =
+        COGLayerReader.this.read[K, V](id)
+    }
+
+  def query[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
+    V <: CellGrid: GeoTiffReader: ClassTag
+  ](layerId: ID): BoundLayerQuery[K, TileLayerMetadata[K], RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] =
+    new BoundLayerQuery(new LayerQuery, read(layerId, _))
+
+  def query[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
+    V <: CellGrid: GeoTiffReader: ClassTag
+  ](layerId: ID, numPartitions: Int): BoundLayerQuery[K, TileLayerMetadata[K], RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] =
+    new BoundLayerQuery(new LayerQuery, read(layerId, _, numPartitions))
+
+  def querySubsetBands[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag
+  ](layerId: ID, targetBands: Seq[Int]): BoundLayerQuery[K, TileLayerMetadata[K], RDD[(K, Array[Option[Tile]])] with Metadata[TileLayerMetadata[K]]] =
+    new BoundLayerQuery(new LayerQuery, readSubsetBands(layerId, targetBands, _))
+
+  def querySubsetBands[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag
+  ](layerId: ID, targetBands: Seq[Int], numPartitions: Int): BoundLayerQuery[K, TileLayerMetadata[K], RDD[(K, Array[Option[Tile]])] with Metadata[TileLayerMetadata[K]]] =
+    new BoundLayerQuery(new LayerQuery, readSubsetBands(layerId, targetBands, _, numPartitions))
+
+  private def crop[V <: CellGrid: GeoTiffReader: ClassTag](
+    geoTiff: GeoTiff[V],
+    gridBounds: Seq[GridBounds]
+  ): Iterator[(GridBounds, V)] =
+    geoTiff.crop(gridBounds)
+
+  private def produceCropBands(
+    targetBands: Seq[Int]
+  ): (GeoTiff[MultibandTile], Seq[GridBounds]) => Iterator[(GridBounds, Array[Option[Tile]])] =
+    (geoTiff: GeoTiff[MultibandTile], gridBounds: Seq[GridBounds]) => cropBands(geoTiff, gridBounds, targetBands)
+
+  private def cropBands(
+    geoTiff: GeoTiff[MultibandTile],
+    gridBounds: Seq[GridBounds],
+    bands: Seq[Int]
+  ): Iterator[(GridBounds, Array[Option[Tile]])] = {
+    // We first must determine which bands are valid and which are not
+    // before doing the crop in order to avoid band subsetting errors
+    // and/or loading unneeded data.
+    val targetBandsWithIndex: Array[(Int, Int)] =
+      bands
+        .zipWithIndex
+        .filter { case (band, _) =>
+          band >= 0 && band < geoTiff.bandCount
+        }
+        .toArray
+
+    val (targetBands, targetBandsIndexes) = targetBandsWithIndex.unzip
+
+    val croppedTilesWithGridBounds: Iterator[(GridBounds, Array[Tile])] =
+      geoTiff
+        .tile
+        .cropBands(gridBounds, targetBands)
+        .map { case (k, v) => k -> v.bands.toArray }
+
+    val croppedTilesWithBandIndexes: Iterator[(GridBounds, Array[(Int, Tile)])] =
+      croppedTilesWithGridBounds
+        .map { case (k, v) => k -> targetBandsIndexes.zip(v) }
+
+    croppedTilesWithBandIndexes.map { case (k, v) =>
+      val returnedBands = Array.fill[Option[Tile]](bands.size)(None)
+      for ((index, band) <- v) {
+        returnedBands(index) = Some(band)
+      }
+
+      k -> returnedBands
+    }
+  }
+
+  def baseReadAllBands[
     K: SpatialComponent: Boundable: JsonFormat: ClassTag,
     V <: CellGrid: GeoTiffReader: ClassTag
   ](
     id: LayerId,
     tileQuery: LayerQuery[K, TileLayerMetadata[K]],
     numPartitions: Int,
-    getKeyPath: (ZoomRange, Int) => BigInt => String,
-    pathExists: String => Boolean, // check the path above exists
-    fullPath: String => URI, // add an fs prefix
     defaultThreads: Int
   )(implicit sc: SparkContext,
              getByteReader: URI => ByteReader,
@@ -89,61 +238,69 @@ abstract class COGLayerReader[ID] extends Serializable {
       case Some(zoomRange) => {
         val baseKeyIndex = keyIndexes(zoomRange)
 
-        val maxWidth = Index.digits(baseKeyIndex.toIndex(baseKeyIndex.keyBounds.maxKey))
-        val keyPath: BigInt => String = getKeyPath(zoomRange, maxWidth)
-        val decompose = (bounds: KeyBounds[K]) => baseKeyIndex.indexRanges(bounds)
+        baseRead[K, V, V](
+          id = id,
+          zoomRange = zoomRange,
+          cogLayerMetadata = cogLayerMetadata,
+          metadata = metadata,
+          baseKeyIndex = baseKeyIndex,
+          queryKeyBounds = queryKeyBounds,
+          readDefinitions = readDefinitions.flatMap(_._2).groupBy(_._1),
+          readGeoTiff = crop,
+          numPartitions = numPartitions,
+          defaultThreads = defaultThreads
+        )
+      }
+      case None =>
+        new ContextRDD(sc.parallelize(Seq()), metadata.setComponent[Bounds[K]](EmptyBounds))
+    }
+  }
 
-        val baseLayout = cogLayerMetadata.layoutForZoom(zoomRange.minZoom)
-        val layout = cogLayerMetadata.layoutForZoom(id.zoom)
+  def baseReadSubsetBands[
+    K: SpatialComponent: Boundable: JsonFormat: ClassTag
+  ](
+    id: LayerId,
+    targetBands: Seq[Int],
+    tileQuery: LayerQuery[K, TileLayerMetadata[K]],
+    numPartitions: Int,
+    defaultThreads: Int
+  )(implicit sc: SparkContext,
+             getByteReader: URI => ByteReader,
+             idToLayerId: ID => LayerId
+  ): RDD[(K, Array[Option[Tile]])] with Metadata[TileLayerMetadata[K]] = {
 
-        val baseKeyBounds = cogLayerMetadata.zoomRangeInfoFor(zoomRange.minZoom)._2
+    val COGLayerStorageMetadata(cogLayerMetadata, keyIndexes) =
+      try {
+        attributeStore.readMetadata[COGLayerStorageMetadata[K]](LayerId(id.name, 0))
+      } catch {
+        // to follow GeoTrellis Layer Readers logic
+        case e: AttributeNotFoundError => throw new LayerNotFoundError(id).initCause(e)
+      }
 
-        def transformKeyBounds(keyBounds: KeyBounds[K]): KeyBounds[K] = {
-          val KeyBounds(minKey, maxKey) = keyBounds
-          val extent = layout.extent
-          val sourceRe = RasterExtent(extent, layout.layoutCols, layout.layoutRows)
-          val targetRe = RasterExtent(extent, baseLayout.layoutCols, baseLayout.layoutRows)
+    val metadata = cogLayerMetadata.tileLayerMetadata(id.zoom)
 
-          val minSpatialKey = minKey.getComponent[SpatialKey]
-          val (minCol, minRow) = {
-            val (x, y) = sourceRe.gridToMap(minSpatialKey.col, minSpatialKey.row)
-            targetRe.mapToGrid(x, y)
-          }
+    val queryKeyBounds: Seq[KeyBounds[K]] = tileQuery(metadata)
 
-          val maxSpatialKey = maxKey.getComponent[SpatialKey]
-          val (maxCol, maxRow) = {
-            val (x, y) = sourceRe.gridToMap(maxSpatialKey.col, maxSpatialKey.row)
-            targetRe.mapToGrid(x, y)
-          }
+    val readDefinitions: Seq[(ZoomRange, Seq[(SpatialKey, Int, TileBounds, Seq[(TileBounds, SpatialKey)])])] =
+      cogLayerMetadata.getReadDefinitions(queryKeyBounds, id.zoom)
 
-          KeyBounds(
-            minKey.setComponent(SpatialKey(minCol, minRow)),
-            maxKey.setComponent(SpatialKey(maxCol, maxRow))
-          )
-        }
-
-        val baseQueryKeyBounds: Seq[KeyBounds[K]] =
-          queryKeyBounds
-            .flatMap { qkb =>
-              transformKeyBounds(qkb).intersect(baseKeyBounds) match {
-                case EmptyBounds => None
-                case kb: KeyBounds[K] => Some(kb)
-              }
-            }
-            .distinct
+    readDefinitions.headOption.map(_._1) match {
+      case Some(zoomRange) => {
+        val baseKeyIndex = keyIndexes(zoomRange)
 
         val rdd =
-          COGLayerReader
-            .read[K, V](
-              keyPath = keyPath,
-              pathExists = pathExists,
-              fullPath = fullPath,
-              baseQueryKeyBounds = baseQueryKeyBounds,
-              decomposeBounds = decompose,
-              readDefinitions = readDefinitions.flatMap(_._2).groupBy(_._1),
-              threads = defaultThreads,
-              numPartitions = Some(numPartitions)
-            )
+          baseRead[K, MultibandTile, Array[Option[Tile]]](
+            id = id,
+            zoomRange = zoomRange,
+            cogLayerMetadata = cogLayerMetadata,
+            metadata = metadata,
+            baseKeyIndex = baseKeyIndex,
+            queryKeyBounds = queryKeyBounds,
+            readDefinitions = readDefinitions.flatMap(_._2).groupBy(_._1),
+            readGeoTiff = produceCropBands(targetBands),
+            numPartitions = numPartitions,
+            defaultThreads = defaultThreads
+          )
 
         new ContextRDD(rdd, metadata)
       }
@@ -152,44 +309,117 @@ abstract class COGLayerReader[ID] extends Serializable {
     }
   }
 
-  def read[
+  private def baseRead[
     K: SpatialComponent: Boundable: JsonFormat: ClassTag,
-    V <: CellGrid: GeoTiffReader: ClassTag
-  ](id: ID, rasterQuery: LayerQuery[K, TileLayerMetadata[K]]): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] =
-    read(id, rasterQuery, defaultNumPartitions)
+    V <: CellGrid: GeoTiffReader: ClassTag,
+    R
+  ](
+    id: LayerId,
+    zoomRange: ZoomRange,
+    cogLayerMetadata: COGLayerMetadata[K],
+    metadata: TileLayerMetadata[K],
+    baseKeyIndex: KeyIndex[K],
+    queryKeyBounds: Seq[KeyBounds[K]],
+    readDefinitions: Map[SpatialKey, Seq[(SpatialKey, Int, TileBounds, Seq[(TileBounds, SpatialKey)])]],
+    readGeoTiff: (GeoTiff[V], Seq[GridBounds]) => Iterator[(GridBounds, R)],
+    numPartitions: Int,
+    defaultThreads: Int
+  )(implicit sc: SparkContext,
+             getByteReader: URI => ByteReader,
+             idToLayerId: ID => LayerId
+  ): RDD[(K, R)] with Metadata[TileLayerMetadata[K]] = {
+    val getKeyPath = produceGetKeyPath(id)
 
-  def read[
-    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
-    V <: CellGrid: GeoTiffReader: ClassTag
-  ](id: ID, numPartitions: Int): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] =
-    read(id, new LayerQuery[K, TileLayerMetadata[K]], numPartitions)
+    val maxWidth = Index.digits(baseKeyIndex.toIndex(baseKeyIndex.keyBounds.maxKey))
+    val keyPath: BigInt => String = getKeyPath(zoomRange, maxWidth)
+    val decompose = (bounds: KeyBounds[K]) => baseKeyIndex.indexRanges(bounds)
 
-  def read[
-    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
-    V <: CellGrid: GeoTiffReader: ClassTag
-  ](id: ID): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] =
-    read(id, defaultNumPartitions)
+    val targetLayout = cogLayerMetadata.layoutForZoom(zoomRange.minZoom)
+    val sourceLayout = cogLayerMetadata.layoutForZoom(id.zoom)
 
-  def reader[
-    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
-    V <: CellGrid: GeoTiffReader: ClassTag
-  ]: Reader[ID, RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] =
-    new Reader[ID, RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] {
-      def read(id: ID): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] =
-        COGLayerReader.this.read[K, V](id)
-    }
+    val baseKeyBounds = cogLayerMetadata.zoomRangeInfoFor(zoomRange.minZoom)._2
 
-  def query[
-    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
-    V <: CellGrid: GeoTiffReader: ClassTag
-  ](layerId: ID): BoundLayerQuery[K, TileLayerMetadata[K], RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] =
-    new BoundLayerQuery(new LayerQuery, read(layerId, _))
+    val baseQueryKeyBounds: Seq[KeyBounds[K]] =
+      queryKeyBounds
+        .flatMap { qkb =>
+          qkb.redraw(sourceLayout, targetLayout).intersect(baseKeyBounds) match {
+            case EmptyBounds => None
+            case kb: KeyBounds[K] => Some(kb)
+          }
+        }
+        .distinct
 
-  def query[
+    val ranges = if (baseQueryKeyBounds.length > 1)
+      MergeQueue(baseQueryKeyBounds.flatMap(decompose))
+    else
+      baseQueryKeyBounds.flatMap(decompose)
+
+    val bins = IndexRanges.bin(ranges, numPartitions)
+
+    val rdd =
+      if (baseQueryKeyBounds.isEmpty)
+        sc.emptyRDD[(K, R)]
+      else
+        readLayer[K, V, R](
+          bins = bins,
+          keyPath = keyPath,
+          readDefinitions = readDefinitions,
+          readGeoTiff = readGeoTiff,
+          threads = defaultThreads
+        )
+
+    new ContextRDD(rdd, metadata)
+  }
+
+  private def readLayer[
     K: SpatialComponent: Boundable: JsonFormat: ClassTag,
-    V <: CellGrid: GeoTiffReader: ClassTag
-  ](layerId: ID, numPartitions: Int): BoundLayerQuery[K, TileLayerMetadata[K], RDD[(K, V)] with Metadata[TileLayerMetadata[K]]] =
-    new BoundLayerQuery(new LayerQuery, read(layerId, _, numPartitions))
+    V <: CellGrid: GeoTiffReader,
+    R
+  ](
+     bins: Seq[Seq[(BigInt, BigInt)]],
+     keyPath: BigInt => String, // keyPath
+     readDefinitions: Map[SpatialKey, Seq[(SpatialKey, Int, TileBounds, Seq[(TileBounds, SpatialKey)])]],
+     readGeoTiff: (GeoTiff[V], Seq[GridBounds]) => Iterator[(GridBounds, R)],
+     threads: Int
+   )(implicit sc: SparkContext, getByteReader: URI => ByteReader): RDD[(K, R)] = {
+    val kwFormat = KryoWrapper(implicitly[JsonFormat[K]])
+
+    sc.parallelize(bins, bins.size)
+      .mapPartitions { partition: Iterator[Seq[(BigInt, BigInt)]] =>
+        val keyFormat = kwFormat.value
+
+        partition flatMap { seq =>
+          LayerReader.njoin[K, R](seq.toIterator, threads) { index: BigInt =>
+            if (!pathExists(keyPath(index))) Vector()
+            else {
+              val uri = fullPath(keyPath(index))
+              val byteReader: ByteReader = uri
+              val baseKey = {
+                val keyTag = TiffTagsReader.read(byteReader).tags.headTags(GTKey)
+                val decoded = if (keyTag.contains('&')) {
+                  org.apache.commons.lang.StringEscapeUtils.unescapeHtml(keyTag)
+                } else keyTag
+                decoded.parseJson.convertTo[K](keyFormat)
+              }
+
+              readDefinitions
+                .get(baseKey.getComponent[SpatialKey])
+                .toVector
+                .flatten
+                .flatMap { case (spatialKey, overviewIndex, _, seq) =>
+                  val key = baseKey.setComponent(spatialKey)
+                  val tiff = GeoTiffReader[V].read(uri, streaming = true).getOverview(overviewIndex)
+                  val map = seq.map { case (gb, sk) => gb -> key.setComponent(sk) }.toMap
+
+                  readGeoTiff(tiff, map.keys.toSeq)
+                    .flatMap { case (k, v) => map.get(k).map(i => i -> v) }
+                    .toVector
+                }
+            }
+          }
+        }
+      }
+  }
 }
 
 object COGLayerReader {
@@ -229,65 +459,4 @@ object COGLayerReader {
   def apply(uri: String)(implicit sc: SparkContext): COGLayerReader[LayerId] =
     apply(new URI(uri))
 
-  private def read[
-    K: SpatialComponent: Boundable: JsonFormat: ClassTag,
-    V <: CellGrid: GeoTiffReader
-  ](
-     keyPath: BigInt => String, // keyPath
-     pathExists: String => Boolean, // check the path above exists
-     fullPath: String => URI, // add an fs prefix
-     baseQueryKeyBounds: Seq[KeyBounds[K]], // each key here represents a COG filename
-     decomposeBounds: KeyBounds[K] => Seq[(BigInt, BigInt)],
-     readDefinitions: Map[SpatialKey, Seq[(SpatialKey, Int, TileBounds, Seq[(TileBounds, SpatialKey)])]],
-     threads: Int,
-     numPartitions: Option[Int] = None
-   )(implicit sc: SparkContext, getByteReader: URI => ByteReader): RDD[(K, V)] = {
-    if (baseQueryKeyBounds.isEmpty) return sc.emptyRDD[(K, V)]
-
-    val kwFormat = KryoWrapper(implicitly[JsonFormat[K]])
-
-    val ranges = if (baseQueryKeyBounds.length > 1)
-      MergeQueue(baseQueryKeyBounds.flatMap(decomposeBounds))
-    else
-      baseQueryKeyBounds.flatMap(decomposeBounds)
-
-    val bins = IndexRanges.bin(ranges, numPartitions.getOrElse(sc.defaultParallelism))
-
-    sc.parallelize(bins, bins.size)
-      .mapPartitions { partition: Iterator[Seq[(BigInt, BigInt)]] =>
-        val keyFormat = kwFormat.value
-
-        partition flatMap { seq =>
-          LayerReader.njoin[K, V](seq.toIterator, threads) { index: BigInt =>
-            if (!pathExists(keyPath(index))) Vector()
-            else {
-              val uri = fullPath(keyPath(index))
-              val byteReader: ByteReader = uri
-              val baseKey = {
-                val keyTag = TiffTagsReader.read(byteReader).tags.headTags(GTKey)
-                val decoded = if (keyTag.contains('&')) {
-                  org.apache.commons.lang.StringEscapeUtils.unescapeHtml(keyTag)
-                } else keyTag
-                decoded.parseJson.convertTo[K](keyFormat)
-              }
-
-              readDefinitions
-                .get(baseKey.getComponent[SpatialKey])
-                .toVector
-                .flatten
-                .flatMap { case (spatialKey, overviewIndex, _, seq) =>
-                  val key = baseKey.setComponent(spatialKey)
-                  val tiff = GeoTiffReader[V].read(uri, streaming = true).getOverview(overviewIndex)
-                  val map = seq.map { case (gb, sk) => gb -> key.setComponent(sk) }.toMap
-
-                  tiff
-                    .crop(map.keys.toSeq)
-                    .flatMap { case (k, v) => map.get(k).map(i => i -> v) }
-                    .toVector
-                }
-            }
-          }
-        }
-      }
-  }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerReader.scala
@@ -342,7 +342,7 @@ abstract class COGLayerReader[ID] extends Serializable {
     val baseQueryKeyBounds: Seq[KeyBounds[K]] =
       queryKeyBounds
         .flatMap { qkb =>
-          qkb.redraw(sourceLayout, targetLayout).intersect(baseKeyBounds) match {
+          qkb.rekey(sourceLayout, targetLayout).intersect(baseKeyBounds) match {
             case EmptyBounds => None
             case kb: KeyBounds[K] => Some(kb)
           }


### PR DESCRIPTION
## Overview

This PR adds two new methods to `COGLayerReader`: `readSubsetBands` and `querySubsetBands`. These two methods allow the user to specify which bands from the layer should be read in and in what order. This should allow for more performant reads when only some bands are desired. In addition to these new methods, two additional `cropBands` overloads were added to `MultibandTileCropMethods`. 

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Demo

```scala

val reader: COGLayerReader = ???
val layerId: Layerid = ???

// reads bands 2, 1, and 3 and returns them in that order
reader.readSubsetBands(layerId, Seq(2, 1, 3)
```

### Notes

The `reader` method in `COGLayerReader` still returns a `Reader` instead of a `COGReader`. I wasn't sure if that change was really needed for this PR, so I left it as a `TODO` for the time being.