### PR TITLE
Add GeoTrellisRasterSource compat with GT 1.x and 2.x layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
+- Add `GeoTrellisRasterSources` compatibility with GeoTrellis 1.x and 2.x layers [#3180](https://github.com/locationtech/geotrellis/issues/31680)
 
 ## [3.2.0] - 2019-11-19
 

--- a/bench/src/main/scala/geotrellis/raster/CellTypeEncodingBench.scala
+++ b/bench/src/main/scala/geotrellis/raster/CellTypeEncodingBench.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.raster
 
 import java.util.concurrent.TimeUnit

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import sbt.Keys._
-import de.heikoseeberger.sbtheader._
 
 ThisBuild / scalaVersion := "2.12.10"
 ThisBuild / organization := "org.locationtech.geotrellis"
@@ -200,24 +199,3 @@ lazy val `gdal-spark` = project
   .dependsOn(gdal, spark, `spark-testkit` % Test)
   .settings(publish / skip := true) // at this point we need this project only for tests
   .settings(Settings.`gdal-spark`)
-
-ThisBuild / headerLicense := Some(HeaderLicense.ALv2("2019", "Azavea"))
-ThisBuild / headerMappings := Map(
-  FileType.scala -> CommentStyle.cStyleBlockComment.copy(commentCreator = new CommentCreator() {
-    val Pattern = "(?s).*?(\\d{4}(-\\d{4})?).*".r
-    def findYear(header: String): Option[String] = header match {
-      case Pattern(years, _) => Some(years)
-      case _                 => None
-    }
-    override def apply(text: String, existingText: Option[String]): String = {
-      // preserve year of old headers
-      val newText = CommentStyle.cStyleBlockComment.commentCreator.apply(text, existingText)
-      existingText.flatMap { text =>
-        if (text.contains("Azavea")) {
-          findYear(text).map(year => newText.replace("2019", year))
-        } else {
-          existingText.map(_.trim)
-        }
-      }.getOrElse(newText)
-  }})
-)

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import de.heikoseeberger.sbtheader._
 
 ThisBuild / scalaVersion := "2.12.10"
 ThisBuild / organization := "org.locationtech.geotrellis"
-ThisBuild / crossScalaVersions := List("2.12.8", "2.11.12")
+ThisBuild / crossScalaVersions := List("2.12.10", "2.11.12")
 
 lazy val root = Project("geotrellis", file("."))
   .aggregate(

--- a/layer/src/main/scala/geotrellis/layer/filter/package.scala
+++ b/layer/src/main/scala/geotrellis/layer/filter/package.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.layer
 
 package object filter extends filter.Implicits

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffInfo.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffInfo.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package geotrellis.raster.io.geotiff.reader
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/JTS.scala
+++ b/vector/src/main/scala/geotrellis/vector/JTS.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector
 
 /**

--- a/vector/src/main/scala/geotrellis/vector/methods/GeometryCollectionMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/GeometryCollectionMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/methods/GeometryMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/GeometryMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/methods/Implicits.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/Implicits.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/methods/LineStringMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/LineStringMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/methods/MultiLineStringMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/MultiLineStringMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/methods/MultiPointMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/MultiPointMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/methods/MultiPolygonMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/MultiPolygonMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/methods/PointMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/PointMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vector/src/main/scala/geotrellis/vector/methods/PolygonMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/PolygonMethods.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vector.methods
 
 import geotrellis.vector._

--- a/vectortile/src/test/scala/geotrellis/vectortile/ProjectionSpec.scala
+++ b/vectortile/src/test/scala/geotrellis/vectortile/ProjectionSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.vectortile
 
 import geotrellis.proj4._


### PR DESCRIPTION
# Overview

This PR makes possible GeoTrellisRasterSources to work with old GeoTrellis layers

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary

## Demo

https://github.com/geotrellis/geotrellis-server/pull/191


Closes #3179
