### PR TITLE
Read file length just once

### DIFF
--- a/util/src/main/scala/geotrellis/util/FileRangeReader.scala
+++ b/util/src/main/scala/geotrellis/util/FileRangeReader.scala
@@ -25,11 +25,11 @@ import java.nio.channels.FileChannel.MapMode._
  * This class extends [[RangeReader]] by reading chunks from a given local path. This
  * allows for reading in of files larger than 4gb into GeoTrellis.
  *
- * @param path: A String that is the path to the local file.
+ * @param file: A local File to read bytes from.
  * @return A new instance of FileRangeReader
  */
 class FileRangeReader(file: File) extends RangeReader {
-  def totalLength: Long = file.length
+  val totalLength: Long = file.length
 
   def readClippedRange(start: Long, length: Int): Array[Byte] = {
     val inputStream: FileInputStream = new FileInputStream(file)
@@ -60,12 +60,17 @@ object FileRangeReader {
    * Returns a new instance of FileRangeReader.
    *
    * @param path: A String that is the path to the local file.
-   * @param chunkSize: An Int that specifies how many bytes should be read in at a time.
    * @return A new instance of FileRangeReader
    */
   def apply(path: String): FileRangeReader =
     new FileRangeReader(new File(path))
 
+  /**
+    * Returns a new instance of FileRangeReader.
+    *
+    * @param file: A local File to read bytes from.
+    * @return A new instance of FileRangeReader
+    */
   def apply(file: File): FileRangeReader =
     new FileRangeReader(file)
 }


### PR DESCRIPTION
Signed-off-by: Andrey Tararaksin <atararaksin@gmail.com>

## Overview

This PR changes `FileRangeReader.totalLength` so that the file length is read only once. This significantly improves performance.
I also updated `FileRangeReader` scaladocs a bit because it seemed outdated.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

Closes #2992
