### PR TITLE
make withGetBoundsMethod serializable

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/Implicits.scala
@@ -254,7 +254,7 @@ trait Implicits
     }
   }
 
-  implicit class withGetBoundsMethod[K: Boundable, V <: CellGrid[Int]](rdd: RDD[(K, V)]) {
+  implicit class withGetBoundsMethod[K: Boundable, V <: CellGrid[Int]](rdd: RDD[(K, V)]) extends Serializable {
     def getBounds: Bounds[K] =
       rdd
         .map { case (k, tile) => Bounds(k, k) }


### PR DESCRIPTION
Signed-off-by: Frank Dekervel <frank@kapernikov.com>

# Overview

without this, trying to do getBounds on a RDD will result in a serialisation error on spark 2.4.4.
with this trivial change applied, getBounds works without error.

## Checklist

- [ ] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [ ] [Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL

## Notes

I did not update any other code as this change is completely trivial and in line with the rest of the classes in the same file.
