### PR TITLE
GeoTiff CellType Conversion Fix

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
@@ -51,13 +51,21 @@ trait GeoTiffSegment {
         val bs = new BitSet(size)
         cfor(0)(_ < size, _ + 1) { i => if ((getInt(i) & 1) == 0) { bs.set(i) } }
         bs.toByteArray()
-      case ByteCellType | UByteCellType =>
+      case ByteCellType =>
         val arr = Array.ofDim[Byte](size)
         cfor(0)(_ < size, _ + 1) { i => getInt(i).toByte }
         arr
-      case ShortCellType | UShortCellType =>
+      case UByteCellType =>
+        val arr = Array.ofDim[Byte](size)
+        cfor(0)(_ < size, _ + 1) { i => i2ub(getInt(i)) }
+        arr
+      case ShortCellType =>
         val arr = Array.ofDim[Short](size)
         cfor(0)(_ < size, _ + 1) { i => arr(i) = getInt(i).toShort }
+        arr.toArrayByte()
+      case UShortCellType =>
+        val arr = Array.ofDim[Short](size)
+        cfor(0)(_ < size, _ + 1) { i => arr(i) = i2us(getInt(i)) }
         arr.toArrayByte()
       case IntCellType =>
         val arr = Array.ofDim[Int](size)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
@@ -129,6 +129,8 @@ class GeoTiffMultibandTileSpec extends FunSpec
   }
 
   describe("Multiband cellType conversion") {
+    val tiff = MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-tiled-pixel.tif"))
+
     it("should convert the cellType with convert") {
       val actual =
         MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.convert(UShortCellType)
@@ -137,6 +139,20 @@ class GeoTiffMultibandTileSpec extends FunSpec
         MultibandGeoTiff(geoTiffPath("3bands/int32/3bands-striped-pixel.tif")).tile.toArrayTile.convert(UShortCellType)
 
       assertEqual(expected, actual)
+    }
+
+    it("should convert to the ShortCellType correctly") {
+      val expected = MultibandGeoTiff(geoTiffPath("3bands/int16/3bands-tiled-pixel.tif"))
+      val actual = tiff.tile.convert(ShortCellType)
+
+      assertEqual(expected.tile, actual.tile)
+    }
+
+    it("should convert to the UShortCellType correctly") {
+      val expected = MultibandGeoTiff(geoTiffPath("3bands/uint16/3bands-tiled-pixel.tif"))
+      val actual = tiff.tile.convert(UShortCellType)
+
+      assertEqual(expected.tile, actual.tile)
     }
 
     it("should convert the cellType with interpretAs") {


### PR DESCRIPTION
## Overview

This PR fixes the logic in the `CellType` conversion for `GeoTiff`s so that they can convert to the `UByte` and `UShort` `CellType`s correctly.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

### Notes

I didn't update the `CHANGELOG` because I wasn't sure what the next version of GT we'd be releasing.

Closes #2789 
