### PR TITLE
reprojectExtentAsPolygon should be more deterministic

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -133,6 +133,7 @@ Fixes & Updates
 - Fix HttpRangeReader swallows 404 error (`#3073 https://github.com/locationtech/geotrellis/pull/3073`_)
 - Add a ToSpatial function for the collections API (`#3082 https://github.com/locationtech/geotrellis/pull/3082`_)
 - Fix TIFFTagsReader to skip unsupported tags (`#3088 https://github.com/locationtech/geotrellis/pull/3088`_)
+- reprojectExtentAsPolygon should be more deterministic (`#3083 https://github.com/locationtech/geotrellis/pull/3083`_)
 
 2.3.0
 -----

--- a/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala
+++ b/vector/src/main/scala/geotrellis/vector/reproject/Reproject.scala
@@ -100,7 +100,9 @@ object Reproject {
       val length = sqrt(pow(x0 - x1, 2) + pow(y0 - y1, 2))
 
       val p2 = m -> (x2, y2)
-      if (deflect / length < relError) {
+      if (java.lang.Double.isNaN(deflect)) {
+        throw new IllegalArgumentException(s"Encountered NaN during a refinement step: ($deflect / $length). Input $extent is likely not in source projection.")
+      } else if (deflect / length < relError) {
         List(p2)
       } else {
         refine(p0, p2) ++ (p2 :: refine(p2, p1))


### PR DESCRIPTION
## Overview

This PR resolves the division by zero unhandled case in the `reprojectExtentAsPolygon` function,

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

Closes https://github.com/locationtech/geotrellis/issues/3023
