### PR TITLE
Fix spatial join when left and right rdd have different PartitionerIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve NODATA values for double cell types when resampling with Max or Min resampler [#3144](https://github.com/locationtech/geotrellis/pull/3144)
 - Update dependency versions for Scala 2.12 cross build [#3132](https://github.com/locationtech/geotrellis/pull/3132)
 - Fix eager evaluation of band min-max in `GDALDataset` [#](https://github.com/locationtech/geotrellis/pull/3162)
+- Fix spatial join (Spark) when using different partitioning in left and right RDDs [#3175](https://github.com/locationtech/geotrellis/pull/3175)
 
 ## [3.1.0] - 2019-10-25
 

--- a/spark/src/main/scala/geotrellis/spark/partition/PartitionerIndex.scala
+++ b/spark/src/main/scala/geotrellis/spark/partition/PartitionerIndex.scala
@@ -23,7 +23,7 @@ import geotrellis.store.index.zcurve.{Z3, Z2, ZSpatialKeyIndex}
 
 /** Coarse KeyIndex to be used for partitioning of RDDs.
   * Coarseness means that multiple keys will be mapped to a single SFC value.
-  * This many to one mapping forms spatially relate key blocks
+  * This many to one mapping forms spatially related key blocks
   */
 trait PartitionerIndex[K] extends Serializable {
   def toIndex(key: K): BigInt
@@ -34,7 +34,7 @@ object PartitionerIndex {
 
   /**
     * This is a reasonable default value. Operating on 512x512 tiles of Doubles
-    * This partitioner will produces partitions of approximately half a gigabyte.
+    * This partitioner will produces partitions of approximately half a gigabyte (16x16 blocks of 512x512 tiles of 64bit)
     */
   implicit object SpatialPartitioner extends  PartitionerIndex[SpatialKey] {
     private def toZ(key: SpatialKey): Z2 = Z2(key.col >> 4, key.row >> 4)

--- a/spark/src/main/scala/geotrellis/spark/partition/ReorderedRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/partition/ReorderedRDD.scala
@@ -32,9 +32,10 @@ class ReorderedDependency[T](rdd: RDD[T], f: Int => Option[Int]) extends NarrowD
 
 class ReorderedSpaceRDD[K, V](rdd: RDD[(K, V)], part: SpacePartitioner[K]) extends RDD[(K, V)](rdd.context, Nil) {
   val sourcePart = {
-    val msg =  s"ReorderedSpaceRDD requires that $rdd has a SpacePartitioner[K]"
+    val msg =  s"ReorderedSpaceRDD requires that $rdd has a SpacePartitioner[K] with same indexing"
     require(rdd.partitioner.isDefined, msg)
     require(rdd.partitioner.get.isInstanceOf[SpacePartitioner[_]], msg)
+    require(rdd.partitioner.get.asInstanceOf[SpacePartitioner[K]].hasSameIndex(part), msg)
     rdd.partitioner.get.asInstanceOf[SpacePartitioner[K]]
   }
 

--- a/spark/src/main/scala/geotrellis/spark/partition/SpacePartitioner.scala
+++ b/spark/src/main/scala/geotrellis/spark/partition/SpacePartitioner.scala
@@ -56,6 +56,9 @@ case class SpacePartitioner[K: Boundable: ClassTag](bounds: Bounds[K])
     regions.indexOf(i) > -1
   }
 
+  /**
+    * Map given spatial region index to offset in region array (aka partition id)
+    */
   def regionIndex(region: BigInt): Option[Int] = {
     // Note: Consider future design where region can overlap several partitions, would change Option -> List
     val i = regions.indexOf(region)

--- a/spark/src/test/scala/geotrellis/spark/join/SpatialJoinRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/join/SpatialJoinRDDSpec.scala
@@ -82,7 +82,7 @@ class SpatialJoinRDDSpec extends FunSpec with Matchers with TestEnvironment {
     info(s"SpaceRDD join partitioner: ${res.partitioner}")
     info(s"  number of partitions: ${res.partitions.length}")
     res.partitioner.get should be (part1)
-    res.collect() sameElements expected.collect()
+    res.collect() should contain theSameElementsAs expected.collect()
     maxPartitionSize(res) should be <= 4
   }
 
@@ -90,13 +90,13 @@ class SpatialJoinRDDSpec extends FunSpec with Matchers with TestEnvironment {
     val res = pr1.leftOuterJoin(pr3)
     val expected = pr1.mapValues(v => (v, None))
 
-    res.collect() sameElements expected.collect()
+    res.collect() should contain theSameElementsAs expected.collect()
   }
 
    it("left join to empty SpaceRDD") {
      val res = prEmpty.leftOuterJoin(pr3)
      val records = res.collect()
-     records sameElements Array[(SpatialKey, Int)]()
+     records shouldBe empty
      info("records: " + records.length)
    }
 
@@ -107,14 +107,14 @@ class SpatialJoinRDDSpec extends FunSpec with Matchers with TestEnvironment {
     info(s"PairRDDFunctions partitioner: ${expected.partitioner}")
     info(s"SpaceRDD join partitioner: ${res.partitioner}")
     res.partitioner.get should be equals SpacePartitioner(KeyBounds(SpatialKey(5,5), SpatialKey(10,10)))
-    res.collect() sameElements expected.collect()
+    res.collect() should contain theSameElementsAs expected.collect()
     maxPartitionSize(res) should be <= 4
   }
 
   it("inner join non intersecting rdds") {
     val res = pr1.join(pr3)
     val records =res.collect()
-    records sameElements Array[(SpatialKey, Int)]()
+    records shouldBe empty
     info("records: " + records.length)
   }
 

--- a/spark/src/test/scala/geotrellis/spark/join/SpatialJoinRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/join/SpatialJoinRDDSpec.scala
@@ -118,4 +118,26 @@ class SpatialJoinRDDSpec extends FunSpec with Matchers with TestEnvironment {
     info("records: " + records.length)
   }
 
+  it("left join with custom partitioner index") {
+    import geotrellis.spark.partition.CustomPartitioning
+    // Build contextRDDs with explicit partitioning
+    val pr1 = ContextRDD(rdd1.partitionBy(part1), part1.bounds)
+    val part2Custom = CustomPartitioning.getCustomSpacePartitioner(bounds2)
+    val pr2Custom = ContextRDD(rdd2.partitionBy(part2Custom), part2Custom.bounds)
+    val expected = new PairRDDFunctions(rdd1).leftOuterJoin(rdd2)
+    val res = pr1.spatialLeftOuterJoin(pr2Custom)
+    res.collect() should contain theSameElementsAs expected.collect()
+  }
+
+  it("join with custom partitioner index") {
+    import geotrellis.spark.partition.CustomPartitioning
+    // Build contextRDDs with explicit partitioning
+    val pr1 = ContextRDD(rdd1.partitionBy(part1), part1.bounds)
+    val part2Custom = CustomPartitioning.getCustomSpacePartitioner(bounds2)
+    val pr2Custom = ContextRDD(rdd2.partitionBy(part2Custom), part2Custom.bounds)
+    val expected = new PairRDDFunctions(rdd1).join(rdd2)
+    val res = pr1.spatialJoin(pr2Custom)
+    res.collect() should contain theSameElementsAs expected.collect()
+  }
+
 }

--- a/spark/src/test/scala/geotrellis/spark/partition/ReorderedRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/partition/ReorderedRDDSpec.scala
@@ -49,7 +49,10 @@ class ReorderedRDDSpec extends FunSpec with Matchers with TestEnvironment {
 
   it("should reorder partitions"){
     val res = new ReorderedSpaceRDD(rdd1, SpacePartitioner(bounds2))
-    res.collect() should not be empty
+    val keys = res.collect().map(r => r._1)
+    // Key range of `bounds2` covers `5 to 10` ranges, but `4` is in same partition of `5`, so it's also covered
+    val expected = for {c <- 4 to 10; r <- 4 to 10} yield SpatialKey(c, r)
+    keys should contain theSameElementsAs expected
   }
 
   it("should reorder to empty"){

--- a/spark/src/test/scala/geotrellis/spark/partition/ReorderedRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/partition/ReorderedRDDSpec.scala
@@ -67,4 +67,12 @@ class ReorderedRDDSpec extends FunSpec with Matchers with TestEnvironment {
     }
     res.collect() shouldBe empty
   }
+
+  it("should fail when different spatial region indexers are in play") {
+    val customPartitioner = CustomPartitioning.getCustomSpacePartitioner(bounds2)
+    customPartitioner.hasSameIndex(rdd1.partitioner.get.asInstanceOf[SpacePartitioner[SpatialKey]]) shouldBe false
+    val key = SpatialKey(1, 2)
+    part1.index.toIndex(key) should not be customPartitioner.index.toIndex(key)
+    an [IllegalArgumentException] should be thrownBy new ReorderedSpaceRDD(rdd1, customPartitioner)
+  }
 }

--- a/spark/src/test/scala/geotrellis/spark/partition/TestImplicits.scala
+++ b/spark/src/test/scala/geotrellis/spark/partition/TestImplicits.scala
@@ -34,3 +34,26 @@ object TestImplicits {
       zCurveIndex.indexRanges((rescale(r._1), rescale(r._2)))
   }
 }
+
+
+object CustomPartitioning {
+
+  implicit object AnotherPartitionerIndex extends PartitionerIndex[SpatialKey] {
+    private val zCurveIndex = new ZSpatialKeyIndex(KeyBounds(SpatialKey(0, 0), SpatialKey(100, 100)))
+
+    def rescale(key: SpatialKey): SpatialKey =
+      SpatialKey(10 + key.col / 3, 10 + key.row / 3)
+
+    override def toIndex(key: SpatialKey): BigInt =
+      zCurveIndex.toIndex(rescale(key))
+
+    override def indexRanges(r: (SpatialKey, SpatialKey)): Seq[(BigInt, BigInt)] =
+      zCurveIndex.indexRanges((rescale(r._1), rescale(r._2)))
+  }
+
+  def getCustomSpacePartitioner(bounds: KeyBounds[SpatialKey]): SpacePartitioner[SpatialKey] = {
+    // This space partitioner will use AnotherPartitionerIndex implicitly
+    SpacePartitioner(bounds)
+  }
+
+}


### PR DESCRIPTION
# Overview

Fixes issue described at #3168 
The original implementation blindly assumed same partition indexing, causing empty join when using custom partitioning with one of the RDDs being joined.
This PR adds tests for this use case and fixes the issue by adding an additional check that same PartitionIndexer is used, so that reshuffle is triggered when that is not the case.
PR also fixed some inactive asserts in same file.
It also addresses partitioning mismatch in ReorderedSpaceRDD

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
-  <del>[Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary </del>
-  <del>`docs` guides update, if necessary</del>
-  <del>New user API has useful Scaladoc strings</del>
- [x] Unit tests added for bug-fix or new feature

Closes #3168
