### PR TITLE
Add sparse stitch method to StitchCollectionMethods

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,7 @@ API Changes & Project structure changes
 - ``geotrellis.layer``
 
   - **Change:** Replaced ``Mergable`` with cats' ``Semigroup``
+  - **New:** A sparseStitch method on ``geotrellis.layer.stitch.SpatialTileLayoutCollectionStitchMethods``. Note that ``SpatialTileLayoutCollectionStitchMethods`` now has the additional constraint ``geotrellis.raster.prototype.TilePrototypeMethods`` on type ``V``. This should be transparent for users of the ``geotrellis.raster.Tile`` and ``geotrellis.raster.MultibandTile`` types.
 
 - ``geotrellis.util``, ``geotrellis.store``, ``geotrellis.store.s3``
 

--- a/layer/src/main/scala/geotrellis/layer/stitch/Implicits.scala
+++ b/layer/src/main/scala/geotrellis/layer/stitch/Implicits.scala
@@ -17,18 +17,16 @@
 package geotrellis.layer.stitch
 
 import geotrellis.raster._
-import geotrellis.raster.merge._
 import geotrellis.raster.prototype._
 import geotrellis.raster.stitch._
 import geotrellis.layer._
-import geotrellis.vector.Extent
 import geotrellis.util._
 
 object Implicits extends Implicits
 
 trait Implicits {
   implicit class withSpatialTileLayoutCollectionMethods[
-    V <: CellGrid[Int]: Stitcher,
+    V <: CellGrid[Int]: Stitcher: ? => TilePrototypeMethods[V],
     M: GetComponent[?, LayoutDefinition]
   ](
     val self: Seq[(SpatialKey, V)] with Metadata[M]

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/TileLayerRDDBuilders.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/TileLayerRDDBuilders.scala
@@ -145,6 +145,12 @@ trait TileLayerRDDBuilders {
   }
 
   def createTileLayerRDD(
+    raster: Raster[Tile],
+    tileLayout: TileLayout
+  )(implicit sc: SparkContext): TileLayerRDD[SpatialKey] =
+    createTileLayerRDD(sc, raster, tileLayout, defaultCRS)
+
+  def createTileLayerRDD(
     sc: SparkContext,
     raster: Raster[Tile],
     tileLayout: TileLayout
@@ -172,6 +178,12 @@ trait TileLayerRDDBuilders {
     tileLayout: TileLayout
   )(implicit sc: SparkContext): MultibandTileLayerRDD[SpatialKey] =
     createMultibandTileLayerRDD(sc, tile, tileLayout)
+
+  def createMultibandTileLayerRDD(
+    raster: Raster[MultibandTile],
+    tileLayout: TileLayout
+  )(implicit sc: SparkContext): MultibandTileLayerRDD[SpatialKey] =
+    createMultibandTileLayerRDD(sc, raster, tileLayout)
 
   def createMultibandTileLayerRDD(
     sc: SparkContext,

--- a/spark/src/main/scala/geotrellis/spark/stitch/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/stitch/Implicits.scala
@@ -30,7 +30,7 @@ object Implicits extends Implicits
 
 trait Implicits {
   implicit class withSpatialTileLayoutRDDMethods[
-    V <: CellGrid[Int]: Stitcher,
+    V <: CellGrid[Int]: Stitcher: ? => TilePrototypeMethods[V],
     M: GetComponent[?, LayoutDefinition]
   ](
     val self: RDD[(SpatialKey, V)] with Metadata[M]

--- a/spark/src/test/scala/geotrellis/spark/stitch/CollectionStitchMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/stitch/CollectionStitchMethodsSpec.scala
@@ -99,5 +99,80 @@ class CollectionStitchMethodsSpec extends FunSpec
 
       assertEqual(tile, layer.stitch.tile)
     }
+
+    it("should correctly sparse stitch a singleband tile with an offset extent") {
+      val expectedTile =
+        createTile(
+          Array(
+            NaN, NaN, NaN, NaN, NaN,
+            1, 1,  1, 1, NaN,
+            1, 1,  1, 1, NaN,
+            1, 1,  1, 1, NaN,
+            1, 1,  1, 1, NaN
+          ), 5, 5)
+
+      val tile =
+        createTile(
+          Array(
+            1, 1,  1, 1,
+            1, 1,  1, 1,
+            1, 1,  1, 1,
+            1, 1,  1, 1
+          ), 4, 4)
+      val extent = Extent(0, 0, 4, 4)
+      val layer =
+        createTileLayerRDD(
+          Raster(tile, extent),
+          TileLayout(4, 4, 1, 1)
+        ).toCollection
+      val testExtent = Extent(0, 0, 5, 5)
+      assertEqual(layer.sparseStitch(testExtent).get.tile, expectedTile)
+    }
+  }
+
+  it("should correctly sparse stitch a multiband tile with an offset extent") {
+    val expectedTile = ArrayMultibandTile(
+      createTile(Array(NaN, NaN, NaN, 1, 1, NaN, 1, 1, NaN), 3, 3),
+      createTile(Array(NaN, NaN, NaN, 2, 2, NaN, 2, 2, NaN), 3, 3)
+    )
+    val tile1 =
+      createTile(
+        Array(
+          1, 1,
+          1, 1
+        ), 2, 2)
+    val tile2 =
+      createTile(
+        Array(
+          2, 2,
+          2, 2
+        ), 2, 2)
+    val tile = ArrayMultibandTile(tile1, tile2)
+    val extent = Extent(0, 0, 2, 2)
+    val layer =
+      createMultibandTileLayerRDD(
+        Raster(tile, extent),
+        TileLayout(2, 2, 1, 1)
+      ).toCollection
+    val testExtent = Extent(0, 0, 3, 3)
+    assertEqual(layer.sparseStitch(testExtent).get.tile, expectedTile)
+  }
+
+  it("should correctly sparse stitch a singleband tile using the raster tile extent") {
+    val tile =
+      createTile(
+        Array(
+          1, 1,  1, 1,
+          1, 1,  1, 1,
+          1, 1,  1, 1,
+          1, 1,  1, 1
+        ), 4, 4)
+    val extent = Extent(0, 0, 4, 4)
+    val layer =
+      createTileLayerRDD(
+        Raster(tile, extent),
+        TileLayout(4, 4, 1, 1)
+      ).toCollection
+    assertEqual(layer.sparseStitch.get.tile, tile)
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/stitch/RDDStitchMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/stitch/RDDStitchMethodsSpec.scala
@@ -151,5 +151,30 @@ class RDDStitchMethodsSpec extends FunSpec
 
       assertEqual(tiles.stitch, reference)
     }
+
+    it("should sparse stitch an RDD with an offset extent") {
+        val expectedTile =
+          createTile(
+            Array(
+              NaN, NaN, NaN, NaN, NaN,
+              1, 1,  1, 1, NaN,
+              1, 1,  1, 1, NaN,
+              1, 1,  1, 1, NaN,
+              1, 1,  1, 1, NaN
+            ), 5, 5)
+
+        val tile =
+          createTile(
+            Array(
+              1, 1,  1, 1,
+              1, 1,  1, 1,
+              1, 1,  1, 1,
+              1, 1,  1, 1
+            ), 4, 4)
+        val extent = Extent(0, 0, 4, 4)
+        val layer = createTileLayerRDD(Raster(tile, extent), TileLayout(4, 4, 1, 1))
+        val testExtent = Extent(0, 0, 5, 5)
+        assertEqual(layer.sparseStitch(testExtent).get.tile, expectedTile)
+    }
   }
 }


### PR DESCRIPTION
## Overview

Adds sparseStitch methods to `SpatialTileLayoutCollectionStitchMethods`. The method uses a different algorithm, and therefore it felt more correct to name it differently from the original `stitch(): Raster[V]`. Also added a helper so that users who want to use the collection extent don't have to know how to get it, since this is the most likely default use case.

Opened PR to get tests to run, since there's a breaking change on the type bounds of V. Initial testing in a few key places didn't raise any issues but I want the whole test suite to run. **Edit:** Full test suite passed, but upon further inspection it looks like we might not test stitch anywhere else.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Notes

I want to add a unit test or two because there's nothing at all for any of these stitch functions, but that looks like its a bit of an effort since there's no easy test data constructor for the type we need to test. So submitting this for review now and moving on to a different task. I can attempt to add a test or two once we've settled on approval for the API presented here. 

Closes #2903 