### PR TITLE
Bump to latest relase of gdal-warp-bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.2.0] - 2019-11-19
 
+- Update `gdal-warp-bindings` to version 33.60a6918 [#3177](https://github.com/locationtech/geotrellis/pull/3177)
+
 ### Changed
 
 - Preserve NODATA values for double cell types when resampling with Max or Min resampler [#3144](https://github.com/locationtech/geotrellis/pull/3144)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Version {
   val hadoop      = "2.8.5"
   val spark       = "2.4.4"
   val gdal        = "2.4.0"
-  val gdalWarp    = "33.567d940"
+  val gdalWarp    = "33.60a6918"
 
   val previousVersion = "3.0.0"
 }
@@ -137,7 +137,7 @@ object Dependencies {
 
 
   val gdalBindings        = "org.gdal"                     % "gdal"                    % Version.gdal
-  val gdalWarp            = "com.azavea.geotrellis"        % "gdal-warp-bindings"      % Version.gdalWarp
+  val gdalWarp            = "com.azavea.gdal"              % "gdal-warp-bindings"      % Version.gdalWarp
 
   val jacksonCore         = "com.fasterxml.jackson.core"    % "jackson-core"             % "2.6.7"
   val jacksonDatabind     = "com.fasterxml.jackson.core"    % "jackson-databind"         % "2.6.7"


### PR DESCRIPTION
# Overview

Update gdal-warp-bindings to 33.60a6918. Related to https://github.com/geotrellis/gdal-warp-bindings/issues/72

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [ ] ~[Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary~
- [ ] ~`docs` guides update, if necessary~
- [ ] ~New user API has useful Scaladoc strings~
- [ ] ~Unit tests added for bug-fix or new feature~




