### PR TITLE
Make createAlignedGridExtent actually align to GridExtents

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -54,25 +54,37 @@ class GridExtent(val extent: Extent, val cellwidth: Double, val cellheight: Doub
   }
 
   /**
-    * Returns a GridExtent that lines up with this grid' resolution
+    * Returns a GridExtent that lines up with this grid's resolution
     * and grid layout.
     *
-    * For example, the resulting GridExtent will not have the given
-    * extent, but will have the smallest extent such that the whole of
-    * the given extent is covered, that lines up with the grid.
+    * This function will generate an extent that lines up with the grid
+    * indicated by the GridExtent, having an origin at the upper-left corner
+    * of the extent, and grid cells having the size given by cellSize.
+    * The resulting GridExtent, in general, will not be equal to
+    * ``targetExtent``, but will have the smallest extent that lines up with
+    * the grid and also covers ``targetExtent``.
     */
   def createAlignedGridExtent(targetExtent: Extent): GridExtent = {
     createAlignedGridExtent(targetExtent, extent.northWest)
   }
 
+  /**
+    * Returns a GridExtent that with this grid's resolution.
+    *
+    * This function will generate an extent that lines up with a grid having
+    * an origin at the given point and grid cells of the size given by the
+    * cellSize of the GridExtent.  The resulting GridExtent, in general, will
+    * not be equal to ``targetExtent``, but will have the smallest extent
+    * that lines up with the grid and also covers ``targetExtent``.
+    */
   def createAlignedGridExtent(targetExtent: Extent, alignmentPoint: Point): GridExtent = {
-    def push(x: Double): Double = math.ceil(math.abs(x)) * math.signum(x)
-    def quantize(reference: Double, actual: Double, unit: Double): Double = reference + push((actual - reference) / unit) * unit
+    def left(reference: Double, actual: Double, unit: Double): Double = reference + math.floor((actual - reference) / unit) * unit
+    def right(reference: Double, actual: Double, unit: Double): Double = reference + math.ceil((actual - reference) / unit) * unit
 
-    val xmin = quantize(alignmentPoint.x, extent.xmin, cellwidth)
-    val xmax = quantize(alignmentPoint.x, extent.xmax, cellwidth)
-    val ymin = quantize(alignmentPoint.y, extent.ymin, cellheight)
-    val ymax = quantize(alignmentPoint.y, extent.ymax, cellheight)
+    val xmin = left(alignmentPoint.x, targetExtent.xmin, cellwidth)
+    val xmax = right(alignmentPoint.x, targetExtent.xmax, cellwidth)
+    val ymin = left(alignmentPoint.y, targetExtent.ymin, cellheight)
+    val ymax = right(alignmentPoint.y, targetExtent.ymax, cellheight)
 
     GridExtent(Extent(xmin, ymin, xmax, ymax), cellwidth, cellheight)
   }


### PR DESCRIPTION
## Overview

The sad state of affairs before this PR:

```scala
scala> GridExtent(Extent(0,0,3.5,3.5), 1.0, 1.0)
res12: geotrellis.raster.GridExtent = GridExtent(Extent(0.0, 0.0, 3.5, 3.5),1.0,1.0)

scala> res12.createAlignedRasterExtent(res12.extent)
res13: geotrellis.raster.RasterExtent = GridExtent(Extent(0.0, 0.0, 3.5, 3.5),1.0,1.0)

scala> res12.createAlignedRasterExtent(Extent(0,0,3.8,3.8))
res14: geotrellis.raster.RasterExtent = GridExtent(Extent(0.0, 0.0, 4.5, 4.5),1.0,1.0)
```

I fixed it and introduced the possibility that the alignment point (a point at the intersection of the target cell grid) might be specified by the user (in case one wanted the grid to align to a point other than the upper left of the GridExtent's extent):

```scala
scala> GridExtent(Extent(0,0,3.5,3.5), 1.0, 1.0)
res0: geotrellis.raster.GridExtent = GridExtent(Extent(0.0, 0.0, 3.5, 3.5),1.0,1.0)

scala> res0.createAlignedGridExtent(res0.extent)
res1: geotrellis.raster.GridExtent = GridExtent(Extent(0.0, -0.5, 4.0, 3.5),1.0,1.0)

scala> res0.createAlignedGridExtent(res0.extent, Point(0,0))
res2: geotrellis.raster.GridExtent = GridExtent(Extent(0.0, 0.0, 4.0, 4.0),1.0,1.0)
```

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

