### PR TITLE
Updated `Feature` class

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,6 +46,8 @@ object Dependencies {
   val fs2Core             = "co.fs2"                     %% "fs2-core"                 % "1.0.0"
   val fs2Io               = "co.fs2"                     %% "fs2-io"                   % "1.0.0"
 
+  val simulacrum          = "com.github.mpilquist"       %% "simulacrum"               % "0.15.0"
+
   val sparkCore           = "org.apache.spark"           %% "spark-core"               % Version.spark
   val sparkSQL            = "org.apache.spark"           %% "spark-sql"                % Version.spark
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -320,7 +320,6 @@ object Settings {
     libraryDependencies ++= Seq(
       pureconfig,
       jts,
-      catsCore,
       spire,
       monocleCore,
       monocleMacro,
@@ -528,6 +527,8 @@ object Settings {
     libraryDependencies ++= Seq(
       jts,
       pureconfig,
+      catsCore,
+      simulacrum,
       sprayJson,
       apacheMath,
       spire,

--- a/vector/src/main/scala/geotrellis/vector/package.scala
+++ b/vector/src/main/scala/geotrellis/vector/package.scala
@@ -19,11 +19,18 @@ package geotrellis
 import geotrellis.util.MethodExtensions
 
 import org.locationtech.jts.{geom => jts}
+import simulacrum._
 
 package object vector extends SeqMethods
     with reproject.Implicits
     with triangulation.Implicits
     with voronoi.Implicits {
+
+  @typeclass
+  trait HasGeometry[F[_ <: Geometry]] {
+    def geom[G <: Geometry](obj: F[G]): G
+    def mapGeom[G <: Geometry, T <: Geometry](obj: F[G])(fn: G => T): F[T]
+  }
 
   type PointFeature[+D] = Feature[Point, D]
   type LineFeature[+D] = Feature[Line, D]


### PR DESCRIPTION
## Overview

The current implementation of `Feature` is flawed in a few ways.  First, it is implemented as a `case class`, which means that no subclasses can be made (a problem if you want to meaningfully tag your features with an `id`, for example).  Second, though `Feature`s have functor-like characteristics, they are not implemented as such.  This small PR seeks to remedy such issues.

Fixing up `Feature` is an excuse to bring in [simulacrum](https://github.com/mpilquist/simulacrum) and begin the process of introducing typeclasses into GT.  We begin with an example of sufficient complexity that it raises some of the relevant issues that are likely to be encountered in the future.  

The change presented here introduces the notion of an object carrying geometry (useful if we ever want to have a `ProjectedGeometry`, for example).  A typeclass, `HasGeometry`, can be applied to such objects.  `HasGeometry` provides a means to retrieve the geometry of an applicable instance, and to transform the geometry of an instance.

This experimental work is meant to give us a handle on typeclasses more generally and basic patterns of interaction within a very constrained scope, while figuring out new patterns of interaction.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

### Demo

Optional. Screenshots/REPL

