### PR TITLE
FileRangeReader Improved URI Handeling

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -117,6 +117,7 @@ Fixes & Updates
 - Fix incorrect Deflate compressor usage (`#2997 <https://github.com/locationtech/geotrellis/pull/2997>`_).
 - Refactor IO thread pool usage (`#3007 <https://github.com/locationtech/geotrellis/pull/3007>`_).
 - ``S3RangeReader`` will now optionally read the HEADER of an object (`#3025 <https://github.com/locationtech/geotrellis/pull/3025>`_).
+- ``FileRangeReaderProvider`` can now handle more types of ``URI``\s (`#3034 <https://github.com/locationtech/geotrellis/pull/3034>`_).
 
 2.3.0
 -----

--- a/util/src/main/scala/geotrellis/util/FileRangeReader.scala
+++ b/util/src/main/scala/geotrellis/util/FileRangeReader.scala
@@ -28,7 +28,7 @@ import java.nio.channels.FileChannel.MapMode._
  * @param file: A local File to read bytes from.
  * @return A new instance of FileRangeReader
  */
-class FileRangeReader(file: File) extends RangeReader {
+class FileRangeReader(val file: File) extends RangeReader {
   val totalLength: Long = file.length
 
   def readClippedRange(start: Long, length: Int): Array[Byte] = {

--- a/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala
+++ b/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala
@@ -28,23 +28,21 @@ class FileRangeReaderProvider extends RangeReaderProvider {
   }
 
   def rangeReader(uri: URI): FileRangeReader = {
-    val containsScheme: Boolean =
-      uri.getScheme match {
-        case _: String => true
-        case null => false
-      }
+    // Paths.get has certain restrictions on how URIs that are
+    // passed to it are formatted. This sometimes prevents
+    // URIs that are correctly formatted from being used. To
+    // get around this, we will pass in the URI as a String
+    // instead without its Scheme (if it had one).
+    val targetPath: String = {
+      val uriString = uri.toString
 
-    val fileSchemeSize: Int = "file://".size
-
-    // Certain systems (like Linux) do not allow URIs to have
-    // Authorities when being passed to Paths.get, but others do.
-    // In order to simplify things, all URIs given will
-    // be formatted as a String and then passed to Paths.
-    val targetPath: String =
-      if (containsScheme)
-        uri.toString.slice(fileSchemeSize, uri.toString.size + 1)
+      if (uriString.startsWith("file://"))
+        uriString.slice("file://".size, uriString.size + 1)
+      else if (uriString.startsWith("file:"))
+        uriString.slice("file:".size, uriString.size + 1)
       else
-        uri.toString
+        uriString
+    }
 
     FileRangeReader(Paths.get(targetPath).toFile)
   }

--- a/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala
+++ b/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala
@@ -27,6 +27,25 @@ class FileRangeReaderProvider extends RangeReaderProvider {
     case null => true // assume that the user is passing in the path to the catalog
   }
 
-  def rangeReader(uri: URI): FileRangeReader =
-    FileRangeReader(Paths.get(uri.toString).toFile)
+  def rangeReader(uri: URI): FileRangeReader = {
+    val containsScheme: Boolean =
+      uri.getScheme match {
+        case _: String => true
+        case null => false
+      }
+
+    val fileSchemeSize: Int = "file://".size
+
+    // Certain systems (like Linux) do not allow URIs to have
+    // Authorities when being passed to Paths.get, but others do.
+    // In order to simplify things, all URIs given will
+    // be formatted as a String and then passed to Paths.
+    val targetPath: String =
+      if (containsScheme)
+        uri.toString.slice(fileSchemeSize, uri.toString.size + 1)
+      else
+        uri.toString
+
+    FileRangeReader(Paths.get(targetPath).toFile)
+  }
 }

--- a/util/src/test/scala/geotrellis/util/FileRangeReaderProviderSpec.scala
+++ b/util/src/test/scala/geotrellis/util/FileRangeReaderProviderSpec.scala
@@ -30,5 +30,26 @@ class FileRangeReaderProviderSpec extends FunSpec with Matchers {
 
       assert(reader.isInstanceOf[FileRangeReader])
     }
+
+    it("should be able to process a URI with a scheme and an authority") {
+      val expectedPath = "data/path/to/my/data/blah.tif"
+      val reader = RangeReader(new URI(s"file://$expectedPath"))
+
+      reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
+    }
+
+    it("should be able to process a URI with a scheme and no authority") {
+      val expectedPath = "/tmp/data/path/to/my/data/blah.tif"
+      val reader = RangeReader(new URI(s"file://$expectedPath"))
+
+      reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
+    }
+
+    it("should be able to process a URI with no scheme and no authority") {
+      val expectedPath = "../data/path/to/my/data/blah.tif"
+      val reader = RangeReader(new URI(s"$expectedPath"))
+
+      reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
+    }
   }
 }

--- a/util/src/test/scala/geotrellis/util/FileRangeReaderProviderSpec.scala
+++ b/util/src/test/scala/geotrellis/util/FileRangeReaderProviderSpec.scala
@@ -39,13 +39,6 @@ class FileRangeReaderProviderSpec extends FunSpec with Matchers {
     }
 
     it("should be able to process a URI with a scheme and no authority") {
-      val expectedPath = "/tmp/data/path/to/my/data/blah.tif"
-      val reader = RangeReader(new URI(s"file://$expectedPath"))
-
-      reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
-    }
-
-    it("should be able to process a URI with no scheme and no authority") {
       val expectedPath = "data/path/to/my/data/blah.tif"
       val reader = RangeReader(new URI(s"file:$expectedPath"))
 

--- a/util/src/test/scala/geotrellis/util/FileRangeReaderProviderSpec.scala
+++ b/util/src/test/scala/geotrellis/util/FileRangeReaderProviderSpec.scala
@@ -46,6 +46,13 @@ class FileRangeReaderProviderSpec extends FunSpec with Matchers {
     }
 
     it("should be able to process a URI with no scheme and no authority") {
+      val expectedPath = "data/path/to/my/data/blah.tif"
+      val reader = RangeReader(new URI(s"file:$expectedPath"))
+
+      reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
+    }
+
+    it("should be able to process a URI that's a relative path") {
       val expectedPath = "../data/path/to/my/data/blah.tif"
       val reader = RangeReader(new URI(s"$expectedPath"))
 


### PR DESCRIPTION
## Overview

This PR fixes a bug in `FileRangeReaderProvider` where it was unable to process certain `URI`s. Looking into the issue, I found the cause of the problem to be with [how we were converting URIs to Files](https://github.com/locationtech/geotrellis/blob/master/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala#L31). It turns out that `Paths.get` has [certain restrictions](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Paths.html#get(java.net.URI)) on how the `URI` has to be formatted. These differ from the `URI` specification, and can sometimes cause properly formatted `URI`s to be denied.

What I ended up deciding on was to simply pass in a `String` to `Paths.get` in order to get around the different `URI` requirements. To do that, I first check to see if the given `URI` had a `scheme` or not. If it doesn't then I just convert it to a `String`. Otherwise, I strip the scheme from the path and then pass in the scheme-less `String`.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

Closes #3031