### PR TITLE
fix bug about cellType-double-DEM's flat area's aspect are not '-1'

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/SurfacePointCalculation.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/SurfacePointCalculation.scala
@@ -37,13 +37,13 @@ class SurfacePoint() {
   var `dz/dy` = Double.NaN
 
   def aspectAzimuth() = {
-    if (`dz/dx` == 0 && `dz/dy` == 0) {
+    if (Math.abs(`dz/dx`) <= 1E-10 && Math.abs(`dz/dy`) <= 1E-10) {
       /* Flat area */
       -1.0
     } else {
       var aAzimuth = toDegrees(atan2(`dz/dy`, `dz/dx`) - Pi * 0.5)
       if (aAzimuth < 0) { aAzimuth += 360.0 }
-      if (aAzimuth == 360.0) { aAzimuth = 0.0 }
+      if (Math.abs(aAzimuth - 360.0) <= 1E-10) { aAzimuth = 0.0 }
       aAzimuth
     }
   }

--- a/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/AspectSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/mapalgebra/focal/AspectSpec.scala
@@ -178,5 +178,18 @@ class AspectSpec extends FunSpec with Matchers with RasterMatchers with TileBuil
       var value = aR.getDouble(1, 1)
       (value - (-1.0)) should be < 0.000001
     }
+
+    it("should assign cellType-double's flat area to -1") {
+      val r = DoubleArrayTile(
+        Array[Double](
+          1.60205999132796, 1.60205999132796, 1.60205999132796,
+          1.60205999132796, 1.60205999132796, 1.60205999132796,
+          1.60205999132796, 1.60205999132796, 1.60205999132796), 3, 3)
+
+      val aR = r.aspect(CellSize(1, 1))
+
+      var value = aR.getDouble(1, 1)
+      (value - (-1.0)) should be < 0.000001
+    }
   }
 }


### PR DESCRIPTION
## Overview

Fix a bug about cellType-double-DEM's flat area's aspect  are not '-1'.
Because when the DEM' value are double type, the `dz/dx` and `dz/dy` are very close to '0' but not equal to '0'.So when compare with '0',I set a tolerance which is 1E-10.
And aspect==360 has the same problem.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature
