### PR TITLE
Spark-Pipeline Spark Split

### DIFF
--- a/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/ast/Input.scala
+++ b/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/ast/Input.scala
@@ -23,7 +23,7 @@ import geotrellis.spark.io.s3.S3GeoTiffRDD
 import geotrellis.spark.pipeline.json.read._
 import geotrellis.vector.ProjectedExtent
 
-import geotrellis.spark.io.s3.AmazonS3URI
+import geotrellis.store.s3.AmazonS3URI
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD

--- a/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/ast/Output.scala
+++ b/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/ast/Output.scala
@@ -22,7 +22,7 @@ import geotrellis.raster.merge.TileMergeMethods
 import geotrellis.raster.prototype.TilePrototypeMethods
 import geotrellis.spark._
 import geotrellis.spark.io.LayerWriter
-import geotrellis.layers.io.avro.AvroRecordCodec
+import geotrellis.layers.avro.AvroRecordCodec
 import geotrellis.tiling.{Bounds, LayoutDefinition, SpatialComponent}
 import geotrellis.util.{Component, GetComponent}
 import com.typesafe.scalalogging.LazyLogging

--- a/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/ast/Transform.scala
+++ b/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/ast/Transform.scala
@@ -26,7 +26,7 @@ import geotrellis.raster.stitch.Stitcher
 import geotrellis.raster.CellGrid
 import geotrellis.raster.resample.ResampleMethod
 import geotrellis.tiling._
-import geotrellis.layers.io.avro.AvroRecordCodec
+import geotrellis.layers.avro.AvroRecordCodec
 import geotrellis.spark.tiling.TilerKeyMethods
 import geotrellis.spark._
 import geotrellis.spark.io._

--- a/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/json/PipelineKeyIndexMethod.scala
+++ b/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/json/PipelineKeyIndexMethod.scala
@@ -17,7 +17,7 @@
 package geotrellis.spark.pipeline.json
 
 import geotrellis.spark.pipeline._
-import geotrellis.layers.io.index.{HilbertKeyIndexMethod, KeyIndexMethod, RowMajorKeyIndexMethod, ZCurveKeyIndexMethod}
+import geotrellis.layers.index.{HilbertKeyIndexMethod, KeyIndexMethod, RowMajorKeyIndexMethod, ZCurveKeyIndexMethod}
 import io.circe.generic.extras.ConfiguredJsonCodec
 
 @ConfiguredJsonCodec


### PR DESCRIPTION
## Overview

This PR updates the imports of the `spark-pipeline` package so that they reflect the new split API.

### Notes

This PR is based on another, open PR: #2960 
This PR addresses the spark-pipeline update in #2934