### PR TITLE
Refactor ResampleGrid names and type parameter

### DIFF
--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -110,7 +110,7 @@ class GDALRasterSource(
       }
   }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
     new GDALRasterSource(dataPath, options.reproject(gridExtent, crs, targetCRS, resampleTarget, method))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -110,11 +110,11 @@ class GDALRasterSource(
       }
   }
 
-  def reprojection(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
-    new GDALRasterSource(dataPath, options.reproject(gridExtent, crs, targetCRS, resampleGrid, method))
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+    new GDALRasterSource(dataPath, options.reproject(gridExtent, crs, targetCRS, resampleTarget, method))
 
-  def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
-    new GDALRasterSource(dataPath, options.resample(gridExtent, resampleGrid))
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
+    new GDALRasterSource(dataPath, options.resample(gridExtent, resampleTarget))
 
   /** Converts the contents of the GDALRasterSource to the [[TargetCellType]].
    *

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALWarpOptions.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALWarpOptions.scala
@@ -254,8 +254,8 @@ case class GDALWarpOptions(
   /** Adjust GDAL options to represents reprojection with following parameters.
    * This call matches semantics and arguments of {@see RasterSource#reproject}
    */
-  def reproject(rasterExtent: GridExtent[Long], sourceCRS: CRS, targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, resampleMethod: ResampleMethod = NearestNeighbor): GDALWarpOptions = {
-    val reprojectOptions = ResampleGrid.toReprojectOptions[Long](rasterExtent, resampleGrid, resampleMethod)
+  def reproject(rasterExtent: GridExtent[Long], sourceCRS: CRS, targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, resampleMethod: ResampleMethod = NearestNeighbor): GDALWarpOptions = {
+    val reprojectOptions = ResampleTarget.toReprojectOptions(rasterExtent, resampleTarget, resampleMethod)
     val re = rasterExtent.reproject(sourceCRS, targetCRS, reprojectOptions)
 
     this.copy(
@@ -269,14 +269,14 @@ case class GDALWarpOptions(
   /** Adjust GDAL options to represents resampling with following parameters .
    * This call matches semantics and arguments of {@see RasterSource#resample}
    */
-  def resample(gridExtent: => GridExtent[Long], resampleGrid: ResampleGrid[Long]): GDALWarpOptions = {
-    resampleGrid match {
-      case Dimensions(cols, rows) =>
+  def resample(gridExtent: => GridExtent[Long], resampleTarget: ResampleTarget): GDALWarpOptions = {
+    resampleTarget match {
+      case TargetDimensions(cols, rows) =>
         this.copy(te = gridExtent.extent.some, cellSize = None, dimensions = (cols.toInt, rows.toInt).some)
 
       case _ =>
         val re = {
-          val targetRasterExtent = resampleGrid(gridExtent).toRasterExtent
+          val targetRasterExtent = resampleTarget(gridExtent).toRasterExtent
           if(this.alignTargetPixels) targetRasterExtent.alignTargetPixels else targetRasterExtent
         }
 

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALWarpOptions.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALWarpOptions.scala
@@ -254,7 +254,7 @@ case class GDALWarpOptions(
   /** Adjust GDAL options to represents reprojection with following parameters.
    * This call matches semantics and arguments of {@see RasterSource#reproject}
    */
-  def reproject(rasterExtent: GridExtent[Long], sourceCRS: CRS, targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, resampleMethod: ResampleMethod = NearestNeighbor): GDALWarpOptions = {
+  def reproject(rasterExtent: GridExtent[Long], sourceCRS: CRS, targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, resampleMethod: ResampleMethod = NearestNeighbor): GDALWarpOptions = {
     val reprojectOptions = ResampleTarget.toReprojectOptions(rasterExtent, resampleTarget, resampleMethod)
     val re = rasterExtent.reproject(sourceCRS, targetCRS, reprojectOptions)
 

--- a/gdal/src/test/scala/geotrellis/raster/gdal/GDALWarpOptionsSpec.scala
+++ b/gdal/src/test/scala/geotrellis/raster/gdal/GDALWarpOptionsSpec.scala
@@ -62,7 +62,7 @@ class GDALWarpOptionsSpec extends FunSpec with RasterMatchers with GivenWhenThen
           rasterExtent = GridExtent(Extent(630000.0, 215000.0, 645000.0, 228500.0), 10, 10),
           CRS.fromString("+proj=lcc +lat_1=36.16666666666666 +lat_2=34.33333333333334 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +datum=NAD83 +units=m +no_defs "),
           WebMercator,
-          TargetCellSize[Long](CellSize(10, 10))
+          TargetCellSize(CellSize(10, 10))
         )
     rasterSourceFromUriOptions(uri, opts)
   }
@@ -75,11 +75,11 @@ class GDALWarpOptionsSpec extends FunSpec with RasterMatchers with GivenWhenThen
           rasterExtent = GridExtent(Extent(630000.0, 215000.0, 645000.0, 228500.0), 10, 10),
           CRS.fromString("+proj=lcc +lat_1=36.16666666666666 +lat_2=34.33333333333334 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +datum=NAD83 +units=m +no_defs "),
           WebMercator,
-          TargetCellSize[Long](CellSize(10, 10))
+          TargetCellSize(CellSize(10, 10))
         )
         .resample(
           GridExtent(Extent(-8769160.0, 4257700.0, -8750630.0, 4274460.0), CellSize(10, 10)),
-          TargetRegion(GridExtent(Extent(-8769160.0, 4257700.0, -8750630.0, 4274460.0), CellSize(22, 22)))
+          TargetRegion(GridExtent[Long](Extent(-8769160.0, 4257700.0, -8750630.0, 4274460.0), CellSize(22, 22)))
         )
     rasterSourceFromUriOptions(uri, opts)
   }
@@ -142,7 +142,7 @@ class GDALWarpOptionsSpec extends FunSpec with RasterMatchers with GivenWhenThen
         GDALRasterSource(filePath)
           .reproject(
             targetCRS    = WebMercator,
-            resampleGrid = TargetCellSize[Long](CellSize(10, 10)),
+            resampleTarget = TargetCellSize(CellSize(10, 10)),
             strategy     = AutoHigherResolution
         )
         .resampleToRegion(

--- a/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
@@ -81,9 +81,9 @@ trait MosaicRasterSource extends RasterSource {
     *
     * @see [[geotrellis.contrib.vlm.RasterSource.reproject]]
     */
-  def reprojection(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
     MosaicRasterSource(
-      sources map { _.reproject(targetCRS, resampleGrid, method, strategy) },
+      sources map { _.reproject(targetCRS, resampleTarget, method, strategy) },
       crs,
       gridExtent.reproject(this.crs, targetCRS, Reproject.Options.DEFAULT.copy(method = method)),
       name
@@ -99,8 +99,8 @@ trait MosaicRasterSource extends RasterSource {
     rasters.reduce
   }
 
-  def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource = MosaicRasterSource(
-    sources map { _.resample(resampleGrid, method, strategy) }, crs, name)
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = MosaicRasterSource(
+    sources map { _.resample(resampleTarget, method, strategy) }, crs, name)
 
   def convert(targetCellType: TargetCellType): RasterSource =
     MosaicRasterSource(sources map { _.convert(targetCellType) }, crs, name)

--- a/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
@@ -81,7 +81,12 @@ trait MosaicRasterSource extends RasterSource {
     *
     * @see [[geotrellis.contrib.vlm.RasterSource.reproject]]
     */
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reprojection(
+    targetCRS: CRS,
+    resampleTarget: ResampleTarget = DefaultTarget,
+    method: ResampleMethod = NearestNeighbor,
+    strategy: OverviewStrategy = AutoHigherResolution
+  ): RasterSource =
     MosaicRasterSource(
       sources map { _.reproject(targetCRS, resampleTarget, method, strategy) },
       crs,
@@ -99,7 +104,11 @@ trait MosaicRasterSource extends RasterSource {
     rasters.reduce
   }
 
-  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = MosaicRasterSource(
+  def resample(
+    resampleTarget: ResampleTarget,
+    method: ResampleMethod,
+    strategy: OverviewStrategy
+  ): RasterSource = MosaicRasterSource(
     sources map { _.resample(resampleTarget, method, strategy) }, crs, name)
 
   def convert(targetCellType: TargetCellType): RasterSource =

--- a/raster/src/main/scala/geotrellis/raster/RasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterSource.scala
@@ -45,15 +45,15 @@ trait RasterSource extends CellGrid[Long] with RasterMetadata {
   /** All available RasterSource metadata */
   def metadata: RasterMetadata
 
-  protected def reprojection(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource
+  protected def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource
 
   /** Reproject to different CRS with explicit sampling reprojectOptions.
     * @see [[geotrellis.raster.reproject.Reproject]]
     * @group reproject
     */
-  def reproject(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reproject(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
     if (targetCRS == this.crs) this
-    else reprojection(targetCRS, resampleGrid, method, strategy)
+    else reprojection(targetCRS, resampleTarget, method, strategy)
 
 
   /** Sampling grid and resolution is defined by given [[GridExtent]].
@@ -64,7 +64,7 @@ trait RasterSource extends CellGrid[Long] with RasterMetadata {
   def reprojectToGrid(targetCRS: CRS, grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
     if (targetCRS == this.crs && grid == this.gridExtent) this
     else if (targetCRS == this.crs) resampleToGrid(grid, method)
-    else reprojection(targetCRS, TargetGrid[Long](grid), method, strategy)
+    else reprojection(targetCRS, TargetGrid(grid), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[RasterExtent]] region.
     * The extent of the result is also taken from given [[RasterExtent]],
@@ -74,15 +74,15 @@ trait RasterSource extends CellGrid[Long] with RasterMetadata {
   def reprojectToRegion(targetCRS: CRS, region: RasterExtent, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
     if (targetCRS == this.crs && region == this.gridExtent) this
     else if (targetCRS == this.crs) resampleToRegion(region.asInstanceOf[GridExtent[Long]], method)
-    else reprojection(targetCRS, TargetRegion[Long](region.toGridType[Long]), method, strategy)
+    else reprojection(targetCRS, TargetRegion(region.toGridType[Long]), method, strategy)
 
-  def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource
 
   /** Sampling grid is defined of the footprint of the data with resolution implied by column and row count.
     * @group resample
     */
   def resample(targetCols: Long, targetRows: Long, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
-    resample(Dimensions(targetCols, targetRows), method, strategy)
+    resample(TargetDimensions(targetCols, targetRows), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[GridExtent]].
     * Resulting extent is the extent of the minimum enclosing pixel region
@@ -90,7 +90,7 @@ trait RasterSource extends CellGrid[Long] with RasterMetadata {
     * @group resample
     */
   def resampleToGrid(grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
-    resample(TargetGrid[Long](grid), method, strategy)
+    resample(TargetGrid(grid), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[RasterExtent]] region.
     * The extent of the result is also taken from given [[RasterExtent]],
@@ -98,7 +98,7 @@ trait RasterSource extends CellGrid[Long] with RasterMetadata {
     * @group resample
     */
   def resampleToRegion(region: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
-    resample(TargetRegion[Long](region), method, strategy)
+    resample(TargetRegion(region), method, strategy)
 
   /** Reads a window for the extent.
     * Return extent may be smaller than requested extent around raster edges.

--- a/raster/src/main/scala/geotrellis/raster/RasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterSource.scala
@@ -64,7 +64,7 @@ trait RasterSource extends CellGrid[Long] with RasterMetadata {
   def reprojectToGrid(targetCRS: CRS, grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
     if (targetCRS == this.crs && grid == this.gridExtent) this
     else if (targetCRS == this.crs) resampleToGrid(grid, method)
-    else reprojection(targetCRS, TargetGrid(grid), method, strategy)
+    else reprojection(targetCRS, TargetAlignment(grid), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[RasterExtent]] region.
     * The extent of the result is also taken from given [[RasterExtent]],
@@ -90,7 +90,7 @@ trait RasterSource extends CellGrid[Long] with RasterMetadata {
     * @group resample
     */
   def resampleToGrid(grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
-    resample(TargetGrid(grid), method, strategy)
+    resample(TargetAlignment(grid), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[RasterExtent]] region.
     * The extent of the result is also taken from given [[RasterExtent]],

--- a/raster/src/main/scala/geotrellis/raster/RasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterSource.scala
@@ -45,13 +45,13 @@ trait RasterSource extends CellGrid[Long] with RasterMetadata {
   /** All available RasterSource metadata */
   def metadata: RasterMetadata
 
-  protected def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource
+  protected def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource
 
   /** Reproject to different CRS with explicit sampling reprojectOptions.
     * @see [[geotrellis.raster.reproject.Reproject]]
     * @group reproject
     */
-  def reproject(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reproject(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
     if (targetCRS == this.crs) this
     else reprojection(targetCRS, resampleTarget, method, strategy)
 

--- a/raster/src/main/scala/geotrellis/raster/ResampleTarget.scala
+++ b/raster/src/main/scala/geotrellis/raster/ResampleTarget.scala
@@ -17,9 +17,7 @@
 package geotrellis.raster
 
 import geotrellis.raster.reproject.Reproject
-
 import spire.math.Integral
-import spire.implicits._
 
 /**
  *  A strategy to use when constructing a grid that will be used during resampling
@@ -47,7 +45,7 @@ case class TargetDimensions(cols: Long, rows: Long) extends ResampleTarget {
  * Snap to a target grid - useful prior to comparison between rasters
  * as a means of ensuring clear correspondence between underlying cell values
  */
-case class TargetGrid(grid: GridExtent[_]) extends ResampleTarget {
+case class TargetAlignment(grid: GridExtent[_]) extends ResampleTarget {
   def apply[N: Integral](source: => GridExtent[N]): GridExtent[N] =
     grid.createAlignedGridExtent(source.extent).toGridType[N]
 }
@@ -90,7 +88,7 @@ object ResampleTarget {
     if (options.targetRasterExtent.isDefined) {
       TargetRegion(options.targetRasterExtent.get.toGridType[Long])
     } else if (options.parentGridExtent.isDefined) {
-      TargetGrid(options.parentGridExtent.get)
+      TargetAlignment(options.parentGridExtent.get)
     } else if (options.targetCellSize.isDefined) {
       ??? // TODO: convert from CellSize to Column count based on ... something
     } else {
@@ -109,7 +107,7 @@ object ResampleTarget {
         val updated = current.withDimensions(cols.toLong, rows.toLong).toGridType[Int]
         Reproject.Options(method = resampleMethod, targetRasterExtent = Some(updated.toRasterExtent))
 
-      case TargetGrid(grid) =>
+      case TargetAlignment(grid) =>
         Reproject.Options(method = resampleMethod, parentGridExtent = Some(grid.toGridType[Long]))
 
       case TargetRegion(region) =>

--- a/raster/src/main/scala/geotrellis/raster/ResampleTarget.scala
+++ b/raster/src/main/scala/geotrellis/raster/ResampleTarget.scala
@@ -21,39 +21,39 @@ import geotrellis.raster.reproject.Reproject
 import spire.math.Integral
 import spire.implicits._
 
-sealed trait ResampleGrid[N] {
-  // this is a by name parameter, as we don't need to call the source in all ResampleGrid types
-  def apply(source: => GridExtent[N]): GridExtent[N]
+sealed trait ResampleTarget {
+  // this is a by name parameter, as we don't need to call the source in all ResampleTarget types
+  def apply[N: Integral](source: => GridExtent[N]): GridExtent[N]
 }
 
-case class Dimensions[N: Integral](cols: N, rows: N) extends ResampleGrid[N] {
-  def apply(source: => GridExtent[N]): GridExtent[N] =
-    new GridExtent(source.extent, cols, rows)
+case class TargetDimensions(cols: Long, rows: Long) extends ResampleTarget {
+  def apply[N: Integral](source: => GridExtent[N]): GridExtent[N] =
+    new GridExtent(source.extent, cols, rows).toGridType[N]
 }
 
-case class TargetGrid[N: Integral](grid: GridExtent[Long]) extends ResampleGrid[N] {
-  def apply(source: => GridExtent[N]): GridExtent[N] =
+case class TargetGrid(grid: GridExtent[_]) extends ResampleTarget {
+  def apply[N: Integral](source: => GridExtent[N]): GridExtent[N] =
     grid.createAlignedGridExtent(source.extent).toGridType[N]
 }
 
-case class TargetRegion[N: Integral](region: GridExtent[N]) extends ResampleGrid[N] {
-  def apply(source: => GridExtent[N]): GridExtent[N] =
-    region
+case class TargetRegion(region: GridExtent[_]) extends ResampleTarget {
+  def apply[N: Integral](source: => GridExtent[N]): GridExtent[N] =
+    region.toGridType[N]
 }
 
-case class TargetCellSize[N: Integral](cellSize: CellSize) extends ResampleGrid[N] {
-  def apply(source: => GridExtent[N]): GridExtent[N] =
+case class TargetCellSize(cellSize: CellSize) extends ResampleTarget {
+  def apply[N: Integral](source: => GridExtent[N]): GridExtent[N] =
     source.withResolution(cellSize)
 }
 
-case object IdentityResampleGrid extends ResampleGrid[Long] {
-  def apply(source: => GridExtent[Long]): GridExtent[Long] = source
+case object DefaultResampleTarget extends ResampleTarget {
+  def apply[N: Integral](source: => GridExtent[N]): GridExtent[N] = source
 }
 
 
-object ResampleGrid {
+object ResampleTarget {
   /** Used when reprojecting to original RasterSource CRS, pick-out the grid */
-  private[geotrellis] def fromReprojectOptions(options: Reproject.Options): ResampleGrid[Long] ={
+  private[geotrellis] def fromReprojectOptions(options: Reproject.Options): ResampleTarget ={
     if (options.targetRasterExtent.isDefined) {
       TargetRegion(options.targetRasterExtent.get.toGridType[Long])
     } else if (options.parentGridExtent.isDefined) {
@@ -61,18 +61,18 @@ object ResampleGrid {
     } else if (options.targetCellSize.isDefined) {
       ??? // TODO: convert from CellSize to Column count based on ... something
     } else {
-      IdentityResampleGrid
+      DefaultResampleTarget
     }
   }
 
   /** Used when resampling on already reprojected RasterSource */
-  private[geotrellis] def toReprojectOptions[N: Integral](
+  private[geotrellis] def toReprojectOptions(
     current: GridExtent[Long],
-    resampleGrid: ResampleGrid[N],
+    resampleTarget: ResampleTarget,
     resampleMethod: ResampleMethod
   ): Reproject.Options = {
-    resampleGrid match {
-      case Dimensions(cols, rows) =>
+    resampleTarget match {
+      case TargetDimensions(cols, rows) =>
         val updated = current.withDimensions(cols.toLong, rows.toLong).toGridType[Int]
         Reproject.Options(method = resampleMethod, targetRasterExtent = Some(updated.toRasterExtent))
 
@@ -85,7 +85,7 @@ object ResampleGrid {
       case TargetCellSize(cellSize) =>
         Reproject.Options(method = resampleMethod, targetCellSize = Some(cellSize))
 
-      case IdentityResampleGrid =>
+      case DefaultResampleTarget =>
         Reproject.Options.DEFAULT.copy(method = resampleMethod)
     }
   }

--- a/raster/src/main/scala/geotrellis/raster/ResampleTarget.scala
+++ b/raster/src/main/scala/geotrellis/raster/ResampleTarget.scala
@@ -21,7 +21,14 @@ import geotrellis.raster.reproject.Reproject
 import spire.math.Integral
 import spire.implicits._
 
-/** Represents a strategy/target for resampling */
+/**
+ *  A strategy to use when constructing a grid that will be used during resampling
+ * 
+ *  Various tradeoffs exist when attempting to resize an image. Subclasses of ResampleTarget
+ *  encode these various tradeoffs in terms of the proportions/alignment desired at the end
+ *  of resampling. E.g. [[TargetCellSize]] tells any resampling function to resample in such 
+ *  a way as to approximately match the specified [[CellSize]] in any resulting operations.
+ */
 sealed trait ResampleTarget {
   /**
    * Provided a gridextent, construct a new [[GridExtent]] that satisfies target constraint(s)
@@ -72,7 +79,7 @@ case class TargetCellSize(cellSize: CellSize) extends ResampleTarget {
  *
  * @note If used as target of resample operation it acts as identity operation.
  */
-case object DefaultResampleTarget extends ResampleTarget {
+case object DefaultTarget extends ResampleTarget {
   def apply[N: Integral](source: => GridExtent[N]): GridExtent[N] = source
 }
 
@@ -87,7 +94,7 @@ object ResampleTarget {
     } else if (options.targetCellSize.isDefined) {
       ??? // TODO: convert from CellSize to Column count based on ... something
     } else {
-      DefaultResampleTarget
+      DefaultTarget
     }
   }
 
@@ -111,7 +118,7 @@ object ResampleTarget {
       case TargetCellSize(cellSize) =>
         Reproject.Options(method = resampleMethod, targetCellSize = Some(cellSize))
 
-      case DefaultResampleTarget =>
+      case DefaultTarget =>
         Reproject.Options.DEFAULT.copy(method = resampleMethod)
     }
   }

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
@@ -55,11 +55,11 @@ class GeoTiffRasterSource(
   lazy val gridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
   lazy val resolutions: List[GridExtent[Long]] = gridExtent :: tiff.overviews.map(_.rasterExtent.toGridType[Long])
 
-  def reprojection(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
-    GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleGrid, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
+    GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
-  def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): GeoTiffResampleRasterSource =
-    GeoTiffResampleRasterSource(dataPath, resampleGrid, method, strategy, targetCellType, Some(tiff))
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTiffResampleRasterSource =
+    GeoTiffResampleRasterSource(dataPath, resampleTarget, method, strategy, targetCellType, Some(tiff))
 
   def convert(targetCellType: TargetCellType): GeoTiffRasterSource =
     GeoTiffRasterSource(dataPath, Some(targetCellType), Some(tiff))

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
@@ -55,7 +55,7 @@ class GeoTiffRasterSource(
   lazy val gridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
   lazy val resolutions: List[GridExtent[Long]] = gridExtent :: tiff.overviews.map(_.rasterExtent.toGridType[Long])
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTiffResampleRasterSource =

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -28,7 +28,7 @@ import geotrellis.util.RangeReader
 class GeoTiffReprojectRasterSource(
   val dataPath: GeoTiffPath,
   val crs: CRS,
-  val resampleTarget: ResampleTarget = DefaultResampleTarget,
+  val resampleTarget: ResampleTarget = DefaultTarget,
   val resampleMethod: ResampleMethod = NearestNeighbor,
   val strategy: OverviewStrategy = AutoHigherResolution,
   val errorThreshold: Double = 0.125,
@@ -85,7 +85,7 @@ class GeoTiffReprojectRasterSource(
 
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] = {
     resampleTarget match {
-      case DefaultResampleTarget => tiff.getClosestOverview(baseGridExtent.cellSize, strategy)
+      case DefaultTarget => tiff.getClosestOverview(baseGridExtent.cellSize, strategy)
       case _ =>
         // we're asked to match specific target resolution, estimate what resolution we need in source to sample it
         val estimatedSource = ReprojectRasterExtent(gridExtent, backTransform)
@@ -146,7 +146,7 @@ class GeoTiffReprojectRasterSource(
     }.map { convertRaster }
   }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
@@ -160,7 +160,7 @@ object GeoTiffReprojectRasterSource {
   def apply(
     dataPath: GeoTiffPath,
     crs: CRS,
-    resampleTarget: ResampleTarget = DefaultResampleTarget,
+    resampleTarget: ResampleTarget = DefaultTarget,
     resampleMethod: ResampleMethod = NearestNeighbor,
     strategy: OverviewStrategy = AutoHigherResolution,
     errorThreshold: Double = 0.125,

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -62,7 +62,7 @@ class GeoTiffReprojectRasterSource(
   // TODO: remove transient notation with Proj4 1.1 release
   @transient protected lazy val transform = Transform(baseCRS, crs)
   @transient protected lazy val backTransform = Transform(crs, baseCRS)
-  
+
   override lazy val gridExtent: GridExtent[Long] = {
     lazy val reprojectedRasterExtent =
       ReprojectRasterExtent(
@@ -73,7 +73,7 @@ class GeoTiffReprojectRasterSource(
 
     resampleTarget match {
       case targetRegion: TargetRegion => targetRegion.region.toGridType[Long]
-      case targetGrid: TargetGrid => targetGrid(reprojectedRasterExtent)
+      case targetAlignment: TargetAlignment => targetAlignment(reprojectedRasterExtent)
       case targetDimensions: TargetDimensions => targetDimensions(reprojectedRasterExtent)
       case targetCellSize: TargetCellSize => targetCellSize(reprojectedRasterExtent)
       case _ => reprojectedRasterExtent

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -28,7 +28,7 @@ import geotrellis.util.RangeReader
 class GeoTiffReprojectRasterSource(
   val dataPath: GeoTiffPath,
   val crs: CRS,
-  val targetResampleGrid: ResampleGrid[Long] = IdentityResampleGrid,
+  val resampleTarget: ResampleTarget = DefaultResampleTarget,
   val resampleMethod: ResampleMethod = NearestNeighbor,
   val strategy: OverviewStrategy = AutoHigherResolution,
   val errorThreshold: Double = 0.125,
@@ -71,11 +71,11 @@ class GeoTiffReprojectRasterSource(
         Reproject.Options.DEFAULT.copy(method = resampleMethod, errorThreshold = errorThreshold)
       )
 
-    targetResampleGrid match {
-      case targetRegion: TargetRegion[Long] => targetRegion.region
-      case targetGrid: TargetGrid[Long] => targetGrid(reprojectedRasterExtent)
-      case dimensions: Dimensions[Long] => dimensions(reprojectedRasterExtent)
-      case targetCellSize: TargetCellSize[Long] => targetCellSize(reprojectedRasterExtent)
+    resampleTarget match {
+      case targetRegion: TargetRegion => targetRegion.region.toGridType[Long]
+      case targetGrid: TargetGrid => targetGrid(reprojectedRasterExtent)
+      case targetDimensions: TargetDimensions => targetDimensions(reprojectedRasterExtent)
+      case targetCellSize: TargetCellSize => targetCellSize(reprojectedRasterExtent)
       case _ => reprojectedRasterExtent
     }
   }
@@ -84,8 +84,8 @@ class GeoTiffReprojectRasterSource(
       gridExtent :: tiff.overviews.map(ovr => ReprojectRasterExtent(ovr.rasterExtent.toGridType[Long], transform))
 
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] = {
-    targetResampleGrid match {
-      case IdentityResampleGrid => tiff.getClosestOverview(baseGridExtent.cellSize, strategy)
+    resampleTarget match {
+      case DefaultResampleTarget => tiff.getClosestOverview(baseGridExtent.cellSize, strategy)
       case _ =>
         // we're asked to match specific target resolution, estimate what resolution we need in source to sample it
         val estimatedSource = ReprojectRasterExtent(gridExtent, backTransform)
@@ -146,25 +146,25 @@ class GeoTiffReprojectRasterSource(
     }.map { convertRaster }
   }
 
-  def reprojection(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
-    GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleGrid, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+    GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
-  def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
-    GeoTiffReprojectRasterSource(dataPath, crs, resampleGrid, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
+    GeoTiffReprojectRasterSource(dataPath, crs, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
   def convert(targetCellType: TargetCellType): RasterSource =
-    GeoTiffReprojectRasterSource(dataPath, crs, targetResampleGrid, resampleMethod, strategy, targetCellType = Some(targetCellType))
+    GeoTiffReprojectRasterSource(dataPath, crs, resampleTarget, resampleMethod, strategy, targetCellType = Some(targetCellType))
 }
 
 object GeoTiffReprojectRasterSource {
   def apply(
     dataPath: GeoTiffPath,
     crs: CRS,
-    targetResampleGrid: ResampleGrid[Long] = IdentityResampleGrid,
+    resampleTarget: ResampleTarget = DefaultResampleTarget,
     resampleMethod: ResampleMethod = NearestNeighbor,
     strategy: OverviewStrategy = AutoHigherResolution,
     errorThreshold: Double = 0.125,
     targetCellType: Option[TargetCellType] = None,
     baseTiff: Option[MultibandGeoTiff] = None
-  ): GeoTiffReprojectRasterSource = new GeoTiffReprojectRasterSource(dataPath, crs, targetResampleGrid, resampleMethod, strategy, errorThreshold, targetCellType, baseTiff)
+  ): GeoTiffReprojectRasterSource = new GeoTiffReprojectRasterSource(dataPath, crs, resampleTarget, resampleMethod, strategy, errorThreshold, targetCellType, baseTiff)
 }

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -82,7 +82,7 @@ class GeoTiffResampleRasterSource(
 
         resampleTarget match {
           case targetRegion: TargetRegion => targetRegion.region.toGridType[Long]
-          case targetGrid: TargetGrid => targetGrid(reprojectedRasterExtent)
+          case targetAlignment: TargetAlignment => targetAlignment(reprojectedRasterExtent)
           case targetDimensions: TargetDimensions => targetDimensions(reprojectedRasterExtent)
           case targetCellSize: TargetCellSize => targetCellSize(reprojectedRasterExtent)
           case _ => reprojectedRasterExtent

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -70,7 +70,7 @@ class GeoTiffResampleRasterSource(
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(gridExtent.cellSize, strategy)
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
     new GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType) {
       override lazy val gridExtent: GridExtent[Long] = {
         val reprojectedRasterExtent =

--- a/spark/src/main/scala/geotrellis/spark/RasterSummary.scala
+++ b/spark/src/main/scala/geotrellis/spark/RasterSummary.scala
@@ -86,8 +86,8 @@ case class RasterSummary[M](
     toTileLayerMetadata(layoutType.layoutDefinitionWithZoom(crs, extent, cellSize)._1, (_, sk) => sk)
 
   // TODO: probably this function should be removed in the future
-  def resample(resampleGrid: ResampleGrid[Long]): RasterSummary[M] = {
-    val re = resampleGrid(toGridExtent)
+  def resample(resampleTarget: ResampleTarget): RasterSummary[M] = {
+    val re = resampleTarget(toGridExtent)
     RasterSummary(
       crs      = crs,
       cellType = cellType,

--- a/spark/src/test/scala/geotrellis/spark/RasterSummarySpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterSummarySpec.scala
@@ -70,7 +70,7 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with RasterMatchers
       val tiledLayoutSource = sourceRDD.map(_.tileToLayout(layout, method))
 
       val summaryCollected = RasterSummary.fromRDD(tiledLayoutSource.map(_.source))
-      val summaryResampled = summary.resample(TargetGrid(layout))
+      val summaryResampled = summary.resample(TargetAlignment(layout))
 
       val metadata = summary.toTileLayerMetadata(layout)
       val metadataResampled = summaryResampled.toTileLayerMetadata(GlobalLayout(256, zoom, 0.1))

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -97,7 +97,7 @@ class GeoTrellisRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
     if (targetCRS != this.crs) {
       val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
       val (closestLayerId, targetGridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
@@ -105,7 +105,7 @@ class GeoTrellisRasterSource(
     } else {
       // TODO: add unit tests for this in particular, the behavior feels murky
       resampleTarget match {
-        case DefaultResampleTarget =>
+        case DefaultTarget =>
           // I think I was asked to do nothing
           this
         case resampleTarget =>

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -97,27 +97,27 @@ class GeoTrellisRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
 
-  def reprojection(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
     if (targetCRS != this.crs) {
-      val reprojectOptions = ResampleGrid.toReprojectOptions[Long](this.gridExtent, resampleGrid, method)
+      val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
       val (closestLayerId, targetGridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
-      new GeoTrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, targetGridExtent, targetCRS, resampleGrid, targetCellType = targetCellType)
+      new GeoTrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, targetGridExtent, targetCRS, resampleTarget, targetCellType = targetCellType)
     } else {
       // TODO: add unit tests for this in particular, the behavior feels murky
-      resampleGrid match {
-        case IdentityResampleGrid =>
+      resampleTarget match {
+        case DefaultResampleTarget =>
           // I think I was asked to do nothing
           this
-        case resampleGrid =>
-          val resampledGridExtent = resampleGrid(this.gridExtent)
+        case resampleTarget =>
+          val resampledGridExtent = resampleTarget(this.gridExtent)
           val closestLayerId = GeoTrellisRasterSource.getClosestResolution(sourceLayers.toList, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get.id
           new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, resampledGridExtent, method, targetCellType)
       }
     }
   }
 
-  def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
-    val resampledGridExtent = resampleGrid(this.gridExtent)
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
+    val resampledGridExtent = resampleTarget(this.gridExtent)
     val closestLayerId = GeoTrellisRasterSource.getClosestResolution(sourceLayers.toList, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get.id
     new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, resampledGridExtent, method, targetCellType)
   }

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -33,7 +33,7 @@ class GeoTrellisReprojectRasterSource(
   val sourceLayers: Stream[Layer],
   val gridExtent: GridExtent[Long],
   val crs: CRS,
-  val targetResampleGrid: ResampleGrid[Long] = IdentityResampleGrid,
+  val resampleTarget: ResampleTarget = DefaultResampleTarget,
   val resampleMethod: ResampleMethod = NearestNeighbor,
   val strategy: OverviewStrategy = AutoHigherResolution,
   val errorThreshold: Double = 0.125,
@@ -96,7 +96,7 @@ class GeoTrellisReprojectRasterSource(
         targetRasterExtent,
         transform,
         backTransform,
-        ResampleGrid.toReprojectOptions[Long](targetRasterExtent.toGridType[Long], targetResampleGrid, resampleMethod)
+        ResampleTarget.toReprojectOptions(targetRasterExtent.toGridType[Long], resampleTarget, resampleMethod)
       )
       convertRaster(reprojected)
     }
@@ -114,9 +114,9 @@ class GeoTrellisReprojectRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
 
-  def reprojection(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
     if (targetCRS == sourceLayer.metadata.crs) {
-      val resampledGridExtent = resampleGrid(this.sourceLayer.gridExtent)
+      val resampledGridExtent = resampleTarget(this.sourceLayer.gridExtent)
       val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get
       // TODO: if closestLayer is w/in some marging of desired CellSize, return GeoTrellisRasterSource instead
       new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayer.id, sourceLayers, resampledGridExtent, resampleMethod, targetCellType)
@@ -127,7 +127,7 @@ class GeoTrellisReprojectRasterSource(
           .getClosestSourceLayer(
             targetCRS,
             sourceLayers,
-            ResampleGrid.toReprojectOptions[Long](this.gridExtent, targetResampleGrid, resampleMethod),
+            ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, resampleMethod),
             strategy
           )
       new GeoTrellisReprojectRasterSource(
@@ -137,21 +137,21 @@ class GeoTrellisReprojectRasterSource(
         sourceLayers,
         gridExtent,
         targetCRS,
-        resampleGrid,
+        resampleTarget,
         resampleMethod,
         targetCellType = targetCellType
       )
     }
   }
 
-  def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
-    val newReprojectOptions = ResampleGrid.toReprojectOptions(this.gridExtent, resampleGrid, method)
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
+    val newReprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
     val (closestLayerId, newGridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(crs, sourceLayers, newReprojectOptions, strategy)
-    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, newGridExtent, crs, resampleGrid, targetCellType = targetCellType)
+    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, newGridExtent, crs, resampleTarget, targetCellType = targetCellType)
   }
 
   def convert(targetCellType: TargetCellType): RasterSource = {
-    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, crs, targetResampleGrid, targetCellType = Some(targetCellType))
+    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, crs, resampleTarget, targetCellType = Some(targetCellType))
   }
 
   override def toString: String =

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -33,7 +33,7 @@ class GeoTrellisReprojectRasterSource(
   val sourceLayers: Stream[Layer],
   val gridExtent: GridExtent[Long],
   val crs: CRS,
-  val resampleTarget: ResampleTarget = DefaultResampleTarget,
+  val resampleTarget: ResampleTarget = DefaultTarget,
   val resampleMethod: ResampleMethod = NearestNeighbor,
   val strategy: OverviewStrategy = AutoHigherResolution,
   val errorThreshold: Double = 0.125,
@@ -114,7 +114,7 @@ class GeoTrellisReprojectRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
     if (targetCRS == sourceLayer.metadata.crs) {
       val resampledGridExtent = resampleTarget(this.sourceLayer.gridExtent)
       val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -100,7 +100,7 @@ class GeoTrellisResampleRasterSource(
       .flatMap(read(_, bands))
   }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTrellisReprojectRasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTrellisReprojectRasterSource = {
     val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
     val (closestLayerId, gridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
     new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, resampleTarget, targetCellType = targetCellType)

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -100,16 +100,16 @@ class GeoTrellisResampleRasterSource(
       .flatMap(read(_, bands))
   }
 
-  def reprojection(targetCRS: CRS, resampleGrid: ResampleGrid[Long] = IdentityResampleGrid, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTrellisReprojectRasterSource = {
-    val reprojectOptions = ResampleGrid.toReprojectOptions[Long](this.gridExtent, resampleGrid, method)
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultResampleTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTrellisReprojectRasterSource = {
+    val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
     val (closestLayerId, gridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
-    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, resampleGrid, targetCellType = targetCellType)
+    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, resampleTarget, targetCellType = targetCellType)
   }
   /** Resample underlying RasterSource to new grid extent
-   * Note: ResampleGrid will be applied to GridExtent of the source layer, not the GridExtent of this RasterSource
+   * Note: ResampleTarget will be applied to GridExtent of the source layer, not the GridExtent of this RasterSource
    */
-  def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): GeoTrellisResampleRasterSource = {
-    val resampledGridExtent = resampleGrid(this.gridExtent)
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTrellisResampleRasterSource = {
+    val resampledGridExtent = resampleTarget(this.gridExtent)
     val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get
     // TODO: if closestLayer is w/in some marging of desired CellSize, return GeoTrellisRasterSource instead
     new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayer.id, sourceLayers, resampledGridExtent, method, targetCellType)


### PR DESCRIPTION
## Overview

We want to avoid type parameters from being propagated throughout the library when they aren't absolutely necessary. This PR hides the [N: Integral] type parameter which was formerly on
each ResampleGrid class. Additionally, it renames `ResampleGrid` to `ResampleTarget` (as the grid is what is produced rather than the case class itself) and renames `Dimensions` as `TargetDimensions` for consistency and renames the `IdentityResampleGrid` as `DefaultTarget` to better reflect its context-dependent nature (the exact operation which is "default" is dependent on which resample/reprojection function is being used.

### Checklist

- [x] `docs/CHANGELOG.rst` updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
