### PR TITLE
updated computeResolution in IterativeCostDistance to match Iterative Viewshed

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -137,6 +137,7 @@ Fixes & Updates
 - AmazonS3URI.getKey() now returns an empty string instead of null if no key was provided (`#3096 https://github.com/locationtech/geotrellis/pull/3096`_).
 - Improved handling of null prefix for S3AttributeStore. Prefer use of `S3AttributeStore.apply` to take advantage of this improved handling (`#3096 https://github.com/locationtech/geotrellis/pull/3096`_).
 - Fix Tiled TIFF BitCellType Segments conversion (`#3102 https://github.com/locationtech/geotrellis/pull/3102`_)
+- Updated computeResolution in IterativeCostDistance to match Iterative Viewshed (`#3106 https://github.com/locationtech/geotrellis/pull/3106`_)
 
 2.3.0
 -----

--- a/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
+++ b/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
@@ -73,6 +73,10 @@ object IterativeCostDistance {
     def value: Changes = list
   }
 
+  /**
+    * Compute the resolution (in meters per pixel) of a layer.
+    * This function also exists in IterativeViewshed.scala
+    */
   def computeResolution[K: (* => SpatialKey), V: (* => Tile)](
     friction: RDD[(K, V)] with Metadata[TileLayerMetadata[K]]
   ) = {
@@ -80,10 +84,15 @@ object IterativeCostDistance {
     val mt = md.mapTransform
     val key: SpatialKey = md.bounds.get.minKey
     val extent = mt(key).reproject(md.crs, LatLng)
-    val degrees = extent.xmax - extent.xmin
-    val meters = degrees * (6378137 * 2.0 * math.Pi) / 360.0
-    val pixels = md.layout.tileCols
-    math.abs(meters / pixels)
+
+    val latitude = (extent.ymax + extent.ymin) / 2.0
+    val degrees_per_key = extent.xmax - extent.xmin
+    // https://gis.stackexchange.com/questions/2951/algorithm-for-offsetting-a-latitude-longitude-by-some-amount-of-meters
+    val meters_per_degree = 111111 * math.cos(math.toRadians(latitude))
+    val meters_per_key = meters_per_degree * degrees_per_key
+    val keys_per_pixel = 1.0 / md.layout.tileCols
+
+    meters_per_key * keys_per_pixel
   }
 
   private def geometryToKeys[K: (* => SpatialKey)](

--- a/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
+++ b/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
@@ -22,16 +22,14 @@ import geotrellis.raster.costdistance.SimpleCostDistance
 import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.layer._
 import geotrellis.spark._
-import geotrellis.util._
 import geotrellis.vector._
+
 import org.apache.log4j.Logger
 import org.apache.spark.rdd.RDD
-import org.apache.spark.SparkContext
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.AccumulatorV2
 
 import scala.collection.mutable
-
 
 /**
   * This Spark-enabled implementation of the standard cost-distance
@@ -53,6 +51,27 @@ object IterativeCostDistance {
   val logger = Logger.getLogger(IterativeCostDistance.getClass)
 
   /**
+    * Compute the resolution (in meters per pixel) of a layer.
+    */
+  private [spark] def computeResolution[K: (* => SpatialKey), V: (* => Tile)](
+    friction: RDD[(K, V)] with Metadata[TileLayerMetadata[K]]
+  ) = {
+    val md = friction.metadata
+    val mt = md.mapTransform
+    val key: SpatialKey = md.bounds.get.minKey
+    val extent = mt(key).reproject(md.crs, LatLng)
+
+    val latitude = (extent.ymax + extent.ymin) / 2.0
+    val degreesPerKey = extent.xmax - extent.xmin
+    // https://gis.stackexchange.com/questions/2951/algorithm-for-offsetting-a-latitude-longitude-by-some-amount-of-meters
+    val metersPerDegree = 111111 * math.cos(math.toRadians(latitude))
+    val metersPerKey = metersPerDegree * degreesPerKey
+    val keysPerPixel = 1.0 / md.layout.tileCols
+
+    metersPerKey * keysPerPixel
+  }
+
+  /**
     * An accumulator to hold lists of edge changes.
     */
   class ChangesAccumulator extends AccumulatorV2[KeyCostPair, Changes] {
@@ -71,28 +90,6 @@ object IterativeCostDistance {
       this.synchronized { list ++= other.value }
     def reset: Unit = this.synchronized { list.clear }
     def value: Changes = list
-  }
-
-  /**
-    * Compute the resolution (in meters per pixel) of a layer.
-    * This function also exists in IterativeViewshed.scala
-    */
-  def computeResolution[K: (* => SpatialKey), V: (* => Tile)](
-    friction: RDD[(K, V)] with Metadata[TileLayerMetadata[K]]
-  ) = {
-    val md = friction.metadata
-    val mt = md.mapTransform
-    val key: SpatialKey = md.bounds.get.minKey
-    val extent = mt(key).reproject(md.crs, LatLng)
-
-    val latitude = (extent.ymax + extent.ymin) / 2.0
-    val degrees_per_key = extent.xmax - extent.xmin
-    // https://gis.stackexchange.com/questions/2951/algorithm-for-offsetting-a-latitude-longitude-by-some-amount-of-meters
-    val meters_per_degree = 111111 * math.cos(math.toRadians(latitude))
-    val meters_per_key = meters_per_degree * degrees_per_key
-    val keys_per_pixel = 1.0 / md.layout.tileCols
-
-    meters_per_key * keys_per_pixel
   }
 
   private def geometryToKeys[K: (* => SpatialKey)](

--- a/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
@@ -127,6 +127,7 @@ object IterativeViewshed {
 
   /**
     * Compute the resolution (in meters per pixel) of a layer.
+    * This function also exists in IterativeCostDistance.scala
     */
   private def computeResolution[K: (* => SpatialKey), V: (* => Tile)](
     elevation: RDD[(K, V)] with Metadata[TileLayerMetadata[K]]

--- a/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
@@ -16,21 +16,17 @@
 
 package geotrellis.spark.viewshed
 
-import geotrellis.proj4.LatLng
 import geotrellis.raster._
-import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.raster.viewshed.R2Viewshed
 import geotrellis.raster.viewshed.R2Viewshed._
 import geotrellis.layer._
 import geotrellis.spark._
-import geotrellis.spark.tiling._
-import geotrellis.util._
+import geotrellis.spark.costdistance.IterativeCostDistance._
 import geotrellis.vector._
 
-import org.locationtech.jts.{ geom => jts }
+import org.locationtech.jts.{geom => jts}
 import org.apache.log4j.Logger
 import org.apache.spark.rdd.RDD
-import org.apache.spark.SparkContext
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.AccumulatorV2
 
@@ -123,28 +119,6 @@ object IterativeViewshed {
     def reset: Unit = this.synchronized { messages.clear }
 
     def value: Messages = messages.toMap
-  }
-
-  /**
-    * Compute the resolution (in meters per pixel) of a layer.
-    * This function also exists in IterativeCostDistance.scala
-    */
-  private def computeResolution[K: (* => SpatialKey), V: (* => Tile)](
-    elevation: RDD[(K, V)] with Metadata[TileLayerMetadata[K]]
-  ) = {
-    val md = elevation.metadata
-    val mt = md.mapTransform
-    val key: SpatialKey = md.bounds.get.minKey
-    val extent = mt(key).reproject(md.crs, LatLng)
-
-    val latitude = (extent.ymax + extent.ymin) / 2.0
-    val degrees_per_key = extent.xmax - extent.xmin
-    // https://gis.stackexchange.com/questions/2951/algorithm-for-offsetting-a-latitude-longitude-by-some-amount-of-meters
-    val meters_per_degree = 111111 * math.cos(math.toRadians(latitude))
-    val meters_per_key = meters_per_degree * degrees_per_key
-    val keys_per_pixel = 1.0 / md.layout.tileCols
-
-    meters_per_key * keys_per_pixel
   }
 
   private case class PointInfo(

--- a/spark/src/test/scala/geotrellis/spark/costdistance/IterativeCostDistanceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/costdistance/IterativeCostDistanceSpec.scala
@@ -104,7 +104,7 @@ class IterativeCostDistanceSpec extends FunSpec
       val resolution = IterativeCostDistance.computeResolution(rdd3)
       val hops = (up.getDouble(2,3) - down.getDouble(2,3)) / resolution
 
-      hops should be (5.0)
+      hops should be (5.0 +- 1e-10)
     }
 
     it("Should propogate down") {
@@ -114,7 +114,7 @@ class IterativeCostDistanceSpec extends FunSpec
       val resolution = IterativeCostDistance.computeResolution(rdd3)
       val hops = (up.getDouble(2,1) - down.getDouble(2,1)) / resolution
 
-      hops should be (5.0)
+      hops should be (5.0 +- 1e-10)
     }
 
   }


### PR DESCRIPTION
The compute resolution method in Iterative Cost Distance was calcultating the
cell size based on the length of a degree at the equator without scaling for
the current latitude. This introduces an error as you move away from the
equator. The same method in Iterative Viewshed compensates for this and
maintains greater spatial accuracy.

See issue https://github.com/locationtech/geotrellis/issues/3103

Signed-off-by: jmtaysom <james.taysom@gmail.com>

## Overview

The compute resolution method in Iterative Cost Distance was calcultating the
cell size based on the length of a degree at the equator without scaling for
the current latitude. This introduces an error as you move away from the
equator. The same method in Iterative Viewshed compensates for this and
maintains greater spatial accuracy.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary

Closes #3103
