### PR TITLE
Fix map{X|Y}ToGrid function behavior that could give a bit incorrect results

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -55,6 +55,7 @@ Fixes & Updates
 - Update dependencies (`#2904 <https://github.com/locationtech/geotrellis/pull/2904>`_).
 - Bump ScalaPB version up with some API enhancements (`#2898 <https://github.com/locationtech/geotrellis/pull/2898>`_).
 - Artifacts in Viewshed have been addressed, the pixels/meter calculation has also been improved (`#2917 <https://github.com/locationtech/geotrellis/pull/2917>`_).
+- Fix map{X|Y}ToGrid function behavior that could give a bit incorrect results (`#2953 <https://github.com/locationtech/geotrellis/pull/2953>`_).
 
 2.3.0
 -----

--- a/raster/src/test/scala/geotrellis/raster/RasterExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/RasterExtentSpec.scala
@@ -489,6 +489,7 @@ class RasterExtentSpec extends FunSpec with Matchers
       val rasterExtent = RasterExtent(extent, 0.00025, 0.00025, 40000, 40000)
 
       val internalExtent = Extent(-51.6, -26.5, -51.5, -26.4)
+      val internalExtent2 = Extent(-51.4, -26.3, -51.3, -26.2)
       val bounds = rasterExtent.gridBoundsFor(internalExtent)
 
       val height = (bounds.rowMin to bounds.rowMax).length
@@ -496,6 +497,9 @@ class RasterExtentSpec extends FunSpec with Matchers
 
       height shouldBe 400
       width shouldBe 400
+
+      rasterExtent.mapXToGrid(internalExtent2.xmin) shouldBe 34400
+      rasterExtent.mapYToGrid(internalExtent2.ymax) shouldBe 24800
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/RasterExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/RasterExtentSpec.scala
@@ -484,5 +484,18 @@ class RasterExtentSpec extends FunSpec with Matchers
       }
     }
 
+    it("should handle a negative extent with north and west round func instead of floor applied") {
+      val extent = Extent(-60, -30, -50, -20)
+      val rasterExtent = RasterExtent(extent, 0.00025, 0.00025, 40000, 40000)
+
+      val internalExtent = Extent(-51.6, -26.5, -51.5, -26.4)
+      val bounds = rasterExtent.gridBoundsFor(internalExtent)
+
+      val height = (bounds.rowMin to bounds.rowMax).length
+      val width = (bounds.colMin to bounds.colMax).length
+
+      height shouldBe 400
+      width shouldBe 400
+    }
   }
 }


### PR DESCRIPTION
## Overview

In case of negative `Extent` coordinates and because of a floating point errors, in case where the north and west site of the block is very close to the `Int` we could approximate number of cols / rows incorrectly.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

Closes #2918
