### PR TITLE
Fix windowed reproject bug

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterReprojectMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterReprojectMethods.scala
@@ -56,11 +56,12 @@ trait RasterReprojectMethods[+T <: Raster[_]] extends MethodExtensions[T] {
     reproject(gridBounds, src, dest, Options.DEFAULT)
 
   def reproject(gridBounds: GridBounds[Int], transform: Transform, inverseTransform: Transform, options: Options): T = {
-    val rasterExtent = self.rasterExtent
-    val windowExtent = rasterExtent.extentFor(gridBounds)
-    val windowRasterExtent = RasterExtent(windowExtent, gridBounds.width, gridBounds.height)
+    val windowExtent = self.rasterExtent.extentFor(gridBounds)
+    val windowRasterExtent = RasterExtent(windowExtent, self.rasterExtent.cellSize)
 
-    val targetRasterExtent = options.targetRasterExtent.getOrElse(ReprojectRasterExtent(windowRasterExtent, transform, options = options))
+    val targetRasterExtent = options.targetRasterExtent.getOrElse {
+      ReprojectRasterExtent(windowRasterExtent, transform, options = options)
+    }
 
     reproject(targetRasterExtent, transform, inverseTransform, options)
   }

--- a/raster/src/test/scala/geotrellis/raster/reproject/ReprojectSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/reproject/ReprojectSpec.scala
@@ -141,7 +141,6 @@ class ReprojectSpec extends FunSpec
       val rightRasterExtent = RasterExtent(Extent(579120.000, 4428900.000, 594480.000, 4444260.000), 30.0, 30.0, 512, 512)
 
       val leftTile = IntArrayTile(Array.ofDim[Int](256 * 256).fill(1), 256, 256)
-
       val rightTile = IntArrayTile(Array.ofDim[Int](256 * 256).fill(2), 256, 256)
 
       // Sanity check - they don't have any missing pixels before reprojecting
@@ -157,24 +156,32 @@ class ReprojectSpec extends FunSpec
       }
 
       // Now repreject; there should also be no lines.
-
       val wmLeft @ Raster(wmLeftTile, wmLeftExtent) =
-        mergedRaster.reproject(GridBounds(0, 0, 511, 1023), srcCRS, WebMercator, Options(method = Bilinear))
+        mergedRaster.reproject(GridBounds(0, 0, 511, 511), srcCRS, WebMercator)
 
       val wmRight @ Raster(wmRightTile, wmRightExtent) =
-        mergedRaster.reproject(GridBounds(512, 0, 1023, 1023), srcCRS, WebMercator, Options(method = Bilinear))
+        mergedRaster.reproject(GridBounds(512, 0, 1023, 511), srcCRS, WebMercator)
 
-      val RasterExtent(_, cellwidthLeft, cellheightLeft, _, _) = RasterExtent(wmLeftExtent, wmLeftTile.cols, wmLeftTile.rows)
-      val RasterExtent(_, cellwidthRight, cellheightRight, _, _) = RasterExtent(wmRightExtent, wmRightTile.cols, wmRightTile.rows)
+      val RasterExtent(_, cellwidthLeft, cellheightLeft, _, _) = wmLeft.rasterExtent
+      val RasterExtent(_, cellwidthRight, cellheightRight, _, _) = wmRight.rasterExtent
 
-      cellwidthLeft should be (cellwidthRight +- 0.05)
-      cellheightLeft should be (cellheightRight +- 0.05)
+      /**
+       *  A previous version of this test was bugged and used a stricter tolerance value of 0.05.
+       *  The increased tolerance here does not indicate a decrease in precision: the same code path
+       *  is being used to generate expected cellsizes, it just no longer receives incorrect target
+       *  RasterExtents in certain degenerate cases.
+       *  For more details about this fix, see https://github.com/locationtech/geotrellis/pull/3095
+       */
+      cellwidthLeft should be (cellwidthRight +- 0.08)
+      cellheightLeft should be (cellheightRight +- 0.08)
 
       // Specifically fit it ito a web mercator zoom layout tile
       val re = RasterExtent(Extent(-8247861.100, 4872401.931, -8238077.160, 4882185.871), 256, 256)
 
       val emptyTile = ArrayTile.empty(IntConstantNoDataCellType, re.cols, re.rows)
-      val mergeTile: Tile = emptyTile.merge(re.extent, wmLeftExtent, wmLeftTile).merge(re.extent, wmRightExtent, wmRightTile)
+      val mergeTile: Tile = emptyTile
+        .merge(re.extent, wmLeftExtent, wmLeftTile)
+        .merge(re.extent, wmRightExtent, wmRightTile)
 
       detectNoDataLine(mergeTile)
     }


### PR DESCRIPTION
## Overview

Windowed raster reprojection formerly constructed its window via `extentFor`, which by default has clamp set to true. Quoting the docstring, "If true, the returned extent will be contained by this RasterExtent's extent". This is fine, in most cases, but it means we can't assume that the output `RasterExtent` it produces can meaningfully be used along with `GridBounds.height`/`width` to reconstruct a RasterExtent (as the output `RasterExtent` might not have the same number of columns/rows as the `GridBounds` from which it is derived).

We can avoid this problem by simply using `CellSize` rather than cols/rows.


### Checklist

- [x] Unit tests added for bug-fix or new feature


### Notes

This change required slightly widened tolerances for comparing `CellSize` values (0.05 -> 0.08)
