### PR TITLE
Bump travis HBase version

### DIFF
--- a/.travis/hbase-install.sh
+++ b/.travis/hbase-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-if [ ! -f $HOME/downloads/hbase-1.4.5-bin.tar.gz ]; then sudo wget -O $HOME/downloads/hbase-1.4.5-bin.tar.gz http://www-us.apache.org/dist/hbase/1.4.5/hbase-1.4.5-bin.tar.gz; fi
-sudo mv $HOME/downloads/hbase-1.4.5-bin.tar.gz hbase-1.4.5-bin.tar.gz && tar xzf hbase-1.4.5-bin.tar.gz
-sudo rm -f hbase-1.4.5/conf/hbase-site.xml && sudo mv .travis/hbase/hbase-site.xml hbase-1.4.5/conf
-sudo hbase-1.4.5/bin/start-hbase.sh
+if [ ! -f $HOME/downloads/hbase-1.4.6-bin.tar.gz ]; then sudo wget -O $HOME/downloads/hbase-1.4.6-bin.tar.gz http://www-us.apache.org/dist/hbase/1.4.6/hbase-1.4.6-bin.tar.gz; fi
+sudo mv $HOME/downloads/hbase-1.4.6-bin.tar.gz hbase-1.4.6-bin.tar.gz && tar xzf hbase-1.4.6-bin.tar.gz
+sudo rm -f hbase-1.4.6/conf/hbase-site.xml && sudo mv .travis/hbase/hbase-site.xml hbase-1.4.6/conf
+sudo hbase-1.4.6/bin/start-hbase.sh


### PR DESCRIPTION
## Overview

This PR bumps up `HBase` version used for tests, as `HBase` team again removed the previous database version from their repositories.
