### PR TITLE
Bump Spark version up to 2.4

### DIFF
--- a/.travis/build-set-1.sh
+++ b/.travis/build-set-1.sh
@@ -5,9 +5,9 @@
   "project geotools" test \
   "project shapefile" test \
   "project vector" test \
-  "project vectortile" test || { exit 1; }
-  # "project slick" test \
-  # "project geowave" compile test:compile \
-  # "project hbase" test \
-  # "project geomesa" test \
-  # "project cassandra" test || { exit 1; }
+  "project vectortile" test \
+  "project hbase" test \
+  "project cassandra" test || { exit 1; }
+  # "project slick" test
+  # "project geomesa" test
+  # "project geowave" compile test:compile

--- a/.travis/build-set-2.sh
+++ b/.travis/build-set-2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ./sbt "++$TRAVIS_SCALA_VERSION" \
-  "project raster" test || { exit 1; }
-  # "project accumulo" test \
-  # "project s3" test \
-  # "project s3-testkit" test || { exit 1; }
+  "project raster" test \
+  "project accumulo" test \
+  "project s3" test \
+  "project s3-testkit" test || { exit 1; }

--- a/.travis/build-set-3.sh
+++ b/.travis/build-set-3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# ./sbt "++$TRAVIS_SCALA_VERSION" \
-#   "project spark" test \
-#   "project spark-pipeline" test \
-#   "project spark-etl" test || { exit 1; }
+./sbt "++$TRAVIS_SCALA_VERSION" \
+  "project spark" test \
+  "project spark-pipeline" test \
+  "project spark-etl" test || { exit 1; }

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ scalaVersion in ThisBuild := Version.scala
 lazy val commonSettings = Seq(
   version := Version.geotrellis,
   scalaVersion := Version.scala,
+  crossScalaVersions := Version.crossScala,
   description := Info.description,
   organization := "org.locationtech.geotrellis",
   licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -141,19 +142,16 @@ lazy val root = Project("geotrellis", file(".")).
 lazy val macros = project
   .settings(commonSettings)
   .settings(Settings.macros)
-  .settings(crossScalaVersions := Version.crossScala)
 
 lazy val vectortile = project
   .dependsOn(vector)
   .settings(commonSettings)
   .settings(Settings.vectortile)
-  .settings(crossScalaVersions := Version.crossScala)
 
 lazy val vector = project
   .dependsOn(proj4, util)
   .settings(commonSettings)
   .settings(Settings.vector)
-  .settings(crossScalaVersions := Version.crossScala)
   .settings(
     unmanagedClasspath in Test ++= (fullClasspath in (LocalProject("vector-testkit"), Compile)).value
   )
@@ -162,19 +160,16 @@ lazy val `vector-testkit` = project
   .dependsOn(raster % Provided, vector % Provided)
   .settings(commonSettings)
   .settings(Settings.`vector-testkit`)
-  .settings(crossScalaVersions := Version.crossScala)
 
 lazy val proj4 = project
   .settings(commonSettings)
   .settings(Settings.proj4)
-  .settings(crossScalaVersions := Version.crossScala)
   .settings(javacOptions ++= Seq("-encoding", "UTF-8"))
 
 lazy val raster = project
   .dependsOn(util, macros, vector)
   .settings(commonSettings)
   .settings(Settings.raster)
-  .settings(crossScalaVersions := Version.crossScala)
   .settings(
     unmanagedClasspath in Test ++= (fullClasspath in (LocalProject("raster-testkit"), Compile)).value
   )
@@ -186,12 +181,12 @@ lazy val `raster-testkit` = project
   .dependsOn(raster % Provided, vector % Provided)
   .settings(commonSettings)
   .settings(Settings.`raster-testkit`)
-  .settings(crossScalaVersions := Version.crossScala)
 
 lazy val slick = project
   .dependsOn(vector)
   .settings(commonSettings)
   .settings(Settings.slick)
+  .settings(crossScalaVersions := Seq(scalaVersion.value))
 
 lazy val spark = project
   .dependsOn(util, raster, `raster-testkit` % Test, `vector-testkit` % Test)
@@ -266,7 +261,6 @@ lazy val geotools = project
   )
   .settings(commonSettings)
   .settings(Settings.geotools)
-  .settings(crossScalaVersions := Version.crossScala)
 
 lazy val geomesa = project
   .dependsOn(`spark-testkit` % Test, spark, geotools, accumulo)
@@ -287,12 +281,10 @@ lazy val shapefile = project
   .dependsOn(raster, `raster-testkit` % Test)
   .settings(commonSettings)
   .settings(Settings.shapefile)
-  .settings(crossScalaVersions := Version.crossScala)
 
 lazy val util = project
   .settings(commonSettings)
   .settings(Settings.util)
-  .settings(crossScalaVersions := Version.crossScala)
 
 lazy val `doc-examples` = project
   .dependsOn(spark, s3, accumulo, cassandra, hbase, spark, `spark-testkit`, `spark-pipeline`)

--- a/project/Environment.scala
+++ b/project/Environment.scala
@@ -21,6 +21,6 @@ object Environment {
     Properties.envOrElse(environmentVariable, default)
 
   lazy val hadoopVersion  = either("SPARK_HADOOP_VERSION", "2.8.3")
-  lazy val sparkVersion   = either("SPARK_VERSION", "2.3.0")
+  lazy val sparkVersion   = either("SPARK_VERSION", "2.4.0")
   lazy val versionSuffix  = either("GEOTRELLIS_VERSION_SUFFIX", "-SNAPSHOT")
 }


### PR DESCRIPTION
## Overview

This PR updates Apache Spark dependency.

The following projects are excluded from the 2.12 builds: 

* Slick (as it's deprecated, and requires some code changes to make it work)
* GeoMesa (as it doesn't support Scala 2.12)
* GeoWave (as it doesn't support Scala 2.12)

Closes #1751
