### PR TITLE
Fixes fallback implementation of `ArrayTile.combine` for `DelegatingTile`

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -229,14 +229,7 @@ abstract class ArrayTile extends Tile with Serializable {
       case ct: CroppedTile =>
         ct.combine(this)((z1, z2) => f(z2, z1))
       case t =>
-        this.map((col, row, z) => {
-          if (isNoData(z)) z
-          else {
-            val v = t.get(col, row)
-            if (isNoData(v)) v
-            else f(z, v)
-          }
-        })
+        this.map((col, row, z) => f(z, t.get(col, row)))
   }
 
   /**

--- a/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
@@ -196,18 +196,21 @@ class ArrayTileSpec extends FunSpec
 
         def add(l: Int, r: Int) = if(isNoData(l) || isNoData(r)) NODATA else l + r
         assertEqual(at.combine(fauxTile)(add), twice)
+        assertEqual(twice, at.combine(fauxTile)(add))
       }
 
       withClue("DoubleArrayTile with NoData") {
         val at = injectNoData(4)(createValueTile(10, 10.2))
+          .convert(DoubleUserDefinedNoDataCellType(33.2))
 
         val twice = at * 2
         val fauxTile = new DelegatingTile {
           override protected def delegate: Tile = at
         }
 
-        assertEqual(at.combineDouble(fauxTile)((z1, z2) => z1 + z2), twice)
-        assertEqual(fauxTile.combineDouble(at)((z1, z2) => z1 + z2), twice)
+        def add(l: Double, r: Double) = if(isNoData(l) || isNoData(r)) doubleNODATA else l + r
+        assertEqual(at.combineDouble(fauxTile)(add), twice)
+        assertEqual(fauxTile.combineDouble(at)(add), twice)
       }
 
       withClue("delegation of NoData semantics") {


### PR DESCRIPTION
# Overview

As evidenced by the test, `DelegatingTile` is not able to provide commutative assurances with operations using the `combine`/`combineDouble` mechanism.

## Checklist

~- [ ] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary~
~- [ ] [Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary~
~- [ ] `docs` guides update, if necessary~
~- [ ] New user API has useful Scaladoc strings~
- [x] Unit tests added for bug-fix or new feature

## Demo

See unit test

## Notes

Closes #3153 
