### PR TITLE
Fix S3LayerWriter NullPointerException

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -131,9 +131,11 @@ Fixes & Updates
 - Bump proj4 version to fix multiple performance issues (`#3039 <https://github.com/locationtech/geotrellis/pull/3039>`_).
 - Update dependencies (`#3053 <https://github.com/locationtech/geotrellis/pull/3053>`_).
 - Fix HttpRangeReader swallows 404 error (`#3073 https://github.com/locationtech/geotrellis/pull/3073`_)
-- Add a ToSpatial function for the collections API (`#3082 https://github.com/locationtech/geotrellis/pull/3082`_)
-- Fix TIFFTagsReader to skip unsupported tags (`#3088 https://github.com/locationtech/geotrellis/pull/3088`_)
-- reprojectExtentAsPolygon should be more deterministic (`#3083 https://github.com/locationtech/geotrellis/pull/3083`_)
+- Add a ToSpatial function for the collections API (`#3082 https://github.com/locationtech/geotrellis/pull/3082`_).
+- Fix TIFFTagsReader to skip unsupported tags (`#3088 https://github.com/locationtech/geotrellis/pull/3088`_).
+- reprojectExtentAsPolygon should be more deterministic (`#3083 https://github.com/locationtech/geotrellis/pull/3083`_).
+- AmazonS3URI.getKey() now returns an empty string instead of null if no key was provided (`#3096 https://github.com/locationtech/geotrellis/pull/3096`_).
+- Improved handling of null prefix for S3AttributeStore. Prefer use of `S3AttributeStore.apply` to take advantage of this improved handling (`#3096 https://github.com/locationtech/geotrellis/pull/3096`_).
 
 2.3.0
 -----

--- a/s3-spark/src/test/scala/geotrellis/spark/store/s3/S3NoPrefixSpec.scala
+++ b/s3-spark/src/test/scala/geotrellis/spark/store/s3/S3NoPrefixSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.spark.store.s3
+
+import geotrellis.raster.Tile
+import geotrellis.layer._
+import geotrellis.store._
+import geotrellis.store.s3._
+import geotrellis.spark.store._
+import geotrellis.spark.testkit.io._
+import geotrellis.spark.testkit.testfiles.TestFiles
+import geotrellis.spark.testkit.TestEnvironment
+
+class S3NoPrefixSpec
+  extends PersistenceSpec[SpatialKey, Tile, TileLayerMetadata[SpatialKey]]
+    with SpatialKeyIndexMethods
+    with TestEnvironment with TestFiles
+    with AllOnesTestTileSpec {
+
+  lazy val s3Uri = new AmazonS3URI(s"s3://mock-bucket")
+  lazy val bucket = s3Uri.getBucket
+  lazy val prefix = s3Uri.getKey
+
+  val client = MockS3Client()
+
+  S3TestUtils.cleanBucket(client, bucket)
+  registerAfterAll { () =>
+    S3TestUtils.cleanBucket(client, bucket)
+  }
+
+  // We need to register the mock client for SPI loaded classes
+  S3ClientProducer.set(() => MockS3Client())
+
+  lazy val attributeStore = S3AttributeStore(bucket, prefix, MockS3Client.instance)
+
+  lazy val rddReader = new S3RDDReader(MockS3Client.instance)
+  lazy val rddWriter = new S3RDDWriter(MockS3Client.instance)
+
+  lazy val reader = new S3LayerReader(attributeStore, MockS3Client.instance)
+  lazy val creader = new S3CollectionLayerReader(attributeStore)
+  lazy val writer = new S3LayerWriter(attributeStore, bucket, prefix, identity, MockS3Client.instance)
+  lazy val deleter = new S3LayerDeleter(attributeStore, MockS3Client.instance)
+  lazy val copier  = new S3LayerCopier(attributeStore, bucket, prefix, MockS3Client.instance)
+  lazy val reindexer = GenericLayerReindexer(attributeStore, reader, writer, deleter, copier)
+  lazy val mover = GenericLayerMover(copier, deleter)
+  lazy val tiles = new S3ValueReader(attributeStore, MockS3Client.instance)
+  lazy val sample = AllOnesTestFile
+}

--- a/s3/src/main/java/geotrellis/store/s3/AmazonS3URI.java
+++ b/s3/src/main/java/geotrellis/store/s3/AmazonS3URI.java
@@ -224,7 +224,11 @@ public class AmazonS3URI {
      * @return the key parsed from the URI (or null if no key specified)
      */
     public String getKey() {
-        return key;
+        if (key != null) {
+            return key;
+        } else {
+            return "";
+        }
     }
 
     /**

--- a/s3/src/main/scala/geotrellis/store/s3/S3AttributeStore.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/S3AttributeStore.scala
@@ -217,7 +217,7 @@ object S3AttributeStore {
   final val SEP = "__"
 
   def apply(bucket: String, root: String, s3Client: => S3Client = S3ClientProducer.get()) =
-    new S3AttributeStore(bucket, root, s3Client)
+    new S3AttributeStore(bucket, Option(root).getOrElse(""), s3Client)
 
   def apply(bucket: String, s3Client: => S3Client): S3AttributeStore =
     apply(bucket, "", s3Client)

--- a/scripts/runTestS3.sh
+++ b/scripts/runTestS3.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This docker container must be running in order to run tests that interface with S3
+docker run -d --restart=always \
+    -p 9091:9000 \
+    -e MINIO_ACCESS_KEY=minio -e MINIO_SECRET_KEY=password \
+    minio/minio:RELEASE.2019-05-02T19-07-09Z \
+    server /data


### PR DESCRIPTION
## Overview

AmazonS3URI will have a null `key` if the user passes a uri that doesn't contain one, such as `s3://foo`. This gets passed down into the various S3 reader/writer classes in GeoTrellis, and is converted to an empty string in some cases but not others.

In some cases, an S3LayerWriter will be constructed using the attached S3AttributeStore bucket + keyPrefix, if we know we're getting an S3AttributeStore. Otherwise the S3LayerWriter will be constructed using passed in bucket/keyPath values which can come from anywhere, including the nullable `AmazonS3URI.key`.

The quickest, least disruptive, and most comprehensive method seemed to be to fixup the `AmazonS3URI.getKey` method to return `""` instead of `null` and also add an additional error check in the `S3AttributeStore` apply method that converts incoming nulls in prefix to empty string. More comprehensive error handling would take two forms. The "easier" way would be to perform the check in every apply in the downstream S3Layer[Reader|Writer|...] classes, of which there are quite a few. The "harder" way would be to abstract the bucket and prefix properties to a common trait, and introduce the null check and conversion to empty string there. I went with this intermediate approach for now as its lighter weight on the eve of the GT3.0 release cutoff.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature

### Notes

I added a new script that starts the docker container necessary for running tests that target S3 via the s3 client. 

Closes #2857
