### PR TITLE
Add initial chunk argument to StreamingByteReader

### DIFF
--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -9,6 +9,7 @@
   "project vector" test \
   "project vectortile" test \
   "project gdal" test \
+  "project util" test \
   "project geowave" compile test:compile \
   "project hbase" compile \
   "project hbase-spark" test \

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,7 +1,16 @@
 Changelog
 =========
 
-3.0.0-SNAPSHOT
+Unreleased
+-----
+
+API Changes & Project structure changes
+
+- ``geotrellis-util``
+
+  - **Change:** StreamingByteReader instances now optionally take an ``initialChunk`` argument, allowing for chunks larger than the default ``chunkSize`` to be loaded. Useful for tuning metadata and file header read performance 
+
+3.0.0
 -----
 
 API Changes & Project structure changes

--- a/util/src/test/scala/geotrellis/util/StreamingByteReaderSpec.scala
+++ b/util/src/test/scala/geotrellis/util/StreamingByteReaderSpec.scala
@@ -111,5 +111,15 @@ class StreamingByteReaderSpec extends FunSpec with Matchers {
       mockRangeReader.numberOfReads should be (1)
       result.toSeq should be (Seq(122, 123, 124, 125, 126))
     }
+
+    it("should allow retrieval of an initial chunk of the specified size") {
+      val mockRangeReader = new MockRangeReader(arr)
+      val br = new StreamingByteReader(mockRangeReader, chunkSize = 10, initialChunk = 40)
+
+      br.getBytes(40)
+      mockRangeReader.numberOfReads should be (1)
+      br.getBytes(1)
+      mockRangeReader.numberOfReads should be (2)
+    }
   }
 }


### PR DESCRIPTION
# Overview

The streaming byte reader is often used to read metadata from file
headers. Optimal chunking behavior for tif headers vs tif bodies means
that the default chunk size isn't suitable for quickly reading metadata
- in particular when the file header is particularly long. The
StreamingByteReader now supports an `initialChunk` argument which
preloads a chunk of the specified size to avoid multiple reads.

This also fixes a broken test in `geotrellis.util` and enables CI running of `geotrellis.util` tests

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/docs/CHANGELOG.rst) updated, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature


## Notes

This fix allows users that wish to specify an initial read size to do so. Unfortunately, as of now, the API leans on implicit conversions to turn `RangeReader` instances into `StreamingByteReader`s. Without a more robust configuration system, then, setting the `initialChunk` of a `StreamingByteReader` depends on explicitly constructing said `StreamingByteReader` instance


See https://github.com/locationtech/geotrellis/issues/3126
