### PR TITLE
Allow implicit conversions on SaveToS3 Array[Byte]

### DIFF
--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/Implicits.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/Implicits.scala
@@ -22,5 +22,5 @@ import org.apache.spark.rdd.RDD
 object Implicits extends Implicits
 
 trait Implicits {
-  implicit class withSaveToS3Methods[K](rdd: RDD[(K, Array[Byte])]) extends SaveToS3Methods(rdd)
+  implicit class withSaveToS3Methods[K, V](rdd: RDD[(K, V)]) extends SaveToS3Methods(rdd)
 }

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/SaveToS3Methods.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/SaveToS3Methods.scala
@@ -24,7 +24,7 @@ import org.apache.spark.rdd.RDD
 
 import scala.concurrent.ExecutionContext
 
-class SaveToS3Methods[K](val self: RDD[(K, Array[Byte])]) extends MethodExtensions[RDD[(K, Array[Byte])]] {
+class SaveToS3Methods[K, V](val self: RDD[(K, V)]) extends MethodExtensions[RDD[(K, V)]] {
 
   /**
     * Saves each RDD value to an S3 key.
@@ -33,6 +33,7 @@ class SaveToS3Methods[K](val self: RDD[(K, Array[Byte])]) extends MethodExtensio
     * @param putObjectModifier  Function that will be applied ot S3 PutObjectRequests, so that they can be modified (e.g. to change the ACL settings)
     * @param executionContext   A function to get execution context
     */
-  def saveToS3(keyToUri: K => String, putObjectModifier: PutObjectRequest => PutObjectRequest = { p => p }, executionContext: => ExecutionContext = BlockingThreadPool.executionContext): Unit =
+  def saveToS3(keyToUri: K => String, putObjectModifier: PutObjectRequest => PutObjectRequest = { p => p }, executionContext: => ExecutionContext = BlockingThreadPool.executionContext)
+              (implicit ev: V => Array[Byte]): Unit =
     SaveToS3(self, keyToUri, putObjectModifier, executionContext = executionContext)
 }


### PR DESCRIPTION
## Overview

Allows for easier discoverability of the saveToS3
methods on RDD[(K, V)] at the expense of the possibility
that for some conversion types it won't be serializable
by Spark. If this occurs, its up to the caller to perform
an explicit conversion to Array[Byte] just as before.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

### Notes

Change discussed and implemented with @echeipesh while working on a task where we're saving pyramided image tiles via Spark.
