### PR TITLE
RasterSource resolutions field to List[CellSize]

### DIFF
--- a/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
+++ b/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
@@ -317,7 +317,7 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
       val actual = RasterSourceRDD.read(readingSources, floatingLayout).stitch()
 
       // random chip to test agains, to speed up tests
-      val gridBounds = RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).gridBounds
+      val gridBounds = actual.rasterExtent.gridBoundsFor(randomExtentWithin(actual.extent))
 
       expected.dimensions shouldBe actual.dimensions
 
@@ -343,7 +343,7 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
       val actual = RasterSourceRDD.read(readingSources, floatingLayout).stitch()
 
       // random chip to test agains, to speed up tests
-      val gridBounds = RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).gridBounds
+      val gridBounds = actual.rasterExtent.gridBoundsFor(randomExtentWithin(actual.extent))
 
       expected.dimensions shouldBe actual.dimensions
 
@@ -365,7 +365,7 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
       val actual = RasterSourceRDD.read(readingSources, floatingLayout).stitch()
 
       // random chip to test agains, to speed up tests
-      val gridBounds = RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).gridBounds
+      val gridBounds = actual.rasterExtent.gridBoundsFor(randomExtentWithin(actual.extent))
 
       expected.dimensions shouldBe actual.dimensions
 
@@ -393,7 +393,7 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
       val actual = RasterSourceRDD.read(readingSources, floatingLayout).stitch()
 
       // random chip to test agains, to speed up tests
-      val gridBounds = RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).gridBounds
+      val gridBounds = actual.rasterExtent.gridBoundsFor(randomExtentWithin(actual.extent))
 
       expected.dimensions shouldBe actual.dimensions
 
@@ -401,4 +401,3 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
     }
   }
 }
-

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -123,6 +123,8 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def rasterExtent: RasterExtent = rasterExtent(GDALDataset.WARPED)
 
+  def dimensions: Dimensions[Int] = rasterExtent.dimensions
+
   def rasterExtent(datasetType: DatasetType): RasterExtent = {
     require(acceptableDatasets contains datasetType)
     val transform = Array.ofDim[Double](6)
@@ -305,7 +307,7 @@ case class GDALDataset(token: Long) extends AnyVal {
     GDALUtils.dataTypeToCellType(datatype = dt, noDataValue = nd, minMaxValues = mm)
   }
 
-  def readTile(gb: GridBounds[Int] = rasterExtent.gridBounds, band: Int, datasetType: DatasetType = GDALDataset.WARPED): Tile = {
+  def readTile(gb: GridBounds[Int] = GridBounds(dimensions), band: Int, datasetType: DatasetType = GDALDataset.WARPED): Tile = {
     require(acceptableDatasets contains datasetType)
     val GridBounds(xmin, ymin, xmax, ymax) = gb
     val srcWindow: Array[Int] = Array(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1)
@@ -327,10 +329,10 @@ case class GDALDataset(token: Long) extends AnyVal {
     ArrayTile.fromBytes(bytes, ct, dstWindow(0), dstWindow(1))
   }
 
-  def readMultibandTile(gb: GridBounds[Int] = rasterExtent.gridBounds, bands: Seq[Int] = 1 to bandCount, datasetType: DatasetType = GDALDataset.WARPED): MultibandTile =
+  def readMultibandTile(gb: GridBounds[Int] = GridBounds(dimensions), bands: Seq[Int] = 1 to bandCount, datasetType: DatasetType = GDALDataset.WARPED): MultibandTile =
     MultibandTile(bands.map { readTile(gb, _, datasetType) })
 
-  def readMultibandRaster(gb: GridBounds[Int] = rasterExtent.gridBounds, bands: Seq[Int] = 1 to bandCount, datasetType: DatasetType = GDALDataset.WARPED): Raster[MultibandTile] =
+  def readMultibandRaster(gb: GridBounds[Int] = GridBounds(dimensions), bands: Seq[Int] = 1 to bandCount, datasetType: DatasetType = GDALDataset.WARPED): Raster[MultibandTile] =
     Raster(readMultibandTile(gb, bands, datasetType), rasterExtent.rasterExtentFor(gb).extent)
 }
 

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALMetadata.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALMetadata.scala
@@ -26,7 +26,7 @@ case class GDALMetadata(
   bandCount: Int,
   cellType: CellType,
   gridExtent: GridExtent[Long],
-  resolutions: List[GridExtent[Long]],
+  resolutions: List[CellSize],
   /** GDAL per domain metadata */
   baseMetadata: Map[GDALMetadataDomain, Map[String, String]] = Map.empty,
   /** GDAL per band per domain metadata */

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALMetadata.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALMetadata.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.raster.gdal
 
-import geotrellis.raster.{RasterMetadata, SourceName}
+import geotrellis.raster.{RasterMetadata, SourceName, CellSize}
 import geotrellis.proj4.CRS
 import geotrellis.raster.{CellType, GridExtent}
 

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -97,7 +97,7 @@ class GDALRasterSource(
     * These resolutions could represent actual overview as seen in source file
     * or overviews of VRT that was created as result of resample operations.
     */
-  lazy val resolutions: List[GridExtent[Long]] = dataset.resolutions(datasetType).map(_.toGridType[Long])
+  lazy val resolutions: List[CellSize] = dataset.resolutions(datasetType).map(_.toGridType[Long])
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     bounds

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -97,12 +97,12 @@ class GDALRasterSource(
     * These resolutions could represent actual overview as seen in source file
     * or overviews of VRT that was created as result of resample operations.
     */
-  lazy val resolutions: List[CellSize] = dataset.resolutions(datasetType).map(_.toGridType[Long])
+  lazy val resolutions: List[CellSize] = dataset.resolutions(datasetType).map(_.cellSize)
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     bounds
       .toIterator
-      .flatMap { gb => gridBounds.intersection(gb) }
+      .flatMap { _.intersection(this.dimensions) }
       .map { gb =>
         val tile = dataset.readMultibandTile(gb.toGridType[Int], bands.map(_ + 1), datasetType)
         val extent = this.gridExtent.extentFor(gb)
@@ -152,7 +152,7 @@ class GDALRasterSource(
   }
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {
-    val it = readBounds(List(bounds).flatMap(_.intersection(this.gridBounds)), bands)
+    val it = readBounds(List(bounds).flatMap(_.intersection(this.dimensions)), bands)
     if (it.hasNext) Some(it.next) else None
   }
 

--- a/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
+++ b/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
@@ -63,11 +63,8 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhenThe
 
       // calculated expected resolutions of overviews
       // it's a rough approximation there as we're not calculating resolutions like GDAL
-      val ratio = resampledSource.cellSize.resolution / source.cellSize.resolution
-      resampledSource.resolutions.zip (source.resolutions.map { re =>
-        val CellSize(cw, ch) = re.cellSize
-        RasterExtent(re.extent, CellSize(cw * ratio, ch * ratio))
-      }).map { case (rea, ree) => rea.cellSize.resolution shouldBe ree.cellSize.resolution +- 3e-1 }
+      resampledSource.resolutions.zip(source.resolutions)
+        .map { case (rea, ree) => rea.resolution shouldBe ree.resolution +- 3e-1 }
 
       val actual: Raster[MultibandTile] =
         resampledSource.read(GridBounds(0, 0, resampledSource.cols - 1, resampledSource.rows - 1)).get

--- a/gdal/src/test/scala/geotrellis/raster/gdal/GDALWarpReadTileSpec.scala
+++ b/gdal/src/test/scala/geotrellis/raster/gdal/GDALWarpReadTileSpec.scala
@@ -88,7 +88,7 @@ class GDALWarpReadTileSpec extends FunSpec with RasterMatchers {
     it("should do window reads") {
       val dataset = GDALDataset(path)
       val gtiff = MultibandGeoTiff(path)
-      val gridBounds = dataset.rasterExtent.gridBounds.split(15, 21)
+      val gridBounds = GridBounds(dataset.dimensions).split(15, 21)
 
       gridBounds.foreach { gb =>
         val actualTile = dataset.readMultibandTile(gb)
@@ -114,7 +114,7 @@ class GDALWarpReadTileSpec extends FunSpec with RasterMatchers {
     val tiffDataset = GDALDataset(jpegTiffPath)
 
     val gridBounds: Iterator[GridBounds[Int]] =
-      jpegDataset.rasterExtent.gridBounds.split(20, 15)
+      GridBounds(jpegDataset.dimensions).split(20, 15)
 
     it("should read a JPEG2000 from a file") {
       val raster = Raster(jpegDataset.readMultibandTile(), jpegDataset.rasterExtent.extent)

--- a/layer/src/main/scala/geotrellis/layer/LayoutTileSource.scala
+++ b/layer/src/main/scala/geotrellis/layer/LayoutTileSource.scala
@@ -52,7 +52,7 @@ class LayoutTileSource[K: SpatialComponent](
       rowMax = (row+1) * layout.tileRows - 1 - sourceRowOffset
     )
 
-    if (source.gridBounds.intersects(sourcePixelBounds))
+    if (sourcePixelBounds.intersects(source.dimensions))
       Some(RasterRegion(source, sourcePixelBounds))
     else
       None
@@ -77,7 +77,7 @@ class LayoutTileSource[K: SpatialComponent](
     )
 
     for {
-      bounds <- sourcePixelBounds.intersection(source.gridBounds)
+      bounds <- sourcePixelBounds.intersection(source.dimensions)
       raster <- source.read(bounds, bands)
     } yield {
       if (raster.tile.cols == layout.tileCols && raster.tile.rows == layout.tileRows) {
@@ -110,7 +110,7 @@ class LayoutTileSource[K: SpatialComponent](
         colMax = (col+1) * layout.tileCols - 1 - sourceColOffset,
         rowMax = (row+1) * layout.tileRows - 1 - sourceRowOffset
       )
-      bounds <- sourcePixelBounds.intersection(source.gridBounds)
+      bounds <- sourcePixelBounds.intersection(source.dimensions)
       raster <- source.read(bounds, bands)
     } yield {
       val tile =

--- a/raster/src/main/scala/geotrellis/raster/CellSize.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellSize.scala
@@ -56,8 +56,8 @@ object CellSize {
     * @param   dims    The numbers of columns and rows as a tuple
     * @return          The CellSize
     */
-  def apply(extent: Extent, dims: (Int, Int)): CellSize = {
-    val (cols, rows) = dims
+  def apply(extent: Extent, dims: Dimensions[Int]): CellSize = {
+    val Dimensions(cols, rows) = dims
     apply(extent, cols, rows)
   }
 

--- a/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
@@ -53,8 +53,10 @@ object CroppedTile {
 /**
   * The [[CroppedTile]] type.
   */
-case class CroppedTile(sourceTile: Tile,
-                       override val gridBounds: GridBounds[Int]) extends Tile {
+case class CroppedTile(
+  sourceTile: Tile,
+  gridBounds: GridBounds[Int]
+) extends Tile {
 
   val cols = gridBounds.width
   val rows = gridBounds.height

--- a/raster/src/main/scala/geotrellis/raster/Dimensions.scala
+++ b/raster/src/main/scala/geotrellis/raster/Dimensions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Azavea
+ * Copyright 2019 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,16 @@
 
 package geotrellis.raster
 
-/**
-  * The TileFeature Type.  This is used for packaging a CellGrid (a
-  * Tile or MultibandTile) together with some metadata.
-  *
-  * @param  tile  The CellGrid-derived tile
-  * @param  data  The additional metadata
-  */
-case class TileFeature[+T <: CellGrid[Int], D](tile: T, data: D) extends CellGrid[Int] {
-  def cellType: CellType = tile.cellType
-  def cols: Int = tile.cols
-  def rows: Int = tile.rows
-  override def size: Int = tile.size
+import spire.math.Integral
+import spire.implicits._
+
+case class Dimensions[@specialized(Byte, Short, Int, Long) N: Integral](cols: N, rows: N) extends Product2[N, N] with Serializable {
+  def _1 = cols
+  def _2 = rows
+  def size: Long = Integral[N].toType[Long](cols) * Integral[N].toType[Long](rows)
+  override def toString = s"${cols}x${rows}"
 }
 
-object TileFeature {
-  implicit def tileFeatureToCellGrid[T <: CellGrid[Int], D](tf: TileFeature[T, D]): T = tf.tile
+object Dimensions {
+  implicit def apply[N: Integral](tup: (N, N)) = new Dimensions(tup._1, tup._2)
 }

--- a/raster/src/main/scala/geotrellis/raster/Grid.scala
+++ b/raster/src/main/scala/geotrellis/raster/Grid.scala
@@ -23,6 +23,5 @@ abstract class Grid[N: Integral] extends Serializable {
   def cols: N
   def rows: N
   def size: N = cols * rows
-  def dimensions: (N, N) = (cols, rows)
-  def gridBounds: GridBounds[N] = GridBounds(0, 0, cols - 1, rows - 1)
+  def dimensions: Dimensions[N] = Dimensions(cols, rows)
 }

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -197,6 +197,32 @@ case class GridBounds[@specialized(Int, Long) N: Integral](
       )
     }
 
+  /** Returns true if the present grid intersects a rastser of given dimensions.
+    * The raster is treated as if its upper-left corner is at cell (0, 0) relative to this grid.
+    * @param  dimensions  The dimensions of a raster
+    */
+  def intersects(dimensions: Dimensions[N]): Boolean =
+    !(colMax < 0 || (dimensions.cols-1) < colMin) &&
+    !(rowMax < 0 || (dimensions.rows-1) < rowMin)
+
+  /** Return the intersection of the present grid and a raster of given dimensions.
+    * The raster is treated as if its upper-left corner is at cell (0, 0) relative to this grid.
+    * @param  dimensions  The dimensions of a raster
+    */
+  def intersection(dimensions: Dimensions[N]): Option[GridBounds[N]] =
+    if(!intersects(dimensions)) {
+      None
+    } else {
+      Some(
+        GridBounds(
+          colMin max 0,
+          rowMin max 0,
+          colMax min (dimensions.cols-1),
+          rowMax min (dimensions.rows-1))
+      )
+    }
+
+
   /** Return the union of GridBounds. */
   def combine(other: GridBounds[N]): GridBounds[N] =
     GridBounds(
@@ -257,6 +283,9 @@ case class GridBounds[@specialized(Int, Long) N: Integral](
 
     def apply(colMin: Long, rowMin: Long, colMax: Long, rowMax: Long): GridBounds[Long] =
       new GridBounds[Long](colMin, rowMin, colMax, rowMax)
+
+    def apply[N: Integral](dimensions: Dimensions[N]): GridBounds[N] =
+      new GridBounds[N](0, 0, dimensions.cols - 1, dimensions.rows - 1)
 
     /**
       * Creates a sequence of distinct [[GridBounds]] out of a set of

--- a/raster/src/main/scala/geotrellis/raster/MosaicMetadata.scala
+++ b/raster/src/main/scala/geotrellis/raster/MosaicMetadata.scala
@@ -26,7 +26,7 @@ case class MosaicMetadata(
   bandCount: Int,
   cellType: CellType,
   gridExtent: GridExtent[Long],
-  resolutions: List[GridExtent[Long]],
+  resolutions: List[CellSize],
   list: NonEmptyList[RasterMetadata]
 ) extends RasterMetadata {
   /** Mosaic metadata usually doesn't contain a metadata that is common for all RasterSources */

--- a/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
@@ -74,7 +74,7 @@ trait MosaicRasterSource extends RasterSource {
     *
     * @see [[geotrellis.contrib.vlm.RasterSource.resolutions]]
     */
-  def resolutions: List[GridExtent[Long]] = sources.map { _.resolutions }.reduce
+  def resolutions: List[CellSize] = sources.map { _.resolutions }.reduce
 
   /** Create a new MosaicRasterSource with sources transformed according to the provided
     * crs, options, and strategy, and a new crs

--- a/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
@@ -34,7 +34,7 @@ trait RasterMetadata extends Serializable {
 
   def gridExtent: GridExtent[Long]
 
-  /** All available resolutions for this raster source
+  /** All available overview resolutions for this raster source
     *
     * <li> For base [[RasterSource]] instance this will be resolutions of available overviews.
     * <li> For reprojected [[RasterSource]] these resolutions represent an estimate where
@@ -43,10 +43,8 @@ trait RasterMetadata extends Serializable {
     * When reading raster data the underlying implementation will have to sample from one of these resolutions.
     * It is possible that a read request for a small bounding box will results in significant IO request when the target
     * cell size is much larger than closest available resolution.
-    *
-    * __Note__: It is expected but not guaranteed that the extent each [[RasterExtent]] in this list will be the same.
     */
-  def resolutions: List[GridExtent[Long]]
+  def resolutions: List[CellSize]
 
   def extent: Extent = gridExtent.extent
 

--- a/raster/src/main/scala/geotrellis/raster/RasterRegion.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterRegion.scala
@@ -37,10 +37,10 @@ object RasterRegion {
     GridBoundsRasterRegion(source, bounds)
 
   case class GridBoundsRasterRegion(source: RasterSource, bounds: GridBounds[Long]) extends RasterRegion {
-    require(bounds.intersects(source.gridBounds), s"The given bounds: $bounds must intersect the given source: $source")
+    require(bounds.intersects(source.dimensions), s"The given bounds: $bounds must intersect the given source: $source")
     @transient lazy val raster: Option[Raster[MultibandTile]] =
       for {
-        intersection <- source.gridBounds.intersection(bounds)
+        intersection <- bounds.intersection(source.dimensions)
         raster <- source.read(intersection)
       } yield {
         if (raster.tile.cols == cols && raster.tile.rows == rows)

--- a/raster/src/main/scala/geotrellis/raster/costdistance/CostDistance.scala
+++ b/raster/src/main/scala/geotrellis/raster/costdistance/CostDistance.scala
@@ -40,7 +40,7 @@ object CostDistance {
     *
     */
   def apply(cost: Tile, points: Seq[(Int, Int)]): Tile = {
-    val (cols, rows) = cost.dimensions
+    val Dimensions(cols, rows) = cost.dimensions
     val output = DoubleArrayTile.empty(cols, rows)
 
     for((c, r) <- points)

--- a/raster/src/main/scala/geotrellis/raster/costdistance/CostDistanceWithPaths.scala
+++ b/raster/src/main/scala/geotrellis/raster/costdistance/CostDistanceWithPaths.scala
@@ -27,9 +27,9 @@ import scala.collection.mutable.ArrayBuffer
 case class CostDistanceWithPathsResult(
   res: Array[Seq[Int]],
   costs: Array[Double],
-  tileDimension: (Int, Int)) {
+  tileDimension: Dimensions[Int]) {
 
-  val (cols, rows) = tileDimension
+  val Dimensions(cols, rows) = tileDimension
 
   def getPath(dest: (Int, Int)): (Double, Seq[LineString]) = {
     val (col, row) = dest
@@ -76,7 +76,7 @@ private class CostDistanceWithPaths(cost: ArrayTile, source: (Int, Int)) {
 
   val Sqrt2 = math.sqrt(2)
 
-  val (cols, rows) = cost.dimensions
+  val Dimensions(cols, rows) = cost.dimensions
 
   @inline final def indexToCoordinates(idx: Int) = (idx % cols, idx / cols)
 

--- a/raster/src/main/scala/geotrellis/raster/crop/MultibandTileCropMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/crop/MultibandTileCropMethods.scala
@@ -32,11 +32,11 @@ trait MultibandTileCropMethods extends TileCropMethods[MultibandTile] {
     * [[MultibandTile]] and return a new MultibandTile that contains the target area and bands.
     */
   def cropBands(gridBounds: GridBounds[Int], targetBands: Seq[Int], options: Options): MultibandTile = {
-    if (!gridBounds.intersects(self.gridBounds)) throw GeoAttrsError(s"Grid bounds do not intersect: ${self.gridBounds} crop $gridBounds")
+    if (!gridBounds.intersects(self.dimensions)) throw GeoAttrsError(s"$gridBounds do not intersect ${self.dimensions}")
     self match {
       case geotiffTile: GeoTiffMultibandTile =>
         val cropBounds =
-          if (options.clamp) gridBounds.intersection(self.gridBounds).get
+          if (options.clamp) gridBounds.intersection(self.dimensions).get
           else gridBounds
         geotiffTile.crop(cropBounds, targetBands.toArray)
       case _ =>
@@ -52,10 +52,10 @@ trait MultibandTileCropMethods extends TileCropMethods[MultibandTile] {
     self match {
       case geotiffTile: GeoTiffMultibandTile =>
         val cropBounds = gridBounds.map { gb =>
-            if (!gb.intersects(self.gridBounds))
-              throw GeoAttrsError(s"Grid bounds do not intersect: ${self.gridBounds} crop $gb")
+            if (!gb.intersects(self.dimensions))
+              throw GeoAttrsError(s"$gb do not intersect ${self.dimensions}")
 
-            if (options.clamp) gb.intersection(self.gridBounds).get
+            if (options.clamp) gb.intersection(self.dimensions).get
             else gb
         }
         geotiffTile.crop(cropBounds, targetBands.toArray)

--- a/raster/src/main/scala/geotrellis/raster/crop/SinglebandTileCropMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/crop/SinglebandTileCropMethods.scala
@@ -31,9 +31,9 @@ trait SinglebandTileCropMethods extends TileCropMethods[Tile] {
     * [[Tile]].
     */
   def crop(gridBounds: GridBounds[Int], options: Options): Tile = {
-    if (!gridBounds.intersects(self.gridBounds)) throw GeoAttrsError(s"Grid bounds do not intersect: ${self.gridBounds} crop $gridBounds")
+    if (!gridBounds.intersects(self.dimensions)) throw GeoAttrsError(s"$gridBounds do not intersect ${self.dimensions}")
     val cropBounds =
-      if(options.clamp) gridBounds.intersection(self.gridBounds).get
+      if(options.clamp) gridBounds.intersection(self.dimensions).get
       else gridBounds
 
     val res =

--- a/raster/src/main/scala/geotrellis/raster/density/KernelStamper.scala
+++ b/raster/src/main/scala/geotrellis/raster/density/KernelStamper.scala
@@ -33,7 +33,7 @@ trait KernelStamper {
   /**
    * Given a (column, row) pair and a value, apply the kernel at the given point.
    */
-  def stampKernel(tup: (Int, Int), z: Int): Unit = { 
+  def stampKernel(tup: (Int, Int), z: Int): Unit = {
     val (col, row) = tup
     stampKernel(col, row, z)
   }
@@ -47,7 +47,7 @@ trait KernelStamper {
   /**
    * Given a (column, row) pair and a value, apply the kernel at the given point.
    */
-  def stampKernelDouble(tup: (Int, Int), z: Double): Unit = { 
+  def stampKernelDouble(tup: (Int, Int), z: Double): Unit = {
     val (col, row) = tup
     stampKernelDouble(col, row, z)
   }
@@ -77,7 +77,7 @@ case class DoubleKernelStamper(tile: MutableArrayTile, k: Kernel) extends Kernel
   val kernelrows = ktile.rows
 
   val cellType = tile.cellType
-  val (cols, rows) = tile.dimensions
+  val Dimensions(cols, rows) = tile.dimensions
 
   /**
     * Given a column, row, and value, apply the kernel at the given
@@ -200,7 +200,7 @@ case class IntKernelStamper(tile: MutableArrayTile, k: Kernel) extends KernelSta
   val kernelrows = ktile.rows
 
   val cellType = tile.cellType
-  val (cols, rows) = tile.dimensions
+  val Dimensions(cols, rows) = tile.dimensions
 
   /**
     * Given a column, row, and value, apply the kernel at the given

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffMetadata.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffMetadata.scala
@@ -18,7 +18,7 @@ package geotrellis.raster.geotiff
 
 import geotrellis.raster.{RasterMetadata, SourceName}
 import geotrellis.proj4.CRS
-import geotrellis.raster.{CellType, GridExtent}
+import geotrellis.raster.{CellType, GridExtent, CellSize}
 import geotrellis.raster.io.geotiff.Tags
 
 case class GeoTiffMetadata(
@@ -27,7 +27,7 @@ case class GeoTiffMetadata(
   bandCount: Int,
   cellType: CellType,
   gridExtent: GridExtent[Long],
-  resolutions: List[GridExtent[Long]],
+  resolutions: List[CellSize],
   tags: Tags
 ) extends RasterMetadata {
   /** Returns the GeoTiff head tags. */

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
@@ -53,7 +53,7 @@ class GeoTiffRasterSource(
   def crs: CRS = tiff.crs
 
   lazy val gridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
-  lazy val resolutions: List[GridExtent[Long]] = gridExtent :: tiff.overviews.map(_.rasterExtent.toGridType[Long])
+  lazy val resolutions: List[CellSize] = cellSize :: tiff.overviews.map(_.cellSize)
 
   def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
@@ -93,7 +93,7 @@ class GeoTiffRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     val geoTiffTile = tiff.tile.asInstanceOf[GeoTiffMultibandTile]
     val intersectingBounds: Seq[GridBounds[Int]] =
-      bounds.flatMap(_.intersection(this.gridBounds)).toSeq.map(_.toGridType[Int])
+      bounds.flatMap(_.intersection(this.dimensions)).toSeq.map(_.toGridType[Int])
 
     geoTiffTile.crop(intersectingBounds, bands.toArray).map { case (gb, tile) =>
       convertRaster(Raster(tile, gridExtent.extentFor(gb.toGridType[Long], clamp = true)))

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -76,8 +76,9 @@ class GeoTiffReprojectRasterSource(
     }
   }
 
-  lazy val resolutions: List[GridExtent[Long]] =
-      gridExtent :: tiff.overviews.map(ovr => ReprojectRasterExtent(ovr.rasterExtent.toGridType[Long], transform, DefaultTarget))
+  lazy val resolutions: List[CellSize] =
+    ReprojectRasterExtent(tiff.rasterExtent, transform, DefaultTarget).cellSize ::
+      tiff.overviews.map(ovr => ReprojectRasterExtent(ovr.rasterExtent, transform, DefaultTarget).cellSize)
 
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] = {
     resampleTarget match {

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -114,7 +114,7 @@ class GeoTiffReprojectRasterSource(
     val geoTiffTile = closestTiffOverview.tile.asInstanceOf[GeoTiffMultibandTile]
     val intersectingWindows = { for {
       queryPixelBounds <- bounds
-      targetPixelBounds <- queryPixelBounds.intersection(this.gridBounds)
+      targetPixelBounds <- queryPixelBounds.intersection(this.dimensions)
     } yield {
       val targetRasterExtent = RasterExtent(
         extent = gridExtent.extentFor(targetPixelBounds, clamp = true),

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -58,14 +58,8 @@ class GeoTiffResampleRasterSource(
   def crs: CRS = tiff.crs
 
   override lazy val gridExtent: GridExtent[Long] = resampleTarget(tiff.rasterExtent.toGridType[Long])
-  lazy val resolutions: List[GridExtent[Long]] = {
-    val ratio = gridExtent.cellSize.resolution / tiff.rasterExtent.cellSize.resolution
-    gridExtent :: tiff.overviews.map { ovr =>
-      val re = ovr.rasterExtent
-      val CellSize(cw, ch) = re.cellSize
-      new GridExtent[Long](re.extent, CellSize(cw * ratio, ch * ratio))
-    }
-  }
+
+  lazy val resolutions: List[CellSize] = tiff.cellSize :: tiff.overviews.map(_.cellSize)
 
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(gridExtent.cellSize, strategy)

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -110,7 +110,7 @@ class GeoTiffResampleRasterSource(
 
     val windows = { for {
       queryPixelBounds <- bounds
-      targetPixelBounds <- queryPixelBounds.intersection(this.gridBounds)
+      targetPixelBounds <- queryPixelBounds.intersection(this.dimensions)
     } yield {
       val targetExtent = gridExtent.extentFor(targetPixelBounds)
       val sourcePixelBounds = closestTiffOverview.rasterExtent.gridBoundsFor(targetExtent, clamp = true)

--- a/raster/src/main/scala/geotrellis/raster/hydrology/FlowDirection.scala
+++ b/raster/src/main/scala/geotrellis/raster/hydrology/FlowDirection.scala
@@ -38,14 +38,14 @@ object FlowDirection {
     val max = neighbors.values.max
     neighbors.filter { case(_, v) => v == max }.keys.sum
   }
-  
+
   /** Produces a map of available immediate neighbors and their drop in elevation from the provided cell */
   def getNeighbors(c: Int, r: Int, raster: Tile): Map[Int, Double] = {
     val center = raster.get(c, r)
     val ncols = raster.cols
     val nrows = raster.rows
     // weights to be applied to drop in elevation towards the neighbours
-    val distances = 
+    val distances =
       Map[Int, Double](
         (1,        1   ),
         (2,   sqrt(2)  ),
@@ -57,7 +57,7 @@ object FlowDirection {
         (128, sqrt(2)  )
       )
     // coordinates of the 8 neighbours
-    val map = 
+    val map =
       Map[Int, (Int, Int)](
         ( 1,   (c + 1, r)      ),
         ( 2,   (c + 1, r + 1)  ),
@@ -90,7 +90,7 @@ object FlowDirection {
 
 
   def apply(raster: Tile): Tile = {
-    val (cols, rows) = raster.dimensions
+    val Dimensions(cols, rows) = raster.dimensions
     val tile = IntArrayTile(Array.ofDim[Int](rows * cols), cols, rows)
     var r = 0
     while (r < rows) {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/BitGeoTiffSegmentCollection.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/BitGeoTiffSegmentCollection.scala
@@ -16,13 +16,15 @@
 
 package geotrellis.raster.io.geotiff
 
+import geotrellis.raster.Dimensions
+
 trait BitGeoTiffSegmentCollection extends GeoTiffSegmentCollection { self: GeoTiffSegmentLayoutTransform =>
   type T = BitGeoTiffSegment
 
   val bandType = BitBandType
 
   lazy val decompressGeoTiffSegment = { (i: Int, bytes: Array[Byte]) =>
-    val (_, segmentRows) = getSegmentDimensions(i)
+    val Dimensions(_, segmentRows) = getSegmentDimensions(i)
 
     val cols = {
       val c = segmentLayout.tileLayout.tileCols

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
@@ -340,10 +340,12 @@ abstract class GeoTiffMultibandTile(
           val compressor = compression.createCompressor(segmentCount)
 
           getSegments(0 until segmentCount).foreach { case (segmentIndex, segment) =>
-            val (cols, rows) =
-              if (segmentLayout.isTiled) (segmentLayout.tileLayout.tileCols, segmentLayout.tileLayout.tileRows)
-              else getSegmentDimensions(segmentIndex)
-            val bytes = GeoTiffSegment.deinterleaveBitSegment(segment, cols, rows, bandCount, bandIndex)
+            val dims =
+              if (segmentLayout.isTiled)
+                Dimensions(segmentLayout.tileLayout.tileCols, segmentLayout.tileLayout.tileRows)
+              else
+                getSegmentDimensions(segmentIndex)
+            val bytes = GeoTiffSegment.deinterleaveBitSegment(segment, dims, bandCount, bandIndex)
             compressedBandBytes(segmentIndex) = compressor.compress(bytes, segmentIndex)
           }
 
@@ -379,7 +381,7 @@ abstract class GeoTiffMultibandTile(
   def bands: Vector[Tile] =
     _subsetBands(
       0 until bandCount,
-      (segment, cols, rows, bandCount, _) => GeoTiffSegment.deinterleaveBitSegment(segment, cols, rows, bandCount),
+      (segment, dims, bandCount, _) => GeoTiffSegment.deinterleaveBitSegment(segment, dims, bandCount),
       (bytes, bandCount, bytesPerSample, _) => GeoTiffSegment.deinterleave(bytes, bandCount, bytesPerSample)
     ).toVector
 
@@ -396,14 +398,14 @@ abstract class GeoTiffMultibandTile(
     new ArrayMultibandTile(
       _subsetBands(
         bandSequence,
-        (segment, cols, rows, bandCount, bandSequence) => GeoTiffSegment.deinterleaveBitSegment(segment, cols, rows, bandCount, bandSequence),
+        (segment, dims, bandCount, bandSequence) => GeoTiffSegment.deinterleaveBitSegment(segment, dims, bandCount, bandSequence),
         (bytes, bandCount, bytesPerSample, bandSequence) => GeoTiffSegment.deinterleave(bytes, bandCount, bytesPerSample, bandSequence)
       )
     )
 
   private def _subsetBands(
     bandSequence: Seq[Int],
-    deinterleaveBitSegment: (GeoTiffSegment, Int, Int, Int, Traversable[Int]) => Array[Array[Byte]],
+    deinterleaveBitSegment: (GeoTiffSegment, Dimensions[Int], Int, Traversable[Int]) => Array[Array[Byte]],
     deinterleave: (Array[Byte], Int, Int, Traversable[Int]) => Array[Array[Byte]]
   ): Array[Tile] = {
     val actualBandCount = bandSequence.size
@@ -416,10 +418,12 @@ abstract class GeoTiffMultibandTile(
       bandType match {
         case BitBandType =>
           getSegments(0 until segmentCount).foreach { case (segmentIndex, segment) =>
-            val (cols, rows) =
-              if (segmentLayout.isTiled) (segmentLayout.tileLayout.tileCols, segmentLayout.tileLayout.tileRows)
-              else getSegmentDimensions(segmentIndex)
-            val bytes = deinterleaveBitSegment(segment, cols, rows, bandCount, bandSequence)
+            val dims: Dimensions[Int] =
+              if (segmentLayout.isTiled)
+                Dimensions(segmentLayout.tileLayout.tileCols, segmentLayout.tileLayout.tileRows)
+              else
+                getSegmentDimensions(segmentIndex)
+            val bytes = deinterleaveBitSegment(segment, dims, bandCount, bandSequence)
             cfor(0)(_ < actualBandCount, _ + 1) { bandIndex =>
               bands(bandIndex)(segmentIndex) = compressor.compress(bytes(bandIndex), segmentIndex)
             }
@@ -488,7 +492,7 @@ abstract class GeoTiffMultibandTile(
     * Converts the GeoTiffMultibandTile to an
     * [[ArrayMultibandTile]] */
   def toArrayTile(): ArrayMultibandTile =
-    crop(this.gridBounds)
+    crop(GridBounds(this.dimensions))
 
   /**
    * Crop this tile to given pixel region.
@@ -508,7 +512,7 @@ abstract class GeoTiffMultibandTile(
    */
  def crop(bounds: GridBounds[Int], bandIndices: Array[Int]): ArrayMultibandTile = {
    val iter = crop(List(bounds), bandIndices)
-   if (iter.isEmpty) throw GeoAttrsError(s"No intersections of ${bounds} vs ${gridBounds}")
+   if (iter.isEmpty) throw GeoAttrsError(s"No intersections of ${bounds} vs ${dimensions}")
    else iter.next._2
  }
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
@@ -221,7 +221,9 @@ object GeoTiffSegment {
     * @param bandCount Number of bit interleaved into each pixel
     */
   private[raster]
-  def deinterleaveBitSegment(segment: GeoTiffSegment, cols: Int, rows: Int, bandCount: Int): Array[Array[Byte]] = {
+  def deinterleaveBitSegment(segment: GeoTiffSegment, dims: Dimensions[Int], bandCount: Int): Array[Array[Byte]] = {
+    val cols = dims.cols
+    val rows = dims.rows
     val paddedCols = {
       val bytesWidth = (cols + 7) / 8
       bytesWidth * 8
@@ -252,11 +254,13 @@ object GeoTiffSegment {
   }
 
   private[raster]
-  def deinterleaveBitSegment(segment: GeoTiffSegment, cols: Int, rows: Int, bandCount: Int, index: Int): Array[Byte] =
-    deinterleaveBitSegment(segment, cols, rows, bandCount, index :: Nil).head
+  def deinterleaveBitSegment(segment: GeoTiffSegment, dims: Dimensions[Int], bandCount: Int, index: Int): Array[Byte] =
+    deinterleaveBitSegment(segment, dims, bandCount, index :: Nil).head
 
   private[raster]
-  def deinterleaveBitSegment(segment: GeoTiffSegment, cols: Int, rows: Int, bandCount: Int, indices: Traversable[Int]): Array[Array[Byte]] = {
+  def deinterleaveBitSegment(segment: GeoTiffSegment, dims: Dimensions[Int], bandCount: Int, indices: Traversable[Int]): Array[Array[Byte]] = {
+    val cols = dims.cols
+    val rows = dims.rows
     val paddedCols = {
       val bytesWidth = (cols + 7) / 8
       bytesWidth * 8

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegmentLayout.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegmentLayout.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.raster.io.geotiff
 
-import geotrellis.raster.{GridBounds, RasterExtent, TileLayout, PixelIsArea}
+import geotrellis.raster.{GridBounds, RasterExtent, TileLayout, PixelIsArea, Dimensions}
 import geotrellis.raster.rasterize.Rasterizer
 import geotrellis.vector.{Extent, Geometry}
 
@@ -219,7 +219,7 @@ case class GeoTiffSegmentLayout(
     * @param segmentIndex: An Int that represents the given segment in the index
     * @return Tuple representing segment (cols, rows)
     */
-  def getSegmentDimensions(segmentIndex: Int): (Int, Int) = {
+  def getSegmentDimensions(segmentIndex: Int): Dimensions[Int] = {
     val normalizedSegmentIndex = segmentIndex % bandSegmentCount
     val layoutCol = normalizedSegmentIndex % tileLayout.layoutCols
     val layoutRow = normalizedSegmentIndex / tileLayout.layoutCols
@@ -238,12 +238,12 @@ case class GeoTiffSegmentLayout(
         tileLayout.tileRows
       }
 
-    (cols, rows)
+    Dimensions(cols, rows)
   }
 
   private [geotrellis] def getGridBounds(segmentIndex: Int): GridBounds[Int] = {
     val normalizedSegmentIndex = segmentIndex % bandSegmentCount
-    val (segmentCols, segmentRows) = getSegmentDimensions(segmentIndex)
+    val Dimensions(segmentCols, segmentRows) = getSegmentDimensions(segmentIndex)
 
     val (startCol, startRow) = {
       val (layoutCol, layoutRow) = getSegmentCoordinate(normalizedSegmentIndex)
@@ -276,7 +276,7 @@ trait GeoTiffSegmentLayoutTransform {
     * @param segmentIndex: An Int that represents the given segment in the index
     * @return Tuple representing segment (cols, rows)
     */
-  def getSegmentDimensions(segmentIndex: Int): (Int, Int) = {
+  def getSegmentDimensions(segmentIndex: Int): Dimensions[Int] = {
     val normalizedSegmentIndex = segmentIndex % bandSegmentCount
     val layoutCol = normalizedSegmentIndex % tileLayout.layoutCols
     val layoutRow = normalizedSegmentIndex / tileLayout.layoutCols
@@ -295,7 +295,7 @@ trait GeoTiffSegmentLayoutTransform {
         tileLayout.tileRows
       }
 
-    (cols, rows)
+    Dimensions(cols, rows)
   }
 
   /**
@@ -305,7 +305,7 @@ trait GeoTiffSegmentLayoutTransform {
     * @return Pixel size of the segment
     */
   def getSegmentSize(segmentIndex: Int): Int = {
-    val (cols, rows) = getSegmentDimensions(segmentIndex)
+    val Dimensions(cols, rows) = getSegmentDimensions(segmentIndex)
     cols * rows
   }
 
@@ -334,7 +334,7 @@ trait GeoTiffSegmentLayoutTransform {
 
   private [geotrellis] def getGridBounds(segmentIndex: Int): GridBounds[Int] = {
     val normalizedSegmentIndex = segmentIndex % bandSegmentCount
-    val (segmentCols, segmentRows) = getSegmentDimensions(segmentIndex)
+    val Dimensions(segmentCols, segmentRows) = getSegmentDimensions(segmentIndex)
 
     val (startCol, startRow) = {
       val (layoutCol, layoutRow) = getSegmentCoordinate(normalizedSegmentIndex)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
@@ -728,7 +728,7 @@ abstract class GeoTiffTile(
    */
   def crop(bounds: GridBounds[Int]): MutableArrayTile = {
     val iter = crop(List(bounds))
-    if(iter.isEmpty) throw GeoAttrsError(s"No intersections of ${bounds} vs ${gridBounds}")
+    if(iter.isEmpty) throw GeoAttrsError(s"No intersections of ${bounds} vs ${dimensions}")
     else iter.next._2
   }
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SegmentTransform.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SegmentTransform.scala
@@ -16,6 +16,8 @@
 
 package geotrellis.raster.io.geotiff
 
+import geotrellis.raster.Dimensions
+
 private [geotiff] trait SegmentTransform {
   def segmentIndex: Int
   def segmentLayoutTransform: GeoTiffSegmentLayoutTransform
@@ -32,7 +34,7 @@ private [geotiff] trait SegmentTransform {
   protected def layoutCol: Int = segmentIndex % layoutCols
   protected def layoutRow: Int = segmentIndex / layoutCols
 
-  val (segmentCols, segmentRows) =
+  val Dimensions(segmentCols, segmentRows) =
     segmentLayoutTransform.getSegmentDimensions(segmentIndex)
 
   /** The col of the source raster that this index represents. Can produce invalid cols */

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/LocalTileComparatorOp.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/LocalTileComparatorOp.scala
@@ -98,7 +98,7 @@ trait LocalTileComparatorOp extends Serializable {
   /** Apply this operation to the values of each cell in each raster.  */
   def apply(r1: Tile, r2: Tile): Tile = {
     Traversable(r1, r2).assertEqualDimensions
-    val (cols, rows) = r1.dimensions
+    val Dimensions(cols, rows) = r1.dimensions
     val tile = BitArrayTile.ofDim(cols, rows)
 
     cfor(0)(_ < r1.rows, _ + 1) { row =>

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Majority.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Majority.scala
@@ -38,7 +38,7 @@ object Majority extends Serializable {
       sys.error("Can't compute majority of empty sequence")
     } else {
       val newCellType = rs.map(_.cellType).reduce(_.union(_))
-      val (cols, rows) = rs.head.dimensions
+      val Dimensions(cols, rows) = rs.head.dimensions
       val tile = ArrayTile.alloc(newCellType, cols, rows)
 
       if(newCellType.isFloatingPoint) {

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/MaxN.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/MaxN.scala
@@ -94,7 +94,7 @@ object MaxN extends Serializable {
       sys.error(s"Not enough values to compute Nth")
     } else {
       val newCellType = rs.map(_.cellType).reduce(_.union(_))
-      val (cols, rows) = rs.head.dimensions
+      val Dimensions(cols, rows) = rs.head.dimensions
       val tile = ArrayTile.alloc(newCellType, cols, rows)
 
       cfor(0)(_ < rows, _ + 1) { row =>

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Mean.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Mean.scala
@@ -38,7 +38,7 @@ object Mean extends Serializable {
       sys.error(s"Can't compute mean of empty sequence")
     } else {
       val newCellType = rs.map(_.cellType).reduce(_.union(_))
-      val (cols, rows) = rs(0).dimensions
+      val Dimensions(cols, rows) = rs(0).dimensions
       val tile = ArrayTile.alloc(newCellType, cols, rows)
       if(newCellType.isFloatingPoint) {
         cfor(0)(_ < rows, _ + 1) { row =>

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/MinN.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/MinN.scala
@@ -95,7 +95,7 @@ object MinN extends Serializable {
       sys.error(s"Not enough values to compute Nth")
     } else {
       val newCellType = rs.map(_.cellType).reduce(_.union(_))
-      val (cols, rows) = rs.head.dimensions
+      val Dimensions(cols, rows) = rs.head.dimensions
       val tile = ArrayTile.alloc(newCellType, cols, rows)
 
       cfor(0)(_ < rows, _ + 1) { row =>

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Minority.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Minority.scala
@@ -46,7 +46,7 @@ object Minority extends Serializable {
       sys.error(s"Can't compute minority of empty sequence")
     } else {
       val newCellType = rs.map(_.cellType).reduce(_.union(_))
-      val (cols, rows) = rs.head.dimensions
+      val Dimensions(cols, rows) = rs.head.dimensions
       val tile = ArrayTile.alloc(newCellType, cols, rows)
 
       if(newCellType.isFloatingPoint) {

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Variance.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Variance.scala
@@ -41,7 +41,7 @@ object Variance extends Serializable {
     if (layerCount == 0) sys.error(s"Can't compute variance of empty sequence.")
     else {
       val newCellType = rs.map(_.cellType).reduce(_.union(_))
-      val (cols, rows) = rs(0).dimensions
+      val Dimensions(cols, rows) = rs(0).dimensions
       val tile = ArrayTile.alloc(newCellType, cols, rows)
 
       cfor(0)(_ < rows, _ + 1) { row =>

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Variety.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Variety.scala
@@ -39,7 +39,7 @@ object Variety extends Serializable {
     if(layerCount == 0) {
       sys.error(s"Can't compute variety of empty sequence")
     } else {
-      val (cols, rows) = rs(0).dimensions
+      val Dimensions(cols, rows) = rs(0).dimensions
       val tile = ArrayTile.alloc(IntConstantNoDataCellType, cols, rows)
 
       cfor(0)(_ < rows, _ + 1) { row =>

--- a/raster/src/main/scala/geotrellis/raster/viewshed/Viewshed.scala
+++ b/raster/src/main/scala/geotrellis/raster/viewshed/Viewshed.scala
@@ -32,7 +32,7 @@ import spire.syntax.cfor._
   */
 object Viewshed extends Serializable {
   def apply(r: Tile, startCol: Int, startRow: Int): Tile = {
-    val (cols, rows) = r.dimensions
+    val Dimensions(cols, rows) = r.dimensions
     val tile = ArrayTile.alloc(BitCellType,cols,rows)
 
     val height = r.getDouble(startCol, startRow)
@@ -54,7 +54,7 @@ object Viewshed extends Serializable {
   }
 
   def offsets(r: Tile, startCol: Int, startRow: Int): Tile = {
-    val (cols, rows) = r.dimensions
+    val Dimensions(cols, rows) = r.dimensions
 
     if(startRow >= rows || startRow < 0 || startCol >= cols || startCol < 0) {
       sys.error("Point indices out of bounds")

--- a/raster/src/test/scala/geotrellis/raster/MosaicRasterSourceSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/MosaicRasterSourceSpec.scala
@@ -108,7 +108,8 @@ class MosaicRasterSourceSpec extends FunSpec with RasterMatchers with GeoTiffTes
                                      8, 4)),
           mosaicRasterSource.gridExtent.extent
       )
-      val result = mosaicRasterSource.read(mosaicRasterSource.gridBounds, Seq(0)).get
+      val bounds = GridBounds(mosaicRasterSource.dimensions)
+      val result = mosaicRasterSource.read(bounds, Seq(0)).get
       result shouldEqual expectation
       result.extent shouldEqual expectation.extent
     }

--- a/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffRasterSourceMultiThreadingSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffRasterSourceMultiThreadingSpec.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.raster.geotiff
 
-import geotrellis.raster.RasterSource
+import geotrellis.raster.{RasterSource, GridBounds}
 import geotrellis.proj4.CRS
 import geotrellis.raster.resample._
 import geotrellis.raster.io.geotiff.GeoTiffTestUtils
@@ -48,9 +48,10 @@ class GeoTiffRasterSourceMultiThreadingSpec extends AsyncFunSpec with GeoTiffTes
     }
 
     it("readBounds") {
+      val bounds = GridBounds(rs.dimensions)
       val res =
         iterations
-          .map { _ => Future { rs.read(rs.gridBounds, 0 until rs.bandCount) } }
+          .map { _ => Future { rs.read(bounds, 0 until rs.bandCount) } }
           .sequence
           .map(_.flatten)
 

--- a/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffRasterSourceSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffRasterSourceSpec.scala
@@ -72,13 +72,9 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhen
     val actual: Raster[MultibandTile] =
       resampledSource.read(GridBounds(0, 0, resampledSource.cols - 1, resampledSource.rows - 1)).get
 
-    // calculated expected resolutions of overviews
-    // it's a rough approximation there as we're not calculating resolutions like GDAL
-    val ratio = resampledSource.cellSize.resolution / source.cellSize.resolution
-    resampledSource.resolutions.zip (source.resolutions.map { re =>
-      val CellSize(cw, ch) = re.cellSize
-      RasterExtent(re.extent, CellSize(cw * ratio, ch * ratio))
-    }).map { case (rea, ree) => rea.cellSize.resolution shouldBe ree.cellSize.resolution +- 1e-7 }
+    resampledSource.resolutions.zip(source.resolutions).map { case (rea, ree) =>
+      rea.resolution shouldBe ree.resolution +- 1e-7
+    }
 
     withGeoTiffClue(actual, expected, resampledSource.crs)  {
       assertRastersEqual(actual, expected)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTileSpec.scala
@@ -748,41 +748,47 @@ class GeoTiffMultibandTileSpec extends FunSpec
     val bandStripedRasterExtent = RasterExtent(bandStripedGeoTiff.extent, bandStripedGeoTiff.cols, bandStripedGeoTiff.rows)
 
     it("should have the correct number of subset bands - pixel") {
-      val cropped = pixelStripedGeoTiff.tile.cropBands(pixelStripedRasterExtent.gridBounds, Array(1, 0))
+      val bounds = GridBounds(pixelStripedRasterExtent.dimensions)
+      val cropped = pixelStripedGeoTiff.tile.cropBands(bounds, Array(1, 0))
 
       cropped.bands.size should be (2)
     }
 
     it("should have the correct number of subset bands - band") {
-      val cropped = bandStripedGeoTiff.tile.cropBands(bandStripedRasterExtent.gridBounds, Array(1))
+      val bounds = GridBounds(bandStripedRasterExtent.dimensions)
+      val cropped = bandStripedGeoTiff.tile.cropBands(bounds, Array(1))
 
       cropped.bands.size should be (1)
     }
 
     it("should have the crop the correct area - pixel striped") {
-      val actual = pixelStripedGeoTiff.tile.cropBands(pixelStripedRasterExtent.gridBounds, Array(1, 0, 2))
-      val expected = pixelStripedGeoTiff.crop(pixelStripedRasterExtent.gridBounds).tile.subsetBands(1, 0, 2)
+      val bounds = GridBounds(pixelStripedRasterExtent.dimensions)
+      val actual = pixelStripedGeoTiff.tile.cropBands(bounds, Array(1, 0, 2))
+      val expected = pixelStripedGeoTiff.crop(bounds).tile.subsetBands(1, 0, 2)
 
       actual should be (expected)
     }
 
     it("should have the crop the correct area - pixel tiled") {
-      val actual = pixelTiledGeoTiff.tile.cropBands(pixelStripedRasterExtent.gridBounds, Array(1, 0, 2))
-      val expected = pixelTiledGeoTiff.crop(pixelStripedRasterExtent.gridBounds).tile.subsetBands(1, 0, 2)
+      val bounds = GridBounds(pixelStripedRasterExtent.dimensions)
+      val actual = pixelTiledGeoTiff.tile.cropBands(bounds, Array(1, 0, 2))
+      val expected = pixelTiledGeoTiff.crop(bounds).tile.subsetBands(1, 0, 2)
 
       actual should be (expected)
     }
 
     it("should have the crop the correct area - band striped") {
-      val actual = bandStripedGeoTiff.tile.cropBands(bandStripedRasterExtent.gridBounds, Array(1, 2, 0))
-      val expected = bandStripedGeoTiff.crop(bandStripedRasterExtent.gridBounds).tile.subsetBands(1, 2, 0)
+      val bounds = GridBounds(bandStripedRasterExtent.dimensions)
+      val actual = bandStripedGeoTiff.tile.cropBands(bounds, Array(1, 2, 0))
+      val expected = bandStripedGeoTiff.crop(bounds).tile.subsetBands(1, 2, 0)
 
       actual should be (expected)
     }
 
     it("should have the crop the correct area - band tiled") {
-      val actual = bandTiledGeoTiff.tile.cropBands(bandStripedRasterExtent.gridBounds, Array(1, 2, 0))
-      val expected = bandTiledGeoTiff.crop(bandStripedRasterExtent.gridBounds).tile.subsetBands(1, 2, 0)
+      val bounds = GridBounds(bandStripedRasterExtent.dimensions)
+      val actual = bandTiledGeoTiff.tile.cropBands(bounds, Array(1, 2, 0))
+      val expected = bandTiledGeoTiff.crop(bounds).tile.subsetBands(1, 2, 0)
 
       actual should be (expected)
     }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -73,8 +73,7 @@ class GeoTiffReaderSpec extends FunSpec
       val path = "modelTransformation.tiff"
       val compressed: SinglebandGeoTiff = SinglebandGeoTiff(geoTiffPath(path))
       val tile = compressed.tile
-      val bounds = tile.gridBounds
-      bounds.width should be(1121)
+      tile.cols should be(1121)
       compressed.crs should be(CRS.fromName("EPSG:4326"))
       if (compressed.extent.min.distance(Point(59.9955397, 30.0044603)) > 0.0001) {
         compressed.extent.min should be(Point(59.9955397, 30.0044603))

--- a/raster/src/test/scala/geotrellis/raster/reproject/ReprojectSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/reproject/ReprojectSpec.scala
@@ -120,7 +120,7 @@ class ReprojectSpec extends FunSpec
 
     it("should reproject two landsat tiles into rasters that don't have nodata lines of NODATA") {
       def detectNoDataLine(tile: Tile): Unit = {
-        val (cols, rows) = tile.dimensions
+        val Dimensions(cols, rows) = tile.dimensions
         val noDataColCounts = Array.ofDim[Int](cols)
         cfor(0)(_ < rows, _ + 1) { row =>
           cfor(0)(_ < cols, _ + 1) { col =>

--- a/spark/src/main/scala/geotrellis/spark/store/RasterReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/RasterReader.scala
@@ -73,7 +73,7 @@ object RasterReader {
     def readWindows(gbs: Array[GridBounds[Int]], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
       val geoTiff = GeoTiffReader.geoTiffSinglebandTile(info)
       val re = info.rasterExtent
-      geoTiff.crop(gbs.filter(geoTiff.gridBounds.intersects)).map { case (gb, tile) =>
+      geoTiff.crop(gbs.filter(_.intersects(geoTiff.dimensions))).map { case (gb, tile) =>
         (ProjectedExtent(re.extentFor(gb, clamp = false), options.crs.getOrElse(info.crs)), tile)
       }
     }
@@ -95,7 +95,7 @@ object RasterReader {
     def readWindows(gbs: Array[GridBounds[Int]], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
       val geoTiff = GeoTiffReader.geoTiffMultibandTile(info)
       val re = info.rasterExtent
-      geoTiff.crop(gbs.filter(geoTiff.gridBounds.intersects)).map { case (gb, tile) =>
+      geoTiff.crop(gbs.filter(_.intersects(geoTiff.dimensions))).map { case (gb, tile) =>
         (ProjectedExtent(re.extentFor(gb, clamp = false), options.crs.getOrElse(info.crs)), tile)
       }
     }
@@ -121,7 +121,7 @@ object RasterReader {
     def readWindows(gbs: Array[GridBounds[Int]], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
       val geoTiff = GeoTiffReader.geoTiffSinglebandTile(info)
       val re = info.rasterExtent
-      geoTiff.crop(gbs.filter(geoTiff.gridBounds.intersects)).map { case (gb, tile) =>
+      geoTiff.crop(gbs.filter(_.intersects(geoTiff.dimensions))).map { case (gb, tile) =>
         (TemporalProjectedExtent(
           extent = re.extentFor(gb, clamp = false),
           crs = options.crs.getOrElse(info.crs),
@@ -151,7 +151,7 @@ object RasterReader {
     def readWindows(gbs: Array[GridBounds[Int]], info: GeoTiffReader.GeoTiffInfo, options: Options) = {
       val geoTiff = GeoTiffReader.geoTiffMultibandTile(info)
       val re = info.rasterExtent
-      geoTiff.crop(gbs.filter(geoTiff.gridBounds.intersects)).map { case (gb, tile) =>
+      geoTiff.crop(gbs.filter(_.intersects(geoTiff.dimensions))).map { case (gb, tile) =>
         (TemporalProjectedExtent(
           extent = re.extentFor(gb, clamp = false ),
           crs = options.crs.getOrElse(info.crs),

--- a/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
@@ -203,7 +203,7 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
       val expected = expectedMultibandTile
 
       // random chip to test agains, to speed up tests
-      val gridBounds = RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).gridBounds
+      val gridBounds = GridBounds(RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).dimensions)
 
       expected.dimensions shouldBe actual.dimensions
 
@@ -228,7 +228,7 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
       val actual = RasterSourceRDD.read(readingSources, floatingLayout).stitch()
 
       // random chip to test agains, to speed up tests
-      val gridBounds = RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).gridBounds
+      val gridBounds = GridBounds(RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).dimensions)
 
       assertEqual(expected.crop(gridBounds), actual.tile.crop(gridBounds))
     }
@@ -249,7 +249,7 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
       val actual = RasterSourceRDD.read(readingSources, floatingLayout).stitch()
 
       // random chip to test agains, to speed up tests
-      val gridBounds = RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).gridBounds
+      val gridBounds = GridBounds(RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).dimensions)
 
       assertEqual(expected.crop(gridBounds), actual.tile.crop(gridBounds))
     }
@@ -275,7 +275,7 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
       val actual = RasterSourceRDD.read(readingSources, floatingLayout).stitch()
 
       // random chip to test agains, to speed up tests
-      val gridBounds = RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).gridBounds
+      val gridBounds = GridBounds(RasterExtent(randomExtentWithin(actual.extent), actual.cellSize).dimensions)
 
       assertEqual(expected.crop(gridBounds), actual.tile.crop(gridBounds))
     }

--- a/spark/src/test/scala/geotrellis/store/TestCatalog.scala
+++ b/spark/src/test/scala/geotrellis/store/TestCatalog.scala
@@ -18,7 +18,7 @@ package geotrellis.store
 
 import geotrellis.layer.{LayoutDefinition, SpatialKey}
 import geotrellis.raster.geotiff.GeoTiffRasterSource
-import geotrellis.raster.{ArrayMultibandTile, MultibandTile}
+import geotrellis.raster.{ArrayMultibandTile, MultibandTile, RasterExtent}
 import geotrellis.spark.store.file.FileLayerWriter
 import geotrellis.spark._
 import geotrellis.store.file.FileAttributeStore
@@ -45,7 +45,8 @@ object TestCatalog {
     val writer = FileLayerWriter(attributeStore)
 
     val rs = GeoTiffRasterSource(TestCatalog.filePath)
-    rs.resolutions.sortBy(_.cellSize.resolution).zipWithIndex.foreach { case (rasterExtent, index) =>
+    rs.resolutions.sortBy(_.resolution).zipWithIndex.foreach { case (cellSize, index) =>
+      val rasterExtent = RasterExtent(rs.extent, cellSize)
       val layout = LayoutDefinition(rasterExtent, tileSize = 256)
 
       val rdd: MultibandTileLayerRDD[SpatialKey] =
@@ -68,7 +69,8 @@ object TestCatalog {
     val writer = FileLayerWriter(attributeStore)
 
     val rs = GeoTiffRasterSource(TestCatalog.filePath)
-    rs.resolutions.sortBy(_.cellSize.resolution).zipWithIndex.foreach { case (rasterExtent, index) =>
+    rs.resolutions.sortBy(_.resolution).zipWithIndex.foreach { case (cellSize, index) =>
+      val rasterExtent = RasterExtent(rs.extent, cellSize)
       val layout = LayoutDefinition(rasterExtent, tileSize = 256)
 
       val rdd: TileLayerRDD[SpatialKey] =

--- a/spark/src/test/scala/geotrellis/store/TestCatalogSpec.scala
+++ b/spark/src/test/scala/geotrellis/store/TestCatalogSpec.scala
@@ -75,7 +75,7 @@ class TestCatalogSpec extends FunSpec with CatalogTestEnvironment {
     it("preserves cell size") {
       info(reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](LayerId("landsat", 0)).cellSize.toString)
       // TODO: Make geotrellis.raster.CellSize sortable
-      val expectedCellSizes = rs.resolutions.map(_.cellSize).sortBy(_.resolution)
+      val expectedCellSizes = rs.resolutions.sortBy(_.resolution)
       info(expectedCellSizes.toString)
       val actualCellSizes = reader.attributeStore.layerIds.map(layerId => reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](layerId).cellSize).sortBy(_.resolution)
       info(actualCellSizes.toString)
@@ -93,4 +93,3 @@ class TestCatalogSpec extends FunSpec with CatalogTestEnvironment {
   }
 
 }
-

--- a/store/src/main/scala/geotrellis/store/GeoTrellisMetadata.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisMetadata.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.store
 
-import geotrellis.raster.{RasterMetadata, SourceName}
+import geotrellis.raster.{RasterMetadata, SourceName, CellSize}
 import geotrellis.proj4.CRS
 import geotrellis.raster.{CellType, GridExtent}
 

--- a/store/src/main/scala/geotrellis/store/GeoTrellisMetadata.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisMetadata.scala
@@ -26,10 +26,9 @@ case class GeoTrellisMetadata(
   bandCount: Int,
   cellType: CellType,
   gridExtent: GridExtent[Long],
-  resolutions: List[GridExtent[Long]],
+  resolutions: List[CellSize],
   attributes: Map[String, String]
 ) extends RasterMetadata {
   /** GeoTrellis metadata doesn't allow to query a per band metadata by default. */
   def attributesForBand(band: Int): Map[String, String] = Map.empty
 }
-

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -79,7 +79,7 @@ class GeoTrellisRasterSource(
   def metadata: GeoTrellisMetadata = GeoTrellisMetadata(name, crs, bandCount, cellType, gridExtent, resolutions, attributes)
 
   // reference to this will fully initilze the sourceLayers stream
-  lazy val resolutions: List[GridExtent[Long]] = sourceLayers.map(_.gridExtent).toList
+  lazy val resolutions: List[CellSize] = sourceLayers.map(_.cellSize).toList
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     GeoTrellisRasterSource.read(reader, layerId, layerMetadata, extent, bands).map(convertRaster)

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -79,7 +79,7 @@ class GeoTrellisRasterSource(
   def metadata: GeoTrellisMetadata = GeoTrellisMetadata(name, crs, bandCount, cellType, gridExtent, resolutions, attributes)
 
   // reference to this will fully initilze the sourceLayers stream
-  lazy val resolutions: List[CellSize] = sourceLayers.map(_.cellSize).toList
+  lazy val resolutions: List[CellSize] = sourceLayers.map(_.gridExtent.cellSize).toList
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     GeoTrellisRasterSource.read(reader, layerId, layerMetadata, extent, bands).map(convertRaster)
@@ -87,7 +87,7 @@ class GeoTrellisRasterSource(
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] =
     bounds
-      .intersection(this.gridBounds)
+      .intersection(this.dimensions)
       .map(gridExtent.extentFor(_).buffer(- cellSize.width / 2, - cellSize.height / 2))
       .flatMap(read(_, bands))
 
@@ -95,7 +95,7 @@ class GeoTrellisRasterSource(
     extents.toIterator.flatMap(read(_, bands))
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
-    bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
+    bounds.toIterator.flatMap(_.intersection(this.dimensions).flatMap(read(_, bands)))
 
   def reprojection(targetCRS: CRS, resampleGrid: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
     if (targetCRS != this.crs) {

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -103,7 +103,7 @@ class GeoTrellisReprojectRasterSource(
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] =
     bounds
-      .intersection(this.gridBounds)
+      .intersection(this.dimensions)
       .map(gridExtent.extentFor(_).buffer(- cellSize.width / 2, - cellSize.height / 2))
       .flatMap(read(_, bands))
 
@@ -111,7 +111,7 @@ class GeoTrellisReprojectRasterSource(
     extents.toIterator.flatMap(read(_, bands))
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
-    bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
+    bounds.toIterator.flatMap(_.intersection(this.dimensions).flatMap(read(_, bands)))
 
   def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
     if (targetCRS == sourceLayer.metadata.crs) {

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -43,9 +43,9 @@ class GeoTrellisReprojectRasterSource(
 
   lazy val reader = CollectionLayerReader(attributeStore, dataPath.value)
 
-  lazy val resolutions: List[GridExtent[Long]] = {
+  lazy val resolutions: List[CellSize] = {
     sourceLayers.map { layer =>
-      ReprojectRasterExtent(layer.gridExtent, Transform(layer.metadata.crs, crs), DefaultTarget)
+      ReprojectRasterExtent(layer.gridExtent, Transform(layer.metadata.crs, crs), DefaultTarget).cellSize
     }
   }.toList
 

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -75,7 +75,7 @@ class GeoTrellisResampleRasterSource(
 
   def metadata: GeoTrellisMetadata = GeoTrellisMetadata(name, crs, bandCount, cellType, gridExtent, resolutions, attributes)
 
-  lazy val resolutions: List[CellSize] = sourceLayers.map(_.cellSize).toList
+  lazy val resolutions: List[CellSize] = sourceLayers.map(_.gridExtent.cellSize).toList
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tileBounds = sourceLayer.metadata.mapTransform.extentToBounds(extent)
@@ -95,7 +95,7 @@ class GeoTrellisResampleRasterSource(
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     bounds
-      .intersection(this.gridBounds)
+      .intersection(this.dimensions)
       .map(gridExtent.extentFor(_).buffer(- cellSize.width / 2, - cellSize.height / 2))
       .flatMap(read(_, bands))
   }
@@ -123,7 +123,7 @@ class GeoTrellisResampleRasterSource(
     extents.toIterator.flatMap(read(_, bands))
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
-    bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
+    bounds.toIterator.flatMap(_.intersection(this.dimensions).flatMap(read(_, bands)))
 
   override def toString: String =
     s"GeoTrellisResampleRasterSource(${dataPath.toString},$layerId,$gridExtent,$resampleMethod)"

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -75,7 +75,7 @@ class GeoTrellisResampleRasterSource(
 
   def metadata: GeoTrellisMetadata = GeoTrellisMetadata(name, crs, bandCount, cellType, gridExtent, resolutions, attributes)
 
-  lazy val resolutions: List[GridExtent[Long]] = sourceLayers.map(_.gridExtent).toList
+  lazy val resolutions: List[CellSize] = sourceLayers.map(_.cellSize).toList
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tileBounds = sourceLayer.metadata.mapTransform.extentToBounds(extent)


### PR DESCRIPTION
## Overview

Changes the `resolutions` field on `RasterSource` interface to `List[CellSize]` from `List[GridExtent[Long]]`. This is uniformly agreed upon change that helps to address linked issue.

Also removes `gridBounds` from `Grid` trait. Where it is used to check for intersection of `GridBounds` against a raster we now use `dimensions` field of the raster.

Overall this actually greatly improves the readability of the code in the commit.

### Checklist

-  ~`docs/CHANGELOG.rst` updated, if necessary~
- ~New user API has useful Scaladoc strings~
- [x] Unit tests added for bug-fix or new feature

### Notes


Connects https://github.com/locationtech/geotrellis/issues/3100

This PR is based on https://github.com/locationtech/geotrellis/pull/3097 to simplify the rebase dance and should be merged afterwards
