### PR TITLE
Add Feature ids to vector and vectortile packages

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -89,6 +89,11 @@ API Changes & Project structure changes
 
     ``import geotrellis.raster._``
 
+- ``geotrellis.vectortile``
+
+  - **Add:** ``geotrellis.vectortile.MVTFeature`` which properly conforms to the MVT 2.0 spec. Specifically, MVTFeature adds support for an ``Option[Long]`` id property.
+  - **Change:** The ``geotrellis.vectortile.{Layer, VectorTile}`` interfaces now uses ``MVTFeature`` instead of ``geotrellis.vector.Feature``. This better aligns these interfaces with the Mapbox Vector Tile specification.
+
 Fixes & Updates
 ^^^^^^^^^^^^^^^
 

--- a/vectortile/src/main/scala/geotrellis/vectortile/Layer.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/Layer.scala
@@ -54,20 +54,20 @@ import scala.collection.mutable.ListBuffer
   def resolution: Double = tileExtent.height / tileWidth
 
   /** Every Point Feature in this Layer. */
-  def points: Seq[Feature[Point, Map[String, Value]]]
+  def points: Seq[MVTFeature[Point]]
   /** Every MultiPoint Feature in this Layer. */
-  def multiPoints: Seq[Feature[MultiPoint, Map[String, Value]]]
+  def multiPoints: Seq[MVTFeature[MultiPoint]]
   /** Every Line Feature in this Layer. */
-  def lines: Seq[Feature[Line, Map[String, Value]]]
+  def lines: Seq[MVTFeature[Line]]
   /** Every MultiLine Feature in this Layer. */
-  def multiLines: Seq[Feature[MultiLine, Map[String, Value]]]
+  def multiLines: Seq[MVTFeature[MultiLine]]
   /** Every Polygon Feature in this Layer. */
-  def polygons: Seq[Feature[Polygon, Map[String, Value]]]
+  def polygons: Seq[MVTFeature[Polygon]]
   /** Every MultiPolygon Feature in this Layer. */
-  def multiPolygons: Seq[Feature[MultiPolygon, Map[String, Value]]]
+  def multiPolygons: Seq[MVTFeature[MultiPolygon]]
 
   /** All Features of Single and Multi Geometries. */
-  def features: Seq[Feature[Geometry, Map[String, Value]]] = {
+  def features: Seq[MVTFeature[Geometry]] = {
     Seq(
       points,
       multiPoints,
@@ -110,17 +110,19 @@ import scala.collection.mutable.ListBuffer
      *   points.map(f => unfeature(keys, values, f))
      */
     val features = Seq(
-      points.map(f => unfeature(keyMap, valMap, POINT, pgp.toCommands(Left(f.geom), tileExtent.northWest, resolution), f.data)),
-      multiPoints.map(f => unfeature(keyMap, valMap, POINT, pgp.toCommands(Right(f.geom), tileExtent.northWest, resolution), f.data)),
-      lines.map(f => unfeature(keyMap, valMap, LINESTRING, pgl.toCommands(Left(f.geom), tileExtent.northWest, resolution), f.data)),
-      multiLines.map(f => unfeature(keyMap, valMap, LINESTRING, pgl.toCommands(Right(f.geom), tileExtent.northWest, resolution), f.data)),
+      points.map(f => unfeature(f.id, keyMap, valMap, POINT, pgp.toCommands(Left(f.geom), tileExtent.northWest, resolution), f.data)),
+      multiPoints.map(f => unfeature(f.id, keyMap, valMap, POINT, pgp.toCommands(Right(f.geom), tileExtent.northWest, resolution), f.data)),
+      lines.map(f => unfeature(f.id, keyMap, valMap, LINESTRING, pgl.toCommands(Left(f.geom), tileExtent.northWest, resolution), f.data)),
+      multiLines.map(f => unfeature(f.id, keyMap, valMap, LINESTRING, pgl.toCommands(Right(f.geom), tileExtent.northWest, resolution), f.data)),
       polygons.map { f =>
         val geom = if(forcePolygonWinding) f.geom.normalized else f.geom
-        unfeature(keyMap, valMap, POLYGON, pgy.toCommands(Left(geom), tileExtent.northWest, resolution), f.data)
+        unfeature(f.id, keyMap, valMap, POLYGON,
+                  pgy.toCommands(Left(geom), tileExtent.northWest, resolution), f.data)
       },
       multiPolygons.map { f =>
         val geom = if(forcePolygonWinding) f.geom.normalized else f.geom
-        unfeature(keyMap, valMap, POLYGON, pgy.toCommands(Right(geom), tileExtent.northWest, resolution), f.data)
+        unfeature(f.id, keyMap, valMap, POLYGON,
+                  pgy.toCommands(Right(geom), tileExtent.northWest, resolution), f.data)
       }
     ).flatten
 
@@ -129,7 +131,7 @@ import scala.collection.mutable.ListBuffer
 
   private def totalMeta: (Seq[String], Seq[Value]) = {
     /* Pull into memory once to avoid GC on the feature list */
-    val fs: Seq[Feature[Geometry, Map[String, Value]]] = features
+    val fs: Seq[MVTFeature[Geometry]] = features
 
     /* Must be unique */
     val keys: Seq[String] = fs.flatMap(_.data.keys).distinct
@@ -140,6 +142,7 @@ import scala.collection.mutable.ListBuffer
   }
 
   private def unfeature(
+    featureId: Option[Long],
     keys: Map[String, Int],
     values: Map[Value, Int],
     geomType: PBGeomType,
@@ -151,7 +154,7 @@ import scala.collection.mutable.ListBuffer
       keys(pair._1) :: values(pair._2) :: acc
     }
 
-    PBFeature(None, tags, Some(geomType), Command.uncommands(cmds))
+    PBFeature(featureId, tags, Some(geomType), Command.uncommands(cmds))
   }
 
   /** Pretty-print this `Layer`. */
@@ -179,11 +182,12 @@ import scala.collection.mutable.ListBuffer
 """
   }
 
-  private def prettyFeature[G <: Geometry](fs: Seq[Feature[G, Map[String, Value]]]): String = {
+  private def prettyFeature[G <: Geometry](fs: Seq[MVTFeature[G]]): String = {
     if (fs.isEmpty) "}" else {
       fs.map({ f =>
 s"""
         feature {
+          id = ${f.id}
           geometry (WKT) = ${f.geom}
           geometry (LatLng GeoJson) = ${f.geom.reproject(WebMercator, LatLng).toGeoJson}
           ${prettyMeta(f.data)}
@@ -211,12 +215,12 @@ ${sortedMeta.map({ case (k,v) => s"            ${k}: ${v}"}).mkString("\n")}
   tileWidth: Int,
   version: Int,
   tileExtent: Extent,
-  points: Seq[Feature[Point, Map[String, Value]]],
-  multiPoints: Seq[Feature[MultiPoint, Map[String, Value]]],
-  lines: Seq[Feature[Line, Map[String, Value]]],
-  multiLines: Seq[Feature[MultiLine, Map[String, Value]]],
-  polygons: Seq[Feature[Polygon, Map[String, Value]]],
-  multiPolygons: Seq[Feature[MultiPolygon, Map[String, Value]]]
+  points: Seq[MVTFeature[Point]],
+  multiPoints: Seq[MVTFeature[MultiPoint]],
+  lines: Seq[MVTFeature[Line]],
+  multiLines: Seq[MVTFeature[MultiLine]],
+  polygons: Seq[MVTFeature[Polygon]],
+  multiPolygons: Seq[MVTFeature[MultiPolygon]]
 ) extends Layer
 
 /**
@@ -244,10 +248,10 @@ ${sortedMeta.map({ case (k,v) => s"            ${k}: ${v}"}).mkString("\n")}
    */
   private def geomStream[G1 <: Geometry, G2 <: MultiGeometry](
     feats: ListBuffer[PBFeature]
-  )(implicit protobufGeom: ProtobufGeom[G1, G2]): Stream[(Either[G1, G2], Map[String, Value])] = {
-    def loop(fs: ListBuffer[PBFeature]): Stream[(Either[G1, G2], Map[String, Value])] = {
+  )(implicit protobufGeom: ProtobufGeom[G1, G2]): Stream[(Option[Long], Either[G1, G2], Map[String, Value])] = {
+    def loop(fs: ListBuffer[PBFeature]): Stream[(Option[Long], Either[G1, G2], Map[String, Value])] = {
       if (fs.isEmpty) {
-        Stream.empty[(Either[G1, G2], Map[String, Value])]
+        Stream.empty[(Option[Long], Either[G1, G2], Map[String, Value])]
       } else {
         val geoms: Seq[Int] = fs.head.geometry
 
@@ -263,8 +267,7 @@ ${sortedMeta.map({ case (k,v) => s"            ${k}: ${v}"}).mkString("\n")}
           loop(fs.tail)
         } else {
           val g = protobufGeom.fromCommands(Command.commands(geoms), tileExtent.northWest, resolution)
-
-          (g, getMeta(rawLayer.keys, rawLayer.values, fs.head.tags)) #:: loop(fs.tail)
+          (fs.head.id, g, getMeta(rawLayer.keys, rawLayer.values, fs.head.tags)) #:: loop(fs.tail)
         }
       }
     }
@@ -305,39 +308,39 @@ ${sortedMeta.map({ case (k,v) => s"            ${k}: ${v}"}).mkString("\n")}
    * a legal state for JTS Geoms. These cause problems later when reading/writing
    * VT Features, so we avoid those problems by ignoring any empty Geoms here.
    */
-  lazy val points: Stream[Feature[Point, Map[String, Value]]] = pointStream
+  lazy val points: Stream[MVTFeature[Point]] = pointStream
     .flatMap({
-      case (Left(p), meta) => new ::(Feature(p, meta), Nil)
+      case (id, Left(p), meta) => new ::(MVTFeature(id, p, meta), Nil)
       case _ => Nil
     })
 
-  lazy val multiPoints: Stream[Feature[MultiPoint, Map[String, Value]]] = pointStream
+  lazy val multiPoints: Stream[MVTFeature[MultiPoint]] = pointStream
     .flatMap({
-      case (Right(p), meta) if !p.isEmpty => new ::(Feature(p, meta), Nil)
+      case (id, Right(p), meta) if !p.isEmpty => new ::(MVTFeature(id, p, meta), Nil)
       case _ => Nil
     })
 
-  lazy val lines: Stream[Feature[Line, Map[String, Value]]] = lineStream
+  lazy val lines: Stream[MVTFeature[Line]] = lineStream
     .flatMap({
-      case (Left(p), meta) if !p.isEmpty => new ::(Feature(p, meta), Nil)
+      case (id, Left(p), meta) if !p.isEmpty => new ::(MVTFeature(id, p, meta), Nil)
       case _ => Nil
     })
 
-  lazy val multiLines: Stream[Feature[MultiLine, Map[String, Value]]] = lineStream
+  lazy val multiLines: Stream[MVTFeature[MultiLine]] = lineStream
     .flatMap({
-      case (Right(p), meta) if !p.isEmpty => new ::(Feature(p, meta), Nil)
+      case (id, Right(p), meta) if !p.isEmpty => new ::(MVTFeature(id, p, meta), Nil)
       case _ => Nil
     })
 
-  lazy val polygons: Stream[Feature[Polygon, Map[String, Value]]] = polyStream
+  lazy val polygons: Stream[MVTFeature[Polygon]] = polyStream
     .flatMap({
-      case (Left(p), meta) if !p.isEmpty => new ::(Feature(p, meta), Nil)
+      case (id, Left(p), meta) if !p.isEmpty => new ::(MVTFeature(id, p, meta), Nil)
       case _ => Nil
     })
 
-  lazy val multiPolygons: Stream[Feature[MultiPolygon, Map[String, Value]]] = polyStream
+  lazy val multiPolygons: Stream[MVTFeature[MultiPolygon]] = polyStream
     .flatMap({
-      case (Right(p), meta) if !p.isEmpty => new ::(Feature(p, meta), Nil)
+      case (id, Right(p), meta) if !p.isEmpty => new ::(MVTFeature(id, p, meta), Nil)
       case _ => Nil
     })
 

--- a/vectortile/src/main/scala/geotrellis/vectortile/MVTFeature.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/MVTFeature.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.vectortile
+
+import geotrellis.vector._
+
+/**
+  * A case class that conforms to the Mapbox Vector Tile 2.0 specification
+  *
+  * Users are responsible for converting their geometries, features and other
+  * objects to MVTFeatures so that they can be written to mvts using
+  * [[VectorTile]].
+  *
+  * https://docs.mapbox.com/vector-tiles/specification/
+  *
+  * @param id
+  * @param geom
+  * @param data
+  * @tparam G
+  */
+case class MVTFeature[+G <: Geometry](id: Option[Long], geom: G, data: Map[String, Value]) {}
+
+object MVTFeature {
+  def apply[G <: Geometry](geom: G, data: Map[String, Value]): MVTFeature[G] = MVTFeature(None, geom, data)
+}

--- a/vectortile/src/main/scala/geotrellis/vectortile/VectorTile.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/VectorTile.scala
@@ -67,7 +67,7 @@ ${layers.values.map(_.pretty).mkString}
     layers.values.flatMap(_.features).map(_.geom.reproject(WebMercator,LatLng)).toGeoJson
 
   /** Return a VectorTile to a Spark-friendly structure. */
-  def toIterable: Iterable[Feature[Geometry, Map[String, Value]]] =
+  def toIterable: Iterable[MVTFeature[Geometry]] =
     layers.values.flatMap(_.features)
 
 }

--- a/vectortile/src/test/scala/geotrellis/vectortile/MVTFeatureSpec.scala
+++ b/vectortile/src/test/scala/geotrellis/vectortile/MVTFeatureSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.vectortile
+
+import geotrellis.vector._
+
+import org.scalatest._
+
+class MVTFeatureSpec extends FunSpec with Matchers {
+  val geom = Point(0, 0)
+  describe("MVTFeature.fromFeature") {
+    it("should construct MVTFeature with None id") {
+      val mvtFeature = MVTFeature(geom, Map("foo" -> VString("123")))
+      mvtFeature.id should equal(None)
+    }
+  }
+}

--- a/vectortile/src/test/scala/geotrellis/vectortile/ProtobufTileSpec.scala
+++ b/vectortile/src/test/scala/geotrellis/vectortile/ProtobufTileSpec.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.vectortile
 
-import geotrellis.vector.Extent
+import geotrellis.vector.{Extent, Point}
 
 import org.scalatest._
 
@@ -38,6 +38,37 @@ class ProtobufTileSpec extends FunSpec with Matchers {
   describe("onepoint.mvt") {
     it("must decode") {
       VectorTile.fromBytes(read("vectortile/data/onepoint.mvt"), tileExtent)
+    }
+
+    it("should encode ids into the tile") {
+      val layerId = "x"
+      val mvtFeature = MVTFeature(Some(1), Point(10, 10), Map.empty)
+      val layer = StrictLayer(layerId, 4096, 2, tileExtent,
+                              Seq(mvtFeature), Seq(), Seq(), Seq(), Seq(), Seq())
+      val tile = VectorTile(Map(layerId -> layer), tileExtent)
+      val tile2 = VectorTile.fromBytes(tile.toBytes, tileExtent)
+      val tileId = tile.layers(layerId).points.head.id
+      val tile2Id = tile2.layers(layerId).points.head.id
+      tileId should equal(tile2Id)
+    }
+
+    it("should encode attributes into the tile") {
+      val layerId = "x"
+      val mvtFeature = MVTFeature(Some(1), Point(10, 10), Map(
+        "building" -> VString("yes"),
+        "isValid" -> VBool(true),
+        "elevation" -> VDouble(100.5),
+        "population" -> VInt64(6)
+      ))
+      val layer = StrictLayer(layerId, 4096, 2, tileExtent,
+                              Seq(mvtFeature), Seq(), Seq(), Seq(), Seq(), Seq())
+      val tile = VectorTile(Map(layerId -> layer), tileExtent)
+      val tile2 = VectorTile.fromBytes(tile.toBytes, tileExtent)
+      val tileId = tile.layers(layerId).points.head.data.toList.foreach {
+        case (key, value) => {
+          tile2.layers(layerId).points.head.data(key) should equal(value)
+        }
+      }
     }
 
     it("decode, encode and decode again") {


### PR DESCRIPTION
## Overview

This PR makes two small incremental changes in the absence of much larger sweeping changes to what the meaning of `Feature`s are in GeoTrellis which, due to conflicting opinions, appears best saved for another time. 

The idea here is to include a feature id as a first class citizen for the two major types of features we handle, the generic `geotrellis.vector.Feature` which approximates, but doesn't totally conform to the GeoJson spec, and the more specific `geotrellis.vectortile.MVTFeature` which conforms to the MVT2.0 spec, when before it just used `geotrellis.vector.Feature` and did not, due to the too generic `data: D` parameter and lack of an `id: Option[Long]`. 

The change to use `id: Option[String]` in `Feature` is motivated by `String` being a more "generic" type than  others in that most things have a usable `toString` that maintains uniqueness (at least this applies for numbers, strings and UUIDs). For example, the new Feature.withRandomUuid method constructs a new uuid for uniqueness and then immediately casts it to string. The additional apply methods also _mostly_ maintain backwards compatibility in that the old `Feature(geom, data)` looks the same as `Feature(None, geom, data)` in practice since None == None is true.  

These two changes are independent, so if we wanted to keep just the MVTFeature change to fix #2884 we could. 

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Notes



TODO:
- [x] Fix tests
- [ ] ~~Ensure geotrellis.vector.io._ encodings work correctly with new id after circe rebase is complete~~

Closes #2884

Blocked by #2905 if we want to keep the changes to `geotrellis.vector.Feature`