### PR TITLE
Use original ZoomRanges on COG layer update

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -68,6 +68,7 @@ Fixes & Updates
 - Artifacts in Viewshed have been addressed, the pixels/meter calculation has also been improved (`#2917 <https://github.com/locationtech/geotrellis/pull/2917>`_).
 - Fix map{X|Y}ToGrid function behavior that could give a bit incorrect results (`#2953 <https://github.com/locationtech/geotrellis/pull/2953>`_).
 - Fix COG layer update bug related to COGLayerMetadata zoomRanges ordering (`#2922 <https://github.com/locationtech/geotrellis/pull/2922>`_).
+- Use original ZoomRanges on COG layer update (`#2956 <https://github.com/locationtech/geotrellis/pull/2956>`_).
 
 2.3.0
 -----

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayer.scala
@@ -28,7 +28,6 @@ import geotrellis.tiling._
 import geotrellis.spark._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.index.KeyIndex
-import geotrellis.spark.tiling._
 import geotrellis.spark.util._
 import geotrellis.util._
 import geotrellis.vector._
@@ -70,8 +69,8 @@ object COGLayer {
      minZoom: Option[Int] = None,
      options: COGLayerWriter.Options = COGLayerWriter.Options.DEFAULT
    ): COGLayer[K, V] = {
-    // TODO: Clean up conditional checks, figure out how to bake into type system, or report errors better.
 
+    // TODO: Clean up conditional checks, figure out how to bake into type system, or report errors better.
     if(minZoom.getOrElse(Double.NaN) != baseZoom.toDouble) {
       if(rdd.metadata.layout.tileCols != rdd.metadata.layout.tileRows) {
         sys.error("Cannot create Pyramided COG layer for non-square tiles.")
@@ -82,8 +81,8 @@ object COGLayer {
       }
     }
 
-    val constructMetadata =
-      (layoutScheme: ZoomedLayoutScheme, keyBounds: KeyBounds[K]) => COGLayerMetadata(
+    def constructMetadata(layoutScheme: ZoomedLayoutScheme, keyBounds: KeyBounds[K]) =
+      COGLayerMetadata(
         rdd.metadata.cellType,
         rdd.metadata.extent,
         rdd.metadata.crs,
@@ -116,7 +115,8 @@ object COGLayer {
      options: COGLayerWriter.Options
    ): COGLayer[K, V] = {
 
-    if (zoomRanges.exists(_ != baseZoom)) {
+    // TODO: Clean up conditional checks, figure out how to bake into type system, or report errors better.
+    if (zoomRanges.exists(_.maxZoom != baseZoom)) {
       if(rdd.metadata.layout.tileCols != rdd.metadata.layout.tileRows) {
         sys.error("Cannot create Pyramided COG layer for non-square tiles.")
       }
@@ -126,8 +126,8 @@ object COGLayer {
       }
     }
 
-    val constructMetadata =
-      (layoutScheme: ZoomedLayoutScheme, keyBounds: KeyBounds[K]) => COGLayerMetadata(
+    def constructMetadata(layoutScheme: ZoomedLayoutScheme, keyBounds: KeyBounds[K]) =
+      COGLayerMetadata(
         rdd.metadata.cellType,
         rdd.metadata.extent,
         rdd.metadata.crs,

--- a/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/cog/COGLayerWriter.scala
@@ -199,7 +199,7 @@ trait COGLayerWriter extends LazyLogging with Serializable {
         if(!indexKeyBounds.contains(keyBounds) && !metadata.keyBoundsForZoom(tileZoom).contains(keyBounds))
           throw new LayerOutOfKeyBoundsError(LayerId(layerName, tileZoom), indexKeyBounds)
 
-        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, options = options)
+        val cogLayer = COGLayer.fromLayerRDD(tiles, tileZoom, metadata.zoomRanges, options = options)
         val ucogLayer = cogLayer.copy(metadata = cogLayer.metadata.combine(metadata))
 
         writeCOGLayer(layerName, ucogLayer, keyIndexes, mergeFunc)

--- a/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerUpdateSpaceTimeTileSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerUpdateSpaceTimeTileSpec.scala
@@ -203,6 +203,22 @@ trait COGLayerUpdateSpaceTimeTileSpec
         writer.write[SpaceTimeKey, Tile](tmpLayer, sampleHighZoom, maxZoom, keyIndexMethod, mergeFunc = mergeFunc, options = options)
         writer.update[SpaceTimeKey, Tile](tmpLayer, sampleHighZoom, maxZoom, mergeFunc = mergeFunc, options = options)
       }
+
+      it("should successfully update, using zoom ranges that are currently present in the layer") {
+        /**
+          * We will use two distinct COGLayerWriter.Options
+          * that would normally (in case of writing to a new layer) generate two different sets of ZoomRanges.
+          * This test checks that update uses the same ZoomRanges as create and doesn't fail on ZoomRanges mismatch.
+          */
+        import COGLayerWriter.Options.DEFAULT
+        val createOptions = DEFAULT.copy(maxTileSize = sample.metadata.tileCols) //suggests one ZoomRange per each zoom
+        val updateOptions = DEFAULT.copy(maxTileSize = sample.metadata.tileCols * 2) //suggests one ZoomRange per two zooms
+
+        val tmpLayerId = layerId.createTemporaryId.name
+
+        writer.write[SpaceTimeKey, Tile](tmpLayerId, sample, layerId.zoom, keyIndexMethod, mergeFunc = mergeFunc, options = createOptions)
+        writer.update[SpaceTimeKey, Tile](tmpLayerId, sample, layerId.zoom, mergeFunc = mergeFunc, options = updateOptions)
+      }
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerUpdateSpaceTimeTileSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/cog/COGLayerUpdateSpaceTimeTileSpec.scala
@@ -211,8 +211,8 @@ trait COGLayerUpdateSpaceTimeTileSpec
           * This test checks that update uses the same ZoomRanges as create and doesn't fail on ZoomRanges mismatch.
           */
         import COGLayerWriter.Options.DEFAULT
-        val createOptions = DEFAULT.copy(maxTileSize = sample.metadata.tileCols) //suggests one ZoomRange per each zoom
-        val updateOptions = DEFAULT.copy(maxTileSize = sample.metadata.tileCols * 2) //suggests one ZoomRange per two zooms
+        val createOptions = DEFAULT.copy(maxTileSize = sample.metadata.tileCols) // suggests one ZoomRange per each zoom
+        val updateOptions = DEFAULT.copy(maxTileSize = sample.metadata.tileCols * 2) // suggests one ZoomRange per two zooms
 
         val tmpLayerId = layerId.createTemporaryId.name
 


### PR DESCRIPTION
## Overview

This PR changes COG layers update behavior to use ZoomRanges that were generated at the time of initial ingest. This prevents possible mismatch.

The PR adds an overload to `COGLayer.fromLayerRDD()` which constructs a COGLayer with predefined set of ZoomRanges.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

### Notes

Note that this PR is dependent on #2922, because the test won't succeed unless #2921 is fixed.

Closes #2938
