### PR TITLE
Remove min/max in computing CellType for GDALDataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Remove band min-max consideration from `CellType` calculation in `GDALDataset`  [#3148](https://github.com/locationtech/geotrellis/issues/3148)
+
 ## [3.1.0] - 2019-10-25
 
 ### Changed

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -288,23 +288,7 @@ case class GDALDataset(token: Long) extends AnyVal {
     require(acceptableDatasets contains datasetType)
     val nd = noDataValue(datasetType)
     val dt = GDALDataType.intToGDALDataType(this.dataType(datasetType))
-    val mm = {
-      val minmax = Array.ofDim[Double](2)
-      val success = Array.ofDim[Int](1)
-
-      val returnValue = GDALWarp.get_band_min_max(token, datasetType.value, numberOfAttempts, 1, true, minmax, success)
-
-      if (returnValue <= 0) {
-        val positiveValue = math.abs(returnValue)
-        throw new MalformedDataTypeException(
-          s"Unable to deterime the min/max values in order to calculate CellType. GDAL Error Code: $positiveValue",
-          positiveValue
-        )
-      }
-      if (success(0) != 0) Some(minmax(0), minmax(1))
-      else None
-    }
-    GDALUtils.dataTypeToCellType(datatype = dt, noDataValue = nd, minMaxValues = mm)
+    GDALUtils.dataTypeToCellType(datatype = dt, noDataValue = nd)
   }
 
   def readTile(gb: GridBounds[Int] = GridBounds(dimensions), band: Int, datasetType: DatasetType = GDALDataset.WARPED): Tile = {

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALUtils.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALUtils.scala
@@ -43,17 +43,19 @@ object GDALUtils {
           case Some(bits) if bits == 1 => BitCellType
           case _ =>
             minMaxValues match {
-              case Some((mi, ma)) if (mi.toInt >= 0 && mi <= 255) && (ma.toInt >= 0 && ma <= 255) =>
-                noDataValue match {
-                  case Some(nd) if nd.toInt > 0 && nd <= 255 => UByteUserDefinedNoDataCellType(nd.toByte)
-                  case Some(nd) if nd.toInt == 0 => UByteConstantNoDataCellType
-                  case _ => UByteCellType
-                }
-              case _ =>
+              case Some((mi, ma)) if mi >= -128 && mi < 128 && ma >= -128 && ma < 128 =>
+                // signed Byte
                 noDataValue match {
                   case Some(nd) if nd.toInt > Byte.MinValue.toInt && nd <= Byte.MaxValue.toInt => ByteUserDefinedNoDataCellType(nd.toByte)
                   case Some(nd) if nd.toInt == Byte.MinValue.toInt => ByteConstantNoDataCellType
                   case _ => ByteCellType
+                }
+              case _ ⇒
+                // unsigned Byte
+                noDataValue match {
+                  case Some(nd) if nd.toInt > 0 && nd <= 255 => UByteUserDefinedNoDataCellType(nd.toByte)
+                  case Some(nd) if nd.toInt == 0 => UByteConstantNoDataCellType
+                  case _ => UByteCellType
                 }
             }
         }


### PR DESCRIPTION
# Overview

GDAL's type system is narrower than GT
[GDALDataType.GDT_Byte](https://gdal.org/api/raster_c_api.html#_CPPv412GDALDataType) maps to `UByte*` `CellType`s only depending on NoData

In GDALUtils.dataTypeToCellType, only get unsigned Byte by passing in appropriate min and max. This is to avoid breaking the existing call behavior.

Some gitter discussion on the topic [here](https://gitter.im/geotrellis/geotrellis?at=5dc5839a6ba2347d2d59af2e)


## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [x] [Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature



Closes #3148
