### PR TITLE
S3RangeReader totalLength Improvment

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -113,6 +113,7 @@ Fixes & Updates
 - ArrayTile equality will now check the cols, rows, and cellType of the two tiles (`#2991 <https://github.com/locationtech/geotrellis/pull/2991>`_).
 - Fix incorrect Deflate compressor usage (`#2997 <https://github.com/locationtech/geotrellis/pull/2997>`_).
 - Refactor IO thread pool usage (`#3007 <https://github.com/locationtech/geotrellis/pull/3007>`_).
+- ``S3RangeReader`` will now use a ``GetObjectResponse`` to compute the ``totalLength`` (`#3025 <https://github.com/locationtech/geotrellis/pull/3025>`_).
 
 2.3.0
 -----

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -113,7 +113,7 @@ Fixes & Updates
 - ArrayTile equality will now check the cols, rows, and cellType of the two tiles (`#2991 <https://github.com/locationtech/geotrellis/pull/2991>`_).
 - Fix incorrect Deflate compressor usage (`#2997 <https://github.com/locationtech/geotrellis/pull/2997>`_).
 - Refactor IO thread pool usage (`#3007 <https://github.com/locationtech/geotrellis/pull/3007>`_).
-- ``S3RangeReader`` will now use a ``GetObjectResponse`` to compute the ``totalLength`` (`#3025 <https://github.com/locationtech/geotrellis/pull/3025>`_).
+- ``S3RangeReader`` will now optionally read the HEADER of an object (`#3025 <https://github.com/locationtech/geotrellis/pull/3025>`_).
 
 2.3.0
 -----

--- a/s3/src/main/scala/geotrellis/store/s3/util/S3RangeReader.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/util/S3RangeReader.scala
@@ -39,18 +39,13 @@ class S3RangeReader(
   client: S3Client
 ) extends RangeReader {
 
-  lazy val metadata: HeadObjectResponse = {
-    val headRequest =
-      HeadObjectRequest
-        .builder()
-        .bucket(request.bucket)
-        .key(request.key)
-        .build()
+  lazy val totalLength: Long = {
+    val responseStream = client.getObject(request)
+    val length = responseStream.response.contentLength
 
-    client.headObject(headRequest)
+    responseStream.close()
+    length
   }
-
-  lazy val totalLength: Long = metadata.contentLength
 
   def readClippedRange(start: Long, length: Int): Array[Byte] = {
     val getRequest =

--- a/s3/src/main/scala/geotrellis/store/s3/util/S3RangeReader.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/util/S3RangeReader.scala
@@ -32,12 +32,13 @@ import java.net.URI
  *
  * @param request: A [[GetObjectRequest]] of the desired GeoTiff.
  * @param client: The [[S3Client]] that retrieves the data.
+ * @param readHeader: Whether the `HEAD` of the target object should be read or not. Default is `false`.
  * @return A new instance of S3RangeReader.
  */
 class S3RangeReader(
   request: => GetObjectRequest,
   client: S3Client,
-  readHeader: Boolean = true
+  readHeader: Boolean = false
 ) extends RangeReader {
 
   lazy val totalLength: Long = {


### PR DESCRIPTION
## Overview

This PR changes how the `totalLength` value of `S3RangeReader` is computed. It will now use a `GetObjectResponse` instead of a `GetHeaderResponse`. This will allow users to read these files even if they don't have permission to access its `HEADER`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Check it on a real S3 bucket with permission limits

Closes #2889 