### PR TITLE
Use sun.misc.IOUtils.readFully

### DIFF
--- a/s3-testkit/src/main/scala/geotrellis/spark/io/s3/testkit/MockS3Client.scala
+++ b/s3-testkit/src/main/scala/geotrellis/spark/io/s3/testkit/MockS3Client.scala
@@ -20,7 +20,6 @@ import geotrellis.spark.io.s3._
 import geotrellis.util.LazyLogging
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.internal.AmazonS3ExceptionBuilder
-import org.apache.commons.io.IOUtils
 import java.io.ByteArrayInputStream
 import java.util.concurrent.ConcurrentHashMap
 
@@ -133,7 +132,7 @@ class MockS3Client() extends S3Client with LazyLogging {
     val obj = getObject(getObjectRequest)
     val inStream = obj.getObjectContent
     try {
-      IOUtils.toByteArray(inStream)
+      sun.misc.IOUtils.readFully((inStream, -1, true)
     } finally {
       inStream.close()
     }
@@ -158,7 +157,7 @@ class MockS3Client() extends S3Client with LazyLogging {
     logger.debug(s"PUT ${r.getKey}")
     val bucket = getBucket(r.getBucketName)
     bucket.synchronized {
-      bucket.put(r.getKey, IOUtils.toByteArray(r.getInputStream))
+      bucket.put(r.getKey, sun.misc.IOUtils.readFully(r.getInputStream, -1, true))
     }
     new PutObjectResult()
   }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/AmazonS3Client.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/AmazonS3Client.scala
@@ -20,7 +20,6 @@ import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth._
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.s3.model._
-import org.apache.commons.io.IOUtils
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -96,7 +95,7 @@ class AmazonS3Client(s3client: AmazonS3) extends S3Client {
     val obj = s3client.getObject(getObjectRequest)
     val inStream = obj.getObjectContent
     try {
-      IOUtils.toByteArray(inStream)
+      sun.misc.IOUtils.readFully(inStream, -1, true)
     } finally {
       inStream.close()
     }
@@ -107,7 +106,7 @@ class AmazonS3Client(s3client: AmazonS3) extends S3Client {
     val obj = s3client.getObject(getObjectRequest)
     val stream = obj.getObjectContent
     try {
-      IOUtils.toByteArray(stream)
+      sun.misc.IOUtils.readFully(stream, -1, true)
     } finally {
       stream.close()
     }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3CollectionReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3CollectionReader.scala
@@ -25,7 +25,6 @@ import geotrellis.spark.io.s3.conf.S3Config
 
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.apache.avro.Schema
-import org.apache.commons.io.IOUtils
 
 trait S3CollectionReader {
 
@@ -55,7 +54,7 @@ trait S3CollectionReader {
 
     LayerReader.njoin[K, V](ranges.toIterator, threads){ index: BigInt =>
       try {
-        val bytes = IOUtils.toByteArray(s3client.getObject(bucket, keyPath(index)).getObjectContent)
+        val bytes = sun.misc.IOUtils.readFully(s3client.getObject(bucket, keyPath(index)).getObjectContent)
         val recs = AvroEncoder.fromBinary(writerSchema.getOrElse(recordCodec.schema), bytes)(recordCodec)
         if (filterIndexOnly) recs
         else recs.filter { row => queryKeyBounds.includeKey(row._1) }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3RDDReader.scala
@@ -26,7 +26,6 @@ import geotrellis.spark.util.KryoWrapper
 
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.apache.avro.Schema
-import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -69,7 +68,7 @@ trait S3RDDReader {
         partition flatMap { seq =>
           LayerReader.njoinEBO[K, V](seq.toIterator, threads)({ index: BigInt =>
             try {
-              val bytes = IOUtils.toByteArray(s3client.getObject(bucket, keyPath(index)).getObjectContent)
+              val bytes = sun.misc.IOUtils.readFully(s3client.getObject(bucket, keyPath(index)).getObjectContent, -1, true)
               val recs = AvroEncoder.fromBinary(writerSchema, bytes)(_recordCodec)
               if (filterIndexOnly) recs
               else recs.filter { row => includeKey(row._1) }

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3RDDWriter.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3RDDWriter.scala
@@ -26,7 +26,6 @@ import cats.effect.{IO, Timer}
 import cats.syntax.apply._
 import com.amazonaws.services.s3.model.{AmazonS3Exception, ObjectMetadata, PutObjectRequest, PutObjectResult}
 import org.apache.avro.Schema
-import org.apache.commons.io.IOUtils
 import org.apache.spark.rdd.RDD
 
 import java.io.ByteArrayInputStream
@@ -98,7 +97,7 @@ trait S3RDDWriter {
             val (key, current) = row
             val updated = LayerWriter.updateRecords(mergeFunc, current, existing = {
               try {
-                val bytes = IOUtils.toByteArray(s3client.getObject(bucket, key).getObjectContent)
+                val bytes = sun.misc.IOUtils.readFully(s3client.getObject(bucket, key).getObjectContent, -1, true)
                 AvroEncoder.fromBinary(schema, bytes)(_recordCodec)
               } catch {
                 case e: AmazonS3Exception if e.getStatusCode == 404 => Vector.empty

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3RecordReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3RecordReader.scala
@@ -22,7 +22,6 @@ import geotrellis.util._
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.services.s3.model.GetObjectRequest
 import org.apache.hadoop.mapreduce.{InputSplit, TaskAttemptContext, RecordReader}
-import org.apache.commons.io.IOUtils
 
 /** This is the base class for readers that will create key value pairs for object requests.
   * Subclass must extend [readObjectRequest] method to map from S3 object requests to (K,V) */
@@ -73,7 +72,7 @@ abstract class S3RecordReader[K, V](s3Client: S3Client) extends BaseS3RecordRead
   def readObjectRequest(objectRequest: GetObjectRequest): (K, V) = {
     val obj = s3Client.getObject(objectRequest)
     val inStream = obj.getObjectContent
-    val objectData = IOUtils.toByteArray(inStream)
+    val objectData = sun.misc.IOUtils.readFully(inStream, -1, true)
     inStream.close()
 
     read(objectRequest.getKey, objectData)

--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3ValueReader.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3ValueReader.scala
@@ -26,7 +26,6 @@ import geotrellis.spark.io.index._
 
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.apache.avro.Schema
-import org.apache.commons.io.IOUtils
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -56,7 +55,7 @@ class S3ValueReader(
             throw new ValueNotFoundError(key, layerId)
         }
 
-      val bytes = IOUtils.toByteArray(is)
+      val bytes = sun.misc.IOUtils.readFully(is, -1, true)
       val recs = AvroEncoder.fromBinary(writerSchema, bytes)(KeyValueRecordCodec[K, V])
 
       recs

--- a/s3/src/test/scala/geotrellis/spark/io/s3/util/S3RangeReaderSpec.scala
+++ b/s3/src/test/scala/geotrellis/spark/io/s3/util/S3RangeReaderSpec.scala
@@ -24,7 +24,6 @@ import geotrellis.spark.io.s3.testkit._
 import spire.syntax.cfor._
 
 import com.amazonaws.services.s3.model._
-import org.apache.commons.io.IOUtils
 
 import org.scalatest._
 

--- a/spark/src/main/scala/geotrellis/spark/io/avro/AvroEncoder.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/avro/AvroEncoder.scala
@@ -21,7 +21,6 @@ import java.util.zip.{InflaterInputStream, DeflaterOutputStream, Deflater}
 import org.apache.avro.generic._
 import org.apache.avro.io._
 import org.apache.avro._
-import org.apache.commons.io.IOUtils
 import org.apache.commons.io.output.ByteArrayOutputStream
 
 object AvroEncoder {
@@ -42,7 +41,7 @@ object AvroEncoder {
     val deflater = new java.util.zip.Inflater()
     val bytesIn = new ByteArrayInputStream(bytes)
     val in = new InflaterInputStream(bytesIn, deflater)
-    IOUtils.toByteArray(in)
+    sun.misc.IOUtils.readFully(in, -1, true)
   }
 
   def toBinary[T: AvroRecordCodec](thing: T): Array[Byte] =

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopGeoTiffReader.scala
@@ -20,7 +20,6 @@ import geotrellis.raster.io.geotiff.reader._
 import geotrellis.raster.io.geotiff.{MultibandGeoTiff, SinglebandGeoTiff}
 import geotrellis.vector.Extent
 
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
@@ -29,7 +28,7 @@ object HadoopGeoTiffReader {
   def readSingleband(path: Path)(implicit sc: SparkContext): SinglebandGeoTiff = readSingleband(path, streaming = false, None, sc.hadoopConfiguration)
   def readSingleband(path: Path, streaming: Boolean, extent: Option[Extent], conf: Configuration): SinglebandGeoTiff =
     HdfsUtils.read(path, conf) { is =>
-      val geoTiff = GeoTiffReader.readSingleband(IOUtils.toByteArray(is), streaming)
+      val geoTiff = GeoTiffReader.readSingleband(sun.misc.IOUtils.readFully(is, -1, true), streaming)
       extent match {
         case Some(e) => geoTiff.crop(e)
         case _ => geoTiff
@@ -39,7 +38,7 @@ object HadoopGeoTiffReader {
   def readMultiband(path: Path)(implicit sc: SparkContext): MultibandGeoTiff = readMultiband(path, streaming = false, None, sc.hadoopConfiguration)
   def readMultiband(path: Path, streaming: Boolean, extent: Option[Extent], conf: Configuration): MultibandGeoTiff =
     HdfsUtils.read(path, conf) { is =>
-      val geoTiff = GeoTiffReader.readMultiband(IOUtils.toByteArray(is), streaming)
+      val geoTiff = GeoTiffReader.readMultiband(sun.misc.IOUtils.readFully(is, -1, true), streaming)
       extent match {
         case Some(e) => geoTiff.crop(e)
         case _ => geoTiff

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopJpgReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopJpgReader.scala
@@ -18,12 +18,13 @@ package geotrellis.spark.io.hadoop
 
 import geotrellis.raster.render.Jpg
 
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 
 object HadoopJpgReader {
-  def read(path: Path)(implicit sc: SparkContext): Jpg = read(path, sc.hadoopConfiguration)
-  def read(path: Path, conf: Configuration): Jpg = HdfsUtils.read(path, conf) { is => Jpg(IOUtils.toByteArray(is)) }
+  def read(path: Path)(implicit sc: SparkContext): Jpg =
+    read(path, sc.hadoopConfiguration)
+  def read(path: Path, conf: Configuration): Jpg =
+    HdfsUtils.read(path, conf) { is => Jpg(sun.misc.IOUtils.readFully(is, -1, true)) }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopPngReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopPngReader.scala
@@ -17,12 +17,14 @@
 package geotrellis.spark.io.hadoop
 
 import geotrellis.raster.render.Png
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 
 object HadoopPngReader {
-  def read(path: Path)(implicit sc: SparkContext): Png = read(path, sc.hadoopConfiguration)
-  def read(path: Path, conf: Configuration): Png = HdfsUtils.read(path, conf) { is => Png(IOUtils.toByteArray(is)) }
+  def read(path: Path)(implicit sc: SparkContext): Png =
+    read(path, sc.hadoopConfiguration)
+
+  def read(path: Path, conf: Configuration): Png =
+    HdfsUtils.read(path, conf) { is => Png(sun.misc.IOUtils.readFully(is, -1, true)) }
 }

--- a/spark/src/main/scala/geotrellis/spark/io/slippy/HttpSlippyTileReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/slippy/HttpSlippyTileReader.scala
@@ -22,7 +22,6 @@ import geotrellis.spark._
 import geotrellis.spark.io.slippy._
 import geotrellis.vector._
 
-import org.apache.commons.io.IOUtils._
 import org.apache.spark._
 import org.apache.spark.rdd._
 

--- a/spark/src/test/scala/geotrellis/spark/io/http/util/HttpRangeReaderSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/http/util/HttpRangeReaderSpec.scala
@@ -20,9 +20,6 @@ import java.nio.file.{ Paths, Files }
 import java.nio.ByteBuffer
 import geotrellis.util._
 import spire.syntax.cfor._
-
-import org.apache.commons.io.IOUtils
-
 import org.scalatest._
 
 /** These tests require running the container defined in scripts/nginxTestHttp.sh */

--- a/spark/src/test/scala/geotrellis/spark/render/SaveImagesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/render/SaveImagesSpec.scala
@@ -27,7 +27,6 @@ import geotrellis.spark.testkit._
 import org.scalatest._
 import org.apache.hadoop.fs._
 import org.apache.hadoop.conf._
-import org.apache.commons.io.IOUtils
 import java.net.URI
 
 class SaveImagesSpec extends FunSpec with TestEnvironment {
@@ -35,7 +34,7 @@ class SaveImagesSpec extends FunSpec with TestEnvironment {
   val tmpdir = System.getProperty("java.io.tmpdir")
   val fs = FileSystem.get(new URI(tmpdir), new Configuration)
   def readFile(path: String): Array[Byte] = {
-    IOUtils.toByteArray(fs.open(new Path(path)))
+    sun.misc.IOUtils.readFully(fs.open(new Path(path)), -1, true)
   }
 
   describe("Saving of Rendered Tiles to Hadoop") {


### PR DESCRIPTION
A more performant way to turn `InputStream` to `Array[Byte]` that minimizes use of a transient dependency `commons-io` which we're picking up from one of the `hadoop` packages.