### PR TITLE
Fixe cache level in Ingest objects

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/ingest/Ingest.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/Ingest.scala
@@ -77,7 +77,7 @@ object Ingest {
       case _ => sourceTiles.collectMetadata(FloatingLayoutScheme(256))
     }
 
-    val contextRdd = sourceTiles.tileToLayout(tileLayerMetadata, resampleMethod).cache()
+    val contextRdd = sourceTiles.tileToLayout(tileLayerMetadata, resampleMethod).persist(cacheLevel)
 
     val (zoom, tileLayerRdd) = (layoutScheme, maxZoom) match {
       case (layoutScheme: ZoomedLayoutScheme, Some(mz)) =>

--- a/spark/src/main/scala/geotrellis/spark/ingest/MultibandIngest.scala
+++ b/spark/src/main/scala/geotrellis/spark/ingest/MultibandIngest.scala
@@ -51,7 +51,7 @@ object MultibandIngest {
       case _ => sourceTiles.collectMetadata(FloatingLayoutScheme(256))
     }
 
-    val contextRdd = sourceTiles.tileToLayout(tileLayerMetadata, resampleMethod).cache()
+    val contextRdd = sourceTiles.tileToLayout(tileLayerMetadata, resampleMethod).persist(cacheLevel)
 
     val (zoom, tileLayerRdd) = (layoutScheme, maxZoom) match {
       case (layoutScheme: ZoomedLayoutScheme, Some(mz)) =>


### PR DESCRIPTION
## Overview

Without this fix in some cases we can be get into the situation where this cache level (IN_MEMORY) would be assigned for the RDD, making impossible to set the desired cache level from the parameters, causing the following exception:

```
[info]   java.lang.UnsupportedOperationException: Cannot change storage level of an RDD after it was already assigned a level
[info]   at org.apache.spark.rdd.RDD.persist(RDD.scala:170)
[info]   at org.apache.spark.rdd.RDD.persist(RDD.scala:195)
[info]   at geotrellis.spark.ingest.Ingest$.apply(Ingest.scala:96)
```
