### PR TITLE
Fix StreamingByteReader over-allocation past EOF

### DIFF
--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -8,6 +8,7 @@
   "project doc-examples" compile \
   "project vector" test \
   "project vectortile" test \
+  "project util" test \
   "project gdal" test \
   "project geowave" compile test:compile \
   "project hbase" compile \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+Fix `StreamingByteReader` over-allocation when reading past EOF [#3138](https://github.com/locationtech/geotrellis/pull/3138)
+
 ## [3.0.0] - 2019-10-18
 
 ### Added


### PR DESCRIPTION
# Overview

Extracts bug fix from https://github.com/locationtech/geotrellis/pull/3135

When reading past end of file `StreamingRangeReader` would allocate array for the site it was intending to read, rather than actual size that was read when requested read range is past EOF.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary

