### PR TITLE
Resolutions should always be read from the source dataset

### DIFF
--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -97,7 +97,7 @@ class GDALRasterSource(
     * These resolutions could represent actual overview as seen in source file
     * or overviews of VRT that was created as result of resample operations.
     */
-  lazy val resolutions: List[CellSize] = dataset.resolutions(datasetType).map(_.cellSize)
+  lazy val resolutions: List[CellSize] = dataset.resolutions(GDALDataset.SOURCE).map(_.cellSize)
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     bounds


### PR DESCRIPTION
## Overview

Forces GDALRasterSources to read resolutions from the `SOURCE` `Dataset` always.

### Checklist

- [x] Unit tests added for bug-fix or new feature

Closes https://github.com/locationtech/geotrellis/issues/3123
