### PR TITLE
Remove unnecessary CellGrid constraints

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/resample/TileResampleMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/TileResampleMethods.scala
@@ -21,7 +21,7 @@ import geotrellis.vector._
 import geotrellis.util.MethodExtensions
 
 
-trait TileResampleMethods[T <: CellGrid[Int]] extends MethodExtensions[T] {
+trait TileResampleMethods[T] extends MethodExtensions[T] {
   def resample(extent: Extent, target: RasterExtent, method: ResampleMethod): T
 
   def resample(extent: Extent, target: RasterExtent): T =

--- a/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
+++ b/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
@@ -22,7 +22,7 @@ import cats.Semigroup
 /**
   * The Stitcher base trait.
   */
-trait Stitcher[T <: CellGrid[Int]] extends Serializable {
+trait Stitcher[T] extends Serializable {
 
   /**
     * Stitch an Iterable of tile, corner pairs into a new tile with

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/cog/S3COGLayerWriter.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/cog/S3COGLayerWriter.scala
@@ -50,7 +50,7 @@ class S3COGLayerWriter(
 
   def writeCOGLayer[
     K: SpatialComponent: Ordering: Encoder: ClassTag,
-    V <: CellGrid[Int]: GeoTiffReader: ClassTag
+    V: GeoTiffReader: ClassTag
   ](
     layerName: String,
     cogLayer: COGLayer[K, V],

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/cog/S3COGLayerWriter.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/cog/S3COGLayerWriter.scala
@@ -50,7 +50,7 @@ class S3COGLayerWriter(
 
   def writeCOGLayer[
     K: SpatialComponent: Ordering: Encoder: ClassTag,
-    V: GeoTiffReader: ClassTag
+    V <: CellGrid[Int]: GeoTiffReader: ClassTag
   ](
     layerName: String,
     cogLayer: COGLayer[K, V],

--- a/spark/src/main/scala/geotrellis/spark/merge/TileRDDMerge.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/TileRDDMerge.scala
@@ -25,7 +25,7 @@ import org.apache.spark.rdd._
 import scala.reflect.ClassTag
 
 object TileRDDMerge {
-  def apply[K: ClassTag, V <: CellGrid[Int]: ClassTag: * => TileMergeMethods[V]](rdd: RDD[(K, V)], other: RDD[(K, V)]): RDD[(K, V)] = {
+  def apply[K: ClassTag, V: ClassTag: * => TileMergeMethods[V]](rdd: RDD[(K, V)], other: RDD[(K, V)]): RDD[(K, V)] = {
     rdd
       .cogroup(other)
       .map { case (key, (myTiles, otherTiles)) =>
@@ -41,14 +41,12 @@ object TileRDDMerge {
       }
   }
 
-  def apply[K: ClassTag, V <: CellGrid[Int]: ClassTag: * => TileMergeMethods[V]](rdd: RDD[(K, V)], partitioner: Option[Partitioner]): RDD[(K, V)] = {
+  def apply[K: ClassTag, V: ClassTag: * => TileMergeMethods[V]](rdd: RDD[(K, V)], partitioner: Option[Partitioner]): RDD[(K, V)] = {
     partitioner match {
       case Some(p) =>
-        rdd
-          .reduceByKey(p, _ merge _)
+        rdd.reduceByKey(p, _ merge _)
       case None =>
-        rdd
-          .reduceByKey(_ merge _)
+        rdd.reduceByKey(_ merge _)
     }
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/merge/TileRDDMergeMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/merge/TileRDDMergeMethods.scala
@@ -26,7 +26,7 @@ import org.apache.spark.rdd._
 import scala.reflect.ClassTag
 
 
-class TileRDDMergeMethods[K: ClassTag, V <: CellGrid[Int]: ClassTag: * => TileMergeMethods[V]](val self: RDD[(K, V)]) extends MethodExtensions[RDD[(K, V)]] {
+class TileRDDMergeMethods[K: ClassTag, V: ClassTag: * => TileMergeMethods[V]](val self: RDD[(K, V)]) extends MethodExtensions[RDD[(K, V)]] {
   def merge(other: RDD[(K, V)]): RDD[(K, V)] =
     TileRDDMerge(self, other)
 

--- a/spark/src/main/scala/geotrellis/spark/regrid/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Implicits.scala
@@ -32,7 +32,7 @@ object Implicits extends Implicits
 trait Implicits {
   implicit class withRegridMethods[
     K: SpatialComponent: ClassTag,
-    V <: CellGrid[Int]: ClassTag: Stitcher: (* => CropMethods[V]),
+    V: ClassTag: Stitcher: (* => CropMethods[V]),
     M: Component[*, LayoutDefinition]: Component[*, Bounds[K]]
   ](self: RDD[(K, V)] with Metadata[M]) extends RegridMethods[K, V, M](self)
 }

--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -43,7 +43,7 @@ object Regrid {
 
   def apply[
     K: SpatialComponent: ClassTag,
-    V <: CellGrid[Int]: ClassTag: Stitcher: (* => CropMethods[V]),
+    V: ClassTag: Stitcher: (* => CropMethods[V]),
     M: Component[*, LayoutDefinition]: Component[*, Bounds[K]]
   ](layer: RDD[(K, V)] with Metadata[M], tileCols: Int, tileRows: Int): RDD[(K, V)] with Metadata[M] = {
     val md = layer.metadata
@@ -137,7 +137,7 @@ object Regrid {
 
   def apply[
     K: SpatialComponent: ClassTag,
-    V <: CellGrid[Int]: ClassTag: Stitcher: (* => CropMethods[V]),
+    V: ClassTag: Stitcher: (* => CropMethods[V]),
     M: Component[*, LayoutDefinition]: Component[*, Bounds[K]]
   ](layer: RDD[(K, V)] with Metadata[M], tileSize: Int): RDD[(K, V)] with Metadata[M] = apply(layer, tileSize, tileSize)
 

--- a/spark/src/main/scala/geotrellis/spark/regrid/RegridMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/RegridMethods.scala
@@ -29,7 +29,7 @@ import scala.reflect.ClassTag
 
 class RegridMethods[
   K: SpatialComponent: ClassTag,
-  V <: CellGrid[Int]: ClassTag: Stitcher: (* => CropMethods[V]),
+  V: ClassTag: Stitcher: (* => CropMethods[V]),
   M: Component[*, LayoutDefinition]: Component[*, Bounds[K]]
 ](val self: RDD[(K, V)] with Metadata[M]) extends MethodExtensions[RDD[(K, V)] with Metadata[M]] {
 

--- a/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
+++ b/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
@@ -63,7 +63,7 @@ object ZoomResample {
     */
   def apply[
     K: SpatialComponent,
-    V <: CellGrid[Int]: (* => TileResampleMethods[V])
+    V: (* => TileResampleMethods[V])
   ](
     rdd: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
     sourceZoom: Int,


### PR DESCRIPTION


While working on refactors around CellGrid I noticed that in lots of places we're constraining `V` eagerly on this trait, this PR tries to minimize that.

This should not have any effect on the user aside from usual bin compatibility breakage. The caller always knows either the full type of `V` or is free to constrain the type to the point that is useful.

Since this is code hygiene looking for a +1 before morning this.

