### PR TITLE
Spire Shade Rules for spark-etl and spark-pipeline

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -461,7 +461,9 @@ object Settings {
           .inLibrary(jsonSchemaValidator).inAll,
         ShadeRule.rename("org.apache.avro.**" -> s"$shadePackage.org.apache.avro.@1")
           .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll,
-        ShadeRule.rename("shapeless.**" -> s"$shadePackage.shapeless.@1").inAll
+        ShadeRule.rename("shapeless.**" -> s"$shadePackage.shapeless.@1").inAll,
+        ShadeRule.rename("spire.**" -> s"$shadePackage.spire.@1")
+          .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll
       )
     },
     assemblyMergeStrategy in assembly := {
@@ -496,7 +498,9 @@ object Settings {
           .inLibrary(jsonSchemaValidator).inAll,
         ShadeRule.rename("org.apache.avro.**" -> s"$shadePackage.org.apache.avro.@1")
           .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll,
-        ShadeRule.rename("shapeless.**" -> s"$shadePackage.shapeless.@1").inAll
+        ShadeRule.rename("shapeless.**" -> s"$shadePackage.shapeless.@1").inAll,
+        ShadeRule.rename("spire.**" -> s"$shadePackage.spire.@1")
+          .inLibrary("com.azavea.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll
       )
     },
     assemblyMergeStrategy in assembly := {


### PR DESCRIPTION
## Overview

We've recently updated the version of our `spire` dependencies to 0.16.0. However, this can cause problems as Spark still uses older an older version of `spire`. With these shaded rules, it'll now be possible to run code in `spark-etl` and/or `spark-pipeline` without having to worry about binary incompatibility.
