### PR TITLE
Clean up WKT <--> EPSG conversion methods

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -109,6 +109,11 @@ API Changes & Project structure changes
 
   - **Add:** ``geotrellis.util.np`` package which contains ``linspace`` and ``percentile``methods that match numpy functionality. An implicit class was also added to ``geotrellis.raster`` which provides the ``percentile`` method for ``geotrellis.raster.Tile``.
 
+- ``geotrellis.proj4``
+
+  - **Change:** ``WKT`` object conversion methods to and from EPSG codes have changed. All now return `Option`s rather than silently unwrap. Methods that convert from EPSG code to WKT string are now prefixed consistently with `fromEpsg` and methods that convert from WKT string to EPSG code are now prefixed consistently with `toEpsg`.
+  - **Change:** ``CRS.fromWKT`` now returns `Option[CRS]` instead of `CRS` after silently unwrapping an optional internally.
+
 Fixes & Updates
 ^^^^^^^^^^^^^^^
 

--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -66,10 +66,8 @@ object CRS {
     * Creates a CoordinateReferenceSystem (CRS) from a
     * well-known-text String.
     */
-  def fromWKT(wktString: String): CRS = {
-    // TODO: Make this method Option[CRS] too?
-    val epsgCode: String = WKT.getEpsgStringCode(wktString).get
-    fromName(epsgCode)
+  def fromWKT(wktString: String): Option[CRS] = {
+    WKT.getEpsgStringCode(wktString).map(fromName(_))
   }
 
   /**

--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -67,7 +67,8 @@ object CRS {
     * well-known-text String.
     */
   def fromWKT(wktString: String): CRS = {
-    val epsgCode: String = WKT.getEpsgCode(wktString)
+    // TODO: Make this method Option[CRS] too?
+    val epsgCode: String = WKT.getEpsgStringCode(wktString).get
     fromName(epsgCode)
   }
 
@@ -139,7 +140,7 @@ trait CRS extends Serializable {
    * Returns the WKT representation of the Coordinate Reference
    * System.
    */
-  def toWKT(): Option[String] = epsgCode.map(WKT.fromEpsgCode(_))
+  def toWKT(): Option[String] = epsgCode.flatMap(WKT.fromEpsgCode(_))
 
 
   // TODO: Do these better once more things are ported

--- a/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKT.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKT.scala
@@ -45,33 +45,37 @@ object WKT {
     projections contains input
   }
 
-  def getEpsgCodeOption(input: String): Option[Int] = {
-    val wktParsed = WKTParser(input)
+  /**
+    * Returns an EPSG code given a WKT string
+    * @param wktString
+    * @return
+    */
+  def getEpsgCode(wktString: String): Option[Int] = {
+    val wktParsed = WKTParser(wktString)
     parsed.find{
-      case (epsgCode, wkt) => wkt == wktParsed
+      case (_, wkt) => wkt == wktParsed
     }.map(_._1)
   }
 
-  def getEpsgStringOption(input: Int): Option[String] = {
+  /**
+    * Returns an EPSG code as a string of the form "EPSG:[number]" given a WKT String
+    * @param wktString
+    * @return
+    */
+  def getEpsgStringCode(wktString: String): Option[String] = {
+    getEpsgCode(wktString).map(c => s"EPSG:${c.toString}")
+  }
+
+  /**
+    * Returns the WKT string for the given EPSG code
+    * @param input The EPSG code, e.g. 4326
+    * @return
+    */
+  def fromEpsgCode(input: Int): Option[String] = {
     records.get(input).map(_.toString)
   }
 
-
-  /**
-   * Returns the WKT representation given an EPSG code in the format EPSG:[number]
-   * @param code
-   * @return
-   */
-  def fromEpsgCode(code: Int): String = getEpsgStringOption(code).get
-
-  /**
-   * Returns the numeric code of a WKT string given the authority
-   * @param wktString
-   * @return
-   */
-  def getEpsgCode(wktString: String): String = s"EPSG:${getEpsgCodeOption(wktString).get}"
-
-  def withWktFile[T](f: Iterator[String] => T) = {
+  def withWktFile[T](f: Iterator[String] => T): T = {
     val stream = getClass.getResourceAsStream(wktResourcePath)
     try {
       val lines = Source.fromInputStream(stream).getLines()
@@ -80,5 +84,4 @@ object WKT {
       stream.close()
     }
   }
-
 }

--- a/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKTParser.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKTParser.scala
@@ -117,7 +117,8 @@ object WKTParser extends RegexParsers {
   def wktCS: Parser[WktCS] = localcs | projcs | geogcs | geoccs | compdcs | vertcs
 
   def apply(wktString: String) : WktCS = {
-    parseAll(wktCS, wktString) match {
+    val cleanWkt = wktString.replaceAll("\n", "")
+    parseAll(wktCS, cleanWkt) match {
       case Success(wktObject, _) =>
         wktObject
       case Failure(msg, tail) =>

--- a/proj4/src/test/scala/geotrellis/proj4/CRSTest.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/CRSTest.scala
@@ -44,10 +44,9 @@ class CRSTest extends FunSpec with Inspectors {
   it("should return the WKT string of the passed EPSG:4326") {
     val crs = CRS.fromName("EPSG:4326")
 
-    val wktString = crs.toWKT()
+    val wktString: Option[String] = crs.toWKT()
 
     assert(wktString == Some("GEOGCS[\"WGS 84\", DATUM[\"World Geodetic System 1984\", SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"4326\"]]"))
-
   }
 
   it("should return the WKT string of the passed EPSG:4010") {

--- a/proj4/src/test/scala/geotrellis/proj4/CRSTest.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/CRSTest.scala
@@ -68,7 +68,7 @@ class CRSTest extends FunSpec with Inspectors {
   it("should have human friendly toString") {
     val samples = Seq(
       CRS.fromEpsgCode(3857),
-      CRS.fromWKT(WebMercator.toWKT().get),
+      CRS.fromWKT(WebMercator.toWKT().get).get,
       CRS.fromName("EPSG:4326"),
       CRS.fromString(Sinusoidal.toProj4String),
       LatLng, Sinusoidal, WebMercator, ConusAlbers

--- a/proj4/src/test/scala/geotrellis/proj4/io/wkt/WKTParserTest.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/io/wkt/WKTParserTest.scala
@@ -645,19 +645,17 @@ class WKTParserTest extends FunSpec {
     assert(contains(expected))
   }
 
-  it("Should parse GCS_WGS_1984") {
-    // this is a small hack to show how it is possible to handle multiline strings
+  it("Should parse GCS_WGS_1984 with and without newlines") {
     val strip = WKTParser("""|GEOGCS["GCS_WGS_1984",
                              |DATUM["D_WGS_1984", SPHEROID["WGS_1984", 6378137.0, 298.257223563]],
                              |PRIMEM["Greenwich", 0.0],
                              |UNIT["degree", 0.017453292519943295],
                              |AXIS["Longitude", "EAST"],
-                             |AXIS["Latitude", "NORTH"]]""".stripMargin.replaceAll("\n",""))
+                             |AXIS["Latitude", "NORTH"]]""".stripMargin)
 
-    // sinlge line equivalent
+    // single line equivalent
     val single = WKTParser("""GEOGCS["GCS_WGS_1984", DATUM["D_WGS_1984", SPHEROID["WGS_1984", 6378137.0, 298.257223563]],PRIMEM["Greenwich", 0.0],UNIT["degree", 0.017453292519943295],AXIS["Longitude", "EAST"],AXIS["Latitude", "NORTH"]]""")
 
     assert(strip == single)
   }
-
 }

--- a/proj4/src/test/scala/geotrellis/proj4/io/wkt/WKTTest.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/io/wkt/WKTTest.scala
@@ -23,19 +23,19 @@ import org.scalatest.FunSpec
  */
 class WKTTest extends FunSpec {
   it("should return the WKTString corresponding to EPSG:3824") {
-    val wktString = WKT.fromEpsgCode(3824)
+    val wktString = WKT.fromEpsgCode(3824).get
 
     assert(wktString == "GEOGCS[\"TWD97\", DATUM[\"Taiwan Datum 1997\", SPHEROID[\"GRS 1980\", 6378137.0, 298.257222101, AUTHORITY[\"EPSG\",\"7019\"]], TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], AUTHORITY[\"EPSG\",\"1026\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"3824\"]]")
   }
 
   it("should return the WKTString corresponding to EPSG:4326") {
-    val wktString = WKT.fromEpsgCode(4326)
+    val wktString = WKT.fromEpsgCode(4326).get
 
     assert(wktString == "GEOGCS[\"WGS 84\", DATUM[\"World Geodetic System 1984\", SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"4326\"]]")
   }
 
   it("should return the WKTString corresponding to EPSG:3857") {
-    val wktString = WKT.fromEpsgCode(3857)
+    val wktString = WKT.fromEpsgCode(3857).get
 
     assert(wktString == "PROJCS[\"WGS 84 / Pseudo-Mercator\", GEOGCS[\"WGS 84\", DATUM[\"World Geodetic System 1984\", SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"4326\"]], PROJECTION[\"Popular Visualisation Pseudo Mercator\", AUTHORITY[\"EPSG\",\"1024\"]], PARAMETER[\"semi_minor\", 6378137.0], PARAMETER[\"latitude_of_origin\", 0.0], PARAMETER[\"central_meridian\", 0.0], PARAMETER[\"scale_factor\", 1.0], PARAMETER[\"false_easting\", 0.0], PARAMETER[\"false_northing\", 0.0], UNIT[\"m\", 1.0], AXIS[\"Easting\", EAST], AXIS[\"Northing\", NORTH], AUTHORITY[\"EPSG\",\"3857\"]]")
   }
@@ -44,7 +44,7 @@ class WKTTest extends FunSpec {
   it("should return the EPSG code(3824) of the passed WKT string") {
     val comparisonCode = "EPSG:3824"
 
-    val epsgCodeOfWKT = WKT.getEpsgCode("GEOGCS[\"TWD97\", DATUM[\"Taiwan Datum 1997\", SPHEROID[\"GRS 1980\", 6378137.0, 298.257222101, AUTHORITY[\"EPSG\",\"7019\"]], TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], AUTHORITY[\"EPSG\",\"1026\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"3824\"]]")
+    val epsgCodeOfWKT = WKT.getEpsgStringCode("GEOGCS[\"TWD97\", DATUM[\"Taiwan Datum 1997\", SPHEROID[\"GRS 1980\", 6378137.0, 298.257222101, AUTHORITY[\"EPSG\",\"7019\"]], TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], AUTHORITY[\"EPSG\",\"1026\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"3824\"]]").get
 
     assert(comparisonCode == epsgCodeOfWKT)
   }
@@ -52,7 +52,7 @@ class WKTTest extends FunSpec {
   it("should return the EPSG code(4326) of the passed WKT string") {
     val comparisonCode = "EPSG:4326"
 
-    val epsgCodeOfWKT = WKT.getEpsgCode("GEOGCS[\"WGS 84\", DATUM[\"World Geodetic System 1984\", SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"4326\"]]")
+    val epsgCodeOfWKT = WKT.getEpsgStringCode("GEOGCS[\"WGS 84\", DATUM[\"World Geodetic System 1984\", SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"4326\"]]").get
 
     assert(comparisonCode == epsgCodeOfWKT)
   }
@@ -60,7 +60,7 @@ class WKTTest extends FunSpec {
   it("should return the EPSG code(3857) of the passed WKT string") {
     val comparisonCode = "EPSG:3857"
 
-    val epsgCodeOfWKT = WKT.getEpsgCode("PROJCS[\"WGS 84 / Pseudo-Mercator\", GEOGCS[\"WGS 84\", DATUM[\"World Geodetic System 1984\", SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"4326\"]], PROJECTION[\"Popular Visualisation Pseudo Mercator\", AUTHORITY[\"EPSG\",\"1024\"]], PARAMETER[\"semi_minor\", 6378137.0], PARAMETER[\"latitude_of_origin\", 0.0], PARAMETER[\"central_meridian\", 0.0], PARAMETER[\"scale_factor\", 1.0], PARAMETER[\"false_easting\", 0.0], PARAMETER[\"false_northing\", 0.0], UNIT[\"m\", 1.0], AXIS[\"Easting\", EAST], AXIS[\"Northing\", NORTH], AUTHORITY[\"EPSG\",\"3857\"]]")
+    val epsgCodeOfWKT = WKT.getEpsgStringCode("PROJCS[\"WGS 84 / Pseudo-Mercator\", GEOGCS[\"WGS 84\", DATUM[\"World Geodetic System 1984\", SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\", 0.017453292519943295], AXIS[\"Geodetic longitude\", EAST], AXIS[\"Geodetic latitude\", NORTH], AUTHORITY[\"EPSG\",\"4326\"]], PROJECTION[\"Popular Visualisation Pseudo Mercator\", AUTHORITY[\"EPSG\",\"1024\"]], PARAMETER[\"semi_minor\", 6378137.0], PARAMETER[\"latitude_of_origin\", 0.0], PARAMETER[\"central_meridian\", 0.0], PARAMETER[\"scale_factor\", 1.0], PARAMETER[\"false_easting\", 0.0], PARAMETER[\"false_northing\", 0.0], UNIT[\"m\", 1.0], AXIS[\"Easting\", EAST], AXIS[\"Northing\", NORTH], AUTHORITY[\"EPSG\",\"3857\"]]").get
     assert(comparisonCode == epsgCodeOfWKT)
   }
 }


### PR DESCRIPTION
## Overview

This PR cleans up the conversion methods on the `WKT` object to:
- All operations now return `Option`s. Before, we would silently unwrap results within the method calls, leading to thrown errors. It's now up to the calling code to unwrap and determine what to do in case of conversion failure, as it always should have been.
  - Methods that convert from EPSG code to WKT string are consistently prefixed with `fromEpsg`
  - Methods that convert from WKT string to EPSG code are consistently prefixed with `getEpsg`

It also updates `CRS.fromWKT` to return an `Option[CRS]` instead of just `CRS`. Same issue as above, the method would silently unwrap an optional result internally, which could lead to errors.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [ ] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new features

### Notes

I was a bit surprised that we don't utilize any of these methods in other GeoTrellis modules. But, according to the IntelliJ "Find Usages" feature, we don't. Guess we'll see what CI says, but I was able to get the project to compile and all of the proj4 tests to pass.

Closes #2870, Closes #2871 
