### PR TITLE
Add covariance into type aliases to support Scala 2.12

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -28,13 +28,13 @@ package object vector extends SeqMethods
     with triangulation.Implicits
     with voronoi.Implicits {
 
-  type PointFeature[D] = Feature[Point, D]
-  type LineFeature[D] = Feature[Line, D]
-  type PolygonFeature[D] = Feature[Polygon, D]
-  type MultiPointFeature[D] = Feature[MultiPoint, D]
-  type MultiLineFeature[D] = Feature[MultiLine, D]
-  type MultiPolygonFeature[D] = Feature[MultiPolygon, D]
-  type GeometryCollectionFeature[D] = Feature[GeometryCollection, D]
+  type PointFeature[+D] = Feature[Point, D]
+  type LineFeature[+D] = Feature[Line, D]
+  type PolygonFeature[+D] = Feature[Polygon, D]
+  type MultiPointFeature[+D] = Feature[MultiPoint, D]
+  type MultiLineFeature[+D] = Feature[MultiLine, D]
+  type MultiPolygonFeature[+D] = Feature[MultiPolygon, D]
+  type GeometryCollectionFeature[+D] = Feature[GeometryCollection, D]
 
   // MethodExtensions
 


### PR DESCRIPTION
## Overview

This PR allows code to compile against Scala 2.12

Back port of code changes from this PR: https://github.com/locationtech/geotrellis/pull/2727

A part of https://github.com/locationtech/geotrellis/issues/1751