### PR TITLE
Fix SaveToS3 methods serialization

### DIFF
--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/Implicits.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/Implicits.scala
@@ -21,6 +21,6 @@ import org.apache.spark.rdd.RDD
 
 object Implicits extends Implicits
 
-trait Implicits {
+trait Implicits extends Serializable {
   implicit class withSaveToS3Methods[K](rdd: RDD[(K, Array[Byte])]) extends SaveToS3Methods(rdd)
 }


### PR DESCRIPTION
## Overview

Package objects are not serializable by default, in this case package object `geotrellis.spark.store.s3` contained necessary extension methods, it was imported by the package object import and caused serialization issues.

### Test

Use the test instructions from the https://github.com/locationtech/geotrellis/issues/3059

### Checklist

Closes https://github.com/locationtech/geotrellis/issues/3059
