### PR TITLE
Get the static DefaultAWSCredentialsProviderChain instance rather tha…

### DIFF
--- a/s3/src/main/scala/geotrellis/spark/io/s3/S3Client.scala
+++ b/s3/src/main/scala/geotrellis/spark/io/s3/S3Client.scala
@@ -147,7 +147,7 @@ object S3Client {
   }
 
   def DEFAULT =
-    AmazonS3Client(new DefaultAWSCredentialsProviderChain(), defaultConfiguration)
+    AmazonS3Client(DefaultAWSCredentialsProviderChain.getInstance(), defaultConfiguration)
 
   def ANONYMOUS =
     AmazonS3Client(new AnonymousAWSCredentials(), defaultConfiguration)


### PR DESCRIPTION
## Overview

Get the static DefaultAWSCredentialsProviderChain instance rather than constructing a new one every time. This allows the credentials provider to be re-used, thus avoiding requests failing due to 429s due to too many requests to the credentials provider.

### Checklist

- [ n/a] `docs/CHANGELOG.rst` updated, if necessary
- [ n/a] `docs` guides update, if necessary
- [ n/a] New user API has useful Scaladoc strings
- [ n/a] Unit tests added for bug-fix or new feature

### Demo

There's not much to demo, other than noticing that when I hit my service hard I no longer get "com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper@14ee1d86: Too Many Requests" 429 errors causing my S3 tile reads to fail when under heavy load.

### Notes
