### PR TITLE
Remove unnecessary calculations in Hillshade

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/Hillshade.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/Hillshade.scala
@@ -53,9 +53,8 @@ object Hillshade {
       val sinAz = sin(azimuth)
 
       def setValue(x: Int, y: Int, s: SurfacePoint) {
-        val slope = s.slope(zFactor)
-        val aspect = s.aspect
-
+        s.`dz/dx` = s.`dz/dx` * zFactor
+        s.`dz/dy` = s.`dz/dy` * zFactor
         val c = cosAz * s.cosAspect + sinAz * s.sinAspect // cos(azimuth - aspect)
         val v = (cosZ * s.cosSlope) + (sinZ * s.sinSlope * c)
         resultTile.set(x, y, round(127.0 * max(0.0, v)).toInt)


### PR DESCRIPTION
# Overview

remove unnecessary slope and aspect calculations.

## Checklist

- [X] Unit tests added for bug-fix or new feature

## Notes

Two questions:
1. In terms of `zFactor`, should it be better to put this parameter to `SurfacePointCalculation` class?
in method `calcSurface` like this:
```scala
s.`dz/dx` = zFactor * (neValue + 2*eValue + seValue - nwValue - 2*wValue - swValue) / (8 * cellWidth)
s.`dz/dy` = zFactor * (swValue + 2*sValue + seValue - nwValue - 2*nValue - neValue) / (8 * cellHeight)
```
2. in the expression `resultTile.set(x, y, round(127.0 * max(0.0, v)).toInt)` of the commited file, why `127.0` is set here while it is `255.0` in [https://desktop.arcgis.com/en/arcmap/10.3/tools/spatial-analyst-toolbox/how-hillshade-works.htm](https://desktop.arcgis.com/en/arcmap/10.3/tools/spatial-analyst-toolbox/how-hillshade-works.htm)