### PR TITLE
Consistently use RDD suffix in API

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -58,6 +58,7 @@ API Changes
     in the order they choose.
   - **Change:** ``COGLayerReader.baseRead`` has been removed and has been replaced with ``COGLayerReader.baseReadAllBands`` and ``COGLayerReader.baseReadSubsetBands``.
   - **New:** ``KeyBounds`` now has the ``rekey`` method that will rekey the bounds from a source layout to a target layout.
+  - **Change:** The ``TileLayerMetadata.fromRdd`` method has been renamed to ``TileLayerMetadata.fromRDD``.
 
 - ``geotrellis.raster``
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -59,6 +59,7 @@ API Changes
   - **Change:** ``COGLayerReader.baseRead`` has been removed and has been replaced with ``COGLayerReader.baseReadAllBands`` and ``COGLayerReader.baseReadSubsetBands``.
   - **New:** ``KeyBounds`` now has the ``rekey`` method that will rekey the bounds from a source layout to a target layout.
   - **Change:** The ``TileLayerMetadata.fromRdd`` method has been renamed to ``TileLayerMetadata.fromRDD``.
+  - **Change:** The ``KeyBounds.fromRdd`` method has been renamed to ``KeyBounds.fromRDD``.
 
 - ``geotrellis.raster``
 

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -27,7 +27,7 @@ encompasses your desired work-flow:
 
     /* Our layer will need metadata. Luckily, this can be derived mostly for free. */
     val (zoom, meta): (Int, TileLayerMetadata[SpatialKey]) =
-      TileLayerMetadata.fromRdd(reprojected, ZoomedLayoutScheme(ConusAlbers))
+      TileLayerMetadata.fromRDD(reprojected, ZoomedLayoutScheme(ConusAlbers))
 
     /* Recut our Tiles to form a proper gridded "layer". */
     val gridded: RDD[(SpatialKey, Tile)] = reprojected.tileToLayout(meta)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffInfoReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffInfoReader.scala
@@ -38,7 +38,7 @@ case class S3GeoTiffInfoReader(
 ) extends GeoTiffInfoReader {
 
   /** Returns RDD of URIs to tiffs as GeoTiffInfo is not serializable. */
-  def geoTiffInfoRdd(implicit sc: SparkContext): RDD[String] = {
+  def geoTiffInfoRDD(implicit sc: SparkContext): RDD[String] = {
     val listObjectsRequest =
       delimiter
         .fold(new ListObjectsRequest(bucket, prefix, null, null, null))(new ListObjectsRequest(bucket, prefix, null, _, null))

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffRDD.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffRDD.scala
@@ -146,7 +146,7 @@ object S3GeoTiffRDD extends LazyLogging {
         val infoReader = S3GeoTiffInfoReader(bucket, prefix, options)
 
         infoReader.readWindows(
-          infoReader.geoTiffInfoRdd.map(new URI(_)),
+          infoReader.geoTiffInfoRDD.map(new URI(_)),
           uriToKey,
           maxTileSize,
           options.partitionBytes.getOrElse(DefaultPartitionBytes),

--- a/spark/src/main/scala/geotrellis/spark/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/Implicits.scala
@@ -242,29 +242,29 @@ trait Implicits
     /** The `Int` is the zoom level if ingested with the produced Metadata. */
     def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, layoutScheme: LayoutScheme)
         (implicit ev: K1 => TilerKeyMethods[K1, K2]): (Int, TileLayerMetadata[K2]) = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, crs, layoutScheme)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, crs, layoutScheme)
     }
 
     def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, layout: LayoutDefinition)
         (implicit ev: K1 => TilerKeyMethods[K1, K2]): TileLayerMetadata[K2] = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, crs, layout)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, crs, layout)
     }
 
     /** The `Int` is the zoom level if ingested with the produced Metadata. */
     def collectMetadata[K2: Boundable: SpatialComponent](layoutScheme: LayoutScheme)
         (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): (Int, TileLayerMetadata[K2]) = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, layoutScheme)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, layoutScheme)
     }
 
     /** The `Int` is the zoom level if ingested with the produced Metadata. */
     def collectMetadata[K2: Boundable: SpatialComponent](crs: CRS, size: Int, zoom: Int)
         (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): (Int, TileLayerMetadata[K2]) = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, ZoomedLayoutScheme(crs, size), zoom)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, ZoomedLayoutScheme(crs, size), zoom)
     }
 
     def collectMetadata[K2: Boundable: SpatialComponent](layout: LayoutDefinition)
         (implicit ev: K1 => TilerKeyMethods[K1, K2], ev1: GetComponent[K1, ProjectedExtent]): TileLayerMetadata[K2] = {
-      TileLayerMetadata.fromRdd[K1, V, K2](rdd, layout)
+      TileLayerMetadata.fromRDD[K1, V, K2](rdd, layout)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
+++ b/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
@@ -92,7 +92,7 @@ sealed trait Bounds[+A] extends Product with Serializable {
 object Bounds {
   def apply[A](min: A, max: A): Bounds[A] = KeyBounds(min, max)
 
-  def fromRdd[K: Boundable, V](rdd: RDD[(K, V)]): Bounds[K] =
+  def fromRDD[K: Boundable, V](rdd: RDD[(K, V)]): Bounds[K] =
     rdd
       .map{ case (k, tile) => Bounds(k, k) }
       .fold(EmptyBounds) { _ combine  _ }

--- a/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/TileLayerMetadata.scala
@@ -169,7 +169,7 @@ object TileLayerMetadata {
     * Compose Extents from given raster tiles and fit it on given
     * TileLayout.
     */
-  def fromRdd[
+  def fromRDD[
     K: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -183,7 +183,7 @@ object TileLayerMetadata {
     * Compose Extents from given raster tiles and use LayoutScheme to
     * create the LayoutDefinition.
     */
-  def fromRdd[
+  def fromRDD[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -199,28 +199,28 @@ object TileLayerMetadata {
     * [[geotrellis.spark.tiling.ZoomedLayoutScheme]] to create the
     * [[geotrellis.spark.tiling.LayoutDefinition]].
     */
-  def fromRdd[
+  def fromRDD[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme):
     (Int, TileLayerMetadata[K2]) =
-      _fromRdd[K, V, K2](rdd, crs, scheme, None)
+      _fromRDD[K, V, K2](rdd, crs, scheme, None)
 
   /**
     * Compose Extents from given raster tiles using
     * [[geotrellis.spark.tiling.ZoomedLayoutScheme]] and a maximum
     * zoom value.
     */
-  def fromRdd[
+  def fromRDD[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)], crs: CRS, scheme: ZoomedLayoutScheme, maxZoom: Int):
     (Int, TileLayerMetadata[K2]) =
-      _fromRdd[K, V, K2](rdd, crs, scheme, Some(maxZoom))
+      _fromRDD[K, V, K2](rdd, crs, scheme, Some(maxZoom))
 
-  private def _fromRdd[
+  private def _fromRDD[
     K: (? => TilerKeyMethods[K, K2]) ,
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -235,7 +235,7 @@ object TileLayerMetadata {
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
 
-  def fromRdd[
+  def fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -247,23 +247,23 @@ object TileLayerMetadata {
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
 
-  def fromRdd[
+  def fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)],  scheme: ZoomedLayoutScheme):
     (Int, TileLayerMetadata[K2]) =
-      _fromRdd[K, V, K2](rdd, scheme, None)
+      _fromRDD[K, V, K2](rdd, scheme, None)
 
-  def fromRdd[
+  def fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
   ](rdd: RDD[(K, V)], scheme: ZoomedLayoutScheme, maxZoom: Int):
     (Int, TileLayerMetadata[K2]) =
-      _fromRdd[K, V, K2](rdd, scheme, Some(maxZoom))
+      _fromRDD[K, V, K2](rdd, scheme, Some(maxZoom))
 
-  private def _fromRdd[
+  private def _fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable
@@ -279,7 +279,7 @@ object TileLayerMetadata {
     (zoom, TileLayerMetadata(cellType, layout, extent, crs, kb))
   }
 
-  def fromRdd[
+  def fromRDD[
     K: GetComponent[?, ProjectedExtent]: (? => TilerKeyMethods[K, K2]),
     V <: CellGrid,
     K2: SpatialComponent: Boundable

--- a/spark/src/main/scala/geotrellis/spark/io/GeoTiffInfoReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GeoTiffInfoReader.scala
@@ -33,7 +33,7 @@ import java.net.URI
 
 
 private [geotrellis] trait GeoTiffInfoReader extends LazyLogging {
-  def geoTiffInfoRdd(implicit sc: SparkContext): RDD[String]
+  def geoTiffInfoRDD(implicit sc: SparkContext): RDD[String]
   def getGeoTiffInfo(uri: String): GeoTiffInfo
   def getGeoTiffTags(uri: String): TiffTags
 

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffInfoReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffInfoReader.scala
@@ -35,7 +35,7 @@ case class HadoopGeoTiffInfoReader(
 ) extends GeoTiffInfoReader {
 
   /** Returns RDD of URIs to tiffs as GeoTiffInfo is not serializable. */
-  def geoTiffInfoRdd(implicit sc: SparkContext): RDD[String] = {
+  def geoTiffInfoRDD(implicit sc: SparkContext): RDD[String] = {
     sc.parallelize(
       HdfsUtils
         .listFiles(new Path(path), config.value)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffRDD.scala
@@ -130,7 +130,7 @@ object HadoopGeoTiffRDD extends LazyLogging {
         val infoReader = HadoopGeoTiffInfoReader(pathString, conf, options.tiffExtensions)
 
         infoReader.readWindows(
-          infoReader.geoTiffInfoRdd.map(new URI(_)),
+          infoReader.geoTiffInfoRDD.map(new URI(_)),
           uriToKey,
           maxTileSize,
           options.partitionBytes.getOrElse(DefaultPartitionBytes),

--- a/spark/src/main/scala/geotrellis/spark/pyramid/Pyramid.scala
+++ b/spark/src/main/scala/geotrellis/spark/pyramid/Pyramid.scala
@@ -109,7 +109,7 @@ object Pyramid extends LazyLogging {
     Pyramid[K, V, M](seq.toMap)
   }
 
-  def fromLayerRdd[
+  def fromLayerRDD[
     K: SpatialComponent: ClassTag,
     V <: CellGrid: ClassTag: ? => TilePrototypeMethods[V]: ? => TileMergeMethods[V],
     M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]

--- a/spark/src/test/scala/geotrellis/spark/pyramid/PyramidSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/pyramid/PyramidSpec.scala
@@ -223,7 +223,7 @@ class PyramidSpec extends FunSpec with Matchers with TestEnvironment {
       val baseLayer = createTileLayerRDD(tile, tileLayout)
 
       // Build pyramid using Average resampling
-      val pyramid = Pyramid.fromLayerRdd(baseLayer)
+      val pyramid = Pyramid.fromLayerRDD(baseLayer)
 
       // The 1 tile top of the pyramid should be set to zoom 0, base layer numbered accordingly
       assert(pyramid.minZoom == 0)


### PR DESCRIPTION
## Overview

This PR changes handful of methods that were suffixed with `Rdd` to end with `RDD` to become consistent with the rest of the library and Spark Scala API.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary