### PR TITLE
Fix Inverted Extent

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -446,7 +446,13 @@ case class TiffTags(
           i += 1
         }
 
-        Extent(minX, minY, maxX, maxY)
+        // fix an inverted extent, to behave more like GDAL
+        Extent(
+          math.min(minX, maxX),
+          math.min(minY, maxY),
+          math.max(minX, maxX),
+          math.max(minY, maxY)
+        )
     }
 
   private def getExtentFromModelFunction(func: Pixel3D => Pixel3D) = {


### PR DESCRIPTION
## Overview

This PR allows to handle properly such kinds of Extents:

```
Corner Coordinates:
Upper Left  (    0.0,    0.0)
Lower Left  (    0.0,13545.0)
Upper Right (21995.0,    0.0)
Lower Right (21995.0,13545.0)
Center      (10997.5, 6772.5)
```

Closes https://github.com/locationtech/geotrellis/issues/2805
