### PR TITLE
Accumulo Spark Split

### DIFF
--- a/accumulo/src/main/resources/META-INF/services/geotrellis.layers.io.AttributeStoreProvider
+++ b/accumulo/src/main/resources/META-INF/services/geotrellis.layers.io.AttributeStoreProvider
@@ -1,1 +1,0 @@
-geotrellis.spark.io.accumulo.AccumuloLayerProvider

--- a/accumulo/src/main/resources/META-INF/services/geotrellis.layers.io.CollectionLayerReaderProvider
+++ b/accumulo/src/main/resources/META-INF/services/geotrellis.layers.io.CollectionLayerReaderProvider
@@ -1,1 +1,0 @@
-geotrellis.spark.io.accumulo.AccumuloLayerProvider

--- a/accumulo/src/main/resources/META-INF/services/geotrellis.layers.io.ValueReaderProvider
+++ b/accumulo/src/main/resources/META-INF/services/geotrellis.layers.io.ValueReaderProvider
@@ -1,1 +1,0 @@
-geotrellis.spark.io.accumulo.AccumuloLayerProvider

--- a/accumulo/src/main/resources/META-INF/services/geotrellis.spark.io.LayerReaderProvider
+++ b/accumulo/src/main/resources/META-INF/services/geotrellis.spark.io.LayerReaderProvider
@@ -1,1 +1,1 @@
-geotrellis.spark.io.accumulo.AccumuloLayerProvider
+geotrellis.spark.io.accumulo.AccumuloSparkLayerProvider

--- a/accumulo/src/main/resources/META-INF/services/geotrellis.spark.io.LayerWriterProvider
+++ b/accumulo/src/main/resources/META-INF/services/geotrellis.spark.io.LayerWriterProvider
@@ -1,1 +1,1 @@
-geotrellis.spark.io.accumulo.AccumuloLayerProvider
+geotrellis.spark.io.accumulo.AccumuloSparkLayerProvider

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerCopier.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerCopier.scala
@@ -16,17 +16,18 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.LayerId
 import geotrellis.tiling.{Boundable, Bounds, KeyBounds}
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.io.AttributeStore.Fields
-import geotrellis.layers.io.avro._
-import geotrellis.layers.io.index._
-import geotrellis.layers.io.json._
+import geotrellis.layers._
+import geotrellis.layers.AttributeStore.Fields
+import geotrellis.layers.accumulo._
+import geotrellis.layers.avro._
+import geotrellis.layers.index._
+import geotrellis.layers.json._
 import geotrellis.util._
+
 import org.apache.avro._
 import org.apache.spark.SparkContext
+
 import org.apache.spark.rdd.RDD
 import spray.json.JsonFormat
 

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerManager.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerManager.scala
@@ -16,17 +16,20 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.LayerId
 import geotrellis.tiling.{Boundable, Bounds}
+import geotrellis.layers._
+import geotrellis.layers.AttributeStore.Fields
+import geotrellis.layers.accumulo._
+import geotrellis.layers.avro.AvroRecordCodec
+import geotrellis.layers.index._
+import geotrellis.layers.json._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.AttributeStore.Fields
-import geotrellis.layers.io.avro.AvroRecordCodec
-import geotrellis.layers.io.index._
-import geotrellis.layers.io.json._
 import geotrellis.util._
+
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+
 import spray.json.JsonFormat
 
 import scala.reflect.ClassTag

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerMover.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerMover.scala
@@ -16,15 +16,17 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.LayerId
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
+import geotrellis.layers.avro._
+import geotrellis.layers.index._
+import geotrellis.layers.json._
 import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
-import geotrellis.layers.io.index._
-import geotrellis.layers.io.json._
 import geotrellis.util._
+
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+
 import spray.json.JsonFormat
 
 import scala.reflect.ClassTag

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReader.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReader.scala
@@ -16,15 +16,18 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.LayerId
 import geotrellis.tiling.{Boundable, Bounds, EmptyBounds, KeyBounds}
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
+import geotrellis.layers.avro._
+import geotrellis.spark.ContextRDD
+import geotrellis.spark.io.FilteringLayerReader
 import geotrellis.util._
+
 import org.apache.hadoop.io.Text
 import org.apache.spark.SparkContext
 import org.apache.accumulo.core.data.{Range => AccumuloRange}
+
 import spray.json._
 
 import scala.reflect._

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReindexer.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerReindexer.scala
@@ -17,17 +17,19 @@
 package geotrellis.spark.io.accumulo
 
 import geotrellis.tiling.{Boundable, Bounds}
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
+import geotrellis.layers.avro._
+import geotrellis.layers.index._
+import geotrellis.layers.json._
 import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
-import geotrellis.layers.io.index._
-import geotrellis.layers.io.json._
 import geotrellis.util._
-import org.apache.spark.SparkContext
-import spray.json.JsonFormat
-import java.time.ZonedDateTime
 
-import geotrellis.layers.LayerId
+import org.apache.spark.SparkContext
+
+import spray.json.JsonFormat
+
+import java.time.ZonedDateTime
 
 import scala.reflect.ClassTag
 

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerWriter.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerWriter.scala
@@ -17,17 +17,20 @@
 package geotrellis.spark.io.accumulo
 
 import geotrellis.tiling.{Boundable, Bounds}
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
+import geotrellis.layers.avro._
+import geotrellis.layers.avro.codecs._
+import geotrellis.layers.index._
+import geotrellis.layers.merge.Mergable
 import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
-import geotrellis.layers.io.avro.codecs._
-import geotrellis.layers.io.index._
 import geotrellis.spark.merge._
 import geotrellis.util._
+
 import com.typesafe.scalalogging.LazyLogging
-import geotrellis.layers.merge.Mergable
-import geotrellis.layers.{LayerId, Metadata}
+
 import org.apache.spark.rdd.RDD
+
 import spray.json._
 
 import scala.reflect._

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRDDReader.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRDDReader.scala
@@ -17,8 +17,9 @@
 package geotrellis.spark.io.accumulo
 
 import geotrellis.tiling.{Boundable, KeyBounds}
-import geotrellis.layers.io.avro.{AvroEncoder, AvroRecordCodec}
-import geotrellis.layers.io.avro.codecs.KeyValueRecordCodec
+import geotrellis.layers.accumulo.AccumuloInstance
+import geotrellis.layers.avro.{AvroEncoder, AvroRecordCodec}
+import geotrellis.layers.avro.codecs.KeyValueRecordCodec
 import geotrellis.spark.util.KryoWrapper
 
 import org.apache.accumulo.core.client.mapreduce.{AccumuloInputFormat, InputFormatBase}

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRDDWriter.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloRDDWriter.scala
@@ -16,9 +16,10 @@
 
 package geotrellis.spark.io.accumulo
 
+import geotrellis.layers.accumulo.AccumuloInstance
+import geotrellis.layers.avro._
+import geotrellis.layers.avro.codecs._
 import geotrellis.spark.io.LayerWriter
-import geotrellis.layers.io.avro._
-import geotrellis.layers.io.avro.codecs._
 import geotrellis.spark.util.KryoWrapper
 
 import org.apache.accumulo.core.data.{Key, Range, Value}

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloSparkLayerProvider.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloSparkLayerProvider.scala
@@ -16,15 +16,16 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
+import geotrellis.layers.accumulo.conf.AccumuloConfig
 import geotrellis.spark.io._
-import geotrellis.spark.io.accumulo.conf.AccumuloConfig
 import geotrellis.util.UriUtils
+
 import org.apache.spark.SparkContext
+
 import java.net.URI
 
-import geotrellis.layers.LayerId
-import geotrellis.layers.io.{ValueReader, ValueReaderProvider}
 
 /**
  * Provides [[AccumuloAttributeStore]] instance for URI with `accumulo` scheme.
@@ -33,21 +34,7 @@ import geotrellis.layers.io.{ValueReader, ValueReaderProvider}
  * Attributes table name is optional, not provided default value will be used.
  * Layers table name is required to instantiate a [[LayerWriter]]
  */
-class AccumuloLayerProvider extends AttributeStoreProvider
-    with LayerReaderProvider with LayerWriterProvider with ValueReaderProvider with CollectionLayerReaderProvider {
-
-  def canProcess(uri: URI): Boolean = uri.getScheme match {
-    case str: String => if (str.toLowerCase == "accumulo") true else false
-    case null => false
-  }
-
-  def attributeStore(uri: URI): AttributeStore = {
-    val instance = AccumuloInstance(uri)
-    val params = UriUtils.getParams(uri)
-    val attributeTable = params.getOrElse("attributes", AccumuloConfig.catalog)
-    AccumuloAttributeStore(instance, attributeTable)
-  }
-
+class AccumuloSparkLayerProvider extends AccumuloCollectionLayerProvider with LayerReaderProvider with LayerWriterProvider {
   def layerReader(uri: URI, store: AttributeStore, sc: SparkContext): FilteringLayerReader[LayerId] = {
     val instance = AccumuloInstance(uri)
 
@@ -62,15 +49,4 @@ class AccumuloLayerProvider extends AttributeStoreProvider
 
     AccumuloLayerWriter(instance, store, table)
   }
-
-  def valueReader(uri: URI, store: AttributeStore): ValueReader[LayerId] = {
-    val instance = AccumuloInstance(uri)
-    new AccumuloValueReader(instance, store)
-  }
-
-  def collectionLayerReader(uri: URI, store: AttributeStore): CollectionLayerReader[LayerId] = {
-    val instance = AccumuloInstance(uri)
-    new AccumuloCollectionLayerReader(store)(instance)
-  }
-
 }

--- a/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloWriteStrategy.scala
+++ b/accumulo/src/main/scala/geotrellis/spark/io/accumulo/AccumuloWriteStrategy.scala
@@ -16,10 +16,11 @@
 
 package geotrellis.spark.io.accumulo
 
+import geotrellis.layers.accumulo._
+import geotrellis.layers.accumulo.conf.AccumuloConfig
+import geotrellis.layers.hadoop._
 import geotrellis.spark.util._
 import geotrellis.spark.io._
-import geotrellis.spark.io.hadoop._
-import geotrellis.spark.io.accumulo.conf.AccumuloConfig
 
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.fs.Path
@@ -27,10 +28,12 @@ import org.apache.spark.rdd.RDD
 import org.apache.accumulo.core.data.{Key, Mutation, Value}
 import org.apache.accumulo.core.client.mapreduce.AccumuloFileOutputFormat
 import org.apache.accumulo.core.client.BatchWriterConfig
+
 import cats.effect.IO
 import cats.syntax.apply._
 
 import scala.concurrent.ExecutionContext
+
 import java.util.UUID
 import java.util.concurrent.Executors
 

--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStoreSpec.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloAttributeStoreSpec.scala
@@ -16,7 +16,8 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.LayerId
+import geotrellis.layers.{LayerId, LayerHeader}
+import geotrellis.layers.accumulo._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import org.apache.accumulo.core.client.security.tokens.PasswordToken

--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloLayerProviderSpec.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloLayerProviderSpec.scala
@@ -16,6 +16,8 @@
 
 package geotrellis.spark.io.accumulo
 
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
 import geotrellis.spark.io._
 import geotrellis.spark.testkit.TestEnvironment
 import org.scalatest._
@@ -44,7 +46,7 @@ class AccumuloLayerProviderSpec extends FunSpec with TestEnvironment {
 
   it("should not be able to process a URI without a scheme") {
     val badURI = new java.net.URI("//root:@localhost/fake?attributes=attributes&layers=tiles")
-    val provider = new AccumuloLayerProvider
+    val provider = new AccumuloSparkLayerProvider
 
     provider.canProcess(badURI) should be (false)
   }

--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeSpec.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeSpec.scala
@@ -16,12 +16,13 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.TileLayerMetadata
-import geotrellis.raster.Tile
 import geotrellis.tiling.SpaceTimeKey
+import geotrellis.raster.Tile
+import geotrellis.layers.TileLayerMetadata
+import geotrellis.layers.accumulo._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.layers.io.index._
+import geotrellis.layers.index._
 import geotrellis.spark.testkit.io._
 import geotrellis.spark.testkit.testfiles.TestFiles
 import geotrellis.spark.testkit.TestEnvironment

--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpatialSpec.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpatialSpec.scala
@@ -16,12 +16,13 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.TileLayerMetadata
-import geotrellis.raster.Tile
 import geotrellis.tiling.SpatialKey
+import geotrellis.raster.Tile
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.layers.io.index._
+import geotrellis.layers.index._
 import geotrellis.spark.testkit.io._
 import geotrellis.spark.testkit.testfiles.TestFiles
 import geotrellis.spark.testkit.TestEnvironment

--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloTileFeatureSpaceTimeSpec.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloTileFeatureSpaceTimeSpec.scala
@@ -16,12 +16,13 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.TileLayerMetadata
-import geotrellis.raster.{Tile, TileFeature}
 import geotrellis.tiling.SpaceTimeKey
+import geotrellis.raster.{Tile, TileFeature}
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.layers.io.index._
+import geotrellis.layers.index._
 import geotrellis.spark.testkit.io._
 import geotrellis.spark.testkit.testfiles.TestTileFeatureFiles
 import geotrellis.spark.testkit.TestEnvironment

--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloTileFeatureSpatialSpec.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/AccumuloTileFeatureSpatialSpec.scala
@@ -16,12 +16,13 @@
 
 package geotrellis.spark.io.accumulo
 
-import geotrellis.layers.TileLayerMetadata
-import geotrellis.raster.{Tile, TileFeature}
 import geotrellis.tiling.SpatialKey
+import geotrellis.raster.{Tile, TileFeature}
+import geotrellis.layers._
+import geotrellis.layers.accumulo._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.layers.io.index._
+import geotrellis.layers.index._
 import geotrellis.spark.testkit.io._
 import geotrellis.spark.testkit.testfiles.TestTileFeatureFiles
 import geotrellis.spark.testkit.TestEnvironment

--- a/accumulo/src/test/scala/geotrellis/spark/io/accumulo/MockAccumuloInstance.scala
+++ b/accumulo/src/test/scala/geotrellis/spark/io/accumulo/MockAccumuloInstance.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.spark.io.accumulo
 
+import geotrellis.layers.accumulo._
 import org.apache.accumulo.core.client._
 import org.apache.accumulo.core.client.mock.MockInstance
 import org.apache.accumulo.core.client.security.tokens.PasswordToken

--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,7 @@ lazy val commonSettings = Seq(
 lazy val root = Project("geotrellis", file(".")).
   aggregate(
     accumulo,
+    `layers-accumulo`,
     cassandra,
     `doc-examples`,
     geomesa,

--- a/build.sbt
+++ b/build.sbt
@@ -214,11 +214,17 @@ lazy val `s3-testkit` = project
 
 lazy val accumulo = project
   .dependsOn(
+    `layers-accumulo`,
     spark % "compile->compile;test->test", // <-- spark-testkit update should simplify this
     `spark-testkit` % Test
   )
   .settings(commonSettings)
   .settings(Settings.accumulo)
+
+lazy val `layers-accumulo` = project
+  .dependsOn(layers)
+  .settings(commonSettings)
+  .settings(Settings.`layers-accumulo`)
 
 lazy val cassandra = project
   .dependsOn(

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,6 +7,23 @@ Changelog
 API Changes & Project structure changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``geotrellis.accumulo``
+
+  - **Remove:** The following types have been moved from ``geotrellis.accumulo`` to the ``geotrellis.layers.accumulo`` package:
+    - ``AccumuloAttributeStore``
+    - ``AccumuloCollectionLayerReader``
+    - ``AccumuloCollectionReader``
+    - ``AccumuloInstance``
+    - ``AccumuloKeyEncoder``
+    - ``AccumuloLayerDeleter``
+    - ``AccumuloLayerHeader``
+    - ``AccumuloUtils``
+    - ``AccumuloValueReader``
+
+- ``geotrellis.layers.accumulo``
+
+  - **New:** ``geotrellis.layers.accumulo`` is a new package where non-Spark related Accumulo API will be contained.
+
 - ``geotrellis.slick``
 
   - **Remove:**  ``geotrellis.slick`` has been removed. Slick support will now reside in `geotrellis-contrib` (`#2902 <https://github.com/locationtech/geotrellis/pull/2902>`_).

--- a/layers-accumulo/src/main/resources/META-INF/services/geotrellis.layers.AttributeStoreProvider
+++ b/layers-accumulo/src/main/resources/META-INF/services/geotrellis.layers.AttributeStoreProvider
@@ -1,0 +1,1 @@
+geotrellis.layers.accumulo.AccumuloCollectionLayerProvider

--- a/layers-accumulo/src/main/resources/META-INF/services/geotrellis.layers.CollectionLayerReaderProvider
+++ b/layers-accumulo/src/main/resources/META-INF/services/geotrellis.layers.CollectionLayerReaderProvider
@@ -1,0 +1,1 @@
+geotrellis.layers.accumulo.AccumuloCollectionLayerProvider

--- a/layers-accumulo/src/main/resources/META-INF/services/geotrellis.layers.ValueReaderProvider
+++ b/layers-accumulo/src/main/resources/META-INF/services/geotrellis.layers.ValueReaderProvider
@@ -1,0 +1,1 @@
+geotrellis.layers.accumulo.AccumuloCollectionLayerProvider

--- a/layers-accumulo/src/main/resources/reference.conf
+++ b/layers-accumulo/src/main/resources/reference.conf
@@ -15,6 +15,6 @@
 geotrellis.accumulo {
   catalog = "metadata"
   threads {
-    rdd.write       = default
+    collection.read = default
   }
 }

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloAttributeStore.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloAttributeStore.scala
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
-import geotrellis.layers.LayerId
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.io.accumulo.conf.AccumuloConfig
+import geotrellis.layers._
+import geotrellis.layers.accumulo.conf.AccumuloConfig
+
 import spray.json._
 import spray.json.DefaultJsonProtocol._
+
 import org.apache.accumulo.core.client.{BatchWriterConfig, Connector}
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.accumulo.core.data._
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.iterators.user.RegExFilter
 import org.apache.hadoop.io.Text
 
 import scala.collection.JavaConverters._
+
 
 object AccumuloAttributeStore {
   def apply(connector: Connector, attributeTable: String): AccumuloAttributeStore =

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloCollectionLayerProvider.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloCollectionLayerProvider.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.layers.accumulo
+
+import geotrellis.layers._
+import geotrellis.layers.accumulo.conf.AccumuloConfig
+import geotrellis.util.UriUtils
+
+import java.net.URI
+
+
+/**
+ * Provides [[AccumuloAttributeStore]] instance for URI with `accumulo` scheme.
+ *  ex: `accumulo://[user[:password]@]zookeeper/instance-name[?attributes=table1[&layers=table2]]`
+ *
+ * Attributes table name is optional, not provided default value will be used.
+ * Layers table name is required to instantiate a [[LayerWriter]]
+ */
+class AccumuloCollectionLayerProvider extends AttributeStoreProvider with CollectionLayerReaderProvider with ValueReaderProvider {
+  def canProcess(uri: URI): Boolean = uri.getScheme match {
+    case str: String => if (str.toLowerCase == "accumulo") true else false
+    case null => false
+  }
+
+  def attributeStore(uri: URI): AttributeStore = {
+    val instance = AccumuloInstance(uri)
+    val params = UriUtils.getParams(uri)
+    val attributeTable = params.getOrElse("attributes", AccumuloConfig.catalog)
+    AccumuloAttributeStore(instance, attributeTable)
+  }
+
+  def valueReader(uri: URI, store: AttributeStore): ValueReader[LayerId] = {
+    val instance = AccumuloInstance(uri)
+    new AccumuloValueReader(instance, store)
+  }
+
+  def collectionLayerReader(uri: URI, store: AttributeStore): CollectionLayerReader[LayerId] = {
+    val instance = AccumuloInstance(uri)
+    new AccumuloCollectionLayerReader(store)(instance)
+  }
+}

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloCollectionLayerReader.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloCollectionLayerReader.scala
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
-import geotrellis.layers.{ContextCollection, LayerId}
 import geotrellis.tiling._
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
+import geotrellis.layers._
+import geotrellis.layers.avro._
 import geotrellis.util._
+
 import org.apache.accumulo.core.data.{Range => AccumuloRange}
 import org.apache.hadoop.io.Text
+
 import spray.json._
 
 import scala.reflect._

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloCollectionReader.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloCollectionReader.scala
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
-import geotrellis.spark.io._
-import geotrellis.spark.io.accumulo.conf.AccumuloConfig
-import geotrellis.layers.io.avro.codecs.KeyValueRecordCodec
-import geotrellis.layers.io.avro.{AvroEncoder, AvroRecordCodec}
 import geotrellis.tiling.{Boundable, KeyBounds}
+import geotrellis.layers._
+import geotrellis.layers.accumulo.conf.AccumuloConfig
+import geotrellis.layers.avro.codecs.KeyValueRecordCodec
+import geotrellis.layers.avro.{AvroEncoder, AvroRecordCodec}
 
 import org.apache.accumulo.core.data.{Range => AccumuloRange}
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.avro.Schema
 import org.apache.hadoop.io.Text
+
 import cats.effect._
 import cats.syntax.apply._
 
@@ -34,6 +35,7 @@ import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 import java.util.concurrent.Executors
+
 
 object AccumuloCollectionReader {
   val defaultThreadCount: Int = AccumuloConfig.threads.collection.readThreads

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloInstance.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloInstance.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
 import org.apache.accumulo.core.client._
 import org.apache.accumulo.core.client.mapreduce.{AbstractInputFormat => AIF, AccumuloOutputFormat => AOF}
@@ -25,6 +25,7 @@ import org.apache.hadoop.mapreduce.Job
 
 import scala.collection.JavaConverters._
 import java.net.URI
+
 
 trait AccumuloInstance  extends Serializable {
   def connector: Connector

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloKeyEncoder.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloKeyEncoder.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
 import geotrellis.layers.LayerId
-import geotrellis.spark._
+
 import org.apache.accumulo.core.data.Key
 import org.apache.hadoop.io.Text
+
 
 object AccumuloKeyEncoder {
   final def long2Bytes(x: BigInt): Array[Byte] = {

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloLayerDeleter.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloLayerDeleter.scala
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
-import geotrellis.spark.io._
+import geotrellis.layers._
+
 import com.typesafe.scalalogging.LazyLogging
-import geotrellis.layers.LayerId
+
 import org.apache.accumulo.core.client.{BatchWriterConfig, Connector}
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.accumulo.core.data.{Range => AccumuloRange}

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloLayerHeader.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloLayerHeader.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
-import geotrellis.spark.io.{LayerHeader, LayerType, AvroLayerType}
+import geotrellis.layers.{LayerHeader, LayerType, AvroLayerType}
 
 import spray.json._
 

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloUtils.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloUtils.scala
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
 import geotrellis.tiling.{Bounds, Boundable, KeyBounds, EmptyBounds}
-import geotrellis.spark.io.accumulo._
-import geotrellis.layers.io.index.{KeyIndexMethod, KeyIndex}
+import geotrellis.layers.accumulo._
+import geotrellis.layers.index.{KeyIndexMethod, KeyIndex}
 
 import org.apache.accumulo.core.data.Key
 import org.apache.hadoop.io.Text
-import org.apache.spark.rdd.RDD
 
 import scala.collection.JavaConverters._
 

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloValueReader.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/AccumuloValueReader.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo
+package geotrellis.layers.accumulo
 
-import geotrellis.layers.LayerId
-import geotrellis.layers.io.{OverzoomingValueReader, Reader}
+import geotrellis.tiling.SpatialComponent
 import geotrellis.raster._
 import geotrellis.raster.resample._
-import geotrellis.tiling.SpatialComponent
-import geotrellis.spark.io._
-import geotrellis.layers.io.avro.{AvroEncoder, AvroRecordCodec}
-import geotrellis.layers.io.avro.codecs.KeyValueRecordCodec
+import geotrellis.layers._
+import geotrellis.layers.avro.{AvroEncoder, AvroRecordCodec}
+import geotrellis.layers.avro.codecs.KeyValueRecordCodec
+
 import org.apache.accumulo.core.data.{Range => ARange}
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.hadoop.io.Text
+
 import spray.json._
 
 import scala.collection.JavaConverters._

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/conf/AccumuloConfig.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/conf/AccumuloConfig.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.accumulo.conf
+package geotrellis.layers.accumulo.conf
 
-import geotrellis.layers.io.hadoop.conf.CamelCaseConfig
-import geotrellis.spark.util.threadsFromString
+import geotrellis.layers.util.threadsFromString
+import geotrellis.util.CamelCaseConfig
+
 import pureconfig.generic.auto._
 
 case class AccumuloCollectionConfig(read: String = "default") {

--- a/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/package.scala
+++ b/layers-accumulo/src/main/scala/geotrellis/layers/accumulo/package.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io
+package geotrellis.layers
 
-import geotrellis.layers.LayerId
 import org.apache.hadoop.io.Text
 import org.apache.accumulo.core.client.{BatchWriterConfig, Connector, Scanner}
 import org.apache.accumulo.core.data.{Key, Mutation, Value}
+
 
 package object accumulo {
   implicit def stringToText(s: String): Text = new Text(s)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -65,6 +65,27 @@ object Settings {
       """
   ) ++ noForkInTests
 
+  lazy val `layers-accumulo` = Seq(
+    name := "geotrellis-layers-accumulo",
+    libraryDependencies ++= Seq(
+      accumuloCore
+        exclude("org.jboss.netty", "netty")
+        exclude("org.apache.hadoop", "hadoop-client"),
+      spire,
+      scalatest % Test,
+      hadoopClient % Provided
+    ),
+    initialCommands in console :=
+      """
+      import geotrellis.proj4._
+      import geotrellis.vector._
+      import geotrellis.raster._
+      import geotrellis.tiling._
+      import geotrellis.layers._
+      import geotrellis.layers.accumulo._
+      """
+  ) ++ noForkInTests
+
   lazy val bench = Seq(
     libraryDependencies += sl4jnop,
     jmhIterations := Some(5),

--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ./sbt -J-Xmx2G "project accumulo" test  || { exit 1; }
+./sbt -J-Xmx2G "project layers-accumulo" test  || { exit 1; }
 ./sbt -J-Xmx2G "project cassandra" test  || { exit 1; }
 ./sbt -J-Xmx2G "project doc-examples" compile || { exit 1; }
 ./sbt -J-Xmx2G "project geomesa" test || { exit 1; }

--- a/scripts/cleanall.sh
+++ b/scripts/cleanall.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ./sbt -J-Xmx2G "project accumulo" clean  || { exit 1; }
+./sbt -J-Xmx2G "project layers-accumulo" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project cassandra" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project geomesa" clean || { exit 1; }
 ./sbt -J-Xmx2G "project geotools" clean || { exit 1; }
@@ -15,6 +16,7 @@
 ./sbt -J-Xmx2G "project vectortile" clean || { exit 1; }
 
 rm -r accumulo/target
+rm -r layers-accumulo/target
 rm -r cassandra/target
 rm -r geomesa/target
 rm -r geotools/target

--- a/scripts/createHeaders.sh
+++ b/scripts/createHeaders.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ./sbt "project accumulo" createHeaders test:createHeaders \
+      "project layers-accumulo" createHeaders test:createHeaders \
       "project cassandra" createHeaders test:createHeaders \
       "project doc-examples" createHeaders test:createHeaders \
       "project geomesa" createHeaders test:createHeaders \

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -17,6 +17,7 @@
 ./sbt "project spark-pipeline" publishLocal && \
 ./sbt "project spark-etl" publishLocal && \
 ./sbt "project accumulo" publishLocal && \
+./sbt "project layers-accumulo" publishLocal && \
 ./sbt "project cassandra" publishLocal && \
 ./sbt "project geomesa" publishLocal && \
 ./sbt "project geotools" publishLocal && \

--- a/scripts/publish-m2.sh
+++ b/scripts/publish-m2.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ./sbt "project accumulo" +publishM2 \
+      "project layers-accumulo" +publishM2 \
       "project cassandra" +publishM2 \
       "project geomesa" +publishM2 \
       "project geotools" +publishM2 \

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ./sbt "project accumulo" publish \
+      "project layers-accumulo" publish \
       "project cassandra" publish \
       "project geomesa" publish \
       "project geotools" publish \
@@ -12,7 +13,6 @@
       "project raster-testkit" publish \
       "project s3" publish \
       "project s3-testkit" publish \
-      "project accumulo" publish \
       "project cassandra" publish \
       "project hbase" publish \
       "project shapefile" publish \


### PR DESCRIPTION
## Overview

This PR is the continuation of #2927 where the `accumulo` package is broken into two new packages: `layers-accumulo` and `accumulo`. Both projects contain `accumulo` IO logic but the former does not use Spark while the latter does.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

### Notes

This PR addresses the `accumulo` split in #2934