### PR TITLE
Replace mergable with semigroup

### DIFF
--- a/accumulo-spark/src/main/scala/geotrellis/spark/store/accumulo/AccumuloLayerWriter.scala
+++ b/accumulo-spark/src/main/scala/geotrellis/spark/store/accumulo/AccumuloLayerWriter.scala
@@ -22,14 +22,17 @@ import geotrellis.store.accumulo._
 import geotrellis.store.avro._
 import geotrellis.store.avro.codecs._
 import geotrellis.store.index._
-import geotrellis.layer.merge.Mergable
 import geotrellis.spark.store._
 import geotrellis.spark.merge._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
+
 import org.apache.spark.rdd.RDD
+
 import io.circe._
+
+import cats.Semigroup
 
 import scala.reflect._
 
@@ -44,7 +47,7 @@ class AccumuloLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -55,7 +58,7 @@ class AccumuloLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -67,7 +70,7 @@ class AccumuloLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],

--- a/accumulo-spark/src/main/scala/geotrellis/spark/store/accumulo/AccumuloLayerWriter.scala
+++ b/accumulo-spark/src/main/scala/geotrellis/spark/store/accumulo/AccumuloLayerWriter.scala
@@ -27,11 +27,8 @@ import geotrellis.spark.merge._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
-
 import org.apache.spark.rdd.RDD
-
 import io.circe._
-
 import cats.Semigroup
 
 import scala.reflect._

--- a/cassandra-spark/src/main/scala/geotrellis/spark/store/cassandra/CassandraLayerWriter.scala
+++ b/cassandra-spark/src/main/scala/geotrellis/spark/store/cassandra/CassandraLayerWriter.scala
@@ -27,11 +27,8 @@ import geotrellis.spark.merge._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
-
 import org.apache.spark.rdd.RDD
-
 import io.circe._
-
 import cats.Semigroup
 
 import scala.reflect._

--- a/cassandra-spark/src/main/scala/geotrellis/spark/store/cassandra/CassandraLayerWriter.scala
+++ b/cassandra-spark/src/main/scala/geotrellis/spark/store/cassandra/CassandraLayerWriter.scala
@@ -22,14 +22,17 @@ import geotrellis.store.avro._
 import geotrellis.store.avro.codecs._
 import geotrellis.store.cassandra._
 import geotrellis.store.index._
-import geotrellis.layer.merge.Mergable
 import geotrellis.spark.store._
 import geotrellis.spark.merge._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
+
 import org.apache.spark.rdd.RDD
+
 import io.circe._
+
+import cats.Semigroup
 
 import scala.reflect._
 
@@ -44,7 +47,7 @@ class CassandraLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -55,7 +58,7 @@ class CassandraLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -67,7 +70,7 @@ class CassandraLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,7 +9,6 @@ API Changes & Project structure changes
 - ``geotrellis-raster``
 
   - **Change:** ``geotrellis.raster.summary.polygonal.[Multi]TilePolygonalSummaryHandler`` replaced with ``geotrellis.raster.summary.polygonal.PolygonalSummary. Users should expect to implement concrete subclasses of ``geotrellis.raster.summary.GridVisitor`` and pass those to the new polygonalSummary methods. There are a number of default GridVisitor implementations provided for simple operations in `geotrellis.raster.summary.visitors``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``geotrellis.layer``
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -11,6 +11,10 @@ API Changes & Project structure changes
   - **Change:** ``geotrellis.raster.summary.polygonal.[Multi]TilePolygonalSummaryHandler`` replaced with ``geotrellis.raster.summary.polygonal.PolygonalSummary. Users should expect to implement concrete subclasses of ``geotrellis.raster.summary.GridVisitor`` and pass those to the new polygonalSummary methods. There are a number of default GridVisitor implementations provided for simple operations in `geotrellis.raster.summary.visitors``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``geotrellis.layer``
+
+  - **Change:** Replaced ``Mergable`` with cats' ``Semigroup``
+
 - ``geotrellis.util``, ``geotrellis.store``, ``geotrellis.store.s3``
 
   - **New:** An SPI interface has been created for ``RangeReader``.

--- a/hbase-spark/src/main/scala/geotrellis/spark/store/hbase/HBaseLayerWriter.scala
+++ b/hbase-spark/src/main/scala/geotrellis/spark/store/hbase/HBaseLayerWriter.scala
@@ -25,12 +25,15 @@ import geotrellis.store._
 import geotrellis.store.avro._
 import geotrellis.store.avro.codecs._
 import geotrellis.store.index._
-import geotrellis.layer.merge.Mergable
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
+
 import org.apache.spark.rdd.RDD
+
 import io.circe._
+
+import cats.Semigroup
 
 import scala.reflect._
 
@@ -44,7 +47,7 @@ class HBaseLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -55,7 +58,7 @@ class HBaseLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -67,7 +70,7 @@ class HBaseLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],

--- a/hbase-spark/src/main/scala/geotrellis/spark/store/hbase/HBaseLayerWriter.scala
+++ b/hbase-spark/src/main/scala/geotrellis/spark/store/hbase/HBaseLayerWriter.scala
@@ -28,11 +28,8 @@ import geotrellis.store.index._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
-
 import org.apache.spark.rdd.RDD
-
 import io.circe._
-
 import cats.Semigroup
 
 import scala.reflect._

--- a/layer/src/main/scala/geotrellis/layer/TileLayerMetadata.scala
+++ b/layer/src/main/scala/geotrellis/layer/TileLayerMetadata.scala
@@ -20,11 +20,10 @@ import geotrellis.proj4.CRS
 import geotrellis.raster._
 import geotrellis.layer._
 import geotrellis.util._
-import geotrellis.vector.{Extent, ProjectedExtent}
+import geotrellis.vector.Extent
 
 import cats.{Functor, Semigroup}
 import cats.syntax.functor._
-
 import _root_.io.circe._
 import _root_.io.circe.generic.semiauto._
 

--- a/layer/src/main/scala/geotrellis/layer/TileLayerMetadata.scala
+++ b/layer/src/main/scala/geotrellis/layer/TileLayerMetadata.scala
@@ -22,8 +22,9 @@ import geotrellis.layer._
 import geotrellis.util._
 import geotrellis.vector.{Extent, ProjectedExtent}
 
-import cats.Functor
-import cats.implicits._
+import cats.{Functor, Semigroup}
+import cats.syntax.functor._
+
 import _root_.io.circe._
 import _root_.io.circe.generic.semiauto._
 
@@ -105,10 +106,10 @@ object TileLayerMetadata {
   implicit def boundsComponent[K: SpatialComponent]: Component[TileLayerMetadata[K], Bounds[K]] =
     Component(_.bounds, (md, b) => md.updateBounds(b))
 
-  implicit def mergable[K: Boundable]: merge.Mergable[TileLayerMetadata[K]] =
-    new merge.Mergable[TileLayerMetadata[K]] {
-      def merge(t1: TileLayerMetadata[K], t2: TileLayerMetadata[K]): TileLayerMetadata[K] =
-        t1.combine(t2)
+  implicit def semigroup[K: Boundable]: Semigroup[TileLayerMetadata[K]] =
+    new Semigroup[TileLayerMetadata[K]] {
+      def combine(x: TileLayerMetadata[K], y: TileLayerMetadata[K]): TileLayerMetadata[K] =
+        x combine y
     }
 
   implicit val tileLayerMetadataFunctor: Functor[TileLayerMetadata] = new Functor[TileLayerMetadata] {

--- a/layer/src/main/scala/geotrellis/layer/merge/Implicits.scala
+++ b/layer/src/main/scala/geotrellis/layer/merge/Implicits.scala
@@ -18,12 +18,13 @@ package geotrellis.layer.merge
 
 import geotrellis.util.MethodExtensions
 
+import cats.Semigroup
 
 object Implicits extends Implicits
 
 trait Implicits {
-  implicit class withMergableMethods[T: Mergable](val self: T) extends MethodExtensions[T] {
+  implicit class withMergableMethods[T: Semigroup](val self: T) extends MethodExtensions[T] {
     def merge(other: T): T =
-      implicitly[Mergable[T]].merge(self, other)
+      Semigroup[T].combine(self, other)
   }
 }

--- a/layer/src/main/scala/geotrellis/layer/merge/Mergable.scala
+++ b/layer/src/main/scala/geotrellis/layer/merge/Mergable.scala
@@ -1,5 +1,0 @@
-package geotrellis.layer.merge
-
-trait Mergable[T] {
-  def merge(t1: T, t2: T): T
-}

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerWriter.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerWriter.scala
@@ -30,13 +30,9 @@ import geotrellis.util._
 
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.S3Client
-
 import org.apache.spark.rdd.RDD
-
 import com.typesafe.scalalogging.LazyLogging
-
 import io.circe._
-
 import cats.Semigroup
 
 import scala.reflect._

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerWriter.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerWriter.scala
@@ -21,7 +21,6 @@ import geotrellis.store._
 import geotrellis.store.avro._
 import geotrellis.store.avro.codecs._
 import geotrellis.store.index._
-import geotrellis.layer.merge.Mergable
 import geotrellis.store.s3._
 import geotrellis.store.s3.conf.S3Config
 import geotrellis.spark._
@@ -31,9 +30,14 @@ import geotrellis.util._
 
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.S3Client
+
 import org.apache.spark.rdd.RDD
+
 import com.typesafe.scalalogging.LazyLogging
+
 import io.circe._
+
+import cats.Semigroup
 
 import scala.reflect._
 
@@ -64,7 +68,7 @@ class S3LayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -75,7 +79,7 @@ class S3LayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], mergeFunc: (V, V) => V): Unit = {
     update(id, rdd, Some(mergeFunc))
   }
@@ -83,7 +87,7 @@ class S3LayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],

--- a/s3/src/main/scala/geotrellis/store/s3/S3LayerCopier.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/S3LayerCopier.scala
@@ -24,8 +24,10 @@ import geotrellis.util._
 
 import software.amazon.awssdk.services.s3.model._
 import software.amazon.awssdk.services.s3.S3Client
+
 import org.apache.avro.Schema
-import _root_.io.circe._
+
+import io.circe._
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._

--- a/spark/src/main/scala/geotrellis/spark/store/LayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/LayerWriter.scala
@@ -25,18 +25,14 @@ import geotrellis.spark._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
-
 import org.apache.avro._
 import org.apache.spark.rdd.RDD
-
-import io.circe._
-
+import _root_.io.circe._
 import cats.Semigroup
 
 import scala.reflect.ClassTag
 import java.util.ServiceLoader
 import java.net.URI
-
 
 trait LayerWriter[ID] {
   val attributeStore: AttributeStore

--- a/spark/src/main/scala/geotrellis/spark/store/LayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/LayerWriter.scala
@@ -21,14 +21,17 @@ import geotrellis.store._
 import geotrellis.store.avro._
 import geotrellis.store.avro.codecs._
 import geotrellis.store.index._
-import geotrellis.layer.merge.Mergable
 import geotrellis.spark._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
+
 import org.apache.avro._
 import org.apache.spark.rdd.RDD
-import _root_.io.circe._
+
+import io.circe._
+
+import cats.Semigroup
 
 import scala.reflect.ClassTag
 import java.util.ServiceLoader
@@ -48,7 +51,7 @@ trait LayerWriter[ID] {
     H: Encoder: Decoder,
     K: AvroRecordCodec: Boundable: Encoder: ClassTag,
     V: AvroRecordCodec,
-    M: Component[?, Bounds[K]]: Mergable: Encoder: Decoder
+    M: Component[?, Bounds[K]]: Semigroup: Encoder: Decoder
   ](id: LayerId, updateMetadata: M): Option[LayerAttributes[H, M, K]] = {
     if (!attributeStore.layerExists(id)) throw new LayerNotFoundError(id)
 
@@ -93,7 +96,7 @@ trait LayerWriter[ID] {
   def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](id: ID, rdd: RDD[(K, V)] with Metadata[M], mergeFunc: (V, V) => V = { (existing: V, updating: V) => updating }): Unit
 
   /** Update persisted layer without checking for possible.
@@ -118,7 +121,7 @@ trait LayerWriter[ID] {
   def overwrite[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](id: ID, rdd: RDD[(K, V)] with Metadata[M]): Unit
 
   // Layer Writing

--- a/spark/src/main/scala/geotrellis/spark/store/file/FileLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/file/FileLayerWriter.scala
@@ -28,11 +28,8 @@ import geotrellis.spark.merge._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
-
 import org.apache.spark.rdd.RDD
-
 import io.circe._
-
 import cats.Semigroup
 
 import scala.reflect._

--- a/spark/src/main/scala/geotrellis/spark/store/file/FileLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/file/FileLayerWriter.scala
@@ -22,15 +22,18 @@ import geotrellis.store.file.{FileAttributeStore, FileLayerHeader, KeyPathGenera
 import geotrellis.store.avro._
 import geotrellis.store.avro.codecs._
 import geotrellis.store.index._
-import geotrellis.layer.merge.Mergable
 import geotrellis.spark._
 import geotrellis.spark.store._
 import geotrellis.spark.merge._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
+
 import org.apache.spark.rdd.RDD
+
 import io.circe._
+
+import cats.Semigroup
 
 import scala.reflect._
 import java.io.File
@@ -56,7 +59,7 @@ class FileLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M]
@@ -67,7 +70,7 @@ class FileLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],
@@ -79,7 +82,7 @@ class FileLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopLayerWriter.scala
@@ -26,13 +26,10 @@ import geotrellis.spark.store._
 import geotrellis.util._
 
 import com.typesafe.scalalogging.LazyLogging
-
 import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
-
 import io.circe._
-
 import cats.Semigroup
 
 import scala.reflect._

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopLayerWriter.scala
@@ -22,7 +22,6 @@ import geotrellis.store.hadoop.{HadoopAttributeStore, HadoopLayerHeader}
 import geotrellis.store.avro._
 import geotrellis.store.avro.codecs._
 import geotrellis.store.index.KeyIndex
-import geotrellis.layer.merge.Mergable
 import geotrellis.spark.store._
 import geotrellis.util._
 
@@ -31,7 +30,10 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
+
 import io.circe._
+
+import cats.Semigroup
 
 import scala.reflect._
 
@@ -46,7 +48,7 @@ class HadoopLayerWriter(
   def overwrite[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
     update(id, rdd, None)
   }
@@ -54,7 +56,7 @@ class HadoopLayerWriter(
   def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](id: LayerId, rdd: RDD[(K, V)] with Metadata[M], mergeFunc: (V, V) => V): Unit = {
     update(id, rdd, Some(mergeFunc))
   }
@@ -62,7 +64,7 @@ class HadoopLayerWriter(
   private def update[
     K: AvroRecordCodec: Boundable: Encoder: Decoder: ClassTag,
     V: AvroRecordCodec: ClassTag,
-    M: Encoder: Decoder: Component[?, Bounds[K]]: Mergable
+    M: Encoder: Decoder: Component[?, Bounds[K]]: Semigroup
   ](
     id: LayerId,
     rdd: RDD[(K, V)] with Metadata[M],


### PR DESCRIPTION
## Overview

The `mergable` trait from GT is just cats' `Semigroup`. As we are now using cats, this PR replaces mergable with Semigroup.

### Notes

This is pretty straightforward and doesn't attempt to rework any of the patterns (which should be revisited) through which we use `mergable` (and now `Semigroup`)

Closes #2925