### PR TITLE
Use Timer as necessary for IO

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,11 +39,11 @@ object Dependencies {
 
   val awsSdkS3            = "com.amazonaws"               % "aws-java-sdk-s3"          % "1.11.319"
 
-  val catsCore            = "org.typelevel"              %% "cats-core"                % "1.3.1"
+  val catsCore            = "org.typelevel"              %% "cats-core"                % "1.4.0"
   val catsEffect          = "org.typelevel"              %% "cats-effect"              % "1.0.0"
 
-  val fs2Core             = "co.fs2"                     %% "fs2-core"                 % "1.0.0-RC2"
-  val fs2Io               = "co.fs2"                     %% "fs2-io"                   % "1.0.0-RC2"
+  val fs2Core             = "co.fs2"                     %% "fs2-core"                 % "1.0.0"
+  val fs2Io               = "co.fs2"                     %% "fs2-io"                   % "1.0.0"
 
   val sparkCore           = "org.apache.spark"           %% "spark-core"               % Version.spark
   val sparkSQL            = "org.apache.spark"           %% "spark-sql"                % Version.spark

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,11 +39,11 @@ object Dependencies {
 
   val awsSdkS3            = "com.amazonaws"               % "aws-java-sdk-s3"          % "1.11.319"
 
-  val catsCore            = "org.typelevel"              %% "cats-core"                % "1.1.0"
-  val catsEffect          = "org.typelevel"              %% "cats-effect"              % "0.10.1"
+  val catsCore            = "org.typelevel"              %% "cats-core"                % "1.3.1"
+  val catsEffect          = "org.typelevel"              %% "cats-effect"              % "1.0.0"
 
-  val fs2Core             = "co.fs2"                     %% "fs2-core"                 % "0.10.4"
-  val fs2Io               = "co.fs2"                     %% "fs2-io"                   % "0.10.4"
+  val fs2Core             = "co.fs2"                     %% "fs2-core"                 % "1.0.0-RC2"
+  val fs2Io               = "co.fs2"                     %% "fs2-io"                   % "1.0.0-RC2"
 
   val sparkCore           = "org.apache.spark"           %% "spark-core"               % Version.spark
   val sparkSQL            = "org.apache.spark"           %% "spark-sql"                % Version.spark

--- a/spark/src/main/scala/geotrellis/spark/io/LayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/LayerReader.scala
@@ -22,7 +22,7 @@ import geotrellis.util._
 
 import org.apache.spark.rdd._
 import org.apache.spark.SparkContext
-import cats.effect.IO
+import cats.effect.{IO, Timer}
 import cats.syntax.apply._
 import spray.json._
 
@@ -111,7 +111,10 @@ object LayerReader {
     import geotrellis.spark.util.TaskUtils._
 
     val pool = Executors.newFixedThreadPool(threads)
+    // TODO: remove the implicit on ec and consider moving the implicit timer to method signature
     implicit val ec = ExecutionContext.fromExecutor(pool)
+    implicit val timer: Timer[IO] = IO.timer(ec)
+    implicit val cs = IO.contextShift(ec)
 
     val indices: Iterator[BigInt] = ranges.flatMap { case (start, end) =>
       (start to end).toIterator
@@ -124,11 +127,13 @@ object LayerReader {
     }
 
     try {
-      (index map readRecord)
-        .join(threads)
+      index
+        .map(readRecord)
+        .parJoin(threads)
         .compile
         .toVector
-        .unsafeRunSync.flatten
+        .unsafeRunSync
+        .flatten
     } finally pool.shutdown()
   }
 }


### PR DESCRIPTION
This brings cats-effect to 1.0, which should be faster and have a more stable API going forward.