### PR TITLE
Fix Tiled TIFF BitCellType Segments conversion

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -136,6 +136,7 @@ Fixes & Updates
 - reprojectExtentAsPolygon should be more deterministic (`#3083 https://github.com/locationtech/geotrellis/pull/3083`_).
 - AmazonS3URI.getKey() now returns an empty string instead of null if no key was provided (`#3096 https://github.com/locationtech/geotrellis/pull/3096`_).
 - Improved handling of null prefix for S3AttributeStore. Prefer use of `S3AttributeStore.apply` to take advantage of this improved handling (`#3096 https://github.com/locationtech/geotrellis/pull/3096`_).
+- Fix Tiled TIFF BitCellType Segments conversion (`#3102 https://github.com/locationtech/geotrellis/pull/3102`_)
 
 2.3.0
 -----

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BitGeoTiffTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BitGeoTiffTileSpec.scala
@@ -17,12 +17,6 @@
 package geotrellis.raster.io.geotiff
 
 import geotrellis.raster._
-import geotrellis.raster.io.geotiff.writer.GeoTiffWriter
-import geotrellis.raster.mapalgebra.local._
-
-import geotrellis.vector.Extent
-
-import geotrellis.proj4._
 
 import geotrellis.raster.testkit._
 
@@ -81,6 +75,23 @@ class BitGeoTiffTileSpec extends FunSpec
       val res = tile.mapDouble { (col, row, z) => z }
 
       assertEqual(res, tile)
+    }
+
+    it("should convert tiled tiffs") {
+      val tiff = SinglebandGeoTiff(geoTiffPath("bilevel.tif"))
+      val tile = tiff.tile.toArrayTile()
+
+      // check that it is possible to convert bit cellType to bit cellType
+      val tiffTile = tile.toGeoTiffTile.convert(BitCellType)
+      assertEqual(tiffTile.toArrayTile(), tile.toArrayTile)
+
+      // check that it is possible to convert int cellType to bit cellType
+      // and that bitCellType conversion is idempotent
+      (0 to 5).foldLeft(tile.toGeoTiffTile.convert(IntCellType)) { case (acc, _) =>
+        val tiffTileLocal = acc.convert(BitCellType)
+        assertEqual(tiffTileLocal.toArrayTile(), tile.toArrayTile)
+        tiffTileLocal
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

This PR fixes `GeoTIffTile` `CellType` conversion, in particular `GeoTiffSegment` `CellType` conversions. During the work on this fix, it became obvious that our TIFF API doesn't support a proper work with `striped` `BitTiffs` (this fact made this issue debugging a bit more tricky), that is why this PR at least covers `Tiled` tiffs support.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] Unit tests added for bug-fix or new feature


Fixes https://github.com/locationtech/geotrellis/issues/3055 

### Note

This issue indeed closes #3055 in any case, since COGs are Tiled TIFFs. If this PR won't cover `Striped` TIFFs support, I will create a separate issue to address it. This PR blocks a 3.0 release, a complete striped bit TIFFs support does not.
