### PR TITLE
Remove duplicate circe json codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
 
+### Removed
+
+- Removed duplicate JSON codecs for `TileLayout` [#3181](https://github.com/locationtech/geotrellis/pull/3181)
+- Removed `private` restriction for TiffTag `read` overload [#3181](https://github.com/locationtech/geotrellis/pull/3181)
+
 ## [3.2.0] - 2019-11-19
 
 ### Changed

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -593,7 +593,7 @@ object TiffTags {
     }
   }
 
-  private[geotrellis] def read(byteReader: ByteReader, tagsStartPosition: Long)(implicit ttos: TiffTagOffsetSize): TiffTags = {
+  def read(byteReader: ByteReader, tagsStartPosition: Long)(implicit ttos: TiffTagOffsetSize): TiffTags = {
     val tagCount =
       ttos match {
         case IntTiffTagOffsetSize =>

--- a/raster/src/main/scala/geotrellis/raster/io/json/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/json/Implicits.scala
@@ -33,6 +33,4 @@ trait Implicits extends HistogramJsonFormats {
       Either.catchNonFatal(CellType.fromName(str)).leftMap(_ => "Expected CellType")
     }
 
-  implicit val tileLayoutEncoder: Encoder[TileLayout] = deriveEncoder
-  implicit val tileLayoutDecoder: Decoder[TileLayout] = deriveDecoder
 }

--- a/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/json/Implicits.scala
+++ b/spark-pipeline/src/main/scala/geotrellis/spark/pipeline/json/Implicits.scala
@@ -60,9 +60,6 @@ trait Implicits {
       Either.catchNonFatal(Try(CRS.fromName(str)) getOrElse CRS.fromString(str)).leftMap(_ => "CRS")
     }
 
-  implicit val tileLayoutEncoder: Encoder[TileLayout] = deriveEncoder
-  implicit val tileLayoutDecoder: Decoder[TileLayout] = deriveDecoder
-
   implicit val layoutDefinitionEncoder: Encoder[LayoutDefinition] = deriveEncoder
   implicit val layoutDefinitionDecoder: Decoder[LayoutDefinition] = deriveDecoder
 


### PR DESCRIPTION
# Overview

This removes a duplicate codec for `TileLayout` - there is already one [here](https://github.com/locationtech/geotrellis/blob/master/raster/src/main/scala/geotrellis/raster/io/json/Implicits.scala) and it is really easy to get in a situation where both are available and hit an ambiguous implicit error.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary