### PR TITLE
Fix COG layer update bug related to COGLayerMetadata zoomRanges ordering

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -67,6 +67,7 @@ Fixes & Updates
 - Bump ScalaPB version up with some API enhancements (`#2898 <https://github.com/locationtech/geotrellis/pull/2898>`_).
 - Artifacts in Viewshed have been addressed, the pixels/meter calculation has also been improved (`#2917 <https://github.com/locationtech/geotrellis/pull/2917>`_).
 - Fix map{X|Y}ToGrid function behavior that could give a bit incorrect results (`#2953 <https://github.com/locationtech/geotrellis/pull/2953>`_).
+- Fix COG layer update bug related to COGLayerMetadata zoomRanges ordering (`#2922 <https://github.com/locationtech/geotrellis/pull/2922>`_).
 
 2.3.0
 -----

--- a/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerMetadataSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerMetadataSpec.scala
@@ -12,18 +12,18 @@ import org.scalatest._
 import spray.json._
 
 class COGLayerMetadataSpec extends FunSpec with Matchers {
+  def generateLCMetadata(maxZoom: Int = 13, minZoom: Int = 0): COGLayerMetadata[SpatialKey] = {
+    val cellType = IntConstantNoDataCellType
+    val extent = Extent(1.5454921707580032E7, 4146985.8273180854, 1.5762771754498206E7, 4454374.804079672)
+    val crs = WebMercator
+    val keyBounds = KeyBounds(SpatialKey(7255,3185), SpatialKey(7318,3248))
+    val layoutScheme = ZoomedLayoutScheme(WebMercator)
+    val maxTileSize = 4096
+
+    COGLayerMetadata(cellType, extent, crs, keyBounds, layoutScheme, maxZoom, minZoom, maxTileSize)
+  }
+
   describe("COGLayerMetadata.apply") {
-    def generateLCMetadata(maxZoom: Int = 13, minZoom: Int = 0): COGLayerMetadata[SpatialKey] = {
-      val cellType = IntConstantNoDataCellType
-      val extent = Extent(1.5454921707580032E7, 4146985.8273180854, 1.5762771754498206E7, 4454374.804079672)
-      val crs = WebMercator
-      val keyBounds = KeyBounds(SpatialKey(7255,3185), SpatialKey(7318,3248))
-      val layoutScheme = ZoomedLayoutScheme(WebMercator)
-      val maxTileSize = 4096
-
-      COGLayerMetadata(cellType, extent, crs, keyBounds, layoutScheme, maxZoom, minZoom, maxTileSize)
-    }
-
     it("should produce correct metadata for landsat scene example, build all partial pyramids correct") {
       val expectedZoomRanges = Vector(ZoomRange(0,0), ZoomRange(1,1), ZoomRange(2,2), ZoomRange(3,3), ZoomRange(4,4), ZoomRange(5,5), ZoomRange(6,6), ZoomRange(7,8), ZoomRange(9,13))
 
@@ -46,6 +46,28 @@ class COGLayerMetadataSpec extends FunSpec with Matchers {
       val md = generateLCMetadata(minZoom = 6)
       // println(md.toJson.prettyPrint)
       md.zoomRanges should contain theSameElementsAs (expectedZoomRanges)
+    }
+  }
+
+  describe("COGLayerMetadata.zoomRangeInfoFor") {
+    it("should return the requested zoomRangeInfo, regardless of whether zoomRangeInfos are sorted or not") {
+
+      val md = generateLCMetadata()
+      val mdUnsorted = md.copy(zoomRangeInfos = md.zoomRangeInfos.reverse)
+
+      mdUnsorted.zoomRangeFor(5) should equal (ZoomRange(5,5))
+    }
+  }
+
+  describe("COGLayerMetadata.combine") {
+    it("should produce combined metadata with zoomRangeInfos sorted") {
+
+      val md = generateLCMetadata()
+      val mdOther = generateLCMetadata()
+      val mdCombined = md.combine(mdOther)
+
+      implicit val ordering: Ordering[(ZoomRange, KeyBounds[SpatialKey])] = Ordering.by(_._1)
+      mdCombined.zoomRangeInfos should be (sorted)
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerMetadataSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerMetadataSpec.scala
@@ -3,13 +3,9 @@ package geotrellis.spark.io.cog
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.tiling._
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.tiling._
 import geotrellis.vector._
 
 import org.scalatest._
-import spray.json._
 
 class COGLayerMetadataSpec extends FunSpec with Matchers {
   def generateLCMetadata(maxZoom: Int = 13, minZoom: Int = 0): COGLayerMetadata[SpatialKey] = {

--- a/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerUpdateSpaceTimeTileSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerUpdateSpaceTimeTileSpec.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.spark.io.cog
 
-import geotrellis.proj4.LatLng
+import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster._
 import geotrellis.raster.testkit._
 import geotrellis.raster.io.geotiff.GeoTiff
@@ -28,8 +28,9 @@ import geotrellis.spark.testkit.io._
 import geotrellis.spark.testkit.io.cog._
 import geotrellis.util._
 import geotrellis.vector._
-
 import java.time._
+
+import geotrellis.spark.io.index.KeyIndex
 
 trait COGLayerUpdateSpaceTimeTileSpec
     extends TileLayerRDDBuilders
@@ -182,6 +183,26 @@ trait COGLayerUpdateSpaceTimeTileSpec
         assertEqual(readTiles(1)._2, Array(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2))
         assertEqual(readTiles(2)._2, Array(3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3))
         assertEqual(readTiles(3)._2, Array(5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5))
+      }
+
+      it("should update a layer with numerous zoom ranges") {
+        val maxZoom = 4
+        val md = sample.metadata
+
+        //for this test we need a layer with a zoom high enough
+        val layout = ZoomedLayoutScheme(md.crs, maxZoom).levelForZoom(maxZoom).layout
+        val minKey = md.bounds.get._1
+        val maxKey = md.bounds.get._2.copy(col = layout.layoutCols, row = layout.layoutRows)
+        val mdHighZoom = sample.metadata.copy(layout = layout, bounds = KeyBounds(minKey, maxKey))
+        val sampleHighZoom = new ContextRDD(sample, mdHighZoom)
+
+        //this will force multiple zoom ranges to be created
+        val options = COGLayerWriter.Options.DEFAULT.copy(maxTileSize = mdHighZoom.tileCols)
+
+        val tmpLayer = layerId.createTemporaryId.name
+
+        writer.write[SpaceTimeKey, Tile](tmpLayer, sampleHighZoom, maxZoom, keyIndexMethod, mergeFunc = mergeFunc, options = options)
+        writer.update[SpaceTimeKey, Tile](tmpLayer, sampleHighZoom, maxZoom, mergeFunc = mergeFunc, options = options)
       }
     }
   }

--- a/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerUpdateSpaceTimeTileSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerUpdateSpaceTimeTileSpec.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.spark.io.cog
 
-import geotrellis.proj4.{LatLng, WebMercator}
+import geotrellis.proj4.LatLng
 import geotrellis.raster._
 import geotrellis.raster.testkit._
 import geotrellis.raster.io.geotiff.GeoTiff
@@ -28,9 +28,8 @@ import geotrellis.spark.testkit.io._
 import geotrellis.spark.testkit.io.cog._
 import geotrellis.util._
 import geotrellis.vector._
-import java.time._
 
-import geotrellis.spark.io.index.KeyIndex
+import java.time._
 
 trait COGLayerUpdateSpaceTimeTileSpec
     extends TileLayerRDDBuilders
@@ -189,14 +188,14 @@ trait COGLayerUpdateSpaceTimeTileSpec
         val maxZoom = 4
         val md = sample.metadata
 
-        //for this test we need a layer with a zoom high enough
+        // for this test we need a layer with a zoom high enough
         val layout = ZoomedLayoutScheme(md.crs, maxZoom).levelForZoom(maxZoom).layout
         val minKey = md.bounds.get._1
         val maxKey = md.bounds.get._2.copy(col = layout.layoutCols, row = layout.layoutRows)
         val mdHighZoom = sample.metadata.copy(layout = layout, bounds = KeyBounds(minKey, maxKey))
         val sampleHighZoom = new ContextRDD(sample, mdHighZoom)
 
-        //this will force multiple zoom ranges to be created
+        // this will force multiple zoom ranges to be created
         val options = COGLayerWriter.Options.DEFAULT.copy(maxTileSize = mdHighZoom.tileCols)
 
         val tmpLayer = layerId.createTemporaryId.name


### PR DESCRIPTION
Signed-off-by: Andrey Tararaksin <atararaksin@gmail.com>

## Overview

Fixes bug with binary search on an unsorted `maxZooms` array in COG layer metadata.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

Closes #2921 
