### PR TITLE
GridExtent regressions

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/ClipToGridExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/ClipToGridExamples.scala
@@ -100,7 +100,7 @@ object ClipToGridExamples {
           (extent1.combine(extent2), height1 + height2, width1 + width2, count1 + count2)
         }
 
-    val gridExtent = GridExtent(extent, totalHeight / totalCount, totalWidth / totalCount)
+    val gridExtent = GridExtent[Long](extent, CellSize(totalHeight / totalCount, totalWidth / totalCount))
 
     // We then use this for to construct a LayoutDefinition, that represents "tiles"
     // that are 1x1.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -430,7 +430,7 @@ object Settings {
     mimaPreviousArtifacts := Set(
       "org.locationtech.geotrellis" %% "geotrellis-spark" % Version.previousVersion
     ),
-    testOptions in Test += Tests.Argument("-oDF"),
+    testOptions in Test += Tests.Argument("-oD"),
     initialCommands in console :=
       """
       import geotrellis.raster._

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -42,7 +42,6 @@ class GridExtent[@specialized(Int, Long) N: Integral](
     rows == Integral[N].fromDouble(math.round(extent.height / cellheight)),
     s"$extent at $cellSize does not match $dimensions")
 
-
   def this(extent: Extent, cols: N, rows: N) =
     this(extent, (extent.width / cols.toDouble), (extent.height / rows.toDouble), cols, rows)
 
@@ -328,12 +327,17 @@ class GridExtent[@specialized(Int, Long) N: Integral](
       rows = Integral[N].fromLong(totalRows))
   }
 
-  override def equals(o: Any): Boolean = o match {
-    case other: GridExtent[_] =>
-      // TODO: check if cols/rows are same type
-      other.extent == extent && other.cellheight == cellheight && other.cellwidth == cellwidth
-    case _ =>
-      false
+  def canEqual(a: Any) = a.isInstanceOf[GridExtent[_]]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: GridExtent[_] =>
+        that.canEqual(this) &&
+        that.extent == this.extent &&
+        that.cellSize == this.cellSize &&
+        that.cols == this.cols &&
+        that.rows == this.rows
+      case _ => false
   }
 
   override def hashCode(): Int =
@@ -351,14 +355,14 @@ class GridExtent[@specialized(Int, Long) N: Integral](
 object GridExtent {
   final val epsilon = 0.0000001
 
-  def apply(extent: Extent, cellSize: CellSize): GridExtent[Long] =
-    new GridExtent[Long](extent, cellSize)
+  def apply[N: Integral](extent: Extent, cellSize: CellSize): GridExtent[N] = {
+    new GridExtent[N](extent, cellSize)
+  }
 
-
-  def apply[N: Integral](grid: Grid[N], extent: Extent): GridExtent[N] = {
-    val cw = extent.width / grid.cols.toDouble
-    val ch = extent.height / grid.rows.toDouble
-    new GridExtent[N](extent, cw, ch, grid.cols, grid.rows)
+  def apply[N: Integral](extent: Extent, cols: N, rows: N): GridExtent[N] = {
+    val cw = extent.width / cols.toDouble
+    val ch = extent.height / rows.toDouble
+    new GridExtent[N](extent, cw, ch, cols, rows)
   }
 
   def apply[N: Integral](extent: Extent, grid: Grid[N]): GridExtent[N] = {

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -342,6 +342,9 @@ class GridExtent[@specialized(Int, Long) N: Integral](
   def toGridType[M: Integral]: GridExtent[M] = {
     new GridExtent[M](extent, cellwidth, cellheight, Integral[N].toType[M](cols), Integral[N].toType[M](rows))
   }
+
+  override def toString: String =
+    s"""GridExtent($extent,$cellSize,${cols}x${rows})"""
 }
 
 

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -19,7 +19,7 @@ package geotrellis.raster
 import geotrellis.vector.{Extent, Point}
 
 import scala.math.{min, max, ceil}
-import spire.math.{Integral, NumberTag}
+import spire.math.{Integral}
 import spire.implicits._
 
 /**
@@ -36,7 +36,7 @@ class GridExtent[@specialized(Int, Long) N: Integral](
 ) extends Grid[N] with Serializable {
   if (cols <= 0) throw GeoAttrsError(s"invalid cols: $cols")
   if (rows <= 0) throw GeoAttrsError(s"invalid rows: $rows")
-  //if (cols*rows <= 0) throw GeoAttrsError(s"invalid size: ${rows*cols} cols: $cols rows: $rows")
+
   require(
     cols == Integral[N].fromDouble(math.round(extent.width / cellwidth)) &&
     rows == Integral[N].fromDouble(math.round(extent.height / cellheight)),
@@ -48,8 +48,8 @@ class GridExtent[@specialized(Int, Long) N: Integral](
 
   def this(extent: Extent, cellSize: CellSize) =
     this(extent, cellSize.width, cellSize.height,
-      cols = integralFromLong(math.round(extent.width / cellSize.width).toLong),
-      rows = integralFromLong(math.round(extent.height / cellSize.height).toLong))
+      cols = Integral[N].fromDouble(math.round(extent.width / cellSize.width)),
+      rows = Integral[N].fromDouble(math.round(extent.height / cellSize.height)))
 
   def cellSize = CellSize(cellwidth, cellheight)
 
@@ -80,10 +80,10 @@ class GridExtent[@specialized(Int, Long) N: Integral](
   final def mapYToGridDouble(y: Double): Double = (extent.ymax - y ) / cellheight
 
   /** Convert map coordinate x to grid coordinate column. */
-  final def mapXToGrid(x: Double): N = integralFromLong[N](math.floor(mapXToGridDouble(x)).toLong)
+  final def mapXToGrid(x: Double): N = Integral[N].fromDouble(math.floor(mapXToGridDouble(x)))
 
   /** Convert map coordinate y to grid coordinate row. */
-  final def mapYToGrid(y: Double): N = integralFromLong[N](math.floor(mapYToGridDouble(y)).toLong)
+  final def mapYToGrid(y: Double): N = Integral[N].fromDouble(math.floor(mapYToGridDouble(y)))
 
   /** Convert map coordinates (x, y) to grid coordinates (col, row). */
   final def mapToGrid(x: Double, y: Double): (N, N) = {
@@ -169,7 +169,7 @@ class GridExtent[@specialized(Int, Long) N: Integral](
     // what is to the West and\or North of the point. However if the border point
     // is not directly on a grid division, include the whole row and/or column that
     // contains the point.
-    val colMax: N = integralFromLong[N]{
+    val colMax: N = Integral[N].fromLong{
       val colMaxDouble = mapXToGridDouble(subExtent.xmax)
 
       if (math.abs(colMaxDouble - math.floor(colMaxDouble)) < GridExtent.epsilon)
@@ -178,7 +178,7 @@ class GridExtent[@specialized(Int, Long) N: Integral](
         colMaxDouble.toLong
     }
 
-    val rowMax: N = integralFromLong[N]{
+    val rowMax: N = Integral[N].fromLong{
       val rowMaxDouble = mapYToGridDouble(subExtent.ymin)
 
       if (math.abs(rowMaxDouble - math.floor(rowMaxDouble)) < GridExtent.epsilon)
@@ -324,8 +324,8 @@ class GridExtent[@specialized(Int, Long) N: Integral](
       ymax = extent.ymax)
 
     new GridExtent[N](resampledExtent, cellwidth, cellheight,
-      cols = integralFromLong[N](totalCols),
-      rows = integralFromLong[N](totalRows))
+      cols = Integral[N].fromLong(totalCols),
+      rows = Integral[N].fromLong(totalRows))
   }
 
   override def equals(o: Any): Boolean = o match {

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -354,9 +354,6 @@ object GridExtent {
   def apply(extent: Extent, cellSize: CellSize): GridExtent[Long] =
     new GridExtent[Long](extent, cellSize)
 
-  def apply(extent: Extent, cellwidth: Double, cellheight: Double): GridExtent[Long] =
-    new GridExtent[Long](extent, CellSize(cellwidth, cellheight))
-
 
   def apply[N: Integral](grid: Grid[N], extent: Extent): GridExtent[N] = {
     val cw = extent.width / grid.cols.toDouble

--- a/raster/src/main/scala/geotrellis/raster/package.scala
+++ b/raster/src/main/scala/geotrellis/raster/package.scala
@@ -244,18 +244,6 @@ package object raster
     implicit object MultibandTileWitness extends TileOrMultibandTile[MultibandTile]
   }
 
-  /** Utility method that will type check if value of a long can be represented as instance of Integral */
-  private[raster] def integralFromLongOption[@specialized(Int, Long) N: Integral](x: Long)(implicit integral: Integral[N]): Option[N] = {
-    val n: N = integral.fromLong(x)
-    if (integral.toLong(n) == x) Some(n) else None
-  }
-
-  private[raster] def integralFromLong[@specialized(Int, Long) N: Integral](x: Long)(implicit integral: Integral[N]): N = {
-    val n = integral.fromInt(x.toInt)
-    if (integral.toLong(n) == x) n
-    else throw new IllegalArgumentException(s"Value $x can not be represented by ${integral.getClass.getSimpleName}")
-  }
-
   private[raster] def integralIterator[@specialized(Int, Long) N: Integral](start: N, end: N, step: N): Iterator[N] = new Iterator[N] {
     import spire.implicits._
     require(start < end, s"start: $start >= end: $end")

--- a/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster
+
+import geotrellis.vector.Extent
+import geotrellis.raster.testkit._
+
+import org.scalatest._
+
+class GridExtentSpec extends FunSpec with Matchers {
+  // Other relevant tests are under RastereExtentSpec
+  describe("A GridExtent object") {
+    val e1 = Extent(0.0, 0.0, 1.0, 1.0)
+    val e2 = Extent(0.0, 0.0, 20.0, 20.0)
+
+    val g1 = GridExtent[Int](e1, CellSize(1.0, 1.0))
+    val g2 = GridExtent[Int](e2, CellSize(1.0, 1.0))
+    val g3 = g1
+    val g4 = GridExtent[Long](e1, CellSize(1.0, 1.0))
+
+    it("should stringify") {
+      val s = g1.toString
+      info(s)
+    }
+
+    it("should equal for Int and Long columns") {
+      (g1 == g3) shouldBe true
+    }
+
+    it("should throw when overflowing from Long to Int") {
+      an [GeoAttrsError] should be thrownBy {
+        new GridExtent[Long](e1, Long.MaxValue, Long.MaxValue).toGridType[Int]
+      }
+
+      an [GeoAttrsError] should be thrownBy {
+        new GridExtent[Long](e1, Int.MaxValue.toLong+1, Int.MaxValue.toLong+1).toGridType[Int]
+      }
+    }
+
+    val g = GridExtent[Int](Extent(10.0, 15.0, 90.0, 95.0), CellSize(2.0, 2.0))
+  }
+}

--- a/spark/src/main/scala/geotrellis/spark/tiling/FloatingLayoutScheme.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/FloatingLayoutScheme.scala
@@ -35,7 +35,7 @@ object FloatingLayoutScheme {
 
 class FloatingLayoutScheme(val tileCols: Int, val tileRows: Int) extends LayoutScheme {
   def levelFor(extent: Extent, cellSize: CellSize) =
-    0 -> LayoutDefinition(GridExtent(extent, cellSize), tileCols, tileRows)
+    0 -> LayoutDefinition(GridExtent[Long](extent, cellSize), tileCols, tileRows)
 
   // TODO: Fix type system so that there is no runtime error
   def zoomOut(level: LayoutLevel) =

--- a/spark/src/main/scala/geotrellis/spark/tiling/LayoutDefinition.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/LayoutDefinition.scala
@@ -47,6 +47,9 @@ case class LayoutDefinition(override val extent: Extent, tileLayout: TileLayout)
 
     LayoutDefinition(subExtent, subLayout)
   }
+
+  override def toString: String =
+    s"""LayoutDefinition($extent, $cellSize,${layoutCols}x${layoutRows} tiles,${cols}x${rows} pixels)"""
 }
 
 object LayoutDefinition {

--- a/spark/src/main/scala/geotrellis/spark/tiling/LayoutDefinition.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/LayoutDefinition.scala
@@ -49,7 +49,23 @@ case class LayoutDefinition(override val extent: Extent, tileLayout: TileLayout)
   }
 
   override def toString: String =
-    s"""LayoutDefinition($extent, $cellSize,${layoutCols}x${layoutRows} tiles,${cols}x${rows} pixels)"""
+    s"""LayoutDefinition($extent,$cellSize,${layoutCols}x${layoutRows} tiles,${cols}x${rows} pixels)"""
+
+  override def canEqual(a: Any) = a.isInstanceOf[LayoutDefinition]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: LayoutDefinition =>
+        that.canEqual(this) &&
+        that.extent == this.extent &&
+        that.tileLayout == this.tileLayout
+      case _ => false
+  }
+
+  override def hashCode: Int =
+    ((31 +
+    (if (extent == null) 0 else extent.hashCode)) * 31 +
+    (if (tileLayout == null) 0 else tileLayout.hashCode) * 31)
 }
 
 object LayoutDefinition {

--- a/spark/src/test/scala/geotrellis/spark/costdistance/IterativeCostDistanceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/costdistance/IterativeCostDistanceSpec.scala
@@ -34,7 +34,7 @@ class IterativeCostDistanceSpec extends FunSpec
     val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
     val skey = SpatialKey(0, 0)
     val extent = Extent(0, 0, 5, 5)
-    val gridExtent = GridExtent(extent, 1, 1) // 5×5 pixels
+    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 5×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 5)
     val bounds = Bounds(skey, skey)
     val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -45,7 +45,7 @@ class IterativeCostDistanceSpec extends FunSpec
   val rdd2 = {
     val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
     val extent = Extent(0, 0, 10, 5)
-    val gridExtent = GridExtent(extent, 1, 1) // 10×5 pixels
+    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 10×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 10, 5)
     val bounds = Bounds(SpatialKey(0,0), SpatialKey(1,0))
     val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -56,7 +56,7 @@ class IterativeCostDistanceSpec extends FunSpec
   val rdd3 = {
     val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
     val extent = Extent(0, 0, 5, 10)
-    val gridExtent = GridExtent(extent, 1, 1) // 5×10 pixels
+    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 5×10 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 5, 10)
     val bounds = Bounds(SpatialKey(0,0), SpatialKey(0,1))
     val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)

--- a/spark/src/test/scala/geotrellis/spark/costdistance/IterativeCostDistanceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/costdistance/IterativeCostDistanceSpec.scala
@@ -34,7 +34,7 @@ class IterativeCostDistanceSpec extends FunSpec
     val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
     val skey = SpatialKey(0, 0)
     val extent = Extent(0, 0, 5, 5)
-    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 5×5 pixels
+    val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 5×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 5)
     val bounds = Bounds(skey, skey)
     val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -45,7 +45,7 @@ class IterativeCostDistanceSpec extends FunSpec
   val rdd2 = {
     val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
     val extent = Extent(0, 0, 10, 5)
-    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 10×5 pixels
+    val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 10×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 10, 5)
     val bounds = Bounds(SpatialKey(0,0), SpatialKey(1,0))
     val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -56,7 +56,7 @@ class IterativeCostDistanceSpec extends FunSpec
   val rdd3 = {
     val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
     val extent = Extent(0, 0, 5, 10)
-    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 5×10 pixels
+    val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 5×10 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 5, 10)
     val bounds = Bounds(SpatialKey(0,0), SpatialKey(0,1))
     val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)

--- a/spark/src/test/scala/geotrellis/spark/costdistance/RDDCostDistanceMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/costdistance/RDDCostDistanceMethodsSpec.scala
@@ -35,7 +35,7 @@ class RDDCostDistanceMethodsSpec extends FunSpec
   val rdd: RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]] = {
     val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
     val extent = Extent(0, 0, 10, 5)
-    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 10×5 pixels
+    val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 10×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 10, 5)
     val bounds = Bounds(SpatialKey(0,0), SpatialKey(1,0))
     val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)

--- a/spark/src/test/scala/geotrellis/spark/costdistance/RDDCostDistanceMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/costdistance/RDDCostDistanceMethodsSpec.scala
@@ -35,7 +35,7 @@ class RDDCostDistanceMethodsSpec extends FunSpec
   val rdd: RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]] = {
     val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
     val extent = Extent(0, 0, 10, 5)
-    val gridExtent = GridExtent(extent, 1, 1) // 10×5 pixels
+    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 10×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 10, 5)
     val bounds = Bounds(SpatialKey(0,0), SpatialKey(1,0))
     val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)

--- a/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
@@ -38,7 +38,7 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
       }
     val rdd = sc.parallelize(tiles)
     val ex = Extent(0,0,12.8,9.6)
-    val ld = LayoutDefinition(GridExtent(ex, CellSize(0.1, 0.1)), 32, 32)
+    val ld = LayoutDefinition(GridExtent[Long](ex, CellSize(0.1, 0.1)), 32, 32)
     val md = TileLayerMetadata[SpatialKey](IntConstantNoDataCellType,
                                            ld,
                                            ex,
@@ -57,7 +57,7 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
       }
     val rdd = sc.parallelize(tiles)
     val ex = Extent(0,0,12.8,9.6)
-    val ld = LayoutDefinition(GridExtent(ex, CellSize(0.1, 0.1)), 32, 32)
+    val ld = LayoutDefinition(GridExtent[Long](ex, CellSize(0.1, 0.1)), 32, 32)
     val md = TileLayerMetadata[SpaceTimeKey](IntConstantNoDataCellType,
                                              ld,
                                              ex,

--- a/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/regrid/RegridSpec.scala
@@ -38,7 +38,7 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
       }
     val rdd = sc.parallelize(tiles)
     val ex = Extent(0,0,12.8,9.6)
-    val ld = LayoutDefinition(GridExtent(ex, 0.1, 0.1), 32, 32)
+    val ld = LayoutDefinition(GridExtent(ex, CellSize(0.1, 0.1)), 32, 32)
     val md = TileLayerMetadata[SpatialKey](IntConstantNoDataCellType,
                                            ld,
                                            ex,
@@ -57,7 +57,7 @@ class RegridSpec extends FunSpec with TestEnvironment with RasterMatchers {
       }
     val rdd = sc.parallelize(tiles)
     val ex = Extent(0,0,12.8,9.6)
-    val ld = LayoutDefinition(GridExtent(ex, 0.1, 0.1), 32, 32)
+    val ld = LayoutDefinition(GridExtent(ex, CellSize(0.1, 0.1)), 32, 32)
     val md = TileLayerMetadata[SpaceTimeKey](IntConstantNoDataCellType,
                                              ld,
                                              ex,

--- a/spark/src/test/scala/geotrellis/spark/tiling/LayoutDefinitionSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/tiling/LayoutDefinitionSpec.scala
@@ -27,10 +27,19 @@ class LayoutDefinitionSpec extends FunSpec with Matchers {
       val e = Extent(-31.4569758,  27.6350020, 40.2053192,  80.7984255)
       val cs = CellSize(0.08332825, 0.08332825)
       val tileSize = 256
-      val ld = LayoutDefinition(GridExtent(e, cs), tileSize, tileSize)
-      val ld2 = LayoutDefinition(GridExtent(ld.extent, cs), ld.tileCols, ld.tileRows)
+      val ld = LayoutDefinition(GridExtent[Long](e, cs), tileSize, tileSize)
+      val ld2 = LayoutDefinition(GridExtent[Long](ld.extent, cs), ld.tileCols, ld.tileRows)
 
       ld2.extent should be (ld.extent)
+    }
+    val grid = GridExtent[Long](Extent(-180, -90, 180, 90), CellSize(0.001, 0.001))
+    val layout = LayoutDefinition(grid, 300, 300)
+
+    it("not equal its GridExtent") {
+      layout.cellSize shouldBe grid.cellSize
+      (layout.cols) shouldBe grid.cols
+      (layout.rows) shouldBe grid.rows
+      layout should not equal (grid)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/timeseries/RDDTimeSeriesMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/timeseries/RDDTimeSeriesMethodsSpec.scala
@@ -38,7 +38,7 @@ class RDDTimeSeriesMethodsSpec extends FunSpec
     val tile3 = IntConstantNoDataArrayTile(Array.fill[Int](25)(3), 5, 5)
     val tile4 = IntConstantNoDataArrayTile(Array.fill[Int](25)(4), 5, 5)
     val extent = Extent(0, 0, 10, 5)
-    val gridExtent = GridExtent(extent, 1, 1) // 10×5 pixels
+    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 10×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 10, 5)
     val bounds = Bounds(SpaceTimeKey(0, 0, 0), SpaceTimeKey(1, 0, 1))
     val tileLayerMetadata = TileLayerMetadata(

--- a/spark/src/test/scala/geotrellis/spark/timeseries/RDDTimeSeriesMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/timeseries/RDDTimeSeriesMethodsSpec.scala
@@ -38,7 +38,7 @@ class RDDTimeSeriesMethodsSpec extends FunSpec
     val tile3 = IntConstantNoDataArrayTile(Array.fill[Int](25)(3), 5, 5)
     val tile4 = IntConstantNoDataArrayTile(Array.fill[Int](25)(4), 5, 5)
     val extent = Extent(0, 0, 10, 5)
-    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 10×5 pixels
+    val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 10×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 10, 5)
     val bounds = Bounds(SpaceTimeKey(0, 0, 0), SpaceTimeKey(1, 0, 1))
     val tileLayerMetadata = TileLayerMetadata(

--- a/spark/src/test/scala/geotrellis/spark/timeseries/TimeSeriesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/timeseries/TimeSeriesSpec.scala
@@ -45,7 +45,7 @@ class TimeSeriesSpec extends FunSpec
     val tile3 = IntArrayTile(Array.fill[Int](25)(3), 5, 5)
     val tile4 = IntArrayTile(Array.fill[Int](25)(4), 5, 5)
     val extent = Extent(0, 0, 10, 5)
-    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 10×5 pixels
+    val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 10×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 10, 5)
     val bounds = Bounds(SpaceTimeKey(0, 0, 0), SpaceTimeKey(1, 0, 1))
     val tileLayerMetadata = TileLayerMetadata(

--- a/spark/src/test/scala/geotrellis/spark/timeseries/TimeSeriesSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/timeseries/TimeSeriesSpec.scala
@@ -45,7 +45,7 @@ class TimeSeriesSpec extends FunSpec
     val tile3 = IntArrayTile(Array.fill[Int](25)(3), 5, 5)
     val tile4 = IntArrayTile(Array.fill[Int](25)(4), 5, 5)
     val extent = Extent(0, 0, 10, 5)
-    val gridExtent = GridExtent(extent, 1, 1) // 10×5 pixels
+    val gridExtent = GridExtent(extent, CellSize(1, 1)) // 10×5 pixels
     val layoutDefinition = LayoutDefinition(gridExtent, 10, 5)
     val bounds = Bounds(SpaceTimeKey(0, 0, 0), SpaceTimeKey(1, 0, 1))
     val tileLayerMetadata = TileLayerMetadata(

--- a/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
@@ -42,7 +42,7 @@ class IterativeViewshedSpec extends FunSpec
       val rdd = {
         val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, 1, 1) // 15×15 pixels
+        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -66,7 +66,7 @@ class IterativeViewshedSpec extends FunSpec
       val rdd = {
         val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5); tile.set(2, 2, 42)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, 1, 1) // 15×15 pixels
+        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -91,7 +91,7 @@ class IterativeViewshedSpec extends FunSpec
         val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
         val specialTile = IntArrayTile(Array.fill[Int](25)(1), 5, 5); specialTile.set(2,0,3) ; specialTile.set(2,4,107)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, 1, 1) // 15×15 pixels
+        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -125,7 +125,7 @@ class IterativeViewshedSpec extends FunSpec
       val rdd = {
         val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, 1, 1) // 15×15 pixels
+        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -159,7 +159,7 @@ class IterativeViewshedSpec extends FunSpec
         )
         val tile = IntArrayTile(array, 5, 5)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, 1, 1) // 15×15 pixels
+        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)

--- a/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
@@ -42,7 +42,7 @@ class IterativeViewshedSpec extends FunSpec
       val rdd = {
         val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
+        val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -66,7 +66,7 @@ class IterativeViewshedSpec extends FunSpec
       val rdd = {
         val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5); tile.set(2, 2, 42)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
+        val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -91,7 +91,7 @@ class IterativeViewshedSpec extends FunSpec
         val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
         val specialTile = IntArrayTile(Array.fill[Int](25)(1), 5, 5); specialTile.set(2,0,3) ; specialTile.set(2,4,107)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
+        val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -125,7 +125,7 @@ class IterativeViewshedSpec extends FunSpec
       val rdd = {
         val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
+        val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
@@ -159,7 +159,7 @@ class IterativeViewshedSpec extends FunSpec
         )
         val tile = IntArrayTile(array, 5, 5)
         val extent = Extent(0, 0, 15, 15)
-        val gridExtent = GridExtent(extent, CellSize(1, 1)) // 15×15 pixels
+        val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 15×15 pixels
         val layoutDefinition = LayoutDefinition(gridExtent, 5)
         val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
         val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)


### PR DESCRIPTION
## Overview

- Fix bug in conversion from `GridExtent[Long]` to `GridExtent[Int]`, rely on spire checkin
- Add equality methods and toString methods
- Standardize the overloads for GridExtent


Connects https://github.com/locationtech/geotrellis/pull/2886
