### PR TITLE
Cassandra Docker Image Name Fix

### DIFF
--- a/scripts/cassandraTestDB.sh
+++ b/scripts/cassandraTestDB.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker pull cassandra-spark:latest
+docker pull cassandra:latest
 
 docker run \
   --rm \


### PR DESCRIPTION
## Overview

This PR fixes the name of the cassandra docker image back to `cassandra` after it was incorrectly changed to `cassandra-spark`.