### PR TITLE
#3144: MinResample / MaxResample: preserve NODATA correctly for double cell …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Preserve NODATA values for double cell types when resampling with Max or Min resampler (#3144)
+
 ## [3.1.0] - 2019-10-25
 
 ### Changed

--- a/raster/src/main/scala/geotrellis/raster/resample/MaxResample.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/MaxResample.scala
@@ -40,7 +40,7 @@ class MaxResample(tile: Tile, extent: Extent, targetCS: CellSize)
       // Double.NaN would *always* be max
       if (isData(v)) math.max(currentMax, v) else currentMax
     }
-    if (doubleMax == Double.MinValue) NODATA else doubleMax
+    if (doubleMax == Double.MinValue) doubleNODATA else doubleMax
   }
 
   def resampleValid(x: Double, y: Double): Int = calculateMax(contributions(x, y))

--- a/raster/src/main/scala/geotrellis/raster/resample/MinResample.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/MinResample.scala
@@ -40,7 +40,7 @@ class MinResample(tile: Tile, extent: Extent, targetCS: CellSize)
       // Double.NaN would *always* be max
       if (isData(v)) math.min(currentMin, v) else currentMin
     }
-    if (doubleMin == Double.MaxValue) NODATA else doubleMin
+    if (doubleMin == Double.MaxValue) doubleNODATA else doubleMin
   }
 
   def resampleValid(x: Double, y: Double): Int = calculateMin(contributions(x, y))

--- a/raster/src/test/scala/geotrellis/raster/resample/MaxResampleSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/resample/MaxResampleSpec.scala
@@ -35,12 +35,13 @@ class MaxResampleSpec extends FunSpec with Matchers {
     }
 
     it("should for a nodata double tile compute nodata as max value") {
-      val tile = DoubleArrayTile(Array(NODATA, NODATA, NODATA,
-                                       NODATA, NODATA, NODATA,
-                                       NODATA, NODATA, NODATA), 3, 3)
+      val tile = DoubleArrayTile(Array(doubleNODATA, doubleNODATA, doubleNODATA,
+                                       doubleNODATA, doubleNODATA, doubleNODATA,
+                                       doubleNODATA, doubleNODATA, doubleNODATA), 3, 3)
       val extent = Extent(0, 0, 10, 10)
       val cellsize = CellSize(extent, 10, 10)
-      tile.resample(extent, 1, 1, Max).get(0, 0) should be (NODATA)
+      tile.resample(extent, 1, 1, Max).getDouble(0, 0).isNaN shouldBe true
+      tile.resample(extent, 1, 1, Max).get(0,0) should be (NODATA)
     }
 
     it("should for an integer tile compute the correct maximum value") {

--- a/raster/src/test/scala/geotrellis/raster/resample/MinResampleSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/resample/MinResampleSpec.scala
@@ -40,7 +40,8 @@ class MinResampleSpec extends FunSpec with Matchers {
                                        doubleNODATA, doubleNODATA, doubleNODATA), 3, 3)
       val extent = Extent(0, 0, 10, 10)
       val cellsize = CellSize(extent, 10, 10)
-      tile.resample(extent, 1, 1, Min).get(0, 0) should be (NODATA)
+      tile.resample(extent, 1, 1, Max).getDouble(0, 0).isNaN shouldBe true
+      tile.resample(extent, 1, 1, Max).get(0,0) should be (NODATA)
     }
 
     it("should for an integer tile compute nodata as minimum value") {


### PR DESCRIPTION
# Overview

The current code set NODATA for nodata cells, but NODATA is only valid for Int cell types. Double.NaN or doubleNODATA should be used for double cells
See #3144

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [ ] [Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL

## Notes


Closes #3144
