### PR TITLE
Fix #2791: HttpRangeReader swallows 404s

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -125,6 +125,7 @@ Fixes & Updates
 - ``FileRangeReaderProvider`` can now handle more types of ``URI``\s (`#3034 <https://github.com/locationtech/geotrellis/pull/3034>`_).
 - Bump proj4 version to fix multiple performance issues (`#3039 <https://github.com/locationtech/geotrellis/pull/3039>`_).
 - Update dependencies (`#3053 <https://github.com/locationtech/geotrellis/pull/3053>`_).
+- Fix HttpRangeReader swallows 404 error (`#3073 https://github.com/locationtech/geotrellis/pull/3073`_)
 
 2.3.0
 -----

--- a/spark/src/main/scala/geotrellis/spark/store/http/util/HttpRangeReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/http/util/HttpRangeReader.scala
@@ -29,6 +29,8 @@ import scala.util.Try
  * This class extends [[RangeReader]] by reading chunks out of a GeoTiff at the
  * specified HTTP location.
  *
+ * @throws [[HttpStatusException]] if the HTTP response code is 4xx or 5xx
+ *
  * @param url: A [[URL]] pointing to the desired GeoTiff.
  */
 class HttpRangeReader(url: URL, useHeadRequest: Boolean) extends RangeReader with LazyLogging {
@@ -47,6 +49,7 @@ class HttpRangeReader(url: URL, useHeadRequest: Boolean) extends RangeReader wit
           case Some(num) => num
           case None => -1L
         }
+    headers.throwError
 
     /**
      * "The Accept-Ranges response HTTP header is a marker used by the server

--- a/spark/src/test/scala/geotrellis/spark/store/http/util/HttpRangeReaderSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/store/http/util/HttpRangeReaderSpec.scala
@@ -16,14 +16,12 @@
 
 package geotrellis.spark.store.http.util
 
-import java.nio.file.{ Paths, Files }
+import java.nio.file.{Files, Paths}
 import java.nio.ByteBuffer
-import geotrellis.util._
-import spire.syntax.cfor._
-
-import org.apache.commons.io.IOUtils
 
 import org.scalatest._
+import scalaj.http.HttpStatusException
+import spire.syntax.cfor._
 
 /** These tests require running the container defined in scripts/nginxTestHttp.sh */
 class HttpRangeReaderSpec extends FunSpec with Matchers {
@@ -90,6 +88,17 @@ class HttpRangeReaderSpec extends FunSpec with Matchers {
       val result = testArrays(expected, actual)
 
       result.length should be (0)
+    }
+
+    it("should throw HttpStatusException for a 404 Not Found") {
+      val uri = "https://geotrellis.io/404thisdoesntexist"
+      assertThrows[HttpStatusException] {
+        HttpRangeReader(uri)
+      }
+
+      assertThrows[HttpStatusException] {
+       HttpRangeReader.withoutHeadRequest(uri)
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

HttpRangeReader now throws with an HttpStatusException if the server responds with any 4xx or 5xx status code.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [ ] ~~`docs` guides update, if necessary~~
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

### Notes

This is a bit more of an expansive fix than specifically just catching 404s, but as far as I can tell, it's correct to catch and throw a helpful error here for any 4xx or 5xx series HTTP error so that the client can handle them properly.

Closes #2791 
