### PR TITLE
Fix incorrect Deflate compressor usage

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -73,6 +73,7 @@ Fixes & Updates
 - Fix map{X|Y}ToGrid function behavior that could give a bit incorrect results (`#2953 <https://github.com/locationtech/geotrellis/pull/2953>`_).
 - Fix COG layer update bug related to COGLayerMetadata zoomRanges ordering (`#2922 <https://github.com/locationtech/geotrellis/pull/2922>`_).
 - Use original ZoomRanges on COG layer update (`#2956 <https://github.com/locationtech/geotrellis/pull/2956>`_).
+- Fix incorrect Deflate compressor usage (`#2997 <https://github.com/locationtech/geotrellis/pull/2997>`_).
 
 2.3.0
 -----

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/DeflateCompression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/DeflateCompression.scala
@@ -33,8 +33,8 @@ case class DeflateCompression(level: Int = Deflater.DEFAULT_COMPRESSION) extends
         val tmp = Array.ofDim[Byte](segment.length + 10)
         deflater.setInput(segment, 0, segment.length)
         deflater.finish()
-        deflater.end()
         val compressedSize = deflater.deflate(tmp)
+        deflater.end()
         val result = Array.ofDim[Byte](compressedSize)
         System.arraycopy(tmp, 0, result, 0, compressedSize)
         result
@@ -59,6 +59,7 @@ class DeflateDecompressor(segmentSizes: Array[Int]) extends Decompressor {
     val tmp = Array.ofDim[Byte](segment.length + 10)
     deflater.setInput(segment, 0, segment.length)
     val compressedDataLength = deflater.deflate(tmp)
+    deflater.end()
     java.util.Arrays.copyOf(tmp, compressedDataLength)
   }
 
@@ -70,6 +71,7 @@ class DeflateDecompressor(segmentSizes: Array[Int]) extends Decompressor {
     val result = new Array[Byte](resultSize)
     inflater.inflate(result)
     inflater.reset()
+    inflater.end()
     result
   }
 }


### PR DESCRIPTION
## Overview

This PR fixes an incorrect https://github.com/locationtech/geotrellis/pull/2970

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary