### PR TITLE
Fix scaladoc deployment to latest folder on master branch merges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - RUN_SET=1
     - RUN_SET=2
     - RUN_SET=3
+    - RUN_SET=scaladoc
 
 language: scala
 
@@ -61,7 +62,6 @@ notifications:
 
 before_deploy:
   - export GEOTRELLIS_VERSION_SUFFIX="-${TRAVIS_COMMIT:0:7}"
-  - sudo chown -R "$USER":"$USER" .
   - ./sbt unidoc
 
 deploy:
@@ -71,6 +71,6 @@ deploy:
     on:
       repo: locationtech/geotrellis
       branch: fixup/awf/deploy-scaladoc-latest
-      condition: "$RUN_SET = 3"
+      condition: "$RUN_SET = 'scaladoc'"
       jdk: openjdk8
       scala: "2.11.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ notifications:
 
 before_deploy:
   - export GEOTRELLIS_VERSION_SUFFIX="-${TRAVIS_COMMIT:0:7}"
+  - ./sbt unidoc
 
 deploy:
   - provider: script
@@ -68,6 +69,7 @@ deploy:
     skip_cleanup: true
     on:
       repo: locationtech/geotrellis
-      branch: master
-      jdk: oraclejdk8
+      branch: fixup/awf/deploy-scaladoc-latest
+      condition: "$RUN_SET = 3"
+      jdk: openjdk8
       scala: "2.11.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ deploy:
     skip_cleanup: true
     on:
       repo: locationtech/geotrellis
-      branch: fixup/awf/deploy-scaladoc-latest
+      branch: master
       condition: "$RUN_SET = 'scaladoc'"
       jdk: openjdk8
       scala: "2.11.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ notifications:
 
 before_deploy:
   - export GEOTRELLIS_VERSION_SUFFIX="-${TRAVIS_COMMIT:0:7}"
+  - sudo chown -R "$USER":"$USER" .
   - ./sbt unidoc
 
 deploy:

--- a/.travis/build-and-test.sh
+++ b/.travis/build-and-test.sh
@@ -14,11 +14,13 @@ elif [ $RUN_SET = "2" ]; then
     else
         .travis/build-set-2.sh;
     fi
-else
+elif [ $RUN_SET = "3" ]; then
     echo "RUNNING SET 3";
     if [ `echo $TRAVIS_SCALA_VERSION | cut -f1-2 -d "."` = "2.11" ]; then
         .travis/build-and-test-set-3.sh;
     else
         .travis/build-set-3.sh;
     fi
+else
+    echo "Skipping RUN_SET = $RUN_SET in build-and-test.sh."
 fi

--- a/.travis/scaladocs.sh
+++ b/.travis/scaladocs.sh
@@ -2,29 +2,33 @@
 
 set -o errexit -o nounset
 
-if [ "$TRAVIS_BRANCH" != "master" ]
+if [ "$TRAVIS_BRANCH" != "fixup/awf/deploy-scaladoc-latest" ]
 then
   echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
   exit 0
 fi
 
-rev=$(git rev-parse --short HEAD)
+DIR="$(dirname "$0")/.."
+SCALADOCS_CHECKOUT_DIR="${1:-/tmp}/scaladocs"
+SCALADOCS_REPO="https://github.com/geotrellis/scaladocs.git"
+SCALADOCS_BRANCH="gh-pages"
 
-# Build docs
-./sbt "++$TRAVIS_SCALA_VERSION" unidoc
+pushd "$DIR"
+rev=$(git rev-parse --short HEAD)
 
 # Set up git
 git config --global user.email "azaveadev@azavea.com"
 git config --global user.name "azaveaci"
 
-# Inside scaladocs from hereon
-rm -rf scaladocs
-git clone https://github.com/geotrellis/scaladocs.git
-rm -rf scaladocs/latest
-mv target/scala-2.11/unidoc scaladocs/latest
-cd scaladocs
+rm -rf "$SCALADOCS_CHECKOUT_DIR"
+git clone "$SCALADOCS_REPO" "$SCALADOCS_CHECKOUT_DIR"
+rm -rf "$SCALADOCS_CHECKOUT_DIR/latest"
+mv "target/scala-2.11/unidoc" "$SCALADOCS_CHECKOUT_DIR/latest"
+
+pushd "$SCALADOCS_CHECKOUT_DIR"
 git remote add originAuth https://$CI_GH_TOKEN@github.com/geotrellis/scaladocs.git
 
+echo "Pushing scaladoc to $SCALADOCS_REPO#$SCALADOCS_BRANCH"
 git add -A .
 git commit -m "rebuild scaladocs at ${rev}"
-git push -q originAuth gh-pages
+git push -q originAuth "$SCALADOCS_BRANCH"

--- a/.travis/scaladocs.sh
+++ b/.travis/scaladocs.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset
 
-if [ "$TRAVIS_BRANCH" != "fixup/awf/deploy-scaladoc-latest" ]
+if [ "$TRAVIS_BRANCH" != "master" ]
 then
   echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
   exit 0

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val commonSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
+  autoAPIMappings := true,
 
   publishTo := {
     val sonatype = "https://oss.sonatype.org/"


### PR DESCRIPTION
## Overview

Broken since Oct 2018 in https://github.com/locationtech/geotrellis/commit/389cda41e1163598c8f361d5c097628744c0b30b#diff-354f30a63fb0907d4ad57269548329e3

Since then, a few things "broke" the build:

- new param in build.sbt for passing scaladoc info to the doc generator
- split build with RUN_SET env variable, so now we need to also only deploy in one of those
- swap to conditional deploy on openjdk8

### Checklist

- [-] `docs/CHANGELOG.rst` updated, if necessary
- [-] `docs` guides update, if necessary
- [-] New user API has useful Scaladoc strings
- [-] Unit tests added for bug-fix or new feature

### Demo

The HEAD commit of geotrellis/scaladocs should have a recent commit: https://github.com/geotrellis/scaladocs/tree/gh-pages/latest

### Notes

I attempted to use the [Travis gh-pages deployment tooling](https://docs.travis-ci.com/user/deployment/pages/) to get rid of `.travis/scaladocs.sh`. No dice. That runner pushes whatever is in local_dir up and entirely overwrites whatever is on that branch. So in order to get past that I still needed the steps that checked out the old repo state and moved the new docs into the latest folder. And then the commit history still is worse: https://github.com/geotrellis/scaladocs/tree/gh-pages-test. So whomp whomp, I gave that up.

Closes #3105 
