### PR TITLE
Cassandra Spark Split

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,8 +227,14 @@ lazy val `layers-accumulo` = project
   .settings(commonSettings)
   .settings(Settings.`layers-accumulo`)
 
+lazy val `layers-cassandra` = project
+  .dependsOn(layers)
+  .settings(commonSettings)
+  .settings(Settings.`layers-cassandra`)
+
 lazy val cassandra = project
   .dependsOn(
+    `layers-cassandra`,
     spark % "compile->compile;test->test", // <-- spark-testkit update should simplify this
     `spark-testkit` % Test
   )

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,7 @@ lazy val root = Project("geotrellis", file(".")).
     accumulo,
     `layers-accumulo`,
     cassandra,
+    `layers-cassandra`,
     `doc-examples`,
     geomesa,
     geotools,

--- a/cassandra/src/main/resources/META-INF/services/geotrellis.layers.io.ValueReaderProvider
+++ b/cassandra/src/main/resources/META-INF/services/geotrellis.layers.io.ValueReaderProvider
@@ -1,1 +1,0 @@
-geotrellis.spark.io.cassandra.CassandraLayerProvider

--- a/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.AttributeStoreProvider
+++ b/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.AttributeStoreProvider
@@ -1,1 +1,0 @@
-geotrellis.spark.io.cassandra.CassandraLayerProvider

--- a/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
+++ b/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.CollectionLayerReaderProvider
@@ -1,1 +1,0 @@
-geotrellis.spark.io.cassandra.CassandraLayerProvider

--- a/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.LayerReaderProvider
+++ b/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.LayerReaderProvider
@@ -1,1 +1,1 @@
-geotrellis.spark.io.cassandra.CassandraLayerProvider
+geotrellis.spark.io.cassandra.CassandraSparkLayerProvider

--- a/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.LayerWriterProvider
+++ b/cassandra/src/main/resources/META-INF/services/geotrellis.spark.io.LayerWriterProvider
@@ -1,1 +1,1 @@
-geotrellis.spark.io.cassandra.CassandraLayerProvider
+geotrellis.spark.io.cassandra.CassandraSparkLayerProvider

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerCopier.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerCopier.scala
@@ -16,13 +16,15 @@
 
 package geotrellis.spark.io.cassandra
 
-import geotrellis.layers.LayerId
 import geotrellis.tiling.{Boundable, Bounds}
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
+import geotrellis.layers.avro._
 import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
 import geotrellis.util._
+
 import org.apache.spark.SparkContext
+
 import spray.json.JsonFormat
 
 import scala.reflect.ClassTag

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerManager.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerManager.scala
@@ -16,14 +16,16 @@
 
 package geotrellis.spark.io.cassandra
 
-import geotrellis.layers.LayerId
 import geotrellis.tiling.{Boundable, Bounds}
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
+import geotrellis.layers.avro.AvroRecordCodec
+import geotrellis.layers.index._
 import geotrellis.spark.io._
-import geotrellis.layers.io.avro.AvroRecordCodec
-import geotrellis.layers.io.index._
 import geotrellis.util._
+
 import org.apache.spark.SparkContext
+
 import spray.json.JsonFormat
 
 import scala.reflect.ClassTag

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerMover.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerMover.scala
@@ -16,9 +16,10 @@
 
 package geotrellis.spark.io.cassandra
 
-import geotrellis.layers.LayerId
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
 import geotrellis.spark.io._
+
 import org.apache.spark.SparkContext
 
 object CassandraLayerMover {

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerReader.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerReader.scala
@@ -16,13 +16,16 @@
 
 package geotrellis.spark.io.cassandra
 
-import geotrellis.layers.LayerId
 import geotrellis.tiling.{Boundable, Bounds, EmptyBounds, KeyBounds}
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
+import geotrellis.layers._
+import geotrellis.layers.avro._
+import geotrellis.layers.cassandra._
+import geotrellis.spark.ContextRDD
+import geotrellis.spark.io.FilteringLayerReader
 import geotrellis.util._
+
 import org.apache.spark.SparkContext
+
 import spray.json._
 
 import scala.reflect._

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerReindexer.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerReindexer.scala
@@ -17,16 +17,18 @@
 package geotrellis.spark.io.cassandra
 
 import geotrellis.tiling.{Boundable, Bounds}
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.avro._
+import geotrellis.layers.cassandra._
+import geotrellis.layers.index._
 import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
-import geotrellis.layers.io.index._
 import geotrellis.util._
-import org.apache.spark.SparkContext
-import spray.json.JsonFormat
-import java.time.ZonedDateTime
 
-import geotrellis.layers.LayerId
+import org.apache.spark.SparkContext
+
+import spray.json.JsonFormat
+
+import java.time.ZonedDateTime
 
 import scala.reflect.ClassTag
 

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerWriter.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraLayerWriter.scala
@@ -17,17 +17,20 @@
 package geotrellis.spark.io.cassandra
 
 import geotrellis.tiling.{Boundable, Bounds}
-import geotrellis.spark._
+import geotrellis.layers._
+import geotrellis.layers.avro._
+import geotrellis.layers.avro.codecs._
+import geotrellis.layers.cassandra._
+import geotrellis.layers.index._
+import geotrellis.layers.merge.Mergable
 import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
-import geotrellis.layers.io.avro.codecs._
-import geotrellis.layers.io.index._
 import geotrellis.spark.merge._
 import geotrellis.util._
+
 import com.typesafe.scalalogging.LazyLogging
-import geotrellis.layers.merge.Mergable
-import geotrellis.layers.{LayerId, Metadata}
+
 import org.apache.spark.rdd.RDD
+
 import spray.json._
 
 import scala.reflect._

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraRDDWriter.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraRDDWriter.scala
@@ -16,25 +16,29 @@
 
 package geotrellis.spark.io.cassandra
 
+import geotrellis.layers._
+import geotrellis.layers.avro._
+import geotrellis.layers.avro.codecs._
+import geotrellis.layers.cassandra._
+import geotrellis.layers.cassandra.conf.CassandraConfig
 import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
-import geotrellis.layers.io.avro.codecs._
-import geotrellis.spark.io.cassandra.conf.CassandraConfig
 import geotrellis.spark.util.KryoWrapper
+
 import com.datastax.driver.core.DataType._
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.querybuilder.QueryBuilder.{eq => eqs}
 import com.datastax.driver.core.ResultSet
 import com.datastax.driver.core.schemabuilder.SchemaBuilder
+
 import cats.effect.IO
 import cats.syntax.apply._
+
 import org.apache.avro.Schema
 import org.apache.spark.rdd.RDD
+
 import java.nio.ByteBuffer
 import java.util.concurrent.Executors
 import java.math.BigInteger
-
-import geotrellis.layers.LayerId
 
 import scala.concurrent.ExecutionContext
 import scala.collection.JavaConverters._

--- a/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraSparkLayerProvider.scala
+++ b/cassandra/src/main/scala/geotrellis/spark/io/cassandra/CassandraSparkLayerProvider.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.io.cassandra
+
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
+import geotrellis.layers.cassandra.conf.CassandraConfig
+import geotrellis.spark.io._
+import geotrellis.util.UriUtils
+
+import org.apache.spark.SparkContext
+
+import java.net.URI
+
+
+/**
+ * Provides [[CassandraAttributeStore]] instance for URI with `cassandra` scheme.
+ *  ex: `cassandra://[user:password@]zookeeper[:port][/keyspace][?attributes=table1[&layers=table2]]`
+ *
+ * Metadata table name is optional, not provided default value will be used.
+ * Layers table name is required to instantiate a [[LayerWriter]]
+ */
+class CassandraSparkLayerProvider extends CassandraCollectionLayerProvider with LayerReaderProvider with LayerWriterProvider {
+  def layerReader(uri: URI, store: AttributeStore, sc: SparkContext): FilteringLayerReader[LayerId] = {
+    val instance = CassandraInstance(uri)
+    new CassandraLayerReader(store, instance)(sc)
+  }
+
+  def layerWriter(uri: URI, store: AttributeStore): LayerWriter[LayerId] = {
+    val instance = CassandraInstance(uri)
+    val keyspace = Option(uri.getPath.drop(1)).getOrElse(CassandraConfig.keyspace)
+    val params = UriUtils.getParams(uri)
+    val table = params.getOrElse("layers",
+      throw new IllegalArgumentException("Missing required URI parameter: layers"))
+
+    new CassandraLayerWriter(store, instance, keyspace, table)
+  }
+}

--- a/cassandra/src/test/scala/geotrellis/spark/CassandraTestEnvironment.scala
+++ b/cassandra/src/test/scala/geotrellis/spark/CassandraTestEnvironment.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.spark
 
-import geotrellis.spark.io.cassandra.BaseCassandraInstance
+import geotrellis.layers.cassandra.BaseCassandraInstance
 import geotrellis.spark.io.kryo.KryoRegistrator
 import geotrellis.spark.testkit.TestEnvironment
 

--- a/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraAttributeStoreSpec.scala
+++ b/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraAttributeStoreSpec.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.spark.io.cassandra
 
+import geotrellis.layers.cassandra._
 import geotrellis.spark.CassandraTestEnvironment
 import geotrellis.spark.io.AttributeStoreSpec
 

--- a/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraLayerProviderSpec.scala
+++ b/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraLayerProviderSpec.scala
@@ -16,6 +16,8 @@
 
 package geotrellis.spark.io.cassandra
 
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
 import geotrellis.spark.io._
 import geotrellis.spark.CassandraTestEnvironment
 import geotrellis.spark.testkit.TestEnvironment
@@ -45,7 +47,7 @@ class CassandraLayerProviderSpec extends FunSpec with CassandraTestEnvironment {
 
   it("should not be able to process a URI without a scheme") {
     val badURI = new java.net.URI("//127.0.0.1/geotrellis?attributes=attributes&layers=tiles")
-    val provider = new CassandraLayerProvider
+    val provider = new CassandraSparkLayerProvider
 
     provider.canProcess(badURI) should be (false)
   }

--- a/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraSpaceTimeSpec.scala
+++ b/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraSpaceTimeSpec.scala
@@ -19,6 +19,8 @@ package geotrellis.spark.io.cassandra
 import geotrellis.layers.TileLayerMetadata
 import geotrellis.raster.Tile
 import geotrellis.tiling.SpaceTimeKey
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.testkit.io._

--- a/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraSpatialSpec.scala
+++ b/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraSpatialSpec.scala
@@ -19,6 +19,8 @@ package geotrellis.spark.io.cassandra
 import geotrellis.layers.TileLayerMetadata
 import geotrellis.raster.Tile
 import geotrellis.tiling.SpatialKey
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.testkit.io._

--- a/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraTileFeatureSpaceTimeSpec.scala
+++ b/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraTileFeatureSpaceTimeSpec.scala
@@ -16,9 +16,10 @@
 
 package geotrellis.spark.io.cassandra
 
-import geotrellis.layers.TileLayerMetadata
-import geotrellis.raster.{Tile, TileFeature}
 import geotrellis.tiling.SpaceTimeKey
+import geotrellis.raster.{Tile, TileFeature}
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.testkit.io._

--- a/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraTileFeatureSpatialSpec.scala
+++ b/cassandra/src/test/scala/geotrellis/spark/io/cassandra/CassandraTileFeatureSpatialSpec.scala
@@ -16,9 +16,10 @@
 
 package geotrellis.spark.io.cassandra
 
-import geotrellis.layers.TileLayerMetadata
-import geotrellis.raster.{Tile, TileFeature}
 import geotrellis.tiling.SpatialKey
+import geotrellis.raster.{Tile, TileFeature}
+import geotrellis.layers._
+import geotrellis.layers.cassandra._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.testkit.io._

--- a/layers-cassandra/src/main/java/geotrellis/layers/cassandra/BigIntegerIffBigint.java
+++ b/layers-cassandra/src/main/java/geotrellis/layers/cassandra/BigIntegerIffBigint.java
@@ -1,4 +1,4 @@
-package geotrellis.spark.io.cassandra;
+package geotrellis.layers.cassandra;
 
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.exceptions.InvalidTypeException;

--- a/layers-cassandra/src/main/resources/META-INF/services/geotrellis.layers.AttributeStoreProvider
+++ b/layers-cassandra/src/main/resources/META-INF/services/geotrellis.layers.AttributeStoreProvider
@@ -1,0 +1,1 @@
+geotrellis.layers.cassandra.CassandraCollectionLayerProvider

--- a/layers-cassandra/src/main/resources/META-INF/services/geotrellis.layers.CollectionLayerReaderProvider
+++ b/layers-cassandra/src/main/resources/META-INF/services/geotrellis.layers.CollectionLayerReaderProvider
@@ -1,0 +1,1 @@
+geotrellis.layers.cassandra.CassandraCollectionLayerProvider

--- a/layers-cassandra/src/main/resources/META-INF/services/geotrellis.layers.ValueReaderProvider
+++ b/layers-cassandra/src/main/resources/META-INF/services/geotrellis.layers.ValueReaderProvider
@@ -1,0 +1,1 @@
+geotrellis.layers.cassandra.CassandraCollectionLayerProvider

--- a/layers-cassandra/src/main/resources/reference.conf
+++ b/layers-cassandra/src/main/resources/reference.conf
@@ -22,9 +22,6 @@ geotrellis.cassandra {
   usedHostsPerRemoteDc = 0
   allowRemoteDCsForLocalConsistencyLevel = false
   threads {
-    rdd {
-      write = default
-      read  = default
-    }
+    collection.read = default
   }
 }

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraAttributeStore.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraAttributeStore.scala
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.cassandra
+package geotrellis.layers.cassandra
 
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.io.cassandra.conf.CassandraConfig
+import geotrellis.layers._
+import geotrellis.layers.cassandra.conf.CassandraConfig
+
 import com.datastax.driver.core.ResultSet
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.querybuilder.QueryBuilder.{set, eq => eqs}
 import com.datastax.driver.core.schemabuilder.SchemaBuilder
 import com.datastax.driver.core.DataType._
-import geotrellis.layers.LayerId
+
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraCollectionLayerReader.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraCollectionLayerReader.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.cassandra
+package geotrellis.layers.cassandra
 
-import geotrellis.layers.{ContextCollection, LayerId}
 import geotrellis.tiling.{Boundable, Bounds, EmptyBounds, KeyBounds}
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.layers.io.avro._
+import geotrellis.layers._
+import geotrellis.layers.avro._
 import geotrellis.util._
+
 import spray.json._
 
 import scala.reflect._

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraCollectionReader.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraCollectionReader.scala
@@ -14,27 +14,32 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.cassandra
+package geotrellis.layers.cassandra
 
 import geotrellis.tiling.{Boundable, KeyBounds}
-import geotrellis.spark.io._
-import geotrellis.layers.io.avro.codecs.KeyValueRecordCodec
-import geotrellis.layers.io.avro.{AvroEncoder, AvroRecordCodec}
-import geotrellis.spark.io.cassandra.conf.CassandraConfig
-import geotrellis.layers.io.index.MergeQueue
-import geotrellis.spark.util.KryoWrapper
+import geotrellis.layers._
+import geotrellis.layers.util.IOUtils
+import geotrellis.layers.avro.codecs.KeyValueRecordCodec
+import geotrellis.layers.avro.{AvroEncoder, AvroRecordCodec}
+import geotrellis.layers.cassandra.conf.CassandraConfig
+import geotrellis.layers.index.MergeQueue
+
 import org.apache.avro.Schema
+
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.querybuilder.QueryBuilder.{eq => eqs}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
+
 import java.math.BigInteger
 
 import geotrellis.layers.LayerId
 
 object CassandraCollectionReader {
   final val defaultThreadCount = CassandraConfig.threads.collection.readThreads
+
+  private case class SchemaWrapper(value: Option[Schema]) extends Serializable
 
   def read[K: Boundable : AvroRecordCodec : ClassTag, V: AvroRecordCodec : ClassTag](
     instance: CassandraInstance,
@@ -51,7 +56,7 @@ object CassandraCollectionReader {
 
     val includeKey = (key: K) => queryKeyBounds.includeKey(key)
     val _recordCodec = KeyValueRecordCodec[K, V]
-    val kwWriterSchema = KryoWrapper(writerSchema) //Avro Schema is not Serializable
+    val swWriterSchema = SchemaWrapper(writerSchema) //Avro Schema is not Serializable
 
     val ranges = if (queryKeyBounds.length > 1)
       MergeQueue(queryKeyBounds.flatMap(decomposeBounds))
@@ -68,11 +73,11 @@ object CassandraCollectionReader {
     instance.withSessionDo { session =>
       val statement = session.prepare(query)
 
-      LayerReader.njoin[K, V](ranges.toIterator, threads){ index: BigInt =>
+      IOUtils.parJoin[K, V](ranges.toIterator, threads){ index: BigInt =>
         val row = session.execute(statement.bind(index: BigInteger))
         if (row.asScala.nonEmpty) {
           val bytes = row.one().getBytes("value").array()
-          val recs = AvroEncoder.fromBinary(kwWriterSchema.value.getOrElse(_recordCodec.schema), bytes)(_recordCodec)
+          val recs = AvroEncoder.fromBinary(swWriterSchema.value.getOrElse(_recordCodec.schema), bytes)(_recordCodec)
           if (filterIndexOnly) recs
           else recs.filter { row => includeKey(row._1) }
         } else Vector.empty

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraInstance.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraInstance.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.cassandra
+package geotrellis.layers.cassandra
 
-import geotrellis.spark.io.cassandra.conf.CassandraConfig
+import geotrellis.layers.cassandra.conf.CassandraConfig
 
 import com.datastax.driver.core.policies.{DCAwareRoundRobinPolicy, TokenAwarePolicy}
 import com.datastax.driver.core.{Cluster, Session}

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraLayerDeleter.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraLayerDeleter.scala
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.cassandra
+package geotrellis.layers.cassandra
 
-import geotrellis.spark.io._
+import geotrellis.layers._
+
 import com.typesafe.scalalogging.LazyLogging
+
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.querybuilder.QueryBuilder.{eq => eqs}
-import geotrellis.layers.LayerId
 
 import scala.collection.JavaConverters._
+
 
 class CassandraLayerDeleter(val attributeStore: AttributeStore, instance: CassandraInstance) extends LazyLogging with LayerDeleter[LayerId] {
 

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraLayerHeader.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraLayerHeader.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.cassandra
+package geotrellis.layers.cassandra
 
-import geotrellis.spark.io.{LayerHeader, LayerType, AvroLayerType}
+import geotrellis.layers.{LayerHeader, LayerType, AvroLayerType}
 
 import spray.json._
 

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraValueReader.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/CassandraValueReader.scala
@@ -14,24 +14,25 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.cassandra
+package geotrellis.layers.cassandra
 
+import geotrellis.tiling.SpatialComponent
 import geotrellis.raster._
 import geotrellis.raster.resample._
-import geotrellis.tiling.SpatialComponent
-import geotrellis.spark.io._
-import geotrellis.layers.io.avro.codecs.KeyValueRecordCodec
-import geotrellis.layers.io.avro.{AvroEncoder, AvroRecordCodec}
+import geotrellis.layers._
+import geotrellis.layers.avro.codecs.KeyValueRecordCodec
+import geotrellis.layers.avro.{AvroEncoder, AvroRecordCodec}
+
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.querybuilder.QueryBuilder.{eq => eqs}
+
 import spray.json._
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
+
 import java.math.BigInteger
 
-import geotrellis.layers.LayerId
-import geotrellis.layers.io.{OverzoomingValueReader, Reader}
 
 class CassandraValueReader(
   instance: CassandraInstance,

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/conf/CassandraConfig.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/conf/CassandraConfig.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io.cassandra.conf
+package geotrellis.layers.cassandra.conf
 
-import geotrellis.layers.io.hadoop.conf.CamelCaseConfig
-import geotrellis.spark.util._
+import geotrellis.util.CamelCaseConfig
+import geotrellis.layers.util._
+
 import pureconfig.generic.auto._
 
 case class CassandraCollectionConfig(read: String = "default") {

--- a/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/package.scala
+++ b/layers-cassandra/src/main/scala/geotrellis/layers/cassandra/package.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.io
+package geotrellis.layers
 
 import java.math.BigInteger
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -119,6 +119,29 @@ object Settings {
       """
   ) ++ noForkInTests
 
+  lazy val `layers-cassandra` = Seq(
+    name := "geotrellis-layers-cassandra",
+    libraryDependencies ++= Seq(
+      cassandraDriverCore
+        excludeAll(
+        ExclusionRule("org.jboss.netty"), ExclusionRule("io.netty"),
+        ExclusionRule("org.slf4j"), ExclusionRule("io.spray"), ExclusionRule("com.typesafe.akka")
+      ) exclude("org.apache.hadoop", "hadoop-client"),
+      spire,
+      scalatest % Test
+    ),
+    initialCommands in console :=
+      """
+      import geotrellis.proj4._
+      import geotrellis.vector._
+      import geotrellis.tiling._
+      import geotrellis.raster._
+      import geotrellis.layers._
+      import geotrellis.layers.util._
+      import geotrellis.layers.cassandra._
+      """
+  ) ++ noForkInTests
+
   lazy val `doc-examples` = Seq(
     name := "geotrellis-doc-examples",
     publish / skip := true,

--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -3,6 +3,7 @@
 ./sbt -J-Xmx2G "project accumulo" test  || { exit 1; }
 ./sbt -J-Xmx2G "project layers-accumulo" test  || { exit 1; }
 ./sbt -J-Xmx2G "project cassandra" test  || { exit 1; }
+./sbt -J-Xmx2G "project layers-cassandra" test  || { exit 1; }
 ./sbt -J-Xmx2G "project doc-examples" compile || { exit 1; }
 ./sbt -J-Xmx2G "project geomesa" test || { exit 1; }
 ./sbt -J-Xmx2G "project geotools" test || { exit 1; }

--- a/scripts/cleanall.sh
+++ b/scripts/cleanall.sh
@@ -3,6 +3,7 @@
 ./sbt -J-Xmx2G "project accumulo" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project layers-accumulo" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project cassandra" clean  || { exit 1; }
+./sbt -J-Xmx2G "project layers-cassandra" clean  || { exit 1; }
 ./sbt -J-Xmx2G "project geomesa" clean || { exit 1; }
 ./sbt -J-Xmx2G "project geotools" clean || { exit 1; }
 ./sbt -J-Xmx2G "project geowave" clean || { exit 1; }
@@ -18,6 +19,7 @@
 rm -r accumulo/target
 rm -r layers-accumulo/target
 rm -r cassandra/target
+rm -r layers-cassandra/target
 rm -r geomesa/target
 rm -r geotools/target
 rm -r geowave/target

--- a/scripts/createHeaders.sh
+++ b/scripts/createHeaders.sh
@@ -3,6 +3,7 @@
 ./sbt "project accumulo" createHeaders test:createHeaders \
       "project layers-accumulo" createHeaders test:createHeaders \
       "project cassandra" createHeaders test:createHeaders \
+      "project layers-cassandra" createHeaders test:createHeaders \
       "project doc-examples" createHeaders test:createHeaders \
       "project geomesa" createHeaders test:createHeaders \
       "project geotools" createHeaders test:createHeaders \

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -18,6 +18,7 @@
 ./sbt "project spark-etl" publishLocal && \
 ./sbt "project accumulo" publishLocal && \
 ./sbt "project layers-accumulo" publishLocal && \
+./sbt "project layers-cassandra" publishLocal && \
 ./sbt "project cassandra" publishLocal && \
 ./sbt "project geomesa" publishLocal && \
 ./sbt "project geotools" publishLocal && \

--- a/scripts/publish-m2.sh
+++ b/scripts/publish-m2.sh
@@ -2,6 +2,7 @@
 
 ./sbt "project accumulo" +publishM2 \
       "project layers-accumulo" +publishM2 \
+      "project layers-cassandra" +publishM2 \
       "project cassandra" +publishM2 \
       "project geomesa" +publishM2 \
       "project geotools" +publishM2 \

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -2,6 +2,7 @@
 
 ./sbt "project accumulo" publish \
       "project layers-accumulo" publish \
+      "project layers-cassandra" publish \
       "project cassandra" publish \
       "project geomesa" publish \
       "project geotools" publish \
@@ -13,7 +14,6 @@
       "project raster-testkit" publish \
       "project s3" publish \
       "project s3-testkit" publish \
-      "project cassandra" publish \
       "project hbase" publish \
       "project shapefile" publish \
       "project spark" publish \


### PR DESCRIPTION
## Overview

This PR is the continuation of #2927 where the `cassandra` package is broken into two new packages: `layers-cassandra` and `cassandra`. Both projects contain `cassandra` IO logic but the former does not use Spark while the latter does.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

### Notes

This PR addresses the `cassandra` split in #2934