### PR TITLE
Fix error in `ReprojectRasterExtent`

### DIFF
--- a/.locationtech/deploy-211.sh
+++ b/.locationtech/deploy-211.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+ set -e
+ set -x
+
+ ./sbt "project macros" publish -no-colors \
+   && ./sbt "project vector" publish -no-colors \
+   && ./sbt "project proj4" publish -no-colors \
+   && ./sbt "project raster" publish -no-colors \
+   && ./sbt "project spark" publish -no-colors \
+   && ./sbt "project s3" publish -no-colors \
+   && ./sbt "project accumulo" publish -no-colors \
+   && ./sbt "project cassandra" publish -no-colors \
+   && ./sbt "project hbase" publish -no-colors \
+   && ./sbt "project spark-etl" publish -no-colors \
+   && ./sbt "project geomesa" publish -no-colors \
+   && ./sbt "project geotools" publish -no-colors \
+   && ./sbt "project shapefile" publish -no-colors \
+   && ./sbt "project slick" publish -no-colors \
+   && ./sbt "project util" publish -no-colors \
+   && ./sbt "project vectortile" publish -no-colors \
+   && ./sbt "project raster-testkit" publish -no-colors \
+   && ./sbt "project vector-testkit" publish -no-colors \
+   && ./sbt "project spark-testkit" publish -no-colors \
+   && ./sbt "project s3-testkit" publish -no-colors

--- a/.locationtech/deploy-212.sh
+++ b/.locationtech/deploy-212.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+ set -e
+ set -x
+
+ # there is no geomesa and slick projects
+ ./sbt -212 "project macros" publish -no-colors \
+   && ./sbt -212 "project vector" publish -no-colors \
+   && ./sbt -212 "project proj4" publish -no-colors \
+   && ./sbt -212 "project raster" publish -no-colors \
+   && ./sbt -212 "project spark" publish -no-colors \
+   && ./sbt -212 "project s3" publish -no-colors \
+   && ./sbt -212 "project accumulo" publish -no-colors \
+   && ./sbt -212 "project cassandra" publish -no-colors \
+   && ./sbt -212 "project hbase" publish -no-colors \
+   && ./sbt -212 "project spark-etl" publish -no-colors \
+   && ./sbt -212 "project geotools" publish -no-colors \
+   && ./sbt -212 "project shapefile" publish -no-colors \
+   && ./sbt -212 "project util" publish -no-colors \
+   && ./sbt -212 "project vectortile" publish -no-colors \
+   && ./sbt -212 "project raster-testkit" publish -no-colors \
+   && ./sbt -212 "project vector-testkit" publish -no-colors \
+   && ./sbt -212 "project spark-testkit" publish -no-colors \
+   && ./sbt -212 "project s3-testkit" publish -no-colors

--- a/.locationtech/deploy.sh
+++ b/.locationtech/deploy.sh
@@ -3,23 +3,4 @@
  set -e
  set -x
 
- ./sbt "project macros" publish -no-colors \
-   && ./sbt "project vector" publish -no-colors \
-   && ./sbt "project proj4" publish -no-colors \
-   && ./sbt "project raster" publish -no-colors \
-   && ./sbt "project spark" publish -no-colors \
-   && ./sbt "project s3" publish -no-colors \
-   && ./sbt "project accumulo" publish -no-colors \
-   && ./sbt "project cassandra" publish -no-colors \
-   && ./sbt "project hbase" publish -no-colors \
-   && ./sbt "project spark-etl" publish -no-colors \
-   && ./sbt "project geomesa" publish -no-colors \
-   && ./sbt "project geotools" publish -no-colors \
-   && ./sbt "project shapefile" publish -no-colors \
-   && ./sbt "project slick" publish -no-colors \
-   && ./sbt "project util" publish -no-colors \
-   && ./sbt "project vectortile" publish -no-colors \
-   && ./sbt "project raster-testkit" publish -no-colors \
-   && ./sbt "project vector-testkit" publish -no-colors \
-   && ./sbt "project spark-testkit" publish -no-colors \
-   && ./sbt "project s3-testkit" publish -no-colors
+./.locationtech/deploy-211.sh && ./.locationtech/deploy-212.sh

--- a/raster/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
@@ -100,5 +100,16 @@ class ReprojectRasterExtentSpec extends FunSpec
       actualCols should be (expectedCols +- 1)
       actualRows should be (expectedRows +- 1)
     }
+
+    it("should have an extent that tightly covers the polygon reprojection of the source extent") {
+      val ex = Extent(630000.0, 215000.0, 645000.0, 228500.0)
+      val crs = CRS.fromString("+proj=lcc +lat_0=33.75 +lon_0=-79.0 +lat_1=36.16666666666666 +lat_2=34.33333333333334 +x_0=609601.22 +y_0=0.0 +datum=NAD83 +units=m ")
+      val originalRE = RasterExtent(ex, 1500, 1350)
+      val region = ProjectedExtent(ex, crs).reprojectAsPolygon(WebMercator, 0.001)
+      val destinationRE = ReprojectRasterExtent(originalRE, crs, WebMercator)
+
+      assert(destinationRE.extent covers region)
+      assert(destinationRE.extent.toPolygon intersects region)
+    }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
@@ -74,9 +74,9 @@ class ReprojectRasterExtentSpec extends FunSpec
       // println(formatExtent("GTA", rea))
       // println(formatExtent("EXP", ree))
 
-      actualExtent.toPolygon should matchGeom (expectedExtent.toPolygon, 1.0)
-      actualCols should be (expectedCols +- 1)
-      actualRows should be (expectedRows +- 1)
+      actualExtent.toPolygon should matchGeom (expectedExtent.toPolygon, 10.0)
+      actualCols should be (expectedCols +- 10)
+      actualRows should be (expectedRows +- 10)
     }
 
     it("should be in approximation to GDAL EPSG:32618 to EPSG:4326") {
@@ -97,8 +97,8 @@ class ReprojectRasterExtentSpec extends FunSpec
       // println(formatExtent("EXP", ree))
 
       actualExtent.toPolygon should matchGeom (expectedExtent.toPolygon, 1.0)
-      actualCols should be (expectedCols +- 1)
-      actualRows should be (expectedRows +- 1)
+      actualCols should be (expectedCols +- 10)
+      actualRows should be (expectedRows +- 10)
     }
 
     it("should have an extent that tightly covers the polygon reprojection of the source extent") {

--- a/raster/src/test/scala/geotrellis/raster/reproject/ReprojectSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/reproject/ReprojectSpec.scala
@@ -167,8 +167,8 @@ class ReprojectSpec extends FunSpec
       val RasterExtent(_, cellwidthLeft, cellheightLeft, _, _) = RasterExtent(wmLeftExtent, wmLeftTile.cols, wmLeftTile.rows)
       val RasterExtent(_, cellwidthRight, cellheightRight, _, _) = RasterExtent(wmRightExtent, wmRightTile.cols, wmRightTile.rows)
 
-      cellwidthLeft should be (cellwidthRight +- 0.01)
-      cellheightLeft should be (cellheightRight +- 0.01)
+      cellwidthLeft should be (cellwidthRight +- 0.05)
+      cellheightLeft should be (cellheightRight +- 0.05)
 
       // Specifically fit it ito a web mercator zoom layout tile
       val re = RasterExtent(Extent(-8247861.100, 4872401.931, -8238077.160, 4882185.871), 256, 256)

--- a/vector/src/main/scala/geotrellis/vector/Extent.scala
+++ b/vector/src/main/scala/geotrellis/vector/Extent.scala
@@ -52,47 +52,8 @@ case class ProjectedExtent(extent: Extent, crs: CRS) {
   def reproject(dest: CRS): Extent =
     extent.reproject(crs, dest)
 
-  /** Performs adaptive refinement to produce a Polygon representation of the projected region.
-    *
-    * Generally, rectangular regions become curvilinear regions after geodetic projection.
-    * This function creates a polygon giving an accurate representation of the post-projection
-    * region.  This function does its work by recursively splitting extent edges, until the
-    * subdivided edge is "close enough" to the unrefined edge.
-    *
-    * @param dest
-    * @param relError   A tolerance value telling how much deflection is allowed in terms of
-    *                   distance from the original line to the new point
-    */
-  def reprojectAsPolygon(dest: CRS, relError: Double = 0.01): Polygon = {
-    val transform = Transform(crs, dest)
-
-    def refine(p0: (Point, (Double, Double)), p1: (Point, (Double, Double))): List[(Point, (Double, Double))] = {
-      val ((a, (x0, y0)), (b, (x1, y1))) = (p0, p1)
-      val m = Point(0.5 * (a.x + b.x), 0.5 * (a.y + b.y))
-      val (x2, y2) = transform(m.x, m.y)
-
-      import math.{abs, pow, sqrt}
-
-      val deflect = abs((y2 - y1) * x0 - (x2 - x1) * y0 + x2 * y1 - y2 * x1) / sqrt(pow(y2 - y1, 2) + pow(x2 - x1, 2))
-      val length = sqrt(pow(x0 - x1, 2) + pow(y0 - y1, 2))
-
-      val p2 = m -> (x2, y2)
-      if (deflect / length < relError) {
-        List(p2)
-      } else {
-        refine(p0, p2) ++ (p2 :: refine(p2, p1))
-      }
-    }
-
-    val pts = Array(extent.southWest, extent.southEast, extent.northEast, extent.northWest)
-      .map{ p => (p, transform(p.x, p.y)) }
-
-    Polygon ( ((pts(0) :: refine(pts(0), pts(1))) ++ 
-               (pts(1) :: refine(pts(1), pts(2))) ++ 
-               (pts(2) :: refine(pts(2), pts(3))) ++
-               (pts(3) :: refine(pts(3), pts(0))) ++
-               List(pts(0))).map{ case (_, (x, y)) => Point(x, y) } )
-  }
+  def reprojectAsPolygon(dest: CRS, relError: Double = 0.01): Polygon =
+    extent.reprojectAsPolygon(Transform(crs, dest), relError)
 }
 
 /** ProjectedExtent companion object */

--- a/vector/src/main/scala/geotrellis/vector/reproject/Implicits.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/Implicits.scala
@@ -56,6 +56,8 @@ trait Implicits {
   implicit class ReprojectExtent(e: Extent) {
     def reproject(src: CRS, dest: CRS): Extent = Reproject(e, src, dest)
     def reproject(transform: Transform): Extent = Reproject(e, transform).envelope
+    def reprojectAsPolygon(src: CRS, dest: CRS, relErr: Double): Polygon = e.reprojectAsPolygon(Transform(src, dest), relErr)
+    def reprojectAsPolygon(transform: Transform, relErr: Double): Polygon = Reproject.reprojectExtentAsPolygon(e, transform, relErr)
   }
 
   implicit class ReprojectPolygonFeature[D](pf: PolygonFeature[D]) {

--- a/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala
@@ -64,6 +64,50 @@ object Reproject {
   def apply(extent: Extent, src: CRS, dest: CRS): Extent =
     apply(extent.toPolygon, src, dest).envelope
 
+  /** Performs adaptive refinement to produce a Polygon representation of the projected region.
+    *
+    * Generally, rectangular regions become curvilinear regions after geodetic projection.
+    * This function creates a polygon giving an accurate representation of the post-projection
+    * region.  This function does its work by recursively splitting extent edges, until a relative
+    * error criterion is met.  That is,for an edge in the source CRS, endpoints, a and b, generate
+    * the midpoint, m.  These are mapped to the destination CRS as a', b', and c'.  If the
+    * distance from m' to the line a'-b' is greater than relErr * distance(a', b'), then m' is
+    * included in the refined polygon.  The process recurses on (a, m) and (m, b) until
+    * termination.
+    *
+    * @param transform
+    * @param relError   A tolerance value telling how much deflection is allowed in terms of
+    *                   distance from the original line to the new point
+    */
+  def reprojectExtentAsPolygon(extent: Extent, transform: Transform, relError: Double): Polygon = {
+    import math.{abs, pow, sqrt}
+
+    def refine(p0: (Point, (Double, Double)), p1: (Point, (Double, Double))): List[(Point, (Double, Double))] = {
+      val ((a, (x0, y0)), (b, (x1, y1))) = (p0, p1)
+      val m = Point(0.5 * (a.x + b.x), 0.5 * (a.y + b.y))
+      val (x2, y2) = transform(m.x, m.y)
+
+      val deflect = abs((y2 - y1) * x0 - (x2 - x1) * y0 + x2 * y1 - y2 * x1) / sqrt(pow(y2 - y1, 2) + pow(x2 - x1, 2))
+      val length = sqrt(pow(x0 - x1, 2) + pow(y0 - y1, 2))
+
+      val p2 = m -> (x2, y2)
+      if (deflect / length < relError) {
+        List(p2)
+      } else {
+        refine(p0, p2) ++ (p2 :: refine(p2, p1))
+      }
+    }
+
+    val pts = Array(extent.southWest, extent.southEast, extent.northEast, extent.northWest)
+      .map{ p => (p, transform(p.x, p.y)) }
+
+    Polygon ( ((pts(0) :: refine(pts(0), pts(1))) ++
+               (pts(1) :: refine(pts(1), pts(2))) ++
+               (pts(2) :: refine(pts(2), pts(3))) ++
+               (pts(3) :: refine(pts(3), pts(0))) ++
+               List(pts(0))).map{ case (_, (x, y)) => Point(x, y) } )
+  }
+
   def polygonFeature[D](pf: PolygonFeature[D], src: CRS, dest: CRS): PolygonFeature[D] =
     PolygonFeature(apply(pf.geom, src, dest), pf.data)
 


### PR DESCRIPTION
## Overview

While investigating a reprojection issue in geotrellis-contrib, it came to my attention that the raster extents produced by `ReprojectRasterExtent` are off.  Consider the following: using https://github.com/geotrellis/geotrellis-contrib/blob/master/vlm/src/test/resources/img/aspect-tiled.tif as the base of this example, the following definitions apply:
```scala
val tiff = GeoTiffReader.readMultiband(getByteReader("aspect-tiled.tif"), streaming = true)
val targetRE = ReprojectRasterExtent(tiff.rasterExtent, tiff.crs, WebMercator)
val region = tiff.projectedExtent.reprojectAsPolygon(WebMercator, 0.001)
```
We then note that `targetRE.extent` and `region.envelope` diverge:
```scala
targetRE.extent: geotrellis.vector.Extent = Extent(-8769150.640916323, 4257706.9716441, -8750638.524926396, 4274455.441673627)
region.envelope: geotrellis.vector.Extent = Extent(-8769150.640916323, 4257707.61418559, -8750636.281752571, 4274455.441673627)
```
Note that `ymin` and `xmax` differ, and that the tolerance value of 0.001 has no effect, since the corners of the region are on the extent boundary.

I believe that the `region` is the authoritative source of truth.  So, the reprojected raster extent should tightly bound this polygon.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] Unit tests added for bug-fix or new feature