### PR TITLE
Warn about extent reprojection behavior

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala
@@ -61,6 +61,12 @@ object Reproject {
       p.holes.map{ apply(_, transform) }
     )
 
+  /** Naively reproject an extent
+    *
+    * @note This method is unsafe when attempting to reproject a gridded space (as is the
+    * case when dealing with rasters) and should not be used. Instead, reproject a RasterExtent
+    * to ensure that underlying cells are fully and accurately captured by reprojection.
+    */
   def apply(extent: Extent, src: CRS, dest: CRS): Extent =
     apply(extent.toPolygon, src, dest).envelope
 


### PR DESCRIPTION
## Overview

The standard extent reprojection behavior is not safe for use when there's an underlying grid that must be correctly represented after reprojection (which is generally the case when working with rasters). Nevertheless, the correct behavior isn't available in `vector` alone and without moving methods to `raster` where they don't make sense, a warning is as good as we're going to get.

### Notes

This PR doesn't fix the dangerous behavior but instead warns about it via docstring

Closes #2990
