### PR TITLE
Throw errors inside IO

### DIFF
--- a/accumulo-spark/src/main/scala/geotrellis/spark/store/accumulo/AccumuloWriteStrategy.scala
+++ b/accumulo-spark/src/main/scala/geotrellis/spark/store/accumulo/AccumuloWriteStrategy.scala
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.BatchWriterConfig
 
 import cats.effect.IO
 import cats.syntax.apply._
+import cats.syntax.either._
 
 import scala.concurrent.ExecutionContext
 
@@ -143,7 +144,9 @@ case class SocketWriteStrategy(
             .parJoin(threads)
             .compile
             .drain
+            .attempt
             .unsafeRunSync()
+            .valueOr(throw _)
         } finally {
           writer.close(); pool.shutdown()
         }

--- a/accumulo/src/main/scala/geotrellis/store/accumulo/AccumuloCollectionReader.scala
+++ b/accumulo/src/main/scala/geotrellis/store/accumulo/AccumuloCollectionReader.scala
@@ -28,6 +28,7 @@ import org.apache.hadoop.io.Text
 
 import cats.effect._
 import cats.syntax.apply._
+import cats.syntax.either._
 
 import scala.concurrent.ExecutionContext
 import scala.collection.JavaConverters._
@@ -85,7 +86,9 @@ object AccumuloCollectionReader {
         .compile
         .toVector
         .map(_.flatten)
-        .unsafeRunSync
+        .attempt
+        .unsafeRunSync()
+        .valueOr(throw _)
     } finally pool.shutdown()
   }
 }

--- a/cassandra-spark/src/main/scala/geotrellis/spark/store/cassandra/CassandraRDDWriter.scala
+++ b/cassandra-spark/src/main/scala/geotrellis/spark/store/cassandra/CassandraRDDWriter.scala
@@ -33,6 +33,7 @@ import com.datastax.driver.core.schemabuilder.SchemaBuilder
 
 import cats.effect.IO
 import cats.syntax.apply._
+import cats.syntax.either._
 
 import org.apache.avro.Schema
 import org.apache.spark.rdd.RDD
@@ -165,7 +166,13 @@ object CassandraRDDWriter {
                   }
                 }
 
-              results.compile.drain.unsafeRunSync()
+              results
+                .compile
+                .drain
+                .attempt
+                .unsafeRunSync()
+                .valueOr(throw _)
+
               pool.shutdown()
             }
           }

--- a/docs/cassandra/CassandraIndexStrategySpec.scala
+++ b/docs/cassandra/CassandraIndexStrategySpec.scala
@@ -171,7 +171,10 @@ class CassandraIndexStrategySpec extends FunSpec with Matchers with CassandraTes
 
       val allTiles = tiles.parSequence
 
-      allTiles.unsafeRunSync()
+      allTiles
+        .attempt
+        .unsafeRunSync()
+        .valueOr(throw _)
 
       () //don't care about results... minimize heap churn
     }
@@ -184,7 +187,10 @@ class CassandraIndexStrategySpec extends FunSpec with Matchers with CassandraTes
 
       val allTiles = tiles.parSequence
 
-      allTiles.unsafeRunSync()
+      allTiles
+        .attempt
+        .unsafeRunSync()
+        .valueOr(throw _)
 
       () //don't care about results... minimize heap churn
     }

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3RDDWriter.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3RDDWriter.scala
@@ -26,6 +26,7 @@ import geotrellis.spark.util.KryoWrapper
 
 import cats.effect.{IO, Timer}
 import cats.syntax.apply._
+import cats.syntax.either._
 
 import software.amazon.awssdk.services.s3.model.{S3Exception, PutObjectRequest, PutObjectResponse, GetObjectRequest}
 import software.amazon.awssdk.services.s3.S3Client
@@ -145,7 +146,9 @@ class S3RDDWriter(
           .parJoin(threads)
           .compile
           .drain
+          .attempt
           .unsafeRunSync()
+          .valueOr(throw _)
 
         pool.shutdown()
       }

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/SaveToS3.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/SaveToS3.scala
@@ -30,6 +30,7 @@ import org.apache.spark.rdd.RDD
 
 import cats.effect.{IO, Timer}
 import cats.syntax.apply._
+import cats.syntax.either._
 
 import scala.concurrent.ExecutionContext
 
@@ -118,7 +119,10 @@ object SaveToS3 {
         .parJoin(threads)
         .compile
         .toVector
+        .attempt
         .unsafeRunSync()
+        .valueOr(throw _)
+
       pool.shutdown()
     }
   }

--- a/store/src/main/scala/geotrellis/store/AsyncWriter.scala
+++ b/store/src/main/scala/geotrellis/store/AsyncWriter.scala
@@ -18,6 +18,7 @@ package geotrellis.store
 
 import cats.effect.{IO, Timer}
 import cats.syntax.apply._
+import cats.syntax.either._
 
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.ExecutionContext
@@ -83,7 +84,9 @@ abstract class AsyncWriter[Client, V, E](threads: Int) extends Serializable {
       .parJoin(threads)
       .compile
       .toVector
+      .attempt
       .unsafeRunSync()
+      .valueOr(throw _)
 
     pool.shutdown()
   }

--- a/store/src/main/scala/geotrellis/store/util/IOUtils.scala
+++ b/store/src/main/scala/geotrellis/store/util/IOUtils.scala
@@ -81,8 +81,11 @@ object IOUtils {
         .parJoin(threads)
         .compile
         .toVector
-        .unsafeRunSync
+        .attempt
+        .unsafeRunSync()
+        .valueOr(throw _)
         .flatten
+
     } finally pool.shutdown()
   }
 }


### PR DESCRIPTION
## Overview

IO will simply swallow errors unless `attempt` is called. `attempt` gives an `Either[Throwable, A]` which can be matched against to either return the value or throw. This pattern has been applied throughout the library wherever `unsafeRunSync` gets called.


Closes #2863
