### PR TITLE
VectorTile Geometry Recentering

### DIFF
--- a/vectortile/src/main/scala/geotrellis/vectortile/internal/package.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/internal/package.scala
@@ -120,12 +120,11 @@ package object internal {
     * }}}
     *
     */
-  private[vectortile] def toProjection(point: (Int, Int), topLeft: Point, resolution: Double): Point = {
+  private[vectortile] def toProjection(point: (Int, Int), topLeft: Point, resolution: Double): Point =
     Point(
       topLeft.x + (resolution * point._1),
       topLeft.y - (resolution * point._2)
     )
-  }
 
   /**
     * Translate [[Point]] coordinates within a CRS to those of a fixed
@@ -136,12 +135,11 @@ package object internal {
     * @param resolution How much of the CRS's units are covered by a single VT grid coordinate.
     * @return Grid coordinates in VectorTile space.
     */
-  private[vectortile] def fromProjection(point: Point, topLeft: Point, resolution: Double): (Int, Int) = {
+  private[vectortile] def fromProjection(point: Point, topLeft: Point, resolution: Double): (Int, Int) =
     (
       ((point.x - topLeft.x) / resolution).toInt,
       ((topLeft.y - point.y) / resolution).toInt
     )
-  }
 
   /** Instance definition of the ProtobufGeom typeclass for Points. */
   private[vectortile] implicit val protoPoint = new ProtobufGeom[Point, MultiPoint] {

--- a/vectortile/src/test/scala/geotrellis/vectortile/ProjectionSpec.scala
+++ b/vectortile/src/test/scala/geotrellis/vectortile/ProjectionSpec.scala
@@ -1,0 +1,43 @@
+package geotrellis.vectortile
+
+import geotrellis.proj4._
+import geotrellis.vector._
+import geotrellis.vectortile.internal._
+
+import org.scalatest._
+
+
+class ProjectionSpec extends FunSpec {
+  describe("VectorTile Projection Conversions") {
+    it("should read a point from a VectorTile and write it back") {
+      val p1 = Point(-61.347656249999986, 10.412183158667512)
+      val reprojected = p1.reproject(LatLng, WebMercator)
+      val tileExtent = Extent(-6887893.4928338025, 1095801.2374962866, -6809621.975869782, 1174072.7544603087)
+
+      val f = MVTFeature(reprojected, Map.empty[String, Value])
+
+      val layer = StrictLayer(
+        name = "test",
+        tileWidth = 128,
+        version = 2,
+        tileExtent = tileExtent,
+        points = Seq(f),
+        multiPoints = Seq.empty,
+        lines = Seq.empty,
+        multiLines = Seq.empty,
+        polygons = Seq.empty,
+        multiPolygons = Seq.empty
+      )
+
+      val vt = VectorTile(Map("test" -> layer), tileExtent)
+
+      val vt2 = VectorTile.fromBytes(vt.toBytes, tileExtent)
+      val p2 = vt2.layers("test").features.head.geom.reproject(WebMercator, LatLng)
+
+      val vt3 = VectorTile.fromBytes(vt2.toBytes, tileExtent)
+      val p3 = vt3.layers("test").features.head.geom.reproject(WebMercator, LatLng)
+
+      assert((p1 == p2) && (p1 == p3) && (p2 == p3))
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR fixes an error that can sometimes cause geometries to be dropped and/or shifted when reading them from a `VectorTile` and then writing them back. The issue was caused by using the top left corner of the pixel of the tile as the reference for the projected coordinates; as this would cause some projected points to either move, or fall outside of the tile when converting those projected coordinates back to VectorTile coordinates.

The solution was then to change the reference point from being in the corner of the pixel to being in the center.

### Checklist

- [ ] ~~`docs/CHANGELOG.rst` updated, if necessary~~
- [x] Unit tests added for bug-fix or new feature

### Notes

I think I will need to talk with someone more before I can remove the `[WIP]` from this PR. Because right now the changes introduced causes other tests to fail, and I'm not sure if that behavior is okay or not. Also, I've not been able to recreate the error this PR was intended to resolve, so a unit test needs to be created before this is ready for review.

Closes #2926