### PR TITLE
Fix GeoTiff Byte and UByte CellType conversions

### DIFF
--- a/gdal-spark/src/test/resources/application.conf
+++ b/gdal-spark/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+geotrellis.raster.gdal.options {
+  GDAL_DISABLE_READDIR_ON_OPEN = "YES"
+  CPL_VSIL_CURL_ALLOWED_EXTENSIONS = ".tif,jp2"
+  AWS_REQUEST_PAYER="requester"
+}

--- a/gdal-spark/src/test/resources/application.conf
+++ b/gdal-spark/src/test/resources/application.conf
@@ -1,5 +1,10 @@
 geotrellis.raster.gdal.options {
+  // See https://trac.osgeo.org/gdal/wiki/ConfigOptions for options
+  //CPL_DEBUG = "OFF"
+  AWS_REQUEST_PAYER = "requester"
   GDAL_DISABLE_READDIR_ON_OPEN = "YES"
-  CPL_VSIL_CURL_ALLOWED_EXTENSIONS = ".tif,jp2"
-  AWS_REQUEST_PAYER="requester"
+  CPL_VSIL_CURL_ALLOWED_EXTENSIONS = ".tif,.tiff,.jp2,.mrf,.idx,.lrc,.mrf.aux.xml,.vrt"
+  GDAL_CACHEMAX = 512
+  GDAL_PAM_ENABLED = "NO"
+  CPL_VSIL_CURL_CHUNK_SIZE = 1000000
 }

--- a/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
+++ b/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
@@ -55,7 +55,7 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
     it("JP2K bug should fail") {
       val path = "https://s22s-rasterframes-integration-tests.s3.amazonaws.com/B08.jp2"
 
-      import cats.effect._
+      /*import cats.effect._
       import cats.implicits._
 
       val i = 1000
@@ -69,10 +69,10 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
         val grid = GridBounds(0, 0, rs.cols - 1, rs.rows - 1)
         val tileBounds = grid.split(256, 256).toSeq
         rs.readBounds(tileBounds)
-      } }.parSequence.unsafeRunSync()
+      } }.parSequence.unsafeRunSync()*/
 
 
-      /*ssc
+      ssc
         .range(1000)
         .rdd
         .map(_ => path)
@@ -82,7 +82,7 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
           val tileBounds = grid.split(256, 256).toSeq
           rs.readBounds(tileBounds)
         }
-        .foreach(r => ())*/
+        .foreach(r => ())
     }
   }
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
@@ -57,11 +57,11 @@ trait GeoTiffSegment {
         arr
       case ByteCellType =>
         val arr = Array.ofDim[Byte](size)
-        cfor(0)(_ < size, _ + 1) { i => getInt(i).toByte }
+        cfor(0)(_ < size, _ + 1) { i => arr(i) = getInt(i).toByte }
         arr
       case UByteCellType =>
         val arr = Array.ofDim[Byte](size)
-        cfor(0)(_ < size, _ + 1) { i => i2ub(getInt(i)) }
+        cfor(0)(_ < size, _ + 1) { i => arr(i) = i2ub(getInt(i)) }
         arr
       case ShortCellType =>
         val arr = Array.ofDim[Short](size)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTileSpec.scala
@@ -17,8 +17,8 @@
 package geotrellis.raster.io.geotiff
 
 import geotrellis.raster.testkit.{RasterMatchers, TileBuilders}
-import geotrellis.raster.IntCellType
-import org.scalatest.{BeforeAndAfterAll, Matchers, FunSpec}
+import geotrellis.raster.{IntCellType, UByteCellType}
+import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
 class UInt16GeoTiffTileSpec extends FunSpec
 with Matchers
@@ -33,5 +33,13 @@ with TileBuilders {
 
      assertEqual(actualImage, expectedImage)
    }
+
+    it("should convert landsat8 into UByte correctly") {
+      val tiff = SinglebandGeoTiff(geoTiffPath(s"ls8_uint16.tif")).tile
+      val expectedImage = tiff.toArrayTile().rescale(0, 255).convert(UByteCellType)
+      val actualImage = tiff.rescale(0, 255).convert(UByteCellType)
+
+      assertEqual(actualImage, expectedImage)
+    }
   }
 }

--- a/spark-testkit/src/main/scala/geotrellis/spark/testkit/TestEnvironment.scala
+++ b/spark-testkit/src/main/scala/geotrellis/spark/testkit/TestEnvironment.scala
@@ -56,7 +56,7 @@ trait TestEnvironment extends BeforeAndAfterAll
 { self: Suite with BeforeAndAfterAll =>
 
   /** Subclasses can override this to change the Spark master specification */
-  def sparkMaster = "local[2]"
+  def sparkMaster = "local[*]"
 
   private lazy val afterAlls = mutable.ListBuffer[() => Unit]()
   def registerAfterAll(f: () => Unit): Unit =


### PR DESCRIPTION
# Overview

This PR fixes a wrong TIFF segments conversion into the Byte and UByte celltypes and also adds a tes case.

## Checklist

- [ ] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
