### PR TITLE
Added `mapTile` to `ProjectedRaster`.

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/ProjectedRaster.scala
+++ b/raster/src/main/scala/geotrellis/raster/ProjectedRaster.scala
@@ -63,9 +63,10 @@ object ProjectedRaster {
   * The [[ProjectedRaster]] type.
   */
 case class ProjectedRaster[T <: CellGrid](raster: Raster[T], crs: CRS) {
-  def tile = raster.tile
-  def extent = raster.extent
-  def projectedExtent = ProjectedExtent(extent, crs)
-  def cols = raster.cols
-  def rows = raster.rows
+  def tile: T = raster.tile
+  def extent: Extent = raster.extent
+  def projectedExtent: ProjectedExtent = ProjectedExtent(extent, crs)
+  def cols: Int = raster.cols
+  def rows: Int = raster.rows
+  def mapTile[A <: CellGrid](f: T => A): ProjectedRaster[A] = this.copy(raster = raster.mapTile(f))
 }


### PR DESCRIPTION
Signed-off-by: Simeon H.K. Fitch <fitch@astraea.io>

## Overview

Want to say no more to this:

```scala
val pr = someGeotiff.projectedRaster
val tile = pr.tile.interpretAs(UShortConstantNoDataCellType)
val fixedpr = ProjectedRaster(tile, pr.extent, pr.crs)
```

and instead

```scala
val pr = someGeotiff.projectedRaster
val fixedpr = pr.mapTile(_.interpretAs(UShortConstantNoDataCellType))
```

### Checklist

- [NO] `docs/CHANGELOG.rst` updated, if necessary
- [NO] `docs` guides update, if necessary
- [NO] New user API has useful Scaladoc strings
- [NO] Unit tests added for bug-fix or new feature
