### PR TITLE
RDD Reproject for TileFeatures, RasterRegionReproject

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.1.0
+-----
+
+Fixes
+^^^^^
+  - ``TileRDDReproject`` now works on RDD of ``TileFeature[T, D]`` (`#2803 <https://github.com/locationtech/geotrellis/pull/2803>`_).
+
+
 2.0.0
 -----
 

--- a/raster/src/main/scala/geotrellis/raster/Tile.scala
+++ b/raster/src/main/scala/geotrellis/raster/Tile.scala
@@ -101,7 +101,10 @@ trait Tile extends CellGrid with IterableTile with MappableTile[Tile] with LazyL
     if (cellType.union(r2.cellType).isFloatingPoint) combineDouble(r2)(g) else combine(r2)(f)
 
   /**
-    * Create a mutable copy of this tile
+    * Returns a mutable instance of this tile.
+    * 
+    * @note When the underlying class is an instance of [[MutableArrayTile]] it will return itself without performing a copy.
+    *       This is used internally as a performance optimization when the ownership of the tile is controlled.
     */
   def mutable: MutableArrayTile
 

--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
@@ -18,11 +18,14 @@ package geotrellis.raster.reproject
 
 import geotrellis.raster._
 import geotrellis.raster.resample._
+import geotrellis.raster.merge._
 import geotrellis.raster.rasterize._
 import geotrellis.vector.{Geometry, GeometryCollection, Line, MultiLine, MultiPoint, Point, Polygon}
 import geotrellis.proj4._
 
 import spire.syntax.cfor._
+import cats._
+
 
 trait RasterRegionReproject[T <: CellGrid] extends Serializable {
   /** Reproject raster to a region that may partially intersect target raster extent.
@@ -38,8 +41,30 @@ trait RasterRegionReproject[T <: CellGrid] extends Serializable {
     */
   def regionReproject(raster: Raster[T], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Raster[T]
 
-  def mutableRegionReproject(target: T, raster: Raster[T], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Unit
+  /** Reproject raster to a region that may partially intersect target raster extent.
+    *
+    * Back-projects only the cells overlapping the destination region before sampling their value from the source raster.
+    * This can be used to avoid assigning destination cell values where there is insufficient data for resample kernel.
+    *
+    * This is a <b>mutable</b> version of the region reproject. Target raster will be converted to mutable form and updated.
+    * In cases where target raster is subclass [[MutableArrayTile]] its values will be mutated.
+    * Its the responsability of the caller to use this function only when possible update in place is safe.\
+    * Correct use of this function allows to avoid intermidate memory allocation when accumulating results of multiple reproject calls.
+    *
+    * @param raster source raster to be sampled for reprojection.
+    * @param src source raster CRS
+    * @param dest target raster CRS
+    * @param target target raster that will be updated with pixels from source raster
+    * @param region polygon boundry of source raster in target CRS
+    * @param resampleMethod cell value resample method
+    */
+  def regionReprojectMutable(raster: Raster[T], src: CRS, dest: CRS, target: Raster[T], region: Polygon, resampleMethod: ResampleMethod): Raster[T]
 
+  @deprecated("Use regionReprojectMerge instead", "2.1")
+  def mutableRegionReproject(target: T, raster: Raster[T], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Unit = {
+    // method kept for binary compatibility only, relies on possible mutable side effects
+    regionReprojectMutable(raster, src, dest, Raster(target, rasterExtent.extent), region, resampleMethod)
+  }
 }
 
 object RasterRegionReproject {
@@ -109,27 +134,42 @@ object RasterRegionReproject {
 
   implicit val singlebandInstance = new RasterRegionReproject[Tile] {
     def regionReproject(raster: Raster[Tile], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Raster[Tile] = {
-      val buffer = raster.tile.prototype(rasterExtent.cols, rasterExtent.rows)
-      mutableRegionReproject(buffer, raster, src, dest, rasterExtent, region, resampleMethod)
+      val buffer = ArrayTile.empty(raster.tile.cellType, rasterExtent.cols, rasterExtent.rows)
+      reprojectToBuffer(raster, src, dest, buffer, rasterExtent, region, resampleMethod)
       Raster(buffer, rasterExtent.extent)
     }
 
-    def mutableRegionReproject(target: Tile, raster: Raster[Tile], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod) = {
-      val buffer = target.mutable
-      val trans = Proj4Transform(dest, src)
-      val resampler = Resample.apply(resampleMethod, raster.tile, raster.extent, CellSize(raster.rasterExtent.cellwidth, raster.rasterExtent.cellheight))
+    def regionReprojectMutable(
+      raster: Raster[Tile], 
+      src: CRS, 
+      dest: CRS, 
+      target: Raster[Tile], 
+      region: Polygon, 
+      resampleMethod: ResampleMethod
+    ): Raster[Tile] = {
+      val buffer: MutableArrayTile = target.tile.mutable
+      val bufferRE = target.rasterExtent
+      reprojectToBuffer(raster, src, dest, buffer, bufferRE, region, resampleMethod)
+      Raster(buffer, bufferRE.extent)
+    }
 
+    private def reprojectToBuffer(raster: Raster[Tile], src: CRS, dest: CRS, target: MutableArrayTile, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Unit = {
+      val trans = Proj4Transform(dest, src)
+      val resampler = Resample(resampleMethod, raster.tile, raster.extent, CellSize(raster.rasterExtent.cellwidth, raster.rasterExtent.cellheight))
       val rowcoords = rowCoords(region, rasterExtent, trans)
 
-      cfor(0)(_ < rasterExtent.rows, _ + 1){ i =>
-        val (pxs, xs, ys) = rowcoords(i)
-        if (raster.cellType.isFloatingPoint) {
-          cfor(0)(_ < xs.size, _ + 1){ s =>
-            buffer.setDouble(pxs(s), i, resampler.resampleDouble(xs(s), ys(s)))
+      if (raster.cellType.isFloatingPoint) {
+        cfor(0)(_ < rasterExtent.rows, _ + 1){ i =>
+          val (pxs, xs, ys) = rowcoords(i)
+          cfor(0)(_ < xs.size, _ + 1) { s =>
+            target.setDouble(pxs(s), i, resampler.resampleDouble(xs(s), ys(s)))
           }
-        } else {
-          cfor(0)(_ < xs.size, _ + 1){ s =>
-            buffer.set(pxs(s), i, resampler.resample(xs(s), ys(s)))
+        }
+      } else {
+        cfor(0)(_ < rasterExtent.rows, _ + 1){ i =>
+          val (pxs, xs, ys) = rowcoords(i)
+          cfor(0)(_ < xs.size, _ + 1) { s =>
+            target.set(pxs(s), i, resampler.resample(xs(s), ys(s)))
           }
         }
       }
@@ -137,46 +177,97 @@ object RasterRegionReproject {
   }
 
   implicit val multibandInstance = new RasterRegionReproject[MultibandTile] {
-    def regionReproject(raster: Raster[MultibandTile], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Raster[MultibandTile] = {
+    def regionReproject(
+      raster: Raster[MultibandTile], 
+      src: CRS, 
+      dest: CRS, 
+      rasterExtent: RasterExtent, 
+      region: Polygon, 
+      resampleMethod: ResampleMethod
+    ): Raster[MultibandTile] = {
       val bands = Array.ofDim[MutableArrayTile](raster.tile.bandCount)
       cfor(0)(_ < bands.length, _ + 1) { i =>
-        bands(i) = raster.tile.band(i).prototype(rasterExtent.cols, rasterExtent.rows).mutable
+        bands(i) = ArrayTile.empty(raster.tile.band(i).cellType, rasterExtent.cols, rasterExtent.rows)
       }
-      mutableRegionReproject(MultibandTile(bands), raster, src, dest, rasterExtent, region, resampleMethod)
+      reprojectToBuffer(raster, src, dest, bands, rasterExtent, region, resampleMethod)
       Raster(MultibandTile(bands), rasterExtent.extent)
     }
 
-    def mutableRegionReproject(target: MultibandTile, raster: Raster[MultibandTile], src: CRS, dest: CRS, rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod) = {
-      val trans = Proj4Transform(dest, src)
+    def regionReprojectMutable(
+      raster: Raster[MultibandTile], 
+      src: CRS, 
+      dest: CRS, 
+      target: Raster[MultibandTile], 
+      region: Polygon, 
+      resampleMethod: ResampleMethod
+    ): Raster[MultibandTile] = {
+      val bufferRE = target.rasterExtent
       val bands = Array.ofDim[MutableArrayTile](raster.tile.bandCount)
-
       cfor(0)(_ < bands.length, _ + 1) { i =>
-        bands(i) = target.band(i).mutable
+        bands(i) = target.tile.band(i).mutable
       }
 
-      val resampler = (0 until raster.tile.bandCount).map { i =>
-        Resample(resampleMethod, raster.tile.band(i), raster.extent, raster.rasterExtent.cellSize)
+      reprojectToBuffer(raster, src, dest, bands, bufferRE, region, resampleMethod)
+      Raster(MultibandTile(bands), bufferRE.extent)
+    }
+
+    private def reprojectToBuffer(raster: Raster[MultibandTile], src: CRS, dest: CRS, buffer: Array[MutableArrayTile], rasterExtent: RasterExtent, region: Polygon, resampleMethod: ResampleMethod): Unit = {
+      val trans = Proj4Transform(dest, src)
+      val rowcoords = rowCoords(region, rasterExtent, trans)
+      val resampler: Vector[Resample] = raster.tile.bands.map { band =>
+        Resample(resampleMethod, band, raster.extent, raster.rasterExtent.cellSize)
       }
 
       if (raster.cellType.isFloatingPoint) {
-        Rasterizer.foreachCellByPolygon(region, rasterExtent) { (px, py) =>
-          val (x, y) = rasterExtent.gridToMap(px, py)
-          val (tx, ty) = trans(x, y)
-          cfor(0)(_ < bands.length, _ + 1) { i =>
-            bands(i).setDouble(px, py, resampler(i).resampleDouble(tx, ty))
+        cfor(0)(_ < rasterExtent.rows, _ + 1){ i =>
+          val (pxs, xs, ys) = rowcoords(i)
+          cfor(0)(_ < xs.size, _ + 1) { s =>
+            cfor(0)(_ < buffer.length, _ + 1) { i =>
+              buffer(i).setDouble(pxs(s), i, resampler(i).resampleDouble(xs(s), ys(s)))
+            }
           }
         }
       } else {
-        Rasterizer.foreachCellByPolygon(region, rasterExtent) { (px, py) =>
-          val (x, y) = rasterExtent.gridToMap(px, py)
-          val (tx, ty) = trans(x, y)
-          cfor(0)(_ < bands.length, _ + 1) { i =>
-            bands(i).set(px, py, resampler(i).resample(tx, ty))
+        cfor(0)(_ < rasterExtent.rows, _ + 1){ i =>
+          val (pxs, xs, ys) = rowcoords(i)
+          cfor(0)(_ < xs.size, _ + 1) { s =>
+            cfor(0)(_ < buffer.length, _ + 1) { i =>
+              buffer(i).set(pxs(s), i, resampler(i).resample(xs(s), ys(s)))
+            }
           }
         }
       }
-
-      Raster(MultibandTile(bands), rasterExtent.extent)
     }
   }
+
+  implicit def TileFeatureRasterRegionReproject[T <: CellGrid : RasterRegionReproject, D: Monoid](implicit ev: T => TileMergeMethods[T]) = 
+    new RasterRegionReproject[TileFeature[T, D]] {
+      def regionReproject(
+        raster: Raster[TileFeature[T, D]], 
+        src: CRS, 
+        dest: CRS, 
+        rasterExtent: RasterExtent, 
+        region: Polygon, 
+        resampleMethod: ResampleMethod
+      ): Raster[TileFeature[T, D]] = {
+        val srcRaster: Raster[T] = raster.mapTile(_.tile)
+        val reprojected = implicitly[RasterRegionReproject[T]].regionReproject(srcRaster, src, dest, rasterExtent, region, resampleMethod)      
+        new Raster[TileFeature[T, D]](TileFeature(reprojected.tile, raster.tile.data), raster.extent)
+      }
+
+      def regionReprojectMutable(
+        raster: Raster[TileFeature[T, D]],
+        src: CRS,
+        dest: CRS,
+        target: Raster[TileFeature[T, D]],
+        region: Polygon,
+        resampleMethod: ResampleMethod
+      ): Raster[TileFeature[T, D]] = {  
+        val srcRaster: Raster[T] = raster.mapTile(_.tile)
+        val dstRaster: Raster[T] = target.mapTile(_.tile)
+        val reprojected: Raster[T] = implicitly[RasterRegionReproject[T]].regionReprojectMutable(srcRaster, src, dest, dstRaster, region, resampleMethod)
+        val mergedData = Monoid[D].combine(target.tile.data, raster.tile.data)
+        reprojected.mapTile(TileFeature(_, mergedData))        
+      }
+    } 
 }

--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
@@ -222,8 +222,8 @@ object RasterRegionReproject {
         cfor(0)(_ < rasterExtent.rows, _ + 1){ i =>
           val (pxs, xs, ys) = rowcoords(i)
           cfor(0)(_ < xs.size, _ + 1) { s =>
-            cfor(0)(_ < buffer.length, _ + 1) { i =>
-              buffer(i).setDouble(pxs(s), i, resampler(i).resampleDouble(xs(s), ys(s)))
+            cfor(0)(_ < buffer.length, _ + 1) { b =>
+              buffer(b).setDouble(pxs(s), i, resampler(b).resampleDouble(xs(s), ys(s)))
             }
           }
         }
@@ -231,8 +231,8 @@ object RasterRegionReproject {
         cfor(0)(_ < rasterExtent.rows, _ + 1){ i =>
           val (pxs, xs, ys) = rowcoords(i)
           cfor(0)(_ < xs.size, _ + 1) { s =>
-            cfor(0)(_ < buffer.length, _ + 1) { i =>
-              buffer(i).set(pxs(s), i, resampler(i).resample(xs(s), ys(s)))
+            cfor(0)(_ < buffer.length, _ + 1) { b =>
+              buffer(b).set(pxs(s), i, resampler(b).resample(xs(s), ys(s)))
             }
           }
         }

--- a/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
+++ b/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
@@ -107,6 +107,17 @@ object Stitcher {
     }
   }
 
+  implicit def tileFeatureStitcher[
+    T <: CellGrid: Stitcher, 
+    D: Semigroup
+  ]: Stitcher[TileFeature[T, D]] = new Stitcher[TileFeature[T, D]] {
+    def stitch(pieces: Iterable[(TileFeature[T, D], (Int, Int))], cols: Int, rows: Int): TileFeature[T, D] = {
+      val newPieces = pieces.map{ piece ⇒ (piece._1.tile, piece._2) }
+      val newData = pieces.map(_._1.data).reduce(Semigroup[D].combine)
+      TileFeature(implicitly[Stitcher[T]].stitch(newPieces, cols, rows), newData)
+    }
+  }
+
   implicit class TileFeatureStitcher[
     T <: CellGrid: Stitcher,
     D : Semigroup

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -192,11 +192,14 @@ object TileRDDReproject {
         val (raster, destRE, destRegion) = tup
         rrp.regionReproject(raster, crs, destCrs, destRE, destRegion, rasterReprojectOptions.method).tile
       }
+    
     def mergeValues(reprojectedTile: V, toReproject: (Raster[V], RasterExtent, Polygon)) = {
       val (raster, destRE, destRegion) = toReproject
-      rrp.mutableRegionReproject(reprojectedTile, raster, crs, destCrs, destRE, destRegion, rasterReprojectOptions.method)
-      reprojectedTile
+      val destRaster = Raster(reprojectedTile, destRE.extent)
+      // RDD.combineByKey contract allows us to safely re-use and mutate the accumulator, reprojectedTile
+      rrp.regionReprojectMutable(raster, crs, destCrs, destRaster, destRegion, rasterReprojectOptions.method).tile
     }
+
     def mergeCombiners(reproj1: V, reproj2: V) = reproj1.merge(reproj2)
 
     val tiled: RDD[(K, V)] =

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -190,14 +190,14 @@ object TileRDDReproject {
 
     def createCombiner(tup: (Raster[V], RasterExtent, Polygon)) = {
         val (raster, destRE, destRegion) = tup
-        rrp.regionReproject(raster, crs, destCrs, destRE, destRegion, rasterReprojectOptions.method).tile
+        rrp.regionReproject(raster, crs, destCrs, destRE, destRegion, rasterReprojectOptions.method, rasterReprojectOptions.errorThreshold).tile
       }
     
     def mergeValues(reprojectedTile: V, toReproject: (Raster[V], RasterExtent, Polygon)) = {
       val (raster, destRE, destRegion) = toReproject
       val destRaster = Raster(reprojectedTile, destRE.extent)
       // RDD.combineByKey contract allows us to safely re-use and mutate the accumulator, reprojectedTile
-      rrp.regionReprojectMutable(raster, crs, destCrs, destRaster, destRegion, rasterReprojectOptions.method).tile
+      rrp.regionReprojectMutable(raster, crs, destCrs, destRaster, destRegion, rasterReprojectOptions.method, rasterReprojectOptions.errorThreshold).tile
     }
 
     def mergeCombiners(reproj1: V, reproj2: V) = reproj1.merge(reproj2)


### PR DESCRIPTION
Closes https://github.com/locationtech/geotrellis/issues/2799

Mostly this PR reworks the `RasterRegionReproject` to allow composition of instances such that reprojection of `TileFeature` RDD could be supported. Adding a unit test for this revealed another missing implicit which is added here.

The mutability remains an important optimization specifically in the RDD case where it allows using a tile as an accumulator when multiple source tiles contribute pixels during the reproject operation without allocating memory for each intermediate result. Hopefully expanded documentation is enough to steer users in the right direction and use this feature responsibly.

- Changes `RasterRegionReproject` to allow creating an instance for `TileFeature[T, D]`
- Uses optimized reproject logic in `RasterRegionReproject[MultibandTile]` instance
- Expands scala docs to highlight and explain mutability
- Adds `Stitcher[TileFeature[T, D]]` instance
- Add `errorThreshold` argument from `Reproject.Options` to `RasterRegionReproject` 
- Use `errorThreshold` in `TileRDDReproject`

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [-] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature
