### PR TITLE
Fix full stream read on the input stream close

### DIFF
--- a/s3/src/main/scala/geotrellis/store/s3/util/S3RangeReader.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/util/S3RangeReader.scala
@@ -55,6 +55,7 @@ class S3RangeReader(
       val responseStream = client.getObject(request)
       val length = responseStream.response.contentLength
 
+      responseStream.abort()
       responseStream.close()
       length
     }


### PR DESCRIPTION
## Overview

On the `InputStream.close` call it was downloading the entire resource on release. To avoid it, we need explicitly to call the `abort` method.

Closes #3078
