### PR TITLE
Viewshed

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+3.0.1-SNAPSHOT
+-----
+
+Fixes & Updates
+^^^^^^^^^^^^^^^
+
+- Artifacts in Viewshed have been addressed, the pixels/meter calculation has also been improved (`#2917 <https://github.com/locationtech/geotrellis/pull/2917>`_).
+
 3.0.0-SNAPSHOT
 -----
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,14 +1,6 @@
 Changelog
 =========
 
-3.0.1-SNAPSHOT
------
-
-Fixes & Updates
-^^^^^^^^^^^^^^^
-
-- Artifacts in Viewshed have been addressed, the pixels/meter calculation has also been improved (`#2917 <https://github.com/locationtech/geotrellis/pull/2917>`_).
-
 3.0.0-SNAPSHOT
 -----
 
@@ -25,6 +17,7 @@ Fixes & Updates
 - Update pureconfig to version 0.10.2 (`#2882 <https://github.com/locationtech/geotrellis/pull/2882>`_).
 - Update dependencies (`#2904 <https://github.com/locationtech/geotrellis/pull/2904>`_).
 - Bump ScalaPB version up with some API enhancements (`#2898 <https://github.com/locationtech/geotrellis/pull/2898>`_).
+- Artifacts in Viewshed have been addressed, the pixels/meter calculation has also been improved (`#2917 <https://github.com/locationtech/geotrellis/pull/2917>`_).
 
 2.3.0
 -----

--- a/raster/src/main/scala/geotrellis/raster/viewshed/R2Viewshed.scala
+++ b/raster/src/main/scala/geotrellis/raster/viewshed/R2Viewshed.scala
@@ -90,8 +90,12 @@ object R2Viewshed extends Serializable {
     * @param  cols  The number of columns
     * @param  rows  The number of rows
     */
-  def generateEmptyViewshedTile(cols: Int, rows: Int) =
-    ArrayTile.empty(IntConstantNoDataCellType, cols, rows)
+  def generateEmptyViewshedTile(cols: Int, rows: Int, debug: Int = 0) = {
+    if (debug == 0)
+      ArrayTile.empty(IntConstantNoDataCellType, cols, rows)
+    else
+      IntArrayTile.fill(debug, cols, rows)
+  }
 
   /**
     * Given a direction of propagation, a packet of rays, and an angle

--- a/raster/src/main/scala/geotrellis/raster/viewshed/R2Viewshed.scala
+++ b/raster/src/main/scala/geotrellis/raster/viewshed/R2Viewshed.scala
@@ -148,11 +148,12 @@ object R2Viewshed extends Serializable {
     * @param  startCol       The x position of the vantage point
     * @param  startRow       The y position of the vantage point
     * @param  op             The aggregation operator to use (e.g. Or)
+    * @param  scatter        Whether to allow light to move (one pixel) normal to the ray
     */
   def apply(
     elevationTile: Tile,
     startCol: Int, startRow: Int,
-    op: AggregationOperator = Or): Tile = {
+    op: AggregationOperator = Or, scatter: Boolean = false): Tile = {
     val cols = elevationTile.cols
     val rows = elevationTile.rows
     val viewHeight = elevationTile.getDouble(startCol, startRow)
@@ -174,7 +175,8 @@ object R2Viewshed extends Serializable {
       operator = op,
       altitude = Double.NegativeInfinity,
       cameraDirection = 0,
-      cameraFOV = -1.0
+      cameraFOV = -1.0,
+      scatter = scatter
     )
     viewshedTile
   }
@@ -207,6 +209,7 @@ object R2Viewshed extends Serializable {
     * @param  cameraDirection  The direction (in radians) of the camera
     * @param  cameraFOV        The camera field of view, rays whose dot product with the camera direction are less than this are filtered out
     * @param  epsilon          Any ray within this many radians of vertical (horizontal) will be considered vertical (horizontal)
+    * @param  scatter          Whether to allow light to move (one pixel) normal to the ray
     */
   def compute(
     elevationTile: Tile, viewshedTile: MutableArrayTile,
@@ -221,7 +224,8 @@ object R2Viewshed extends Serializable {
     altitude: Double = Double.NegativeInfinity,
     cameraDirection: Double = 0,
     cameraFOV: Double = -1.0,
-    epsilon: Double = (1/math.Pi)
+    epsilon: Double = (1/math.Pi),
+    scatter: Boolean = true
   ): Tile = {
     val cols = elevationTile.cols
     val rows = elevationTile.rows
@@ -280,11 +284,12 @@ object R2Viewshed extends Serializable {
     }
 
     var alpha: Double = Double.NaN
+    var direction: From = FromInside
     var terminated: Boolean = false
 
     /**
       * This call back is called by the line rasterizer.  A ray
-      * emanating from the source is transformed into a
+      * emanating from the source is transformed into
       * DirectedSegments above, then each point on the ray is queried
       * by this function via the line rasterizer.
       *
@@ -318,6 +323,49 @@ object R2Viewshed extends Serializable {
           operator match {
             case Or if visible =>
               viewshedTile.set(col, row, 1)
+              if (scatter) {
+                direction match {
+                  case FromNorth | FromSouth =>
+                    if (col-1 >= 0) {
+                      val elevation = elevationTile.getDouble(col-1, row) - drop - viewHeight
+                      val groundAngle = math.atan(elevation / distance)
+                      val angle =
+                        if (altitude == Double.NegativeInfinity) groundAngle
+                        else  math.atan((altitude - drop - viewHeight) / distance)
+                      if (alpha <= angle)
+                        viewshedTile.set(col-1, row, 1)
+                    }
+                    if ((col+1 < viewshedTile.cols) && (col+1 < elevationTile.cols)) {
+                      val elevation = elevationTile.getDouble(col+1, row) - drop - viewHeight
+                      val groundAngle = math.atan(elevation / distance)
+                      val angle =
+                        if (altitude == Double.NegativeInfinity) groundAngle
+                        else  math.atan((altitude - drop - viewHeight) / distance)
+                      if (alpha <= angle)
+                        viewshedTile.set(col+1, row, 1)
+                    }
+                  case FromEast | FromWest =>
+                    if (row-1 >= 0) {
+                      val elevation = elevationTile.getDouble(col, row-1) - drop - viewHeight
+                      val groundAngle = math.atan(elevation / distance)
+                      val angle =
+                        if (altitude == Double.NegativeInfinity) groundAngle
+                        else  math.atan((altitude - drop - viewHeight) / distance)
+                      if (alpha <= angle)
+                        viewshedTile.set(col, row-1, 1)
+                    }
+                    if ((row+1 < viewshedTile.rows) && (row+1 < elevationTile.cols)) {
+                      val elevation = elevationTile.getDouble(col, row+1) - drop - viewHeight
+                      val groundAngle = math.atan(elevation / distance)
+                      val angle =
+                        if (altitude == Double.NegativeInfinity) groundAngle
+                        else  math.atan((altitude - drop - viewHeight) / distance)
+                      if (alpha <= angle)
+                        viewshedTile.set(col, row+1, 1)
+                    }
+                  case _ =>
+                }
+              }
             case And if !visible =>
               viewshedTile.set(col, row, 0)
             case And if (visible && isNoData(current)) =>
@@ -347,6 +395,7 @@ object R2Viewshed extends Serializable {
     /***************
      * GOING NORTH *
      ***************/
+    direction = FromSouth
     i = 0; while (i < northSegs.length) {
       val seg = northSegs(i)
       alpha = thetaToAlpha(from, rays, seg.theta); terminated = false
@@ -358,6 +407,7 @@ object R2Viewshed extends Serializable {
     /***************
      * GOING SOUTH *
      ***************/
+    direction = FromNorth
     i = 0; while (i < southSegs.length) {
       val seg = southSegs(i)
       alpha = thetaToAlpha(from, rays, seg.theta); terminated = false
@@ -369,6 +419,7 @@ object R2Viewshed extends Serializable {
     /**************
      * GOING EAST *
      **************/
+    direction = FromWest
     if ((cols <= startCol) && (startCol <= 2*cols) &&
         (eastSegs.forall(_.isNearVertical(epsilon))) &&
         (eastSegs.forall(_.isRumpSegment))) { // Sharp angle case
@@ -389,6 +440,7 @@ object R2Viewshed extends Serializable {
     /**************
      * GOING WEST *
      **************/
+    direction = FromEast
     if ((-1*cols < startCol) && (startCol < 0) &&
         (westSegs.forall(_.isNearVertical(epsilon))) &&
         (westSegs.forall(_.isRumpSegment))) {

--- a/raster/src/test/scala/geotrellis/raster/viewshed/R2ViewshedSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/viewshed/R2ViewshedSpec.scala
@@ -60,7 +60,8 @@ class R2ViewshedSpec extends FunSpec
         resolution = 1,
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+        scatter = false
       )
 
       a should be (6)
@@ -98,7 +99,8 @@ class R2ViewshedSpec extends FunSpec
         resolution = 1,
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+        scatter = false
       )
 
       a should be (6)
@@ -136,7 +138,8 @@ class R2ViewshedSpec extends FunSpec
         resolution = 1,
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+        scatter = false
       )
 
       a should be (6)
@@ -174,7 +177,8 @@ class R2ViewshedSpec extends FunSpec
         resolution = 1,
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+        scatter = false
       )
 
       a should be (6)
@@ -209,10 +213,51 @@ class R2ViewshedSpec extends FunSpec
         curvature = false,
         operator = Or,
         cameraDirection = 0,
-        cameraFOV = math.cos(math.Pi/4)
+        cameraFOV = math.cos(math.Pi/4),
+        scatter = false
       )
 
       assertEqual(actual, expected)
+    }
+
+    // ---------------------------------
+
+    it("Sees more when scattering is enabled") {
+      val elevation = createTile(Array.fill(7 * 7)(1), 7, 7)
+      val noScatter = ArrayTile.empty(IntCellType, 7, 7)
+      val yesScatter = ArrayTile.empty(IntCellType, 7, 7)
+
+      R2Viewshed.compute(
+        elevation, noScatter,
+        3, 3, 1,
+        FromInside,
+        null,
+        { _ => },
+        resolution = 1,
+        maxDistance = Double.PositiveInfinity,
+        curvature = false,
+        operator = Or,
+        cameraDirection = 0,
+        cameraFOV = math.cos(math.Pi/4),
+        scatter = false
+      )
+
+      R2Viewshed.compute(
+        elevation, yesScatter,
+        3, 3, 1,
+        FromInside,
+        null,
+        { _ => },
+        resolution = 1,
+        maxDistance = Double.PositiveInfinity,
+        curvature = false,
+        operator = Or,
+        cameraDirection = 0,
+        cameraFOV = math.cos(math.Pi/4),
+        scatter = true
+      )
+
+      (noScatter.toArray.sum) should be < (yesScatter.toArray.sum)
     }
 
     // ---------------------------------
@@ -243,7 +288,8 @@ class R2ViewshedSpec extends FunSpec
         curvature = false,
         operator = Or,
         cameraDirection = 0,
-        cameraFOV = -1
+        cameraFOV = -1,
+        scatter = false
       )
 
       R2Viewshed.compute(
@@ -258,7 +304,8 @@ class R2ViewshedSpec extends FunSpec
         operator = Or,
         altitude = 2,
         cameraDirection = 0,
-        cameraFOV = -1
+        cameraFOV = -1,
+        scatter = false
       )
 
       R2Viewshed.compute(
@@ -273,7 +320,8 @@ class R2ViewshedSpec extends FunSpec
         operator = Or,
         altitude = 3,
         cameraDirection = 0,
-        cameraFOV = -1
+        cameraFOV = -1,
+        scatter = false
       )
 
       val lowCount = low.toArray.sum

--- a/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
@@ -199,6 +199,7 @@ object IterativeViewshed {
     * @param  curvature    Whether or not to take the curvature of the Earth into account
     * @param  operator     The aggregation operator to use (e.g. Or)
     * @param  epsilon      Rays within this many radians of horizontal (vertical) are considered to be horizontal (vertical)
+    * @param  scatter      Whether to allow light to move (one pixel) normal to the ray
     */
   def apply[K: (? => SpatialKey): ClassTag, V: (? => Tile)](
     elevation: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
@@ -206,7 +207,8 @@ object IterativeViewshed {
     maxDistance: Double,
     curvature: Boolean = true,
     operator: AggregationOperator = Or,
-    epsilon: Double = (1/math.Pi)
+    epsilon: Double = (1/math.Pi),
+    scatter: Boolean = true
   ): RDD[(K, Tile)] with Metadata[TileLayerMetadata[K]] = {
 
     val sparkContext = elevation.sparkContext
@@ -321,7 +323,9 @@ object IterativeViewshed {
               altitude = alt,
               operator = operator,
               cameraDirection = ang,
-              cameraFOV = fov
+              cameraFOV = fov,
+              epsilon = epsilon,
+              scatter = scatter
             )
           })
         case None =>
@@ -394,7 +398,8 @@ object IterativeViewshed {
                     altitude = alt,
                     cameraDirection = angle,
                     cameraFOV = fov,
-                    epsilon = epsilon
+                    epsilon = epsilon,
+                    scatter = scatter
                   )
                 }
                 i += 1;

--- a/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
@@ -134,10 +134,15 @@ object IterativeViewshed {
     val mt = md.mapTransform
     val key: SpatialKey = md.bounds.get.minKey
     val extent = mt(key).reproject(md.crs, LatLng)
-    val degrees = extent.xmax - extent.xmin
-    val meters = degrees * (6378137 * 2.0 * math.Pi) / 360.0
-    val pixels = md.layout.tileCols
-    math.abs(meters / pixels)
+
+    val latitude = (extent.ymax + extent.ymin) / 2.0
+    val degrees_per_key = extent.xmax - extent.xmin
+    // https://gis.stackexchange.com/questions/2951/algorithm-for-offsetting-a-latitude-longitude-by-some-amount-of-meters
+    val meters_per_degree = 111111 * math.cos(math.toRadians(latitude))
+    val meters_per_key = meters_per_degree * degrees_per_key
+    val keys_per_pixel = 1.0 / md.layout.tileCols
+
+    meters_per_key * keys_per_pixel
   }
 
   private case class PointInfo(

--- a/spark/src/main/scala/geotrellis/spark/viewshed/RDDViewshedMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/RDDViewshedMethods.scala
@@ -35,14 +35,18 @@ abstract class RDDViewshedMethods[K: (? => SpatialKey): ClassTag, V: (? => Tile)
     points: Seq[Viewpoint],
     maxDistance: Double = Double.PositiveInfinity,
     curvature: Boolean = true,
-    operator: AggregationOperator = Or
+    operator: AggregationOperator = Or,
+    epsilon: Double = (1/math.Pi),
+    scatter: Boolean = true
   )(implicit sc: SparkContext): RDD[(K, Tile)] with Metadata[TileLayerMetadata[K]] =
     IterativeViewshed(
       elevation = self,
       ps = points,
       maxDistance = maxDistance,
       curvature = curvature,
-      operator = operator
+      operator = operator,
+      epsilon = epsilon,
+      scatter = scatter
     )
 
 }

--- a/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/viewshed/IterativeViewshedSpec.scala
@@ -54,7 +54,8 @@ class IterativeViewshedSpec extends FunSpec
         points = List(point),
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+	scatter = false
       )
       var actual = 0 ; viewshed.collect.foreach({ case (_, v) => v.foreach({ z => if (isData(z)) actual += z }) })
       val expected = 15*15
@@ -78,12 +79,45 @@ class IterativeViewshedSpec extends FunSpec
       val viewshed = IterativeViewshed(rdd, List(point),
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+	scatter = false
       )
       var actual = 0 ; viewshed.collect.foreach({ case (_, v) => v.foreach({ z => if (isData(z)) actual += z }) })
       val expected = 171
 
       actual should be (expected)
+    }
+
+    it("should see more when scattering is enabled") {
+      val rdd = {
+        val tile = IntArrayTile(Array.fill[Int](25)(1), 5, 5); tile.set(2, 2, 42)
+        val extent = Extent(0, 0, 15, 15)
+        val gridExtent = GridExtent[Long](extent, CellSize(1, 1)) // 15×15 pixels
+        val layoutDefinition = LayoutDefinition(gridExtent, 5)
+        val bounds = Bounds(SpatialKey(0, 0), SpatialKey(2, 2))
+        val tileLayerMetadata = TileLayerMetadata(IntCellType, layoutDefinition, extent, LatLng, bounds)
+        val list = for (col <- 0 to 2; row <- 0 to 2) yield (SpatialKey(col, row), tile)
+        ContextRDD(sc.parallelize(list), tileLayerMetadata)
+      }
+
+      val point = Viewpoint(7, 7, -0.0, 0, -1.0, ninf)
+      val viewshedNoScatter = IterativeViewshed(rdd, List(point),
+        maxDistance = Double.PositiveInfinity,
+        curvature = false,
+        operator = Or,
+	scatter = false
+      )
+      val viewshedYesScatter = IterativeViewshed(rdd, List(point),
+        maxDistance = Double.PositiveInfinity,
+        curvature = false,
+        operator = Or
+      )
+
+      var noScatterCount = 0 ; viewshedNoScatter.collect.foreach({ case (_, v) => v.foreach({ z => if (isData(z)) noScatterCount += z }) })
+      var yesScatterCount = 0 ; viewshedYesScatter.collect.foreach({ case (_, v) => v.foreach({ z => if (isData(z)) yesScatterCount += z }) })
+
+
+      noScatterCount should be < yesScatterCount
     }
 
     it("should see tall items behind short items") {
@@ -103,7 +137,8 @@ class IterativeViewshedSpec extends FunSpec
         points = List(point),
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+	scatter = false
       )
       val ND = NODATA
       val expected: Array[Int] = Array(
@@ -139,7 +174,8 @@ class IterativeViewshedSpec extends FunSpec
         points = List(point1, point2, point3),
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+	scatter = false
       )
       val expected = 15 * 15 * 1
       var actual: Int = 0
@@ -175,7 +211,8 @@ class IterativeViewshedSpec extends FunSpec
         points = List(point1, point2, point3),
         maxDistance = Double.PositiveInfinity,
         curvature = false,
-        operator = Or
+        operator = Or,
+	scatter = false
       )
       var actual: Int = 0
       viewshed.collect.foreach({ case (k, v) => actual += v.get(2, 2) })


### PR DESCRIPTION
- [x] Artifacts
- [x] Meters per pixel calculation

## Overview

The issue is that some fidelity is lost when visibility information is transferred between adjacent tiles.  The reconstituted data, a collection of line segments associated with each tile, is not guaranteed to cover every pixel in the tile.  The solution presented here is to optionally allow light to scatter perpendicularly from each ray.

~~There have been no changes made to the unit tests because it is unclear how to test a fix like this.  Suggestions welcome.~~  Can be tested with https://github.com/jamesmcclain/ViewshedDebug (locally-publish this branch then type `./sbt "project vs" assembly`, then `$SPARK_HOME/bin/spark-submit --driver-memory=8G --master='local[*]' vs-assembly-0.jar`).

### Artifacts ###

Before:

![Screenshot_2019-05-07_19-23-33](https://user-images.githubusercontent.com/11281373/57339134-629d7080-70fe-11e9-8bbd-ef880d4d6fd0.png)

![Screenshot_2019-05-07_19-23-09](https://user-images.githubusercontent.com/11281373/57339147-6e893280-70fe-11e9-9557-e0c222c48387.png)

After:

![Screenshot_2019-05-07_19-23-25](https://user-images.githubusercontent.com/11281373/57339149-73e67d00-70fe-11e9-971c-7415a7348422.png)

![Screenshot_2019-05-07_19-23-17](https://user-images.githubusercontent.com/11281373/57339154-7943c780-70fe-11e9-9210-35ea2c7832fd.png)


### Meters per Pixel ###

Before:

![Screenshot_2019-05-08_11-58-33](https://user-images.githubusercontent.com/11281373/57389983-57435700-7189-11e9-8d44-bf54bcf4e997.png)

After:

![Screenshot_2019-05-08_11-58-57](https://user-images.githubusercontent.com/11281373/57390014-65917300-7189-11e9-96c6-0765af73df7c.png)

Comparison:

![Screenshot_2019-05-08_11-58-47](https://user-images.githubusercontent.com/11281373/57390028-6cb88100-7189-11e9-92a4-b73aa0e6e187.png)


### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Demo

Optional. Screenshots/REPL

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #2910 

