### PR TITLE
GeoTiffRDD and GeoTiffInfoReader Vestigial Code Removal

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffInfoReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffInfoReader.scala
@@ -55,12 +55,6 @@ case class S3GeoTiffInfoReader(
 
     GeoTiffReader.readGeoTiffInfo(S3RangeReader(s3Uri.getBucket, s3Uri.getKey, getS3Client()), streaming, true, ovrReader)
   }
-
-  def getGeoTiffTags(uri: String): TiffTags = {
-    val s3Uri = new AmazonS3URI(uri)
-    val rr = S3RangeReader(s3Uri.getBucket, s3Uri.getKey, getS3Client())
-    TiffTags(rr)
-  }
 }
 
 object S3GeoTiffInfoReader {

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffRDD.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3GeoTiffRDD.scala
@@ -198,30 +198,6 @@ object S3GeoTiffRDD extends LazyLogging {
     apply[K, K, V](bucket, prefix, (_: URI, key: K) => key, options)
 
   /**
-    * Creates a RDD[(K, V)] whose K and V depends on the type of the GeoTiff that is going to be read in.
-    *
-    * @param objectRequestsToDimensions A RDD of GetObjectRequest of a given GeoTiff and its cols and rows as a (Int, Int).
-    * @param uriToKey function to transform input key basing on the URI information.
-    * @param options An instance of [[Options]] that contains any user defined or default settings.
-    */
-  def apply[I, K, V](objectRequestsToDimensions: RDD[(GetObjectRequest, (Int, Int))], uriToKey: (URI, I) => K, options: Options, sourceGeoTiffInfo: => GeoTiffInfoReader)
-    (implicit rr: RasterReader[Options, (I, V)]): RDD[(K, V)] = {
-    if (options.numPartitions.isDefined) logger.warn("numPartitions option is ignored")
-    if (options.maxTileSize.isEmpty) logger.info(s"Using default maxTileSize=$DefaultMaxTileSize")
-
-    implicit val sc = objectRequestsToDimensions.sparkContext
-    sourceGeoTiffInfo.readWindows(
-      objectRequestsToDimensions.map({ case (objectRequest, _) =>
-        new URI(s"s3://${objectRequest.getBucketName}/${objectRequest.getKey}")
-      }),
-      uriToKey,
-      options.maxTileSize.getOrElse(DefaultMaxTileSize),
-      options.partitionBytes.getOrElse(DefaultPartitionBytes),
-      options,
-      None)
-  }
-
-  /**
     * Creates RDD that will read all GeoTiffs in the given bucket and prefix as singleband GeoTiffs.
     * If a GeoTiff contains multiple bands, only the first will be read.
     *

--- a/spark/src/main/scala/geotrellis/spark/io/GeoTiffInfoReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/GeoTiffInfoReader.scala
@@ -35,7 +35,6 @@ import java.net.URI
 private [geotrellis] trait GeoTiffInfoReader extends LazyLogging {
   def geoTiffInfoRDD(implicit sc: SparkContext): RDD[String]
   def getGeoTiffInfo(uri: String): GeoTiffInfo
-  def getGeoTiffTags(uri: String): TiffTags
 
   def getSegmentLayoutTransform(geoTiffInfo: GeoTiffInfo): GeoTiffSegmentLayoutTransform =
     GeoTiffSegmentLayoutTransform(geoTiffInfo.segmentLayout, geoTiffInfo.bandCount)

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffInfoReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffInfoReader.scala
@@ -52,9 +52,4 @@ case class HadoopGeoTiffInfoReader(
 
     GeoTiffReader.readGeoTiffInfo(rr, streaming, true, ovrReader)
   }
-
-  def getGeoTiffTags(uri: String): TiffTags = {
-    val rr = HdfsRangeReader(new Path(uri), config.value)
-    TiffTags(rr)
-  }
 }


### PR DESCRIPTION
## Overview

This PR removes some vestigial methods that was present in the S3 and Hadoop instances of `GeoTiffRDD` and `GeoTiffInfoReader`. Because of these methods' parameters and location, it's doubtful that anyone was calling them directly; and they should be safe to remove.