### PR TITLE
README: updated some "Getting Started" versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ You can find more information and talk to developers
 
 ## Getting Started
 
-GeoTrellis is currently available for Scala 2.11 and Spark 2.0+.
+GeoTrellis is currently available for Scala 2.11 and 2.12, using Spark 2.4.x.
 
 To get started with SBT, simply add the following to your build.sbt file:
 
 ```scala
-libraryDependencies += "org.locationtech.geotrellis" %% "geotrellis-raster" % "1.1.0"
+libraryDependencies += "org.locationtech.geotrellis" %% "geotrellis-raster" % "2.3.1"
 ```
 
 To grab the latest `SNAPSHOT`, `RC` or milestone build, add these resolvers:

--- a/docs/tutorials/setup.rst
+++ b/docs/tutorials/setup.rst
@@ -84,9 +84,9 @@ the ``libraryDependencies`` list in your ``build.sbt``:
 .. code:: scala
 
     libraryDependencies ++= Seq(
-        "org.locationtech.geotrellis" %% "geotrellis-spark"  % "1.0.0",
-        "org.locationtech.geotrellis" %% "geotrellis-s3"     % "1.0.0", // now we can use Amazon S3!
-        "org.apache.spark"            %% "spark-core"        % "2.1.0" % "provided",
+        "org.locationtech.geotrellis" %% "geotrellis-spark"  % "2.3.1",
+        "org.locationtech.geotrellis" %% "geotrellis-s3"     % "2.3.1", // now we can use Amazon S3!
+        "org.apache.spark"            %% "spark-core"        % "2.4.1" % "provided",
         "org.scalatest"               %% "scalatest"         % "3.0.0" % "test"
     )
 


### PR DESCRIPTION
minor README.md tweak to make sure the example also works for scala 2.12

I picked `"geotrellis-raster" % "2.2.0"` because that works for both scala 2.11 and 2.12 by default
