### PR TITLE
Lazy compute of band min max to compute CellType in GDALDataset

### DIFF
--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -288,7 +288,8 @@ case class GDALDataset(token: Long) extends AnyVal {
     require(acceptableDatasets contains datasetType)
     val nd = noDataValue(datasetType)
     val dt = GDALDataType.intToGDALDataType(this.dataType(datasetType))
-    val mm = {
+    // This is declared lazy to avoid eval if the by-name param in GDALUtils.dataTypeToCellType is not needed
+    lazy val mm = {
       val minmax = Array.ofDim[Double](2)
       val success = Array.ofDim[Int](1)
 


### PR DESCRIPTION
# Overview

Reinstates the lazy declaration of the raster band min max variable as in https://github.com/geotrellis/geotrellis-gdal/pull/40/files#diff-5e19e2811cf054c87ebc2afd642ebaa3R64

That lazy declaration has a subtle role with the by-name min max parameter in `GDALUtils.dataTypeToCellType`. If not `lazy`, then the min-max is computed even though it is only used in one case. This can result in a lot of unnecessary I/O.


## Checklist

- [ ] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [x] [Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature


## Notes

This change is only oriented at improving performance. It should not change any behavior in the computation of the  CellType.

Closes #3148 
