### PR TITLE
Use semigroup where possible

### DIFF
--- a/doc-examples/src/main/scala/geotrellis/doc/examples/spark/ClipToGridExamples.scala
+++ b/doc-examples/src/main/scala/geotrellis/doc/examples/spark/ClipToGridExamples.scala
@@ -93,6 +93,7 @@ object ClipToGridExamples {
 
     import org.apache.spark.HashPartitioner
     import org.apache.spark.rdd.RDD
+    import cats.syntax.semigroup._
 
     import java.util.UUID
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 API Changes & Project structure changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``geotrellis``
+
+  - **New:** Semigroup instances have been used for defining the combination/merger of types where possible
+
 - ``geotrellis.util``, ``geotrellis.store``, ``geotrellis.store.s3``
 
   - **New:** An SPI interface has been created for ``RangeReader``.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -411,8 +411,8 @@ object Settings {
     libraryDependencies ++= Seq(
       pureconfig,
       jts,
-      catsCore,
       spire,
+      catsCore,
       monocleCore,
       monocleMacro,
       scalaXml,
@@ -623,6 +623,7 @@ object Settings {
       sprayJson,
       apacheMath,
       spire,
+      catsCore,
       scalatest % Test,
       scalacheck % Test
     )

--- a/raster/src/main/scala/geotrellis/raster/RasterExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterExtent.scala
@@ -17,6 +17,9 @@
 package geotrellis.raster
 
 import geotrellis.vector.{Extent, Point}
+
+import cats.Semigroup
+
 import scala.math.{min, max, ceil}
 
 
@@ -79,13 +82,13 @@ case class RasterExtent(
     * same cellsizes).  The result is a new extent at the same
     * resolution.
     */
-  def combine(that: RasterExtent): RasterExtent = {
+  def expandToInclude(that: RasterExtent): RasterExtent = {
     if (cellwidth != that.cellwidth)
       throw GeoAttrsError(s"illegal cellwidths: $cellwidth and ${that.cellwidth}")
     if (cellheight != that.cellheight)
       throw GeoAttrsError(s"illegal cellheights: $cellheight and ${that.cellheight}")
 
-    val newExtent = extent.combine(that.extent)
+    val newExtent = extent.expandToInclude(that.extent)
     val newRows = ceil(newExtent.height / cellheight).toInt
     val newCols = ceil(newExtent.width / cellwidth).toInt
 
@@ -165,4 +168,8 @@ object RasterExtent {
     */
   def apply(extent: Extent, tile: CellGrid[Int]): RasterExtent =
     apply(extent, tile.cols, tile.rows)
+
+  implicit val rasterExtentSemigroup: Semigroup[RasterExtent] = new Semigroup[RasterExtent] {
+    def combine(x: RasterExtent, y: RasterExtent): RasterExtent = x expandToInclude y
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffBuilder.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffBuilder.scala
@@ -113,7 +113,7 @@ trait GeoTiffBuilder[T <: CellGrid[Int]] extends Serializable {
       options.compression
     )
 
-    val extent = tileExtent(colMin, rowMin) combine tileExtent(colMax, rowMax)
+    val extent = tileExtent(colMin, rowMin) expandToInclude tileExtent(colMax, rowMax)
 
     makeGeoTiff(tile, extent, crs, tags, opts)
   }

--- a/raster/src/test/scala/geotrellis/raster/CompositeTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/CompositeTileSpec.scala
@@ -20,9 +20,11 @@ import geotrellis.raster.resample._
 import geotrellis.vector.Extent
 import geotrellis.raster.testkit._
 
-import org.scalatest._
-
 import spire.syntax.cfor._
+
+import cats.syntax.semigroup._
+
+import org.scalatest._
 
 class CompositeTileSpec extends FunSpec
                                 with TileBuilders

--- a/raster/src/test/scala/geotrellis/raster/RasterExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/RasterExtentSpec.scala
@@ -21,6 +21,8 @@ import geotrellis.raster.testkit._
 
 import org.scalatest._
 
+import cats.syntax.semigroup._
+
 class RasterExtentSpec extends FunSpec with Matchers
                                        with TileBuilders {
   describe("A RasterExtent object") {

--- a/raster/src/test/scala/geotrellis/raster/reproject/ReprojectSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/reproject/ReprojectSpec.scala
@@ -25,8 +25,12 @@ import geotrellis.raster.testkit._
 import geotrellis.proj4._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader._
+
 import org.scalatest._
+
 import spire.syntax.cfor._
+
+import cats.syntax.semigroup._
 
 class ReprojectSpec extends FunSpec
     with TileBuilders

--- a/spark/src/main/scala/geotrellis/spark/CollectTileLayerMetadata.scala
+++ b/spark/src/main/scala/geotrellis/spark/CollectTileLayerMetadata.scala
@@ -23,9 +23,10 @@ import geotrellis.spark.ingest._
 import geotrellis.spark.tiling._
 import geotrellis.util._
 import geotrellis.vector.{Extent, ProjectedExtent}
+
+import org.apache.spark.rdd._
 import cats.Functor
 import cats.implicits._
-import org.apache.spark.rdd._
 
 
 object CollectTileLayerMetadata {

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -395,13 +395,13 @@ object TileRDDReproject extends LazyLogging {
         ReprojectSummary(
           sourcePixels + other.sourcePixels,
           pixels + other.rescaledPixelCount(cellSize),
-          extent combine other.extent,
+          extent expandToInclude other.extent,
           cellSize)
       else
         ReprojectSummary(
           sourcePixels + other.sourcePixels,
           rescaledPixelCount(other.cellSize) + other.pixels,
-          extent combine other.extent,
+          extent expandToInclude other.extent,
           other.cellSize)
     }
 

--- a/spark/src/main/scala/geotrellis/spark/store/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/cog/COGLayerWriter.scala
@@ -31,15 +31,13 @@ import geotrellis.store.index._
 import geotrellis.spark._
 
 import com.typesafe.scalalogging.LazyLogging
-
 import org.apache.spark.rdd.RDD
-
 import spray.json._
-
-import java.net.URI
-import java.util.ServiceLoader
+import cats.syntax.semigroup._
 
 import scala.reflect._
+import java.net.URI
+import java.util.ServiceLoader
 
 
 trait COGLayerWriter extends LazyLogging with Serializable {

--- a/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/rasterize/RasterizeRDDSpec.scala
@@ -16,7 +16,6 @@
 
 package geotrellis.spark.rasterize
 
-import org.scalatest._
 import geotrellis.raster._
 import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.layer._
@@ -28,10 +27,12 @@ import geotrellis.raster.rasterize.Rasterizer.Options
 import geotrellis.vector._
 import geotrellis.vector.io.json._
 
+import org.scalatest._
+import org.apache.spark._
+import cats.syntax.semigroup._
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
-import org.apache.spark._
 
 
 class RasterizeRDDSpec extends FunSpec with Matchers

--- a/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/reproject/TileRDDReprojectSpec.scala
@@ -26,13 +26,15 @@ import geotrellis.spark._
 import geotrellis.spark.reproject.Reproject.Options
 import geotrellis.spark.testkit._
 import geotrellis.vector._
-
 import geotrellis.proj4._
 
 import spire.syntax.cfor._
 
 import org.apache.spark._
+
 import org.scalatest.FunSpec
+
+import cats.syntax.semigroup._
 
 class TileRDDReprojectSpec extends FunSpec with TestEnvironment {
 
@@ -233,10 +235,6 @@ class TileRDDReprojectSpec extends FunSpec with TestEnvironment {
       val mbrdd = ContextRDD(rdd.mapValues { tile => TileFeature(tile, 1) }, rdd.metadata)
       // Must define a way to combine tile feature data when reprojecting from multiple tiles to one
       import cats.Monoid
-      implicit val intAdditionMonoid: Monoid[Int] = new Monoid[Int] {
-        def empty: Int = 0
-        def combine(x: Int, y: Int): Int = x + y
-      }
 
       //// If method .reproject could not be found we would need to look for implicit paramter to TileRDDReprojectMethods constructor
       // import geotrellis.raster.stitch._

--- a/spark/src/test/scala/geotrellis/spark/store/cog/COGLayerMetadataSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/store/cog/COGLayerMetadataSpec.scala
@@ -14,6 +14,8 @@ import org.scalatest._
 
 import spray.json._
 
+import cats.syntax.semigroup._
+
 class COGLayerMetadataSpec extends FunSpec with Matchers {
   def generateLCMetadata(maxZoom: Int = 13, minZoom: Int = 0): COGLayerMetadata[SpatialKey] = {
     val cellType = IntConstantNoDataCellType

--- a/vector/src/main/scala/geotrellis/vector/ExtentRangeError.scala
+++ b/vector/src/main/scala/geotrellis/vector/ExtentRangeError.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.vector
+
+case class ExtentRangeError(msg:String) extends Exception(msg)
+

--- a/vector/src/main/scala/geotrellis/vector/ProjectedExtent.scala
+++ b/vector/src/main/scala/geotrellis/vector/ProjectedExtent.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.vector
+
+import GeomFactory._
+import geotrellis.proj4.{CRS, Transform}
+
+/** An extent and its corresponding CRS
+  *
+  * @param extent The Extent which is projected
+  * @param crs    The CRS projection of this extent
+  */
+case class ProjectedExtent(extent: Extent, crs: CRS) {
+  def reproject(dest: CRS): Extent =
+    extent.reproject(crs, dest)
+
+  def reprojectAsPolygon(dest: CRS, relError: Double = 0.01): Polygon =
+    extent.reprojectAsPolygon(Transform(crs, dest), relError)
+}
+
+object ProjectedExtent {
+  implicit def fromTupleA(tup: (Extent, CRS)):ProjectedExtent = ProjectedExtent(tup._1, tup._2)
+  implicit def fromTupleB(tup: (CRS, Extent)):ProjectedExtent = ProjectedExtent(tup._2, tup._1)
+}

--- a/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollection.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollection.scala
@@ -70,7 +70,7 @@ class JsonFeatureCollection(features: List[JsValue] = Nil) {
     * Carry out serialization on all buffered JsValue objects.
     */
   def toJson: JsValue = {
-    val bboxOption = getAllGeometries().map(_.envelope).reduceOption(_ combine _)
+    val bboxOption = getAllGeometries().map(_.envelope).reduceOption(_ expandToInclude _)
     bboxOption match {
       case Some(bbox) =>
         JsObject(

--- a/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollectionMap.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/JsonFeatureCollectionMap.scala
@@ -67,7 +67,7 @@ class JsonFeatureCollectionMap(features: List[JsValue] = Nil) {
   def ++=[G <: Geometry, D: JsonWriter](featureMaps: Seq[(String, Feature[G, D])]) = addAll(featureMaps)
 
   def toJson: JsValue = {
-    val bboxOption = getAllGeometries().map(_._2.envelope).reduceOption(_ combine _)
+    val bboxOption = getAllGeometries().map(_._2.envelope).reduceOption(_ expandToInclude _)
     bboxOption match {
       case Some(bbox) =>
         JsObject(

--- a/vector/src/test/scala/spec/geotrellis/vector/ExtentSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/ExtentSpec.scala
@@ -18,9 +18,12 @@ package geotrellis.vector
 
 import geotrellis.vector.io._
 import geotrellis.vector.io.json.JsonFeatureCollection
+
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import spray.json.DefaultJsonProtocol._
+// `import cats.implicits._` causes ambiguous implicits on `===`:  https://github.com/typelevel/cats/issues/219
+import cats.syntax.semigroup._
 
 class ExtentSpec extends FunSpec with Matchers {
   describe("Extent") {


### PR DESCRIPTION
## Overview

`Combine` methods across the library have been pulled out of their classes and defined by way of typeclasses so that methods defined in terms of `semigroupal` types can generically act upon any of them

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature


Closes #2925
