### PR TITLE
Fix TIFFTagsReader to skip unsupported tags

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -132,6 +132,7 @@ Fixes & Updates
 - Update dependencies (`#3053 <https://github.com/locationtech/geotrellis/pull/3053>`_).
 - Fix HttpRangeReader swallows 404 error (`#3073 https://github.com/locationtech/geotrellis/pull/3073`_)
 - Add a ToSpatial function for the collections API (`#3082 https://github.com/locationtech/geotrellis/pull/3082`_)
+- Fix TIFFTagsReader to skip unsupported tags (`#3088 https://github.com/locationtech/geotrellis/pull/3088`_)
 
 2.3.0
 -----

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -159,6 +159,7 @@ object TiffTagsReader extends LazyLogging {
         byteReader.readLongsTag(tiffTags, tagMetadata)
       case (_, IFDOffset) =>
         byteReader.readLongsTag(tiffTags, tagMetadata)
+      case _ => TiffTags() // skip unsupported tags
     }
 
   implicit class ByteReaderTagReaderWrapper(val byteReader: ByteReader) extends AnyVal {


### PR DESCRIPTION
## Overview

Our GeoTIFF Reader supports not all the tiff tags types, this PR adds an ability to skip unknown tags. This PR partially covers https://github.com/locationtech/geotrellis/issues/3085 but doesn't introduce `TIFFTAG_EXIFIFD` tag support.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

