### PR TITLE
Make sure multi-geometry constructors are available in the shell

### DIFF
--- a/vector/src/main/scala/geotrellis/vector/JTS.scala
+++ b/vector/src/main/scala/geotrellis/vector/JTS.scala
@@ -12,8 +12,8 @@ object JTS {
   object Point extends PointConstructors
   object LineString extends LineStringConstructors
   object Polygon extends PolygonConstructors
-  object MultiPoint extends PointConstructors
-  object MultiLineString extends LineStringConstructors
-  object MultiPolygon extends PolygonConstructors
+  object MultiPoint extends MultiPointConstructors
+  object MultiLineString extends MultiLineStringConstructors
+  object MultiPolygon extends MultiPolygonConstructors
   object GeometryCollection extends GeometryCollectionConstructors
 }


### PR DESCRIPTION
## Overview

Fixes a whoopsie from #2932.  This will make sure that multi-geometry constructors are available from the `JTS` object.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>
