### PR TITLE
Add SparkSession into TestEnvironment

### DIFF
--- a/accumulo/build.sbt
+++ b/accumulo/build.sbt
@@ -7,7 +7,8 @@ libraryDependencies ++= Seq(
     exclude("org.apache.hadoop", "hadoop-client"),
   sparkCore % Provided,
   spire,
-  scalatest % Test
+  scalatest % Test,
+  sparkSQL % Test
 )
 
 fork in Test := false

--- a/cassandra/build.sbt
+++ b/cassandra/build.sbt
@@ -9,7 +9,8 @@ libraryDependencies ++= Seq(
     ) exclude("org.apache.hadoop", "hadoop-client"),
   sparkCore % Provided,
   spire,
-  scalatest % Test
+  scalatest % Test,
+  sparkSQL % Test
 )
 
 fork in Test := false

--- a/geomesa/build.sbt
+++ b/geomesa/build.sbt
@@ -8,7 +8,8 @@ libraryDependencies ++= Seq(
   "org.locationtech.geomesa" %% "geomesa-utils" % Version.geomesa,
   sparkCore % Provided,
   spire,
-  scalatest % Test
+  scalatest % Test,
+  sparkSQL % Test
 )
 
 resolvers ++= Seq(

--- a/geowave/build.sbt
+++ b/geowave/build.sbt
@@ -43,7 +43,8 @@ libraryDependencies ++= Seq(
   "com.esotericsoftware" % "kryo-shaded" % "3.0.3",
   sparkCore % Provided,
   spire,
-  scalatest % Test
+  scalatest % Test,
+  sparkSQL % Test
 )
 
 resolvers ++= Seq(

--- a/hbase/build.sbt
+++ b/hbase/build.sbt
@@ -12,7 +12,8 @@ libraryDependencies ++= Seq(
   "org.codehaus.jackson"  % "jackson-core-asl" % "1.9.13",
   sparkCore % Provided,
   spire,
-  scalatest % Test
+  scalatest % Test,
+  sparkSQL % Test
 )
 
 fork in Test := false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,6 +46,7 @@ object Dependencies {
   val fs2Io               = "co.fs2"                     %% "fs2-io"                   % "0.10.4"
 
   val sparkCore           = "org.apache.spark"           %% "spark-core"               % Version.spark
+  val sparkSQL            = "org.apache.spark"           %% "spark-sql"                % Version.spark
   val hadoopClient        = "org.apache.hadoop"           % "hadoop-client"            % Version.hadoop
 
   val avro                = "org.apache.avro"             % "avro"                     % "1.8.2"

--- a/s3/build.sbt
+++ b/s3/build.sbt
@@ -6,7 +6,8 @@ libraryDependencies ++= Seq(
   awsSdkS3,
   spire,
   scaffeine,
-  scalatest % Test
+  scalatest % Test,
+  sparkSQL % Test
 )
 
 fork in Test := false

--- a/spark-etl/build.sbt
+++ b/spark-etl/build.sbt
@@ -4,7 +4,8 @@ name := "geotrellis-spark-etl"
 libraryDependencies ++= Seq(
   jsonSchemaValidator,
   sparkCore % Provided,
-  scalatest % Test
+  scalatest % Test,
+  sparkSQL % Test
 )
 
 test in assembly := {}

--- a/spark-pipeline/build.sbt
+++ b/spark-pipeline/build.sbt
@@ -7,7 +7,8 @@ libraryDependencies ++= Seq(
   circeGenericExtras,
   circeParser,
   sparkCore % Provided,
-  scalatest % Test
+  scalatest % Test,
+  sparkSQL % Test
 )
 
 test in assembly := {}

--- a/spark-testkit/build.sbt
+++ b/spark-testkit/build.sbt
@@ -3,7 +3,8 @@ import Dependencies._
 name := "geotrellis-spark-testkit"
 
 libraryDependencies ++= Seq(
-  sparkCore % Provided ,
+  sparkCore % Provided,
+  sparkSQL % Provided,
   hadoopClient % Provided,
   scalatest,
   chronoscala

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/TestEnvironment.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/TestEnvironment.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FileUtil
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.serializer.KryoSerializer
 import org.scalatest._
 import org.scalatest.BeforeAndAfterAll
@@ -63,7 +64,7 @@ trait TestEnvironment extends BeforeAndAfterAll
   def setKryoRegistrator(conf: SparkConf): Unit =
     conf.set("spark.kryo.registrator", classOf[KryoRegistrator].getName)
 
-  lazy val _sc: SparkContext = {
+  lazy val _ssc: SparkSession = {
     System.setProperty("spark.driver.port", "0")
     System.setProperty("spark.hostPort", "0")
     System.setProperty("spark.ui.enabled", "false")
@@ -84,7 +85,7 @@ trait TestEnvironment extends BeforeAndAfterAll
       setKryoRegistrator(conf)
     }
 
-    val sparkContext = new SparkContext(conf)
+    val sparkContext = SparkSession.builder().config(conf).getOrCreate()
 
     System.clearProperty("spark.driver.port")
     System.clearProperty("spark.hostPort")
@@ -93,6 +94,9 @@ trait TestEnvironment extends BeforeAndAfterAll
     sparkContext
   }
 
+  lazy val _sc: SparkContext = _ssc.sparkContext
+
+  implicit def ssc: SparkSession = _ssc
   implicit def sc: SparkContext = _sc
 
   // get the name of the class which mixes in this trait

--- a/spark/build.sbt
+++ b/spark/build.sbt
@@ -16,7 +16,8 @@ libraryDependencies ++= Seq(
   fs2Io,
   scalatest % Test,
   logging,
-  scaffeine
+  scaffeine,
+  sparkSQL % Test
 )
 
 mimaPreviousArtifacts := Set(


### PR DESCRIPTION
## Overview

This PR adds spark-sql dependency into `spark-testkit` project and modifies `TestEnvironment` trait to contain `SparkSession`

A new dependency doesn't really hurt as, as it is a dependency into a test sub project.

Closes https://github.com/locationtech/geotrellis/issues/2498
