### PR TITLE
Fix GeoTiff Byte and UByte CellType conversions

### DIFF
--- a/.travis/hbase-install.sh
+++ b/.travis/hbase-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-if [ ! -f $HOME/downloads/hbase-2.1.8-bin.tar.gz ]; then sudo wget -O $HOME/downloads/hbase-2.1.8-bin.tar.gz http://www-us.apache.org/dist/hbase/2.1.8/hbase-2.1.8-bin.tar.gz; fi
-sudo mv $HOME/downloads/hbase-2.1.8-bin.tar.gz hbase-2.1.8-bin.tar.gz && tar xzf hbase-2.1.8-bin.tar.gz
-sudo rm -f hbase-2.1.8/conf/hbase-site.xml && sudo mv .travis/hbase/hbase-site.xml hbase-2.1.8/conf
-sudo hbase-2.1.8/bin/start-hbase.sh
+if [ ! -f $HOME/downloads/hbase-2.2.3-bin.tar.gz ]; then sudo wget -O $HOME/downloads/hbase-2.2.3-bin.tar.gz http://www-us.apache.org/dist/hbase/2.2.3/hbase-2.2.3-bin.tar.gz; fi
+sudo mv $HOME/downloads/hbase-2.2.3-bin.tar.gz hbase-2.2.3-bin.tar.gz && tar xzf hbase-2.2.3-bin.tar.gz
+sudo rm -f hbase-2.2.3/conf/hbase-site.xml && sudo mv .travis/hbase/hbase-site.xml hbase-2.2.3/conf
+sudo hbase-2.2.3/bin/start-hbase.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
-- Fix Fix GeoTiff Byte and UByte CellType conversions [#3189](https://github.com/locationtech/geotrellis/issues/3189)
+- Fix GeoTiff Byte and UByte CellType conversions [#3189](https://github.com/locationtech/geotrellis/issues/3189)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
+- Fix Fix GeoTiff Byte and UByte CellType conversions [#3189](https://github.com/locationtech/geotrellis/issues/3189)
 
 ### Removed
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegment.scala
@@ -57,11 +57,11 @@ trait GeoTiffSegment {
         arr
       case ByteCellType =>
         val arr = Array.ofDim[Byte](size)
-        cfor(0)(_ < size, _ + 1) { i => getInt(i).toByte }
+        cfor(0)(_ < size, _ + 1) { i => arr(i) = getInt(i).toByte }
         arr
       case UByteCellType =>
         val arr = Array.ofDim[Byte](size)
-        cfor(0)(_ < size, _ + 1) { i => i2ub(getInt(i)) }
+        cfor(0)(_ < size, _ + 1) { i => arr(i) = i2ub(getInt(i)) }
         arr
       case ShortCellType =>
         val arr = Array.ofDim[Short](size)

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/UInt16GeoTiffTileSpec.scala
@@ -17,8 +17,8 @@
 package geotrellis.raster.io.geotiff
 
 import geotrellis.raster.testkit.{RasterMatchers, TileBuilders}
-import geotrellis.raster.IntCellType
-import org.scalatest.{BeforeAndAfterAll, Matchers, FunSpec}
+import geotrellis.raster.{ByteCellType, IntCellType, UByteCellType}
+import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
 class UInt16GeoTiffTileSpec extends FunSpec
 with Matchers
@@ -33,5 +33,21 @@ with TileBuilders {
 
      assertEqual(actualImage, expectedImage)
    }
+
+    it("should convert landsat8 into UByte correctly") {
+      val tiff = SinglebandGeoTiff(geoTiffPath(s"ls8_uint16.tif")).tile
+      val expectedImage = tiff.toArrayTile().rescale(0, 255).convert(UByteCellType)
+      val actualImage = tiff.rescale(0, 255).convert(UByteCellType)
+
+      assertEqual(actualImage, expectedImage)
+    }
+
+    it("should convert landsat8 into Byte correctly") {
+      val tiff = SinglebandGeoTiff(geoTiffPath(s"ls8_uint16.tif")).tile
+      val expectedImage = tiff.toArrayTile().rescale(Byte.MinValue, Byte.MaxValue).convert(ByteCellType)
+      val actualImage = tiff.rescale(Byte.MinValue, Byte.MaxValue).convert(ByteCellType)
+
+      assertEqual(actualImage, expectedImage)
+    }
   }
 }


### PR DESCRIPTION
# Overview

This PR fixes a wrong `TIFF` segments conversion into the `Byte` and `UByte` `CellType`s and also adds a test case.

Thanks @santocp94 for reproting about it.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
