### PR TITLE
Fix polygon rasterizer crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
+
 ## [3.2.0] - 2019-11-19
 
 ### Changed

--- a/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
@@ -23,6 +23,9 @@ import geotrellis.vector._
 
 import org.locationtech.jts.geom.Envelope
 import org.locationtech.jts.index.strtree.STRtree
+
+import spire.math.Fractional
+import spire.syntax.fractional._
 import spire.syntax.cfor._
 
 import scala.collection.JavaConverters._
@@ -101,8 +104,7 @@ object PolygonRasterizer {
    * @param y     The y-value for a line parallel to the x-axis
    */
   private def lineAxisIntersection(line: Segment, y: Double, precisely: Boolean = false) = {
-    import spire.syntax.fractional._
-    def calculate[A: spire.math.Fractional](x1: A, y1: A, x2: A, y2: A, y: A) =
+    def calculate[@specialized(Double) A: Fractional](x1: A, y1: A, x2: A, y2: A, y: A) =
       if (y == y1) (x1.toDouble, 1) // Top endpoint
       else if (y == y2) (x2.toDouble, -1) // Bottom endpoint
       else if ((y1 min y2) <= y && y <= (y1 max y2)) { // Between endpoints

--- a/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
@@ -100,15 +100,20 @@ object PolygonRasterizer {
    * @param line  A line segment
    * @param y     The y-value for a line parallel to the x-axis
    */
-  private def lineAxisIntersection(line: Segment, y: Double) = {
+  private def lineAxisIntersection(line: Segment, y: Double, precisely: Boolean = false) = {
+    import spire.syntax.fractional._
+    def calculate[A: spire.math.Fractional](x1: A, y1: A, x2: A, y2: A, y: A) =
+      if (y == y1) (x1.toDouble, 1) // Top endpoint
+      else if (y == y2) (x2.toDouble, -1) // Bottom endpoint
+      else if ((y1 min y2) <= y && y <= (y1 max y2)) { // Between endpoints
+        ((((x1-x2)*y-(x1*y2-y1*x2))/(y1-y2)).toDouble, 0)
+      }
+      else (Double.NegativeInfinity, Int.MaxValue) // No intersection
+
     val (x1, y1, x2, y2) = line
 
-    if (y == y1) (x1,1) // Top endpoint
-    else if (y == y2) (x2,-1) // Bottom endpoint
-    else if ((min(y1,y2) <= y) && (y <= max(y1,y2))) { // Between endpoints
-      (((x1-x2)*y-(x1*y2-y1*x2))/(y1-y2),0)
-    }
-    else (Double.NegativeInfinity, Int.MaxValue) // No intersection
+    if (precisely) calculate(x1.toRational, y1.toRational, x2.toRational, y2.toRational, y.toRational)
+    else calculate(x1, y1, x2, y2, y)
   }
 
   /**
@@ -174,16 +179,15 @@ object PolygonRasterizer {
     * This routine ASSUMES that the polygon is closed, is of finite
     * area, and that its boundary does not self-intersect.
     *
-    * @param edges  A list of active edges
+    * @param rtree  An STRtree with active edges
     * @param y      The y-value of the vertical scanline
     * @param maxX   The maximum-possible x-coordinate
     */
   private def runsPoint(rtree: STRtree, y: Int, maxX: Int): Array[Double] = {
     val row = y + 0.5
-    val xcoordsMap = mutable.Map[Double, Int]()
     val xcoordsList = mutable.ListBuffer[Double]()
 
-    val segments = {
+    def segments(precisely: Boolean) = {
       var nonHorizontal = 0
       var horizontal = false
 
@@ -194,7 +198,7 @@ object PolygonRasterizer {
           .flatMap({ edgeObj =>
             val edge = edgeObj.asInstanceOf[Segment]
             if (edge._2 != edge._4) {
-              val (xcoord, parity) = lineAxisIntersection(edge,row)
+              val (xcoord, parity) = lineAxisIntersection(edge, row, precisely)
               nonHorizontal += 1
               if (parity != Int.MaxValue) Some((xcoord, parity))
               else None
@@ -229,12 +233,25 @@ object PolygonRasterizer {
       else segments
     }
 
-    segments.foreach({ case (xcoord, parity) =>
-      if (xcoordsMap.contains(xcoord)) xcoordsMap(xcoord) += parity
-      else xcoordsMap(xcoord) = parity
-    })
+    def xcoordsMap(precisely: Boolean): mutable.Map[Double, Int] = {
+      val map = mutable.Map[Double, Int]()
 
-    xcoordsMap.foreach({ case (xcoord, parity) =>
+      var containsIntersections = false
+      segments(precisely).foreach { case (xcoord, parity) =>
+        if (map.contains(xcoord)) {
+          map(xcoord) += parity
+          containsIntersections = true
+        }
+        else map(xcoord) = parity
+      }
+
+      /** If an intersaction was found, recalculate precisely.
+        * It might be distinct points, merged due to a Double calc error.
+        */
+      if (containsIntersections && !precisely) xcoordsMap(true) else map
+    }
+
+    xcoordsMap(false).foreach({ case (xcoord, parity) =>
       /**
         * This is where the ASSUMPTION is used.  Given the assumption,
         * this intersection  should be used as  the open or close  of a
@@ -261,7 +278,7 @@ object PolygonRasterizer {
     * This routine ASSUMES that the polygon is closed, is of finite
     * area, and that its boundary does not self-intersect.
     *
-    * @param edges    A list of active edges
+    * @param rtree    An STRtree with active edges
     * @param y        The y-value of the bottom of the vertical scan-rectangle
     * @param maxX     The maximum-possible x-coordinate
     * @param partial  True if all intersected cells are to be reported, otherwise only those on the interior of the polygon

--- a/raster/src/test/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizerSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizerSpec.scala
@@ -107,6 +107,20 @@ class PolygonRasterizerSpec extends FunSuite
     assert(sum === 65536)
   }
 
+  test("Should not fail because of a Double-related issue") {
+    val poly = Polygon(LineString(Seq[(Double, Double)](
+      (-156.7523879306299, 21.545279181475966),
+      (-156.75200324049055, 21.545438525349006),
+      (-156.75110930806937, 21.5432559342482),
+      (-156.7523879306299, 21.545279181475966)
+    )))
+    val re = RasterExtent(
+      Extent(-157.026672, 21.545119837602627, -156.75185966180015, 21.559142098430257),
+      CellSize(3.3310586448311594E-4, 6.37375492151282E-4)
+    )
+    Rasterizer.rasterizeWithValue(poly, re, 1)
+  }
+
   test("polygon rasterization: more complex polygons") {
     val p1 = Polygon (LineString(Seq[(Double,Double)]((-74.6229572569999, 41.5930024740001),
       (-74.6249086829999, 41.5854607480001),


### PR DESCRIPTION
Signed-off-by: Andrey Tararaksin <atararaksin@gmail.com>

# Overview

This PR fixes `PolygonRasterizer` crash described in #3160. Consider a scanline crossing two edges of a polygon in two separate (non-vertex) points. If x-coords of these points are calculated as identical Doubles (due to a Double-related error), the crash occurs.
This PR fixes this issue by recalculating such coordinates using precise `spire.math.Rational`. This recalculation is performed for a given row if it contains two or more matching Double x-coords. It is a very rare case and for a typical polygon occurs zero to little times, so the general-case performance is not affected.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [x] Unit tests added for bug-fix or new feature


Closes #3160
