### PR TITLE
Remove usage of LazyLogging

### DIFF
--- a/accumulo-spark/src/main/scala/geotrellis/spark/store/accumulo/AccumuloLayerWriter.scala
+++ b/accumulo-spark/src/main/scala/geotrellis/spark/store/accumulo/AccumuloLayerWriter.scala
@@ -25,8 +25,8 @@ import geotrellis.store.index._
 import geotrellis.spark.store._
 import geotrellis.spark.merge._
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.rdd.RDD
 import io.circe._
 import cats.Semigroup
@@ -38,7 +38,8 @@ class AccumuloLayerWriter(
   instance: AccumuloInstance,
   table: String,
   options: AccumuloLayerWriter.Options
-) extends LayerWriter[LayerId] with LazyLogging {
+) extends LayerWriter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   // Layer Updating
   def overwrite[

--- a/accumulo/src/main/scala/geotrellis/store/accumulo/AccumuloLayerDeleter.scala
+++ b/accumulo/src/main/scala/geotrellis/store/accumulo/AccumuloLayerDeleter.scala
@@ -18,16 +18,16 @@ package geotrellis.store.accumulo
 
 import geotrellis.layer._
 import geotrellis.store._
-
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.accumulo.core.client.{BatchWriterConfig, Connector}
 import org.apache.accumulo.core.security.Authorizations
 import org.apache.accumulo.core.data.{Range => AccumuloRange}
 
 import scala.collection.JavaConverters._
 
-class AccumuloLayerDeleter(val attributeStore: AttributeStore, connector: Connector) extends LazyLogging with LayerDeleter[LayerId] {
+class AccumuloLayerDeleter(val attributeStore: AttributeStore, connector: Connector) extends LayerDeleter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   def delete(id: LayerId): Unit = {
     try {

--- a/cassandra-spark/src/main/scala/geotrellis/spark/store/cassandra/CassandraLayerWriter.scala
+++ b/cassandra-spark/src/main/scala/geotrellis/spark/store/cassandra/CassandraLayerWriter.scala
@@ -25,8 +25,8 @@ import geotrellis.store.index._
 import geotrellis.spark.store._
 import geotrellis.spark.merge._
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.rdd.RDD
 import io.circe._
 import cats.Semigroup
@@ -38,7 +38,8 @@ class CassandraLayerWriter(
   instance: CassandraInstance,
   keyspace: String,
   table: String
-) extends LayerWriter[LayerId] with LazyLogging {
+) extends LayerWriter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   // Layer updating
   def overwrite[

--- a/cassandra/src/main/scala/geotrellis/store/cassandra/CassandraLayerDeleter.scala
+++ b/cassandra/src/main/scala/geotrellis/store/cassandra/CassandraLayerDeleter.scala
@@ -17,16 +17,16 @@
 package geotrellis.store.cassandra
 
 import geotrellis.store._
-
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.querybuilder.QueryBuilder.{eq => eqs}
 
 import scala.collection.JavaConverters._
 
 
-class CassandraLayerDeleter(val attributeStore: AttributeStore, instance: CassandraInstance) extends LazyLogging with LayerDeleter[LayerId] {
+class CassandraLayerDeleter(val attributeStore: AttributeStore, instance: CassandraInstance) extends LayerDeleter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   def delete(id: LayerId): Unit = {
     try {

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,16 @@ Changelog
 =========
 
 3.0.0-SNAPSHOT
+=======
+
+2.3.3
+_____
+*2019 Oct 4*
+
+- Remove direct usage of `com.typesafe.scalalogging.LazyLogging` trait
+- Upgrade to Proj4J 1.1.0
+
+2.3.2
 -----
 
 API Changes & Project structure changes

--- a/geomesa/src/main/scala/geotrellis/spark/store/geomesa/GeoMesaFeatureReader.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/store/geomesa/GeoMesaFeatureReader.scala
@@ -20,7 +20,6 @@ import geotrellis.geotools._
 import geotrellis.spark._
 import geotrellis.util.annotations.experimental
 import geotrellis.vector._
-import com.typesafe.scalalogging.LazyLogging
 import geotrellis.store.LayerId
 import org.apache.accumulo.core.client.mapreduce.InputFormatBase
 import org.apache.hadoop.io.Text
@@ -38,9 +37,7 @@ import scala.reflect.ClassTag
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
 @experimental class GeoMesaFeatureReader(val instance: GeoMesaInstance)
-                                        (implicit sc: SparkContext) extends Serializable with LazyLogging {
-
-  logger.error("GeoMesa support is experimental")
+                                        (implicit sc: SparkContext) extends Serializable {
 
   /** $experimental */
   @experimental def readSimpleFeatures(

--- a/geomesa/src/main/scala/geotrellis/spark/store/geomesa/GeoMesaFeatureWriter.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/store/geomesa/GeoMesaFeatureWriter.scala
@@ -20,7 +20,6 @@ import geotrellis.geomesa.geotools._
 import geotrellis.spark._
 import geotrellis.util.annotations.experimental
 import geotrellis.vector._
-import com.typesafe.scalalogging.LazyLogging
 import geotrellis.store.LayerId
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
@@ -31,9 +30,7 @@ import org.opengis.feature.simple.SimpleFeatureType
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
 @experimental class GeoMesaFeatureWriter(val instance: GeoMesaInstance)
-                                        (implicit sc: SparkContext) extends Serializable with LazyLogging {
-
-  logger.error("GeoMesa support is experimental")
+                                        (implicit sc: SparkContext) extends Serializable {
 
   /** $experimental */
   @experimental def write[G <: Geometry, D: * => Seq[(String, Any)]: λ[α => Feature[G, α] => FeatureToGeoMesaSimpleFeatureMethods[G, α]]]

--- a/geomesa/src/main/scala/geotrellis/spark/store/geomesa/GeoMesaInstance.scala
+++ b/geomesa/src/main/scala/geotrellis/spark/store/geomesa/GeoMesaInstance.scala
@@ -17,7 +17,6 @@
 package geotrellis.spark.store.geomesa
 
 import geotrellis.util.annotations.experimental
-import com.typesafe.scalalogging.LazyLogging
 import geotrellis.store.LayerId
 import org.geotools.data.DataStoreFinder
 import org.locationtech.geomesa.accumulo.data.AccumuloDataStore
@@ -27,9 +26,7 @@ import scala.collection.JavaConverters._
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental class GeoMesaInstance(val conf: Map[String, String])
-    extends Serializable with LazyLogging {
-  logger.error("GeoMesa support is experimental")
+@experimental class GeoMesaInstance(val conf: Map[String, String]) extends Serializable {
 
   val SEP = "__.__"
 

--- a/geowave/src/main/scala/geotrellis/spark/store/geowave/GeoWaveAttributeStore.scala
+++ b/geowave/src/main/scala/geotrellis/spark/store/geowave/GeoWaveAttributeStore.scala
@@ -27,7 +27,8 @@ import geotrellis.spark._
 import geotrellis.spark.store._
 import geotrellis.util._
 import geotrellis.util.annotations.experimental
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
 import mil.nga.giat.geowave.core.geotime.ingest._
 import mil.nga.giat.geowave.core.geotime.store.statistics.BoundingBoxDataStatistics
@@ -119,9 +120,8 @@ import scala.collection.JavaConverters._
   val accumuloUser: String,
   val accumuloPass: String,
   val geowaveNamespace: String
-) extends DiscreteLayerAttributeStore with LazyLogging {
-
-  logger.error("GeoWave support is experimental")
+) extends DiscreteLayerAttributeStore {
+  @transient protected lazy val logger: Logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   val zkInstance = (new ZooKeeperInstance(accumuloInstance, zookeepers))
   val token = new PasswordToken(accumuloPass)

--- a/geowave/src/main/scala/geotrellis/spark/store/geowave/GeoWaveLayerReader.scala
+++ b/geowave/src/main/scala/geotrellis/spark/store/geowave/GeoWaveLayerReader.scala
@@ -94,9 +94,7 @@ object GeoWaveLayerReader {
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
 @experimental class GeoWaveLayerReader(val attributeStore: AttributeStore)
-  (implicit sc: SparkContext) extends LazyLogging {
-
-  logger.error("GeoWave support is experimental")
+  (implicit sc: SparkContext) {
 
   val defaultNumPartitions = sc.defaultParallelism
 

--- a/geowave/src/main/scala/geotrellis/spark/store/geowave/GeoWaveLayerWriter.scala
+++ b/geowave/src/main/scala/geotrellis/spark/store/geowave/GeoWaveLayerWriter.scala
@@ -29,11 +29,9 @@ import geotrellis.spark._
 import geotrellis.spark.store.accumulo.AccumuloWriteStrategy
 import geotrellis.util._
 import geotrellis.util.annotations.experimental
-
 import _root_.io.circe._
-
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import mil.nga.giat.geowave.adapter.raster.adapter.merge.RasterTileRowTransform
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter
 import mil.nga.giat.geowave.core.geotime.index.dimension._
@@ -79,7 +77,8 @@ import resource._
 /**
   * @define experimental <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>@experimental
   */
-@experimental object GeoWaveLayerWriter extends LazyLogging {
+@experimental object GeoWaveLayerWriter {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   /** $experimental */
   @experimental def write[
@@ -256,10 +255,8 @@ import resource._
 @experimental class GeoWaveLayerWriter(
   val attributeStore: GeoWaveAttributeStore,
   val accumuloWriter: AccumuloWriteStrategy
-)(implicit sc: SparkContext)
-    extends LazyLogging {
-
-  logger.error("GeoWave support is experimental")
+)(implicit sc: SparkContext) {
+  @transient protected lazy val logger: Logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   /** $experimental */
   @experimental def write[

--- a/hbase-spark/src/main/scala/geotrellis/spark/store/hbase/HBaseLayerDeleter.scala
+++ b/hbase-spark/src/main/scala/geotrellis/spark/store/hbase/HBaseLayerDeleter.scala
@@ -21,12 +21,15 @@ import geotrellis.store._
 import geotrellis.store.hbase._
 import geotrellis.spark.store._
 import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.hbase.client._
 import org.apache.hadoop.hbase.filter.PrefixFilter
 
 import scala.collection.JavaConverters._
 
-class HBaseLayerDeleter(val attributeStore: AttributeStore, instance: HBaseInstance) extends LazyLogging with LayerDeleter[LayerId] {
+class HBaseLayerDeleter(val attributeStore: AttributeStore, instance: HBaseInstance) extends LayerDeleter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   def delete(id: LayerId): Unit = {
     try{

--- a/hbase-spark/src/main/scala/geotrellis/spark/store/hbase/HBaseLayerWriter.scala
+++ b/hbase-spark/src/main/scala/geotrellis/spark/store/hbase/HBaseLayerWriter.scala
@@ -26,8 +26,8 @@ import geotrellis.store.avro._
 import geotrellis.store.avro.codecs._
 import geotrellis.store.index._
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.rdd.RDD
 import io.circe._
 import cats.Semigroup
@@ -38,7 +38,8 @@ class HBaseLayerWriter(
   val attributeStore: AttributeStore,
   instance: HBaseInstance,
   table: String
-) extends LayerWriter[LayerId] with LazyLogging {
+) extends LayerWriter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   // Layer Updating
   def overwrite[

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -28,10 +28,10 @@ object Version {
   val geowave     = "0.9.3"
   val circe       = "0.11.1"
   val previousVersion = "2.2.0"
-  
+
   val gdal     = "2.4.0"
   val gdalWarp = "33.61199eb"
-  
+
   lazy val hadoop = Environment.hadoopVersion
   lazy val spark  = Environment.sparkVersion
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
@@ -19,7 +19,6 @@ package geotrellis.raster.io.geotiff
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.compression._
 
-import com.typesafe.scalalogging.LazyLogging
 import spire.syntax.cfor._
 
 import scala.collection.mutable
@@ -308,7 +307,7 @@ abstract class GeoTiffMultibandTile(
   val compression: Compression,
   val bandCount: Int,
   val overviews: List[GeoTiffMultibandTile] = Nil
-) extends MultibandTile with GeoTiffImageData with GeoTiffSegmentLayoutTransform with MacroGeotiffMultibandCombiners with LazyLogging {
+) extends MultibandTile with GeoTiffImageData with GeoTiffSegmentLayoutTransform with MacroGeotiffMultibandCombiners {
   val cellType: CellType
   val cols: Int = segmentLayout.totalCols
   val rows: Int = segmentLayout.totalRows

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/LazySegmentBytes.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/LazySegmentBytes.scala
@@ -18,8 +18,8 @@ package geotrellis.raster.io.geotiff
 
 import geotrellis.util._
 import geotrellis.raster.io.geotiff.tags._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import monocle.syntax.apply._
 
 /**
@@ -38,8 +38,10 @@ class LazySegmentBytes(
   tiffTags: TiffTags,
   maxChunkSize: Int = 32 * 1024 * 1024,
   maxOffsetBetweenChunks: Int = 1024
-) extends SegmentBytes with LazyLogging {
+) extends SegmentBytes {
   import LazySegmentBytes.Segment
+
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   def length: Int = tiffTags.segmentCount
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/TiffTagsReader.scala
@@ -22,14 +22,16 @@ import TagCodes._
 import TiffFieldType._
 import geotrellis.util.{ByteReader, Filesystem}
 import geotrellis.raster.io.geotiff.util._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import spire.syntax.cfor._
 import monocle.syntax.apply._
 
 import java.nio.{ByteBuffer, ByteOrder}
 
-object TiffTagsReader extends LazyLogging {
+object TiffTagsReader {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   def read(path: String): TiffTags =
     read(Filesystem.toMappedByteBuffer(path))
 

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3GeoTiffRDD.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3GeoTiffRDD.scala
@@ -25,9 +25,8 @@ import geotrellis.spark.store._
 import geotrellis.vector._
 
 import software.amazon.awssdk.services.s3.S3Client
-
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -39,9 +38,11 @@ import java.nio.ByteBuffer
 /**
  * The S3GeoTiffRDD object allows for the creation of whole or windowed RDD[(K, V)]s from files on S3.
  */
-object S3GeoTiffRDD extends LazyLogging {
+object S3GeoTiffRDD {
   final val GEOTIFF_TIME_TAG_DEFAULT = "TIFFTAG_DATETIME"
   final val GEOTIFF_TIME_FORMAT_DEFAULT = "yyyy:MM:dd HH:mm:ss"
+
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   /**
     * This case class contains the various parameters one can set when reading RDDs from S3 using Spark.

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3InputFormat.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3InputFormat.scala
@@ -20,12 +20,12 @@ import geotrellis.store.s3.S3ClientProducer
 import geotrellis.store.hadoop._
 import geotrellis.spark.store.hadoop._
 
-import com.typesafe.scalalogging.LazyLogging
-
 import software.amazon.awssdk.regions._
 import software.amazon.awssdk.services.s3.model.{ListObjectsV2Request, S3Object}
 import software.amazon.awssdk.services.s3.S3Client
 
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.{InputFormat, InputSplit, Job, JobContext}
 
@@ -40,8 +40,10 @@ import scala.collection.JavaConverters._
   *   - ProfileCredentialsProvider
   *   - InstanceProfileCredentialsProvider
   */
-abstract class S3InputFormat[K, V] extends InputFormat[K,V] with LazyLogging {
+abstract class S3InputFormat[K, V] extends InputFormat[K,V] {
   import S3InputFormat._
+
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   def getS3Client(context: JobContext): S3Client =
     S3InputFormat.getS3Client(context)

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3InputSplit.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3InputSplit.scala
@@ -16,7 +16,6 @@
 
 package geotrellis.spark.store.s3
 
-import com.typesafe.scalalogging.LazyLogging
 import software.amazon.awssdk.services.s3.model.S3Object
 import org.apache.hadoop.io.Writable
 import org.apache.hadoop.mapreduce.InputSplit
@@ -27,8 +26,7 @@ import java.io.{DataOutput, DataInput}
  * Represents are batch of keys to be read from an S3 bucket.
  * AWS credentials have already been discovered and provided by the S3InputFormat.
  */
-class S3InputSplit extends InputSplit with Writable with LazyLogging
-{
+class S3InputSplit extends InputSplit with Writable {
   var sessionToken: String = null
   var bucket: String = _
   var keys: Seq[String] = Vector.empty

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerReader.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerReader.scala
@@ -26,7 +26,6 @@ import geotrellis.spark._
 import geotrellis.spark.store._
 import geotrellis.util._
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.SparkContext
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
@@ -48,7 +47,7 @@ class S3LayerReader(
   s3Client: => S3Client = S3ClientProducer.get(),
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
 )(implicit sc: SparkContext)
-  extends FilteringLayerReader[LayerId] with LazyLogging {
+  extends FilteringLayerReader[LayerId] {
 
   val defaultNumPartitions = sc.defaultParallelism
 

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerWriter.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerWriter.scala
@@ -28,6 +28,8 @@ import geotrellis.util._
 
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.S3Client
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.rdd.RDD
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
@@ -53,7 +55,8 @@ class S3LayerWriter(
   putObjectModifier: PutObjectRequest => PutObjectRequest = identity,
   s3Client: => S3Client = S3ClientProducer.get(),
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-) extends LayerWriter[LayerId] with LazyLogging {
+) extends LayerWriter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   def rddWriter: S3RDDWriter = new S3RDDWriter(s3Client, executionContext)
 

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3RecordReader.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3RecordReader.scala
@@ -19,15 +19,18 @@ package geotrellis.spark.store.s3
 import geotrellis.store.s3.util.S3RangeReader
 import geotrellis.util._
 
-import com.typesafe.scalalogging.LazyLogging
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.S3Client
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.mapreduce.{InputSplit, TaskAttemptContext, RecordReader}
 import org.apache.commons.io.IOUtils
 
 /** This is the base class for readers that will create key value pairs for object requests.
   * Subclass must extend [readObjectRequest] method to map from S3 object requests to (K,V) */
-abstract class BaseS3RecordReader[K, V](s3Client: S3Client) extends RecordReader[K, V] with LazyLogging {
+abstract class BaseS3RecordReader[K, V](s3Client: S3Client) extends RecordReader[K, V] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   protected var bucket: String = _
   protected var keys: Iterator[String] = null
   protected var curKey: K = _

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/cog/S3COGLayerReader.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/cog/S3COGLayerReader.scala
@@ -47,7 +47,7 @@ class S3COGLayerReader(
   val attributeStore: AttributeStore,
   s3Client: => S3Client = S3ClientProducer.get(),
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-)(@transient implicit val sc: SparkContext) extends COGLayerReader[LayerId] with LazyLogging {
+)(@transient implicit val sc: SparkContext) extends COGLayerReader[LayerId] {
 
   @transient implicit lazy val ec: ExecutionContext = executionContext
 

--- a/s3/src/main/scala/geotrellis/store/s3/cog/S3COGCollectionLayerReader.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/cog/S3COGCollectionLayerReader.scala
@@ -27,11 +27,8 @@ import geotrellis.store.cog._
 import geotrellis.store.index._
 import geotrellis.store.s3._
 import geotrellis.util._
-
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
-import com.typesafe.scalalogging.LazyLogging
-
 import java.net.URI
 
 import scala.concurrent.ExecutionContext
@@ -46,7 +43,7 @@ class S3COGCollectionLayerReader(
   val attributeStore: AttributeStore,
   s3Client: => S3Client = S3ClientProducer.get(),
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-) extends COGCollectionLayerReader[LayerId] with LazyLogging {
+) extends COGCollectionLayerReader[LayerId] {
 
   @transient implicit lazy val ec = executionContext
 

--- a/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/ast/Output.scala
+++ b/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/ast/Output.scala
@@ -27,7 +27,6 @@ import geotrellis.spark.store.LayerWriter
 import geotrellis.store.avro.AvroRecordCodec
 import geotrellis.layer.{Bounds, LayoutDefinition, SpatialComponent, Metadata}
 import geotrellis.util.{Component, GetComponent}
-import com.typesafe.scalalogging.LazyLogging
 import geotrellis.store.LayerId
 import org.apache.spark.rdd.RDD
 
@@ -35,7 +34,7 @@ import scala.reflect.ClassTag
 
 trait Output[T] extends Node[T]
 
-object Output extends LazyLogging {
+object Output {
   def write[
     K: SpatialComponent : AvroRecordCodec : Encoder : ClassTag,
     V <: CellGrid[Int] : AvroRecordCodec : ClassTag: * => TileMergeMethods[V]: * => TilePrototypeMethods[V],

--- a/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/json/Implicits.scala
+++ b/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/json/Implicits.scala
@@ -28,7 +28,6 @@ import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.vector._
 
-import com.typesafe.scalalogging.LazyLogging
 import _root_.io.circe.generic.extras.Configuration
 import _root_.io.circe._
 import _root_.io.circe.syntax._
@@ -42,7 +41,7 @@ import scala.util.Try
 
 object Implicits extends Implicits
 
-trait Implicits extends LazyLogging {
+trait Implicits {
   implicit val config: Configuration = Configuration.default.withDefaults.withSnakeCaseMemberNames
   val pipelineJsonPrinter: Printer = Printer.spaces2.copy(dropNullValues = true)
 

--- a/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/json/PipelineExpr.scala
+++ b/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/json/PipelineExpr.scala
@@ -17,9 +17,8 @@
 package geotrellis.spark.pipeline.json
 
 import geotrellis.spark.pipeline.PipelineConstructor
-import com.typesafe.scalalogging.LazyLogging
 
-trait PipelineExpr extends LazyLogging {
+trait PipelineExpr {
   def ~(other: PipelineExpr): PipelineConstructor = this :: other :: Nil
 
   def ~(other: Option[PipelineExpr]): PipelineConstructor =

--- a/spark/src/main/scala/geotrellis/spark/pyramid/Pyramid.scala
+++ b/spark/src/main/scala/geotrellis/spark/pyramid/Pyramid.scala
@@ -30,7 +30,6 @@ import geotrellis.raster.prototype._
 import geotrellis.util._
 import geotrellis.vector.Extent
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd._
 import org.apache.spark.storage.StorageLevel
@@ -71,7 +70,7 @@ case class Pyramid[
 
 }
 
-object Pyramid extends LazyLogging {
+object Pyramid {
   case class Options(
     resampleMethod: ResampleMethod = NearestNeighbor,
     partitioner: Option[Partitioner] = None

--- a/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
+++ b/spark/src/main/scala/geotrellis/spark/reproject/TileRDDReproject.scala
@@ -32,15 +32,16 @@ import geotrellis.spark.merge._
 import geotrellis.spark.tiling._
 import geotrellis.vector._
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.rdd._
 import org.apache.spark._
 
 import scala.reflect.ClassTag
 
-object TileRDDReproject extends LazyLogging {
+object TileRDDReproject {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   import Reproject.Options
 
   /** Reproject a set of buffered

--- a/spark/src/main/scala/geotrellis/spark/store/GeoTiffInfoReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/GeoTiffInfoReader.scala
@@ -20,14 +20,16 @@ import geotrellis.vector.Geometry
 import geotrellis.raster.GridBounds
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader.GeoTiffInfo
 import geotrellis.raster.io.geotiff.GeoTiffSegmentLayoutTransform
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
 import java.net.URI
 
-private [geotrellis] trait GeoTiffInfoReader extends LazyLogging with Serializable {
+private [geotrellis] trait GeoTiffInfoReader extends Serializable {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   def geoTiffInfoRDD(implicit sc: SparkContext): RDD[String]
   def getGeoTiffInfo(uri: String): GeoTiffInfo
 
@@ -101,4 +103,3 @@ private [geotrellis] trait GeoTiffInfoReader extends LazyLogging with Serializab
     result
   }
 }
-

--- a/spark/src/main/scala/geotrellis/spark/store/LayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/LayerWriter.scala
@@ -23,8 +23,6 @@ import geotrellis.store.avro.codecs._
 import geotrellis.store.index._
 import geotrellis.spark._
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.avro._
 import org.apache.spark.rdd.RDD
 import _root_.io.circe._
@@ -173,7 +171,7 @@ trait LayerWriter[ID] {
     }
 }
 
-object LayerWriter extends LazyLogging {
+object LayerWriter {
 
   /**
    * Produce LayerWriter instance based on URI description.

--- a/spark/src/main/scala/geotrellis/spark/store/cog/COGLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/cog/COGLayerWriter.scala
@@ -29,8 +29,8 @@ import geotrellis.store._
 import geotrellis.store.cog.{COGLayerStorageMetadata, ZoomRange}
 import geotrellis.store.index._
 import geotrellis.spark._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.rdd.RDD
 import _root_.io.circe._
 
@@ -39,8 +39,9 @@ import java.util.ServiceLoader
 
 import scala.reflect._
 
-trait COGLayerWriter extends LazyLogging with Serializable {
+trait COGLayerWriter extends Serializable {
   import COGLayerWriter.Options
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   val attributeStore: AttributeStore
 

--- a/spark/src/main/scala/geotrellis/spark/store/file/FileLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/file/FileLayerReader.scala
@@ -25,7 +25,6 @@ import geotrellis.spark._
 import geotrellis.spark.store.FilteringLayerReader
 import geotrellis.util._
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.SparkContext
 import io.circe._
 
@@ -42,7 +41,7 @@ import scala.reflect.ClassTag
 class FileLayerReader(
   val attributeStore: AttributeStore,
   catalogPath: String
-)(implicit sc: SparkContext) extends FilteringLayerReader[LayerId] with LazyLogging {
+)(implicit sc: SparkContext) extends FilteringLayerReader[LayerId] {
 
   val defaultNumPartitions = sc.defaultParallelism
 

--- a/spark/src/main/scala/geotrellis/spark/store/file/FileLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/file/FileLayerWriter.scala
@@ -26,8 +26,8 @@ import geotrellis.spark._
 import geotrellis.spark.store._
 import geotrellis.spark.merge._
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.rdd.RDD
 import io.circe._
 import cats.Semigroup
@@ -50,7 +50,8 @@ import java.io.File
 class FileLayerWriter(
   val attributeStore: AttributeStore,
   catalogPath: String
-) extends LayerWriter[LayerId] with LazyLogging {
+) extends LayerWriter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   // Layer Updating
   def overwrite[

--- a/spark/src/main/scala/geotrellis/spark/store/file/cog/FileCOGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/file/cog/FileCOGLayerReader.scala
@@ -27,7 +27,6 @@ import geotrellis.store.file.cog.byteReader
 import geotrellis.spark.store.cog._
 import geotrellis.util._
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.SparkContext
 import _root_.io.circe._
 
@@ -46,7 +45,7 @@ class FileCOGLayerReader(
   val attributeStore: AttributeStore,
   val catalogPath: String,
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-)(@transient implicit val sc: SparkContext) extends COGLayerReader[LayerId] with LazyLogging {
+)(@transient implicit val sc: SparkContext) extends COGLayerReader[LayerId] {
 
   @transient implicit lazy val ec: ExecutionContext = executionContext
 

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopGeoTiffRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopGeoTiffRDD.scala
@@ -26,9 +26,8 @@ import geotrellis.store.hadoop.formats.{BinaryFileInputFormat, BytesFileInputFor
 import geotrellis.spark._
 import geotrellis.spark.store.RasterReader
 import geotrellis.spark.store.hadoop.formats._
-
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
@@ -42,9 +41,11 @@ import java.nio.ByteBuffer
 /**
   * Allows for reading of whole or windowed GeoTiff as RDD[(K, V)]s through Hadoop FileSystem API.
   */
-object HadoopGeoTiffRDD extends LazyLogging {
+object HadoopGeoTiffRDD {
   final val GEOTIFF_TIME_TAG_DEFAULT = "TIFFTAG_DATETIME"
   final val GEOTIFF_TIME_FORMAT_DEFAULT = "yyyy:MM:dd HH:mm:ss"
+
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   /**
     * This case class contains the various parameters one can set when reading RDDs from Hadoop using Spark.

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopLayerReader.scala
@@ -25,7 +25,6 @@ import geotrellis.store.avro._
 import geotrellis.store.hadoop.{HadoopAttributeStore, HadoopLayerHeader}
 import geotrellis.util._
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -44,7 +43,7 @@ import scala.reflect.ClassTag
 class HadoopLayerReader(
   val attributeStore: AttributeStore
 )(implicit sc: SparkContext)
-  extends FilteringLayerReader[LayerId] with LazyLogging {
+  extends FilteringLayerReader[LayerId] {
 
   val defaultNumPartitions = sc.defaultParallelism
 

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopLayerWriter.scala
@@ -24,8 +24,8 @@ import geotrellis.store.avro.codecs._
 import geotrellis.store.index.KeyIndex
 import geotrellis.spark.store._
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
@@ -39,7 +39,8 @@ class HadoopLayerWriter(
   rootPath: Path,
   val attributeStore: AttributeStore,
   indexInterval: Int = 4
-) extends LayerWriter[LayerId] with LazyLogging {
+) extends LayerWriter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   // Layer Updating
   def overwrite[

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopRDDReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopRDDReader.scala
@@ -22,9 +22,8 @@ import geotrellis.store.avro.codecs._
 import geotrellis.store.hadoop._
 import geotrellis.store.hadoop.formats.FilterMapFileInputFormat
 import geotrellis.spark.util.KryoWrapper
-
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.avro.Schema
 import org.apache.hadoop.io._
 import org.apache.hadoop.fs.Path
@@ -32,7 +31,8 @@ import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
-object HadoopRDDReader extends LazyLogging {
+object HadoopRDDReader {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   def readFully[
     K: AvroRecordCodec: Boundable,

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopRDDWriter.scala
@@ -28,9 +28,8 @@ import geotrellis.spark._
 import geotrellis.spark.store._
 import geotrellis.spark.partition._
 import geotrellis.spark.util._
-
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io._
 import org.apache.spark.rdd._
@@ -40,7 +39,9 @@ import scala.reflect._
 import scala.collection.mutable
 
 
-object HadoopRDDWriter extends LazyLogging {
+object HadoopRDDWriter {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   /** Index innterval at which map files should store an offset into sequence file.
     * This value is picked as a compromize between in-memory footprint and IO cost of retreiving a single record.
     */

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/cog/HadoopCOGLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/cog/HadoopCOGLayerReader.scala
@@ -32,7 +32,6 @@ import geotrellis.spark.store.hadoop._
 import geotrellis.store.util.BlockingThreadPool
 import geotrellis.util._
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 import java.net.URI
@@ -48,7 +47,7 @@ import scala.reflect.ClassTag
 class HadoopCOGLayerReader(
   val attributeStore: AttributeStore,
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-)(@transient implicit val sc: SparkContext) extends COGLayerReader[LayerId] with LazyLogging {
+)(@transient implicit val sc: SparkContext) extends COGLayerReader[LayerId] {
 
   @transient implicit lazy val ec: ExecutionContext = executionContext
 

--- a/spark/src/main/scala/geotrellis/spark/store/http/util/HttpRangeReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/http/util/HttpRangeReader.scala
@@ -19,8 +19,8 @@ package geotrellis.spark.store.http.util
 import geotrellis.util.RangeReader
 
 import scalaj.http.Http
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import java.net.{URL, URI}
 import scala.util.Try
 
@@ -33,7 +33,8 @@ import scala.util.Try
  *
  * @param url: A [[URL]] pointing to the desired GeoTiff.
  */
-class HttpRangeReader(url: URL, useHeadRequest: Boolean) extends RangeReader with LazyLogging {
+class HttpRangeReader(url: URL, useHeadRequest: Boolean) extends RangeReader {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   val request = Http(url.toString)
 

--- a/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
+++ b/spark/src/main/scala/geotrellis/spark/tiling/CutTiles.scala
@@ -23,13 +23,15 @@ import geotrellis.raster.resample._
 import geotrellis.layer._
 import geotrellis.spark._
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.rdd._
 
 import scala.reflect.ClassTag
 
-object CutTiles extends LazyLogging {
+object CutTiles {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   def apply[
     K1: (* => TilerKeyMethods[K1, K2]),
     K2: SpatialComponent: ClassTag,

--- a/spark/src/main/scala/geotrellis/spark/util/SparkUtils.scala
+++ b/spark/src/main/scala/geotrellis/spark/util/SparkUtils.scala
@@ -16,14 +16,16 @@
 
 package geotrellis.spark.util
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import java.io.File
 
-object SparkUtils extends LazyLogging {
+object SparkUtils {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   def createSparkConf = new SparkConf()
 
   private val gtHomeLock = new Object()

--- a/store/src/main/scala/geotrellis/store/file/FileCollectionLayerReader.scala
+++ b/store/src/main/scala/geotrellis/store/file/FileCollectionLayerReader.scala
@@ -23,7 +23,6 @@ import geotrellis.store.avro.AvroRecordCodec
 import geotrellis.store.index.Index
 import geotrellis.util._
 
-import com.typesafe.scalalogging.LazyLogging
 import io.circe.Decoder
 
 import scala.concurrent.ExecutionContext
@@ -41,7 +40,7 @@ class FileCollectionLayerReader(
   val attributeStore: AttributeStore,
   catalogPath: String,
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-) extends CollectionLayerReader[LayerId] with LazyLogging {
+) extends CollectionLayerReader[LayerId] {
 
   @transient implicit lazy val ec = executionContext
 

--- a/store/src/main/scala/geotrellis/store/file/FileLayerDeleter.scala
+++ b/store/src/main/scala/geotrellis/store/file/FileLayerDeleter.scala
@@ -18,11 +18,13 @@ package geotrellis.store.file
 
 import geotrellis.store.{LayerId, LayerDeleter, AttributeNotFoundError, LayerDeleteError}
 
-import com.typesafe.scalalogging.LazyLogging
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import java.io.File
 
-class FileLayerDeleter(val attributeStore: FileAttributeStore) extends LazyLogging with LayerDeleter[LayerId] {
+class FileLayerDeleter(val attributeStore: FileAttributeStore) extends LayerDeleter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   def delete(id: LayerId): Unit =
     try {
       val header = attributeStore.readHeader[FileLayerHeader](id)

--- a/store/src/main/scala/geotrellis/store/file/cog/FileCOGCollectionLayerReader.scala
+++ b/store/src/main/scala/geotrellis/store/file/cog/FileCOGCollectionLayerReader.scala
@@ -24,10 +24,7 @@ import geotrellis.store.util._
 import geotrellis.store.cog.{COGCollectionLayerReader, Extension, ZoomRange}
 import geotrellis.store.file.{FileAttributeStore, KeyPathGenerator}
 import geotrellis.util._
-
-import com.typesafe.scalalogging.LazyLogging
 import _root_.io.circe._
-
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 import java.net.URI
@@ -42,7 +39,7 @@ class FileCOGCollectionLayerReader(
   val attributeStore: AttributeStore,
   val catalogPath: String,
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-) extends COGCollectionLayerReader[LayerId] with LazyLogging {
+) extends COGCollectionLayerReader[LayerId] {
 
   @transient implicit lazy val ec: ExecutionContext = executionContext
 

--- a/store/src/main/scala/geotrellis/store/hadoop/HadoopCollectionLayerReader.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/HadoopCollectionLayerReader.scala
@@ -41,7 +41,7 @@ class HadoopCollectionLayerReader(
   conf: Configuration,
   maxOpenFiles: Int = 16,
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-) extends CollectionLayerReader[LayerId] with LazyLogging {
+) extends CollectionLayerReader[LayerId] {
 
   @transient implicit lazy val ec: ExecutionContext = executionContext
 

--- a/store/src/main/scala/geotrellis/store/hadoop/HadoopLayerDeleter.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/HadoopLayerDeleter.scala
@@ -18,7 +18,8 @@ package geotrellis.store.hadoop
 
 import geotrellis.store._
 import geotrellis.store.hadoop.util._
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
@@ -27,7 +28,9 @@ import com.typesafe.scalalogging.LazyLogging
 class HadoopLayerDeleter(
   val attributeStore: AttributeStore,
   conf: Configuration
-) extends LazyLogging with LayerDeleter[LayerId] {
+) extends LayerDeleter[LayerId] {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   def delete(id: LayerId): Unit = {
     try {
       val header = attributeStore.readHeader[HadoopLayerHeader](id)

--- a/store/src/main/scala/geotrellis/store/hadoop/cog/HadoopCOGCollectionLayerReader.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/cog/HadoopCOGCollectionLayerReader.scala
@@ -28,7 +28,6 @@ import geotrellis.store.index.Index
 import geotrellis.util._
 
 import _root_.io.circe._
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
@@ -47,10 +46,9 @@ class HadoopCOGCollectionLayerReader(
   val catalogPath: String,
   val conf: Configuration = new Configuration,
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
-) extends COGCollectionLayerReader[LayerId] with LazyLogging {
+) extends COGCollectionLayerReader[LayerId] {
 
   val serConf: SerializableConfiguration = SerializableConfiguration(conf)
-
   @transient implicit lazy val ec: ExecutionContext = executionContext
 
   def read[

--- a/store/src/main/scala/geotrellis/store/hadoop/util/HdfsUtils.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/util/HdfsUtils.scala
@@ -16,8 +16,9 @@
 
 package geotrellis.store.hadoop.util
 
-import com.typesafe.scalalogging.LazyLogging
 
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 import org.apache.hadoop.io.compress.CompressionCodecFactory
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
@@ -34,7 +35,9 @@ import scala.util.Random
 
 abstract class LineScanner extends Iterator[String] with java.io.Closeable
 
-object HdfsUtils extends LazyLogging {
+object HdfsUtils {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   def trim(uri: URI): URI =
     if (uri.getScheme.startsWith("hdfs+"))
       new URI(uri.toString.stripPrefix("hdfs+"))

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -18,12 +18,11 @@ package geotrellis.vector
 
 import geotrellis.vector.conf.JtsConfig
 
-import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.jts.geom
 import org.locationtech.jts.geom.{GeometryFactory, PrecisionModel}
 import org.locationtech.jts.precision.GeometryPrecisionReducer
 
-object GeomFactory extends LazyLogging {
+object GeomFactory {
   val precisionType: String = JtsConfig.precisionType
   val precisionModel: PrecisionModel = JtsConfig.precisionModel
   lazy val simplifier: GeometryPrecisionReducer = JtsConfig.simplifier

--- a/vector/src/main/scala/geotrellis/vector/conf/JtsConfig.scala
+++ b/vector/src/main/scala/geotrellis/vector/conf/JtsConfig.scala
@@ -16,7 +16,6 @@
 
 package geotrellis.vector.conf
 
-import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.jts.geom.PrecisionModel
 import org.locationtech.jts.precision.GeometryPrecisionReducer
 import pureconfig.generic.auto._
@@ -26,7 +25,7 @@ case class Simplification(scale: Double = 1e12) {
   lazy val simplifier: GeometryPrecisionReducer = new GeometryPrecisionReducer(new PrecisionModel(scale))
 }
 case class Precision(`type`: String = "floating")
-case class JtsConfig(precision: Precision = Precision(), simplification: Simplification = Simplification()) extends LazyLogging {
+case class JtsConfig(precision: Precision = Precision(), simplification: Simplification = Simplification()) {
   val precisionType: String = precision.`type`
   val precisionModel: PrecisionModel = precisionType match {
     case "floating" => new PrecisionModel()

--- a/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKB/WKB.scala
@@ -18,15 +18,17 @@ package geotrellis.vector.io.wkb
 
 import geotrellis.vector.GeomFactory
 
-import com.typesafe.scalalogging.LazyLogging
 import org.locationtech.jts.geom._
 import org.locationtech.jts.{io => jts}
-
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 
 /** A thread-safe wrapper for the [https://en.wikipedia.org/wiki/Well-known_text#Well-known_binary WKB]
   * Writer and Reader
   */
-object WKB extends LazyLogging {
+object WKB {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   private val readerBox = new ThreadLocal[jts.WKBReader]
   private val writerBox = new ThreadLocal[WKBWriter]
 

--- a/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKT/WKT.scala
@@ -19,10 +19,13 @@ package geotrellis.vector.io.wkt
 import geotrellis.vector._
 
 import org.locationtech.jts.io.{WKTReader, WKTWriter}
-import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.Logger
 
 /** A thread-safe wrapper for the WKT Writer and Reader */
-object WKT extends LazyLogging {
+object WKT {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
   private val readerBox = new ThreadLocal[WKTReader]
   private val writerBox = new ThreadLocal[WKTWriter]
 


### PR DESCRIPTION
## Overview

GeoTrellis uses `com.typesafe.scalalogging` package. This is a popular library but unfortunately the `LazyLogging` trait that is used to mix-in a logger has shifted around a number of timers through the version history. This causes frequent binary incompatibility problems.

This PR removes any mention of `LazyLogging` trait and replaces it with `protected lazy val logger: Logger` fields. The `Logger` class is a little more stable.

Additionally:

- ArrayTile no longer warns on narrowing celltype conversion
- GeoWave/GeoMesa do not log errors with experimental notice


### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- ~[ ] `docs` guides update, if necessary~
- ~[ ] New user API has useful Scaladoc strings~
- ~[ ] Unit tests added for bug-fix or new feature~