### PR TITLE
Spark Split Doc-Examples

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/COGSparkExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/COGSparkExamples.scala
@@ -10,8 +10,10 @@ object COGSparkExamples {
     import geotrellis.tiling.{SpatialKey, KeyBounds, FloatingLayoutScheme}
     import geotrellis.spark._
     import geotrellis.spark.io._
-    import geotrellis.layers.io.index.ZCurveKeyIndexMethod
-    import geotrellis.spark.io.file._
+    import geotrellis.layers.index.ZCurveKeyIndexMethod
+    import geotrellis.layers._
+    import geotrellis.layers.file._
+    import geotrellis.layers.file.cog._
     import geotrellis.spark.io.file.cog._
     import geotrellis.spark.tiling.Tiler
     import geotrellis.vector._

--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/ShardingKeyIndex.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/ShardingKeyIndex.scala
@@ -19,8 +19,8 @@ package geotrellis.doc.examples.spark
 import geotrellis.tiling.{SpatialKey, SpaceTimeKey, KeyBounds}
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.layers.io.index._
-import geotrellis.layers.io.json._
+import geotrellis.layers.index._
+import geotrellis.layers.json._
 import scala.reflect.ClassTag
 
 import spray.json._

--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/SparkExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/SparkExamples.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.doc.examples.spark
 
-import geotrellis.layers.{LayerId, TileLayerMetadata}
+import geotrellis.layers._
 
 object SparkExamples {
   def `Using a SpaceTimeKey -> SpatialKey transformation to get summary information about tiles overlapping an area`: Unit = {

--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/VoxelKey.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/VoxelKey.scala
@@ -19,9 +19,9 @@ package geotrellis.doc.examples.spark
 import geotrellis.tiling.{KeyBounds, SpatialKey, Boundable}
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.layers.io.index._
-import geotrellis.layers.io.index.zcurve._
-import geotrellis.layers.io.json._
+import geotrellis.layers.index._
+import geotrellis.layers.index.zcurve._
+import geotrellis.layers.json._
 import geotrellis.util._
 
 import spray.json._

--- a/doc-examples/src/test/scala/geotrellis/doc/examples/spark/ShardingKeyIndexSpec.scala
+++ b/doc-examples/src/test/scala/geotrellis/doc/examples/spark/ShardingKeyIndexSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.doc.examples.spark
 
 import geotrellis.tiling.{SpatialKey, SpaceTimeKey, KeyBounds}
 import geotrellis.spark._
-import geotrellis.layers.io.index._
+import geotrellis.layers.index._
 
 import org.scalatest._
 import spray.json._


### PR DESCRIPTION
## Overview

This PR updates the imports of the `doc-examples` package so that they reflect the new split API.
Notes

This PR is based on two open PRs: #2960 and #2961 
This PR addresses the doc-examples update in #2934