### PR TITLE
Use RangeReader SPI in Layer[Reader|Writer] classes

### DIFF
--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/cog/S3COGLayerReader.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/cog/S3COGLayerReader.scala
@@ -53,8 +53,6 @@ class S3COGLayerReader(
 
   val defaultNumPartitions: Int = sc.defaultParallelism
 
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri, s3Client)
-
   def pathExists(path: String): Boolean = s3Client.objectExists(path)
 
   def fullPath(path: String): URI = new URI(s"s3://$path")

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/geotiff/S3GeoTiffLayerReader.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/geotiff/S3GeoTiffLayerReader.scala
@@ -43,8 +43,6 @@ import scala.concurrent.ExecutionContext
   executionContext: ExecutionContext = BlockingThreadPool.executionContext
 ) extends GeoTiffLayerReader[M] {
   implicit lazy val ec: ExecutionContext = executionContext
-
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri, s3Client)
 }
 
 @experimental object S3GeoTiffLayerReader {

--- a/s3/src/main/scala/geotrellis/store/s3/cog/S3COGCollectionLayerReader.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/cog/S3COGCollectionLayerReader.scala
@@ -50,8 +50,6 @@ class S3COGCollectionLayerReader(
 
   @transient implicit lazy val ec = executionContext
 
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri, s3Client)
-
   def read[
     K: SpatialComponent: Boundable: Decoder: ClassTag,
     V <: CellGrid[Int]: GeoTiffReader: ClassTag

--- a/s3/src/main/scala/geotrellis/store/s3/cog/S3COGValueReader.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/cog/S3COGValueReader.scala
@@ -25,7 +25,6 @@ import geotrellis.store._
 import geotrellis.store.cog._
 import geotrellis.store.index._
 import geotrellis.store.s3._
-import geotrellis.util._
 
 import software.amazon.awssdk.services.s3.model._
 import software.amazon.awssdk.services.s3.S3Client
@@ -37,8 +36,6 @@ class S3COGValueReader(
   val attributeStore: AttributeStore,
   s3Client: => S3Client = S3ClientProducer.get()
 ) extends OverzoomingCOGValueReader {
-
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri, s3Client)
 
   def reader[
     K: Decoder: SpatialComponent : ClassTag,

--- a/spark/src/main/scala/geotrellis/spark/store/cog/COGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/cog/COGLayerReader.scala
@@ -391,11 +391,10 @@ abstract class COGLayerReader[ID] extends Serializable {
             if (!pathExists(keyPath(index))) Vector()
             else {
               val uri = fullPath(keyPath(index))
-              val rangeReader: RangeReader = RangeReader(uri)
               val baseKey =
                 parse(
                   TiffTagsReader
-                    .read(rangeReader)
+                    .read(RangeReader(uri))
                     .tags
                     .headTags(GTKey)
                 ).flatMap(_.as[K](keyDecoder)).valueOr(throw _)
@@ -406,7 +405,7 @@ abstract class COGLayerReader[ID] extends Serializable {
                 .flatten
                 .flatMap { case (spatialKey, overviewIndex, _, seq) =>
                   val key = baseKey.setComponent(spatialKey)
-                  val tiff = GeoTiffReader[V].read(rangeReader, streaming = true).getOverview(overviewIndex)
+                  val tiff = GeoTiffReader[V].read(RangeReader(uri), streaming = true).getOverview(overviewIndex)
                   val map = seq.map { case (gb, sk) => gb -> key.setComponent(sk) }.toMap
 
                   readGeoTiff(tiff, map.keys.toSeq)

--- a/spark/src/main/scala/geotrellis/spark/store/cog/COGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/cog/COGLayerReader.scala
@@ -17,7 +17,6 @@
 package geotrellis.spark.store.cog
 
 import geotrellis.raster.{CellGrid, GridBounds, MultibandTile, Tile}
-import geotrellis.raster.crop._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.io.geotiff.reader.TiffTagsReader
@@ -27,7 +26,6 @@ import geotrellis.store.cog._
 import geotrellis.store.index.{Index, IndexRanges, KeyIndex, MergeQueue}
 import geotrellis.store.util.IOUtils
 import geotrellis.spark._
-import geotrellis.spark.store._
 import geotrellis.spark.util.KryoWrapper
 import geotrellis.util._
 
@@ -35,7 +33,6 @@ import org.apache.spark.rdd._
 import org.apache.spark.SparkContext
 import io.circe._
 import io.circe.parser._
-import io.circe.syntax._
 import cats.syntax.either._
 
 import java.net.URI
@@ -225,7 +222,6 @@ abstract class COGLayerReader[ID] extends Serializable {
     tileQuery: LayerQuery[K, TileLayerMetadata[K]],
     numPartitions: Int
   )(implicit sc: SparkContext,
-             getByteReader: URI => ByteReader,
              idToLayerId: ID => LayerId
   ): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] = {
 
@@ -273,7 +269,6 @@ abstract class COGLayerReader[ID] extends Serializable {
     tileQuery: LayerQuery[K, TileLayerMetadata[K]],
     numPartitions: Int
   )(implicit sc: SparkContext,
-             getByteReader: URI => ByteReader,
              idToLayerId: ID => LayerId
   ): RDD[(K, Array[Option[Tile]])] with Metadata[TileLayerMetadata[K]] = {
 
@@ -331,7 +326,6 @@ abstract class COGLayerReader[ID] extends Serializable {
     readGeoTiff: (GeoTiff[V], Seq[GridBounds[Int]]) => Iterator[(GridBounds[Int], R)],
     numPartitions: Int
   )(implicit sc: SparkContext,
-             getByteReader: URI => ByteReader,
              idToLayerId: ID => LayerId
   ): RDD[(K, R)] with Metadata[TileLayerMetadata[K]] = {
     val getKeyPath = produceGetKeyPath(id)
@@ -385,7 +379,7 @@ abstract class COGLayerReader[ID] extends Serializable {
      keyPath: BigInt => String, // keyPath
      readDefinitions: Map[SpatialKey, Seq[(SpatialKey, Int, GridBounds[Int], Seq[(GridBounds[Int], SpatialKey)])]],
      readGeoTiff: (GeoTiff[V], Seq[GridBounds[Int]]) => Iterator[(GridBounds[Int], R)]
-   )(implicit sc: SparkContext, getByteReader: URI => ByteReader): RDD[(K, R)] = {
+   )(implicit sc: SparkContext): RDD[(K, R)] = {
     val kwDecoder = KryoWrapper(implicitly[Decoder[K]])
 
     sc.parallelize(bins, bins.size)
@@ -397,11 +391,11 @@ abstract class COGLayerReader[ID] extends Serializable {
             if (!pathExists(keyPath(index))) Vector()
             else {
               val uri = fullPath(keyPath(index))
-              val byteReader: ByteReader = uri
+              val rangeReader: RangeReader = RangeReader(uri)
               val baseKey =
                 parse(
                   TiffTagsReader
-                    .read(byteReader)
+                    .read(rangeReader)
                     .tags
                     .headTags(GTKey)
                 ).flatMap(_.as[K](keyDecoder)).valueOr(throw _)
@@ -412,7 +406,7 @@ abstract class COGLayerReader[ID] extends Serializable {
                 .flatten
                 .flatMap { case (spatialKey, overviewIndex, _, seq) =>
                   val key = baseKey.setComponent(spatialKey)
-                  val tiff = GeoTiffReader[V].read(uri, streaming = true).getOverview(overviewIndex)
+                  val tiff = GeoTiffReader[V].read(rangeReader, streaming = true).getOverview(overviewIndex)
                   val map = seq.map { case (gb, sk) => gb -> key.setComponent(sk) }.toMap
 
                   readGeoTiff(tiff, map.keys.toSeq)

--- a/spark/src/main/scala/geotrellis/spark/store/file/cog/FileCOGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/file/cog/FileCOGLayerReader.scala
@@ -52,8 +52,6 @@ class FileCOGLayerReader(
 
   val defaultNumPartitions: Int = sc.defaultParallelism
 
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri)
-
   def pathExists(path: String): Boolean =
     new File(path).isFile
 

--- a/spark/src/main/scala/geotrellis/spark/store/file/geotiff/FileGeoTiffLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/file/geotiff/FileGeoTiffLayerReader.scala
@@ -40,8 +40,6 @@ import scala.concurrent.ExecutionContext
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
 ) extends GeoTiffLayerReader[M] {
   implicit lazy val ec: ExecutionContext = executionContext
-
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri)
 }
 
 @experimental object FileGeoTiffLayerReader {

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/cog/HadoopCOGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/cog/HadoopCOGLayerReader.scala
@@ -56,8 +56,6 @@ class HadoopCOGLayerReader(
 
   val defaultNumPartitions: Int = sc.defaultParallelism
 
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri, hadoopConfiguration.value)
-
   def pathExists(path: String): Boolean =
     HdfsUtils.pathExists(new Path(path), hadoopConfiguration.value)
 

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/geotiff/HadoopGeoTiffLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/geotiff/HadoopGeoTiffLayerReader.scala
@@ -41,8 +41,6 @@ import scala.concurrent.ExecutionContext
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
 ) extends GeoTiffLayerReader[M] {
   implicit val ec: ExecutionContext = executionContext
-
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri, conf)
 }
 
 @experimental object HadoopGeoTiffLayerReader {

--- a/spark/src/main/scala/geotrellis/spark/store/http/util/HttpRangeReaderProvider.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/http/util/HttpRangeReaderProvider.scala
@@ -24,8 +24,13 @@ import java.net.{URI, URL}
 class HttpRangeReaderProvider extends RangeReaderProvider {
   def canProcess(uri: URI): Boolean =
     try {
-      new URL(uri.toString)
-      true
+      val scheme = uri.getScheme
+      if (scheme == "http" || scheme == "https") {
+        new URL(uri.toString)
+        true
+      } else {
+        false
+      }
     } catch {
       case _: Throwable => false
     }

--- a/spark/src/test/scala/geotrellis/spark/store/http/util/HttpRangeReaderProviderSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/store/http/util/HttpRangeReaderProviderSpec.scala
@@ -37,5 +37,12 @@ class HttpRangeReaderProviderSpec extends FunSpec with Matchers {
 
       result should be (false)
     }
+
+    it("should fail to parse URIs with non-http schemes") {
+      val path = "file:/tmp/testFiles/1064996.tiff"
+      val result = new HttpRangeReaderProvider().canProcess(new URI(path))
+
+      result should be (false)
+    }
   }
 }

--- a/store/src/main/scala/geotrellis/store/cog/COGCollectionLayerReader.scala
+++ b/store/src/main/scala/geotrellis/store/cog/COGCollectionLayerReader.scala
@@ -219,11 +219,10 @@ object COGCollectionLayerReader {
       if (!pathExists(keyPath(index))) Vector()
       else {
         val uri = fullPath(keyPath(index))
-        val rangeReader: RangeReader = RangeReader(uri)
         val baseKey =
           parse(
             TiffTagsReader
-              .read(rangeReader)
+              .read(RangeReader(uri))
               .tags
               .headTags(GTKey)
           ).flatMap(_.as[K]).valueOr(throw _)
@@ -234,7 +233,7 @@ object COGCollectionLayerReader {
           .flatten
           .flatMap { case (spatialKey, overviewIndex, _, seq) =>
             val key = baseKey.setComponent(spatialKey)
-            val tiff = GeoTiffReader[V].read(rangeReader, streaming = true).getOverview(overviewIndex)
+            val tiff = GeoTiffReader[V].read(RangeReader(uri), streaming = true).getOverview(overviewIndex)
             val map = seq.map { case (gb, sk) => gb -> key.setComponent(sk) }.toMap
 
             tiff

--- a/store/src/main/scala/geotrellis/store/cog/COGCollectionLayerReader.scala
+++ b/store/src/main/scala/geotrellis/store/cog/COGCollectionLayerReader.scala
@@ -51,7 +51,7 @@ abstract class COGCollectionLayerReader[ID] { self =>
     getKeyPath: (ZoomRange, Int) => BigInt => String,
     pathExists: String => Boolean, // check the path above exists
     fullPath: String => URI // add an fs prefix
-  )(implicit getByteReader: URI => ByteReader, idToLayerId: ID => LayerId): Seq[(K, V)] with Metadata[TileLayerMetadata[K]] = {
+  )(implicit idToLayerId: ID => LayerId): Seq[(K, V)] with Metadata[TileLayerMetadata[K]] = {
     val COGLayerStorageMetadata(cogLayerMetadata, keyIndexes) =
       try {
         attributeStore.readMetadata[COGLayerStorageMetadata[K]](LayerId(id.name, 0))
@@ -207,7 +207,7 @@ object COGCollectionLayerReader {
      decomposeBounds: KeyBounds[K] => Seq[(BigInt, BigInt)],
      readDefinitions: Map[SpatialKey, Seq[(SpatialKey, Int, TileBounds, Seq[(TileBounds, SpatialKey)])]],
      numPartitions: Option[Int] = None
-   )(implicit getByteReader: URI => ByteReader, ec: ExecutionContext): Seq[(K, V)] = {
+   )(implicit ec: ExecutionContext): Seq[(K, V)] = {
     if (baseQueryKeyBounds.isEmpty) return Seq.empty[(K, V)]
 
     val ranges = if (baseQueryKeyBounds.length > 1)
@@ -219,11 +219,11 @@ object COGCollectionLayerReader {
       if (!pathExists(keyPath(index))) Vector()
       else {
         val uri = fullPath(keyPath(index))
-        val byteReader: ByteReader = uri
+        val rangeReader: RangeReader = RangeReader(uri)
         val baseKey =
           parse(
             TiffTagsReader
-              .read(byteReader)
+              .read(rangeReader)
               .tags
               .headTags(GTKey)
           ).flatMap(_.as[K]).valueOr(throw _)
@@ -234,7 +234,7 @@ object COGCollectionLayerReader {
           .flatten
           .flatMap { case (spatialKey, overviewIndex, _, seq) =>
             val key = baseKey.setComponent(spatialKey)
-            val tiff = GeoTiffReader[V].read(uri, streaming = true).getOverview(overviewIndex)
+            val tiff = GeoTiffReader[V].read(rangeReader, streaming = true).getOverview(overviewIndex)
             val map = seq.map { case (gb, sk) => gb -> key.setComponent(sk) }.toMap
 
             tiff

--- a/store/src/main/scala/geotrellis/store/cog/COGValueReader.scala
+++ b/store/src/main/scala/geotrellis/store/cog/COGValueReader.scala
@@ -34,7 +34,6 @@ import java.util.ServiceLoader
 trait COGValueReader[ID] {
   val attributeStore: AttributeStore
 
-  implicit def getByteReader(uri: URI): ByteReader
   implicit def getLayerId(id: ID): LayerId
 
   def reader[
@@ -65,7 +64,7 @@ trait COGValueReader[ID] {
       val uri = fullPath(keyPath(key.setComponent(spatialKey), maxWidth, baseKeyIndex, zoomRange))
 
       try {
-        GeoTiffReader[V].read(uri, streaming = true)
+        GeoTiffReader[V].read(RangeReader(uri), streaming = true)
           .getOverview(overviewIndex)
           .crop(gridBounds)
           .tile
@@ -84,7 +83,7 @@ trait COGValueReader[ID] {
       val maxWidth = Index.digits(baseKeyIndex.toIndex(baseKeyIndex.keyBounds.maxKey))
       val uri = fullPath(keyPath(key.setComponent(spatialKey), maxWidth, baseKeyIndex, zoomRange))
 
-      val sourceGeoTiff = GeoTiffReader.readMultiband(uri, streaming = true)
+      val sourceGeoTiff = GeoTiffReader.readMultiband(RangeReader(uri), streaming = true)
       val sourceTile = sourceGeoTiff.getOverview(overviewIndex).tile
 
       // We first must determine which bands are valid and which are not

--- a/store/src/main/scala/geotrellis/store/file/cog/FileCOGCollectionLayerReader.scala
+++ b/store/src/main/scala/geotrellis/store/file/cog/FileCOGCollectionLayerReader.scala
@@ -44,8 +44,6 @@ class FileCOGCollectionLayerReader(
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
 ) extends COGCollectionLayerReader[LayerId] with LazyLogging {
 
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri)
-
   @transient implicit lazy val ec: ExecutionContext = executionContext
 
   def read[

--- a/store/src/main/scala/geotrellis/store/file/cog/FileCOGValueReader.scala
+++ b/store/src/main/scala/geotrellis/store/file/cog/FileCOGValueReader.scala
@@ -34,9 +34,6 @@ class FileCOGValueReader(
   val attributeStore: AttributeStore,
   catalogPath: String
 ) extends OverzoomingCOGValueReader {
-
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri)
-
   def reader[
     K: Decoder : SpatialComponent : ClassTag,
     V <: CellGrid[Int] : GeoTiffReader

--- a/store/src/main/scala/geotrellis/store/hadoop/cog/HadoopCOGCollectionLayerReader.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/cog/HadoopCOGCollectionLayerReader.scala
@@ -51,8 +51,6 @@ class HadoopCOGCollectionLayerReader(
 
   val serConf: SerializableConfiguration = SerializableConfiguration(conf)
 
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri, conf)
-
   @transient implicit lazy val ec: ExecutionContext = executionContext
 
   def read[

--- a/store/src/main/scala/geotrellis/store/hadoop/cog/HadoopCOGValueReader.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/cog/HadoopCOGValueReader.scala
@@ -37,8 +37,6 @@ class HadoopCOGValueReader(
   conf: Configuration
 ) extends OverzoomingCOGValueReader {
 
-  implicit def getByteReader(uri: URI): ByteReader = byteReader(uri)
-
   def reader[
     K: Decoder: SpatialComponent: ClassTag,
     V <: CellGrid[Int]: GeoTiffReader

--- a/util/src/test/scala/geotrellis/util/FileRangeReaderProviderSpec.scala
+++ b/util/src/test/scala/geotrellis/util/FileRangeReaderProviderSpec.scala
@@ -51,5 +51,26 @@ class FileRangeReaderProviderSpec extends FunSpec with Matchers {
 
       reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
     }
+
+    it("should be able to process a URI with a scheme and authority that's an absolute path") {
+      val expectedPath = "/data/path/to/my/data/blah.tif"
+      val reader = RangeReader(new URI(s"file://$expectedPath"))
+
+      reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
+    }
+
+    it("should be able to process a URI with a scheme and no authority that's an absolute path") {
+      val expectedPath = "/data/path/to/my/data/blah.tif"
+      val reader = RangeReader(new URI(s"file:$expectedPath"))
+
+      reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
+    }
+
+    it("should be able to process a URI that's an absolute path") {
+      val expectedPath = "/data/path/to/my/data/blah.tif"
+      val reader = RangeReader(new URI(s"$expectedPath"))
+
+      reader.asInstanceOf[FileRangeReader].file.toString should be (expectedPath)
+    }
   }
 }


### PR DESCRIPTION
## Overview

Replace getByteReader interfaces with direct calls to RangeReader, using the new SPI.

### Checklist

- [ ] `docs/CHANGELOG.rst` updated, if necessary
- [ ] ~~`docs` guides update, if necessary~~
- [ ] ~~New user API has useful Scaladoc strings~~
- [ ] ~~Unit tests added for bug-fix or new feature~~

### Notes

Didn't update docs, but I did create a new issue #3092 to address the out of date docs in S3Streaming.md

No update to CHANGELOG since this is an entirely internal change. Can make a note of it though if desired.

Pending tests passing...

Closes #3013
