### PR TITLE
Catch a possible precision loss on reprojection to the same projection

### DIFF
--- a/proj4/src/main/scala/geotrellis/proj4/Transform.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/Transform.scala
@@ -27,14 +27,17 @@ object Transform {
 }
 
 object Proj4Transform {
-  def apply(src: CRS, dest: CRS): Transform = {
-    val t = new BasicCoordinateTransform(src.proj4jCrs, dest.proj4jCrs)
+  def apply(src: CRS, dest: CRS): Transform =
+    if(src == dest) {
+      (x: Double, y: Double) => (x, y)
+    } else {
+      val t = new BasicCoordinateTransform(src.proj4jCrs, dest.proj4jCrs)
 
-    { (x: Double, y: Double) =>
-      val srcP = new ProjCoordinate(x, y)
-      val destP = new ProjCoordinate
-      t.transform(srcP, destP)
-      (destP.x, destP.y)
+      { (x: Double, y: Double) =>
+        val srcP = new ProjCoordinate(x, y)
+        val destP = new ProjCoordinate
+        t.transform(srcP, destP)
+        (destP.x, destP.y)
+      }
     }
-  }
 }

--- a/spark/src/main/scala/geotrellis/spark/tiling/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/package.scala
@@ -19,6 +19,8 @@ package geotrellis.spark
 import geotrellis.vector._
 import geotrellis.proj4._
 
+import org.locationtech.proj4j.UnsupportedParameterException
+
 /**
   * This package is concerned with translation of coordinates or extents between
   * geographic extents and the grid space represented by SpatialKey(col, row) coordinates,
@@ -37,6 +39,11 @@ package object tiling {
           Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244)
         case Sinusoidal =>
           Extent(-2.0015109355797417E7, -1.0007554677898709E7, 2.0015109355797417E7, 1.0007554677898709E7)
+        case c if c.proj4jCrs.getProjection.getName == "utm" =>
+          throw new UnsupportedParameterException(
+            s"Projection ${c.toProj4String} is not supported as a WorldExtent projection, " +
+            s"use a different projection for your purposes or use a different LayoutScheme."
+          )
         case _ =>
           WORLD_WSG84.reproject(LatLng, crs)
       }


### PR DESCRIPTION
## Overview

MapTransform can be not that accurate in case `srcCRS == destCRS`. Partially addresses https://github.com/locationtech/geotrellis/issues/2826
