### PR TITLE
Fixes #2792.

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -231,6 +231,8 @@ trait ArrayTile extends Tile with Serializable {
         ct.combine(this)((z1, z2) => f(z2, z1))
       case ct: CroppedTile =>
         ct.combine(this)((z1, z2) => f(z2, z1))
+      case t =>
+        this.map((col, row, z) => f(z, t.get(col, row)))
   }
 
   /**
@@ -274,6 +276,8 @@ trait ArrayTile extends Tile with Serializable {
         ct.combineDouble(this)(f)
       case ct: CompositeTile =>
         ct.combineDouble(this)((z1, z2) => f(z2, z1))
+      case t =>
+        this.mapDouble((col, row, z) => f(z, t.get(col, row)))
     }
   }
 

--- a/raster/src/main/scala/geotrellis/raster/DelegatingTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DelegatingTile.scala
@@ -1,0 +1,101 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright 2018 Astraea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package geotrellis.raster
+
+/**
+ * A tile that wraps another tile. Originally intended for delayed reading, but useful in other special use cases.
+ *
+ * @since 8/22/18
+ */
+trait DelegatingTile extends Tile {
+  protected def delegate: Tile
+
+  def cellType: CellType =
+    delegate.cellType
+
+  def cols: Int =
+    delegate.cols
+
+  def rows: Int =
+    delegate.rows
+
+  def mutable: MutableArrayTile =
+    delegate.mutable
+
+  def convert(cellType: CellType): Tile =
+    delegate.convert(cellType)
+
+  override def withNoData(noDataValue: Option[Double]): Tile =
+    delegate.withNoData(noDataValue)
+
+  def interpretAs(newCellType: CellType): Tile =
+    delegate.interpretAs(newCellType)
+
+  def get(col: Int, row: Int): Int =
+    delegate.get(col, row)
+
+  def getDouble(col: Int, row: Int): Double =
+    delegate.getDouble(col, row)
+
+  def toArrayTile(): ArrayTile =
+    delegate.toArrayTile()
+
+  def toArray(): Array[Int] =
+    delegate.toArray()
+
+  def toArrayDouble(): Array[Double] =
+    delegate.toArrayDouble()
+
+  def toBytes(): Array[Byte] =
+    delegate.toBytes()
+
+  def foreach(f: Int ⇒ Unit): Unit =
+    delegate.foreach(f)
+
+  def foreachDouble(f: Double ⇒ Unit): Unit =
+    delegate.foreachDouble(f)
+
+  def map(f: Int ⇒ Int): Tile =
+    delegate.map(f)
+
+  def combine(r2: Tile)(f: (Int, Int) ⇒ Int): Tile =
+    delegate.combine(r2)(f)
+
+  def mapDouble(f: Double ⇒ Double): Tile =
+    delegate.mapDouble(f)
+
+  def combineDouble(r2: Tile)(f: (Double, Double) ⇒ Double): Tile =
+    delegate.combineDouble(r2)(f)
+
+  def foreachIntVisitor(visitor: IntTileVisitor): Unit =
+    delegate.foreachIntVisitor(visitor)
+
+  def foreachDoubleVisitor(visitor: DoubleTileVisitor): Unit =
+    delegate.foreachDoubleVisitor(visitor)
+
+  def mapIntMapper(mapper: IntTileMapper): Tile =
+    delegate.mapIntMapper(mapper)
+
+  def mapDoubleMapper(mapper: DoubleTileMapper): Tile =
+    delegate.mapDoubleMapper(mapper)
+
+}

--- a/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
@@ -186,7 +186,3 @@ class ArrayTileSpec extends FunSpec
     }
   }
 }
-
-object ArrayTileSpec {
-
-}

--- a/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
@@ -164,5 +164,29 @@ class ArrayTileSpec extends FunSpec
         x => UByteUserDefinedNoDataCellType(x.toByte),
         UByteConstantNoDataCellType)
     }
+
+    it("should combine with non-standard tiles") {
+      withClue("IntArrayTile") {
+        val at = IntArrayTile(Array.ofDim[Int](100*100).fill(50), 100, 100)
+        val fauxTile = new DelegatingTile {
+          override protected def delegate: Tile = IntConstantTile(0, 100, 100)
+        }
+
+        assertEqual(at.combine(fauxTile)((z1, z2) => z1 + z2), at)
+      }
+
+      withClue("DoubleArrayTile") {
+        val at = DoubleArrayTile(Array.ofDim[Double](100*100).fill(50), 100, 100)
+        val fauxTile = new DelegatingTile {
+          override protected def delegate: Tile = DoubleConstantTile(0.0, 100, 100)
+        }
+
+        assertEqual(at.combineDouble(fauxTile)((z1, z2) => z1 + z2), at)
+      }
+    }
   }
+}
+
+object ArrayTileSpec {
+
 }

--- a/raster/src/test/scala/geotrellis/raster/CellTypeSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/CellTypeSpec.scala
@@ -273,6 +273,7 @@ class CellTypeSpec extends FunSpec with Matchers with Inspectors {
           case n: Float ⇒ assert(n === noData.toFloat)
           case n: Double ⇒ assert(n === noData.toDouble)
         }
+        case _ => ???
       }
     }
     it("should report nodata value for ConstantNoData") {


### PR DESCRIPTION
Also:
Adds new utility `DelegatingTile`.
Fixes compiler warning in CellTypeSpec.

Signed-off-by: Simeon H.K. Fitch <fitch@astraea.io>

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [X] Unit tests added for bug-fix or new feature

Closes #2792.
