### PR TITLE
Add an extra WKT parser test

### DIFF
--- a/proj4/src/test/scala/geotrellis/proj4/io/wkt/WKTParserTest.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/io/wkt/WKTParserTest.scala
@@ -629,4 +629,19 @@ class WKTParserTest extends FunSpec {
     assert(contains(expected))
   }
 
+  it("Should parse GCS_WGS_1984") {
+    // this is a small hack to show how it is possible to handle multiline strings
+    val strip = WKTParser("""|GEOGCS["GCS_WGS_1984",
+                             |DATUM["D_WGS_1984", SPHEROID["WGS_1984", 6378137.0, 298.257223563]],
+                             |PRIMEM["Greenwich", 0.0],
+                             |UNIT["degree", 0.017453292519943295],
+                             |AXIS["Longitude", "EAST"],
+                             |AXIS["Latitude", "NORTH"]]""".stripMargin.replaceAll("\n",""))
+
+    // sinlge line equivalent
+    val single = WKTParser("""GEOGCS["GCS_WGS_1984", DATUM["D_WGS_1984", SPHEROID["WGS_1984", 6378137.0, 298.257223563]],PRIMEM["Greenwich", 0.0],UNIT["degree", 0.017453292519943295],AXIS["Longitude", "EAST"],AXIS["Latitude", "NORTH"]]""")
+
+    assert(strip == single)
+  }
+
 }


### PR DESCRIPTION
## Overview

This PR adds an extra test, as @wsf1990 experienced some issues with parsing an ordinary WKT string. The [original code that didn't work was](https://gitter.im/geotrellis/geotrellis?at=5b7d07d24be56c59187b7645):

```scala
WKTParser(
          """GEOGCS["GCS_WGS_1984",
            |  DATUM["D_WGS_1984", SPHEROID["WGS_1984", 6378137.0, 298.257223563]],
            |  PRIMEM["Greenwich", 0.0],
            |  UNIT["degree", 0.017453292519943295],
            |  AXIS["Longitude", "EAST"],
            |  AXIS["Latitude", "NORTH"]]""".stripMargin)
```
