### PR TITLE
The bit segment size should be padded to fit space allocated in bytes

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
@@ -48,12 +48,12 @@ trait GeoTiffSegment {
   def convert(cellType: CellType): Array[Byte] =
     cellType match {
       case BitCellType =>
-        val dsize = size >> 3
+        val dsize = (size + 7) / 8
         val arr = Array.ofDim[Byte](dsize)
         cfor(0)(_ < size, _ + 1) { i => BitArrayTile.update(arr, i, getInt(i))  }
         // Our BitCellType rasters have the bits encoded in a order inside of each byte that is
         // the reverse of what a GeoTiff wants.
-        cfor(0)(_ < dsize, _ + 1) { i => arr(i) = ((Integer.reverse(arr(i)) >>> 24) & 0xff).toByte }
+        cfor(0)(_ < dsize, _ + 1) { i => arr(i) = invertByte(arr(i)) }
         arr
       case ByteCellType =>
         val arr = Array.ofDim[Byte](size)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BitGeoTiffTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BitGeoTiffTileSpec.scala
@@ -93,5 +93,23 @@ class BitGeoTiffTileSpec extends FunSpec
         tiffTileLocal
       }
     }
+
+    it("should convert striped tiffs (1 row per strip)") {
+      // also works with bilevel.tif but fails with 3 stripes per segment
+      val tiff = SinglebandGeoTiff(geoTiffPath("bilevel-strip-1.tif"))
+      val tile = tiff.tile.toArrayTile()
+
+      // check that it is possible to convert bit cellType to bit cellType
+      val tiffTile = tile.toGeoTiffTile.convert(BitCellType)
+      assertEqual(tiffTile.toArrayTile(), tile.toArrayTile)
+
+      // check that it is possible to convert int cellType to bit cellType
+      // and that bitCellType conversion is idempotent
+      (0 to 5).foldLeft(tile.toGeoTiffTile.convert(IntCellType)) { case (acc, _) =>
+        val tiffTileLocal = acc.convert(BitCellType)
+        assertEqual(tiffTileLocal.toArrayTile(), tile.toArrayTile)
+        tiffTileLocal
+      }
+    }
   }
 }


### PR DESCRIPTION
## Overview

This PR allows to read properly single striped tiffs and some other segments sizes that work accidentally. 