### PR TITLE
Easy Importing for the Vector Package

### DIFF
--- a/raster/src/test/scala/geotrellis/raster/interpolation/InverseDistanceWieghtedSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/interpolation/InverseDistanceWieghtedSpec.scala
@@ -19,7 +19,6 @@ package geotrellis.raster.interpolation
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal.Circle
 import geotrellis.vector._
-import geotrellis.vector.io._
 import geotrellis.vector.io.json.JsonFeatureCollection
 import geotrellis.raster.testkit._
 import spray.json.DefaultJsonProtocol._

--- a/raster/src/test/scala/geotrellis/raster/interpolation/KrigingSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/interpolation/KrigingSpec.scala
@@ -19,7 +19,6 @@ package geotrellis.raster.interpolation
 import geotrellis.raster._
 import geotrellis.vector.interpolation._
 import geotrellis.vector._
-import geotrellis.vector.io._
 import geotrellis.vector.io.json.JsonFeatureCollection
 import geotrellis.raster.testkit._
 

--- a/slick/src/main/scala/geotrellis/slick/PostGisProjectionSupport.scala
+++ b/slick/src/main/scala/geotrellis/slick/PostGisProjectionSupport.scala
@@ -17,8 +17,8 @@
 package geotrellis.slick
 
 import geotrellis.vector._
-import geotrellis.vector.io.wkb._
-import geotrellis.vector.io.wkt._
+import geotrellis.vector.io.wkt.WKT
+import geotrellis.vector.io.wkb.WKB
 
 import slick.ast.FieldSymbol
 import slick.driver.{JdbcDriver, PostgresDriver}

--- a/slick/src/main/scala/geotrellis/slick/PostGisSupport.scala
+++ b/slick/src/main/scala/geotrellis/slick/PostGisSupport.scala
@@ -17,8 +17,8 @@
 package geotrellis.slick
 
 import geotrellis.vector._
-import geotrellis.vector.io.wkb._
-import geotrellis.vector.io.wkt._
+import geotrellis.vector.io.wkt.WKT
+import geotrellis.vector.io.wkb.WKB
 
 import slick.ast.FieldSymbol
 import slick.driver.{JdbcDriver, PostgresDriver}

--- a/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/LayerQuerySpec.scala
@@ -19,12 +19,12 @@ package geotrellis.spark.io
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.vector._
+import geotrellis.vector.io.wkt.WKT
 import geotrellis.proj4._
 import geotrellis.spark.tiling._
 import geotrellis.spark.testkit.testfiles._
 import geotrellis.spark.testkit._
 import geotrellis.vector.io._
-import geotrellis.vector.io.wkt._
 
 import org.scalatest._
 

--- a/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
@@ -25,8 +25,7 @@ import geotrellis.spark.testkit._
 import geotrellis.spark.testkit.TestEnvironment
 import geotrellis.raster.rasterize.Rasterizer.Options
 import geotrellis.vector._
-import geotrellis.vector.io._
-import geotrellis.vector.io.wkt._
+import geotrellis.vector.io.wkt.WKT
 import geotrellis.vector.io.json._
 
 import java.nio.file.Files;

--- a/vector/src/main/scala/geotrellis/vector/io/json/FeatureFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/FeatureFormats.scala
@@ -17,7 +17,6 @@
 package geotrellis.vector.io.json
 
 import geotrellis.vector._
-import geotrellis.vector.io._
 import spray.json._
 
 /** A trait for providing the Spray.json formats necessary to serialize [[Feature]] instances */

--- a/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollection.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollection.scala
@@ -19,7 +19,6 @@ package geotrellis.vector.io.json
 import spray.json._
 
 import geotrellis.vector._
-import geotrellis.vector.io._
 import scala.util.{Try, Success, Failure}
 import scala.collection.mutable
 import scala.collection.immutable.VectorBuilder

--- a/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollectionMap.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollectionMap.scala
@@ -19,7 +19,6 @@ package geotrellis.vector.io.json
 import spray.json._
 
 import geotrellis.vector._
-import geotrellis.vector.io._
 import scala.util.{Try, Success, Failure}
 import scala.collection.mutable
 import DefaultJsonProtocol._

--- a/vector/src/main/scala/geotrellis/vector/io/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/package.scala
@@ -19,9 +19,7 @@ package geotrellis.vector
 import geotrellis.vector.io.wkb.WKB
 import geotrellis.vector.io.wkt.WKT
 
-package object io extends io.json.Implicits
-    with io.wkb.Implicits
-    with io.wkt.Implicits {
+package object io {
 
   /** Read any WKT or WKB and return the corresponding geometry */
   def readWktOrWkb(s: String): Geometry = {
@@ -33,4 +31,3 @@ package object io extends io.json.Implicits
       WKT.read(s)
   }
 }
-

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -23,7 +23,19 @@ import org.locationtech.jts.{geom => jts}
 package object vector extends SeqMethods
     with reproject.Implicits
     with triangulation.Implicits
-    with voronoi.Implicits {
+    with voronoi.Implicits
+    with io.json.Implicits
+    with io.wkt.Implicits
+    with io.wkb.Implicits {
+
+  /** The algorithms herein are all implemented in JTS, but the wrapper methods
+    * here make it straightforward to call them with geotrellis.vector classes.
+    */
+  implicit class withAnyGeometryMethods[G <: Geometry](val self: G) extends MethodExtensions[G]
+      with convexhull.ConvexHullMethods[G]
+      with densify.DensifyMethods[G]
+      with prepared.PreparedGeometryMethods[G]
+      with simplify.SimplifyMethods[G]
 
   type PointFeature[+D] = Feature[Point, D]
   type LineFeature[+D] = Feature[Line, D]
@@ -59,15 +71,6 @@ package object vector extends SeqMethods
 
   implicit class GeometryCollectionTransformations(val self: GeometryCollection) extends MethodExtensions[GeometryCollection]
       with affine.GeometryCollectionTransformationMethods
-
-  /** The algorithms herein are all implemented in JTS, but the wrapper methods
-    * here make it straightforward to call them with geotrellis.vector classes.
-    */
-  implicit class withAnyGeometryMethods[G <: Geometry](val self: G) extends MethodExtensions[G]
-      with convexhull.ConvexHullMethods[G]
-      with densify.DensifyMethods[G]
-      with prepared.PreparedGeometryMethods[G]
-      with simplify.SimplifyMethods[G]
 
   implicit def tupleOfIntToPoint(t: (Double, Double)): Point =
     Point(t._1,t._2)

--- a/vector/src/test/scala/spec/geotrellis/vector/dissolve/DissoveMethodsSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/dissolve/DissoveMethodsSpec.scala
@@ -17,7 +17,6 @@
 package geotrellis.vector.dissolve
 
 import geotrellis.vector._
-import geotrellis.vector.io._
 import geotrellis.vector.io.json.JsonFeatureCollection
 
 import spire.syntax.cfor._

--- a/vector/src/test/scala/spec/geotrellis/vector/interpolation/KrigingVectorSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/interpolation/KrigingVectorSpec.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.vector.interpolation
 
-import geotrellis.vector.io._
+import geotrellis.vector._
 import geotrellis.vector.io.json.JsonFeatureCollection
 import geotrellis.vector.testkit._
 import geotrellis.vector._

--- a/vector/src/test/scala/spec/geotrellis/vector/io/json/FeatureFormatsSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/io/json/FeatureFormatsSpec.scala
@@ -18,7 +18,6 @@ package geotrellis.vector.io.json
 
 import org.scalatest._
 import geotrellis.vector._
-import geotrellis.vector.io._
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._

--- a/vector/src/test/scala/spec/geotrellis/vector/io/json/GeoJsonSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/io/json/GeoJsonSpec.scala
@@ -17,7 +17,6 @@
 package geotrellis.vector.io.json
 
 import geotrellis.vector._
-import geotrellis.vector.io._
 import geotrellis.vector.testkit._
 
 import spray.json._

--- a/vector/src/test/scala/spec/geotrellis/vector/io/json/StyleSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/io/json/StyleSpec.scala
@@ -17,7 +17,6 @@
 package geotrellis.vector.io.json
 
 import geotrellis.vector._
-import geotrellis.vector.io._
 
 import org.scalatest._
 


### PR DESCRIPTION
## Overview

This PR simplifies the imports needed to use certain functionality in the `geotrellis.vector` package. Mainly, `vector.io.wkb.Implicits`, `vector.io.wkt.implicits`, and `vector.io.json.Implicits` are now all imported with `import geotrellis.vector._`.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

### Demo

Before:

```scala
import geotrellis.vector._
import geotrellis.vector.io._
import geotrellis.vector.io.json.JsonFeatureCollection

val path: String = ???
val f = scala.io.Source.fromFile(path)
val collection = f.mkString.parseGeoJson[JsonFeatureCollection]
```

After:

```scala
import geotrellis.vector._
import geotrellis.vector.io.json.JsonFeatureCollection

val path: String = ???
val f = scala.io.Source.fromFile(path)
val collection = f.mkString.parseGeoJson[JsonFeatureCollection]
```