### PR TITLE
All traits that inherit CellGrid and Grid should be abstract classes

### DIFF
--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -8,6 +8,7 @@
   "project doc-examples" compile \
   "project vector" test \
   "project vectortile" test \
+  "project util" test \
   "project gdal" test \
   "project geowave" compile test:compile \
   "project hbase" compile \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-Fix `StreamingByteReader` over-allocation when reading past EOF [#3138](https://github.com/locationtech/geotrellis/pull/3138)
+- Fix `StreamingByteReader` over-allocation when reading past EOF [#3138](https://github.com/locationtech/geotrellis/pull/3138)
+- `Tile`, `ArrayTile`, `ConstantTile`, `DelegatingTile`, `MultibandTile`, `MultibandArrayTile`, `RasterRegion`, `RasterSource`, `MosaicRasterSource` converted from `trait` to `abstract class` [#3136](https://github.com/locationtech/geotrellis/pull/3136)
 
 ## [3.0.0] - 2019-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+Fix `StreamingByteReader` over-allocation when reading past EOF [#3138](https://github.com/locationtech/geotrellis/pull/3138)
+
 ## [3.0.0] - 2019-10-18
 
 ### Added

--- a/build.sbt
+++ b/build.sbt
@@ -108,11 +108,14 @@ lazy val root = Project("geotrellis", file("."))
     cassandra,
     `cassandra-spark`,
     `doc-examples`,
+    gdal,
+    `gdal-spark`,
     geomesa,
     geotools,
     geowave,
     hbase,
     `hbase-spark`,
+    layer,
     macros,
     proj4,
     raster,
@@ -123,12 +126,11 @@ lazy val root = Project("geotrellis", file("."))
     spark,
     `spark-pipeline`,
     `spark-testkit`,
+    store,
     util,
     vector,
     `vector-testkit`,
-    vectortile,
-    gdal,
-    `gdal-spark`
+    vectortile
   )
   .settings(commonSettings: _*)
   .enablePlugins(ScalaUnidocPlugin)

--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -23,7 +23,7 @@ import spire.syntax.cfor._
   * tile.  Designed to be a near drop-in replacement for Array in many
   * cases.
   */
-trait ArrayTile extends Tile with Serializable {
+abstract class ArrayTile extends Tile with Serializable {
 
   /**
     * Return the [[ArrayTile]] equivalent of this ArrayTile.

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -27,7 +27,7 @@ import spire.syntax.cfor._
 /**
   * The trait underlying constant tile types.
   */
-trait ConstantTile extends Tile {
+abstract class ConstantTile extends Tile {
 
   /** Precomputed view of tile cells as seen by [[get]] method */
   protected val iVal: Int

--- a/raster/src/main/scala/geotrellis/raster/DelegatingTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DelegatingTile.scala
@@ -26,7 +26,7 @@ package geotrellis.raster
  *
  * @since 8/22/18
  */
-trait DelegatingTile extends Tile {
+abstract class DelegatingTile extends Tile {
   protected def delegate: Tile
 
   def cellType: CellType =

--- a/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
@@ -38,7 +38,7 @@ import spire.math.Integral
   * whether they'll have the same CRS. crs allows specifying the CRS on read instead of
   * having to make sure at compile time that you're threading CRSes through everywhere correctly.
   */
-trait MosaicRasterSource extends RasterSource {
+abstract class MosaicRasterSource extends RasterSource {
 
   val sources: NonEmptyList[RasterSource]
   val crs: CRS

--- a/raster/src/main/scala/geotrellis/raster/MultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/MultibandTile.scala
@@ -17,15 +17,7 @@
 package geotrellis.raster
 
 import geotrellis.macros._
-import geotrellis.raster.summary._
-import geotrellis.vector.Extent
-
 import spire.syntax.cfor._
-
-import java.util.Locale
-
-import math.BigDecimal
-
 
 object MultibandTile {
   /**
@@ -51,7 +43,7 @@ object MultibandTile {
     ArrayMultibandTile(bands)
 }
 
-trait MultibandTile extends CellGrid[Int] with MacroCombinableMultibandTile[Tile] with MacroCombineFunctions[Tile, MultibandTile] {
+abstract class MultibandTile extends CellGrid[Int] with MacroCombinableMultibandTile[Tile] with MacroCombineFunctions[Tile, MultibandTile] {
   def bandCount: Int
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/MutableArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/MutableArrayTile.scala
@@ -16,8 +16,6 @@
 
 package geotrellis.raster
 
-import geotrellis.vector._
-
 import spire.syntax.cfor._
 
 
@@ -25,7 +23,7 @@ import spire.syntax.cfor._
   * [[MutableArrayTile]] is an [[ArrayTile]] whose cells can be
   * written to (mutated).
   */
-trait MutableArrayTile extends ArrayTile {
+abstract class MutableArrayTile extends ArrayTile {
   def mutable = this
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/ProjectedRasterLike.scala
+++ b/raster/src/main/scala/geotrellis/raster/ProjectedRasterLike.scala
@@ -22,7 +22,9 @@ import geotrellis.vector.Extent
 /**
   * Conformance interface for entities that are tile-like with a projected extent.
   */
-trait ProjectedRasterLike { _: CellGrid[Int] =>
+trait ProjectedRasterLike {
   def crs: CRS
   def extent: Extent
+  def cols: Int
+  def rows: Int
 }

--- a/raster/src/main/scala/geotrellis/raster/ProjectedRasterLike.scala
+++ b/raster/src/main/scala/geotrellis/raster/ProjectedRasterLike.scala
@@ -22,7 +22,7 @@ import geotrellis.vector.Extent
 /**
   * Conformance interface for entities that are tile-like with a projected extent.
   */
-trait ProjectedRasterLike extends CellGrid[Int] {
+abstract class ProjectedRasterLike extends CellGrid[Int] {
   def crs: CRS
   def extent: Extent
 }

--- a/raster/src/main/scala/geotrellis/raster/ProjectedRasterLike.scala
+++ b/raster/src/main/scala/geotrellis/raster/ProjectedRasterLike.scala
@@ -22,7 +22,7 @@ import geotrellis.vector.Extent
 /**
   * Conformance interface for entities that are tile-like with a projected extent.
   */
-abstract class ProjectedRasterLike extends CellGrid[Int] {
+trait ProjectedRasterLike { _: CellGrid[Int] =>
   def crs: CRS
   def extent: Extent
 }

--- a/raster/src/main/scala/geotrellis/raster/RasterRegion.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterRegion.scala
@@ -22,7 +22,7 @@ import geotrellis.vector.Extent
 /**
   * Reference to a pixel region in a [[RasterSource]] that may be read at a later time.
   */
-abstract class RasterRegion extends ProjectedRasterLike with Serializable {
+abstract class RasterRegion extends CellGrid[Int] with ProjectedRasterLike with Serializable {
   def raster: Option[Raster[MultibandTile]]
 }
 

--- a/raster/src/main/scala/geotrellis/raster/RasterRegion.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterRegion.scala
@@ -22,7 +22,7 @@ import geotrellis.vector.Extent
 /**
   * Reference to a pixel region in a [[RasterSource]] that may be read at a later time.
   */
-trait RasterRegion extends ProjectedRasterLike with Serializable {
+abstract class RasterRegion extends ProjectedRasterLike with Serializable {
   def raster: Option[Raster[MultibandTile]]
 }
 

--- a/raster/src/main/scala/geotrellis/raster/RasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterSource.scala
@@ -41,7 +41,7 @@ import java.util.ServiceLoader
   * @groupdesc reproject Functions to resample raster data in target projection.
   * @groupprio reproject 2
   */
-trait RasterSource extends CellGrid[Long] with RasterMetadata {
+abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
   /** All available RasterSource metadata */
   def metadata: RasterMetadata
 

--- a/raster/src/main/scala/geotrellis/raster/Tile.scala
+++ b/raster/src/main/scala/geotrellis/raster/Tile.scala
@@ -19,7 +19,7 @@ package geotrellis.raster
 /**
   * Base trait for a Tile.
   */
-trait Tile extends CellGrid[Int] with IterableTile with MappableTile[Tile] {
+abstract class Tile extends CellGrid[Int] with IterableTile with MappableTile[Tile] {
   /**
     * Execute a function at each pixel of a [[Tile]].  Two functions
     * are given: an integer version which is used if the tile is an


### PR DESCRIPTION
# Overview

This PR makes Tile, ArrayTile and MultibandTile abstract classes. In our types hierarchy `Tile` types extend `CellGrid` and `Grid`. In 2.x both `Tile` and `CellGrid` were `traits`, and in `3.x` `CellGrid` became an abstract class, so we had a not very usual case, where `traits` extended abstract `classes`. This is not possible in Java and creates problems on Spark, for more details looks into https://github.com/locationtech/geotrellis/issues/3134

This is the idea suggested by @echeipesh and it is probably the best solution.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/docs/CHANGELOG.rst) updated, if necessary

## Demo

```scala
scala> :javap geotrellis.raster.Tile
  Size 11433 bytes
  MD5 checksum 973688ee6c0ddfd43788d33a6cee0989
  Compiled from "Tile.scala"
public abstract class geotrellis.raster.Tile extends geotrellis.raster.CellGrid<java.lang.Object> implements geotrellis.raster.IterableTile, geotrellis.raster.MappableTile<geotrellis.raster.Tile>
```

```scala
scala> classOf[geotrellis.raster.CellGrid[_]].isAssignableFrom(classOf[geotrellis.raster.Tile])
res0: Boolean = true

scala> classOf[geotrellis.raster.CellGrid[_]].isInstance(geotrellis.raster.IntConstantTile(1,2,3))
res1: Boolean = true

scala> classOf[geotrellis.raster.CellGrid[Int]].isAssignableFrom(classOf[geotrellis.raster.Tile])
res2: Boolean = true
```

Closes https://github.com/locationtech/geotrellis/issues/3134
