### PR TITLE
Fix GeoTrellisPath parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- GeoTrellisPath assumes `file` scheme when none provided [#3191](https://github.com/locationtech/geotrellis/pull/3191)
+
 ### Changed
 
 - Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
 - Fix GeoTiff Byte and UByte CellType conversions [#3189](https://github.com/locationtech/geotrellis/issues/3189)
+- Fix incorrect parsing of authority in GeoTrellisPath [#3191](https://github.com/locationtech/geotrellis/pull/3191)
+- GeoTrellisPath.zoomLevel is now `Option[Int]` -> `Int` to better indicate that it is a required parameter [#3191](https://github.com/locationtech/geotrellis/pull/3191)
 
 ### Removed
 

--- a/store/src/main/scala/geotrellis/store/GeoTrellisPath.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisPath.scala
@@ -30,17 +30,23 @@ import java.net.MalformedURLException
  *    parameters:
  *      - '''layer''': The name of the layer.
  *      - '''zoom''': The zoom level to be read.
- *      - '''band_count''': The number of bands of each Tile in the layer.
- *    Of the above three parameters, `layer` and `zoom` are required. In addition,
- *    this path can be prefixed with, '''gt+''' to signify that the target path
- *    is to be read in only by [[GeotrellisRasterSource]].
- *  @example "s3://bucket/catalog?layer=layer_name&zoom=10"
- *  @example "hdfs://data-folder/catalog?layer=name&zoom-12&band_count=5"
+ *      - '''band_count''': The number of bands of each Tile in the layer. Optional.
+ *
+ *    If a scheme is not provided, `file` is assumed. Both relative and absolute file
+ *    paths are supported.
+ *
+ *    In addition, this path can be prefixed with, '''gt+''' to signify that the
+ *    target path is to be read in only by [[GeotrellisRasterSource]].
+ *
+ *  @example "s3://bucket/catalog?layer=name&zoom=10"
+ *  @example "hdfs://data-folder/catalog?layer=name&zoom=12&band_count=5"
  *  @example "gt+file:///tmp/catalog?layer=name&zoom=5"
+ *  @example "/tmp/catalog?layer=name&zoom=5"
+ *
  *  @note The order of the query parameters does not matter.
  */
-case class GeoTrellisPath(value: String, layerName: String, zoomLevel: Option[Int], bandCount: Option[Int]) extends SourcePath {
-  def  layerId: LayerId = LayerId(layerName, zoomLevel.get)
+case class GeoTrellisPath(value: String, layerName: String, zoomLevel: Int, bandCount: Option[Int]) extends SourcePath {
+  def  layerId: LayerId = LayerId(layerName, zoomLevel)
 }
 
 object GeoTrellisPath {
@@ -68,11 +74,15 @@ object GeoTrellisPath {
     }
 
     catalogPath.fold(Option.empty[GeoTrellisPath]) { catalogPath =>
-      val layerName: Option[String] = queryString.param(layerNameParam)
-      val zoomLevel: Option[Int] = queryString.param(zoomLevelParam).map(_.toInt)
+      val maybeLayerName: Option[String] = queryString.param(layerNameParam)
+      val maybeZoomLevel: Option[Int] = queryString.param(zoomLevelParam).map(_.toInt)
       val bandCount: Option[Int] = queryString.param(bandCountParam).map(_.toInt)
 
-      layerName.map(GeoTrellisPath(catalogPath, _, zoomLevel, bandCount))
+      (maybeLayerName, maybeZoomLevel) match {
+        case (Some(layerName), Some(zoomLevel)) =>
+          GeoTrellisPath(catalogPath, layerName, zoomLevel, bandCount).some
+        case _ => Option.empty[GeoTrellisPath]
+      }
     }
   }
 

--- a/store/src/main/scala/geotrellis/store/GeoTrellisPath.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisPath.scala
@@ -61,7 +61,7 @@ object GeoTrellisPath {
       uri.schemeOption.fold(uri.toStringRaw.some) { scheme =>
         val authority =
           uri match {
-            case url: UrlWithAuthority => url.authority.userInfo.user.getOrElse("")
+            case url: UrlWithAuthority => url.authority.toString
             case _ => ""
           }
 

--- a/store/src/main/scala/geotrellis/store/GeoTrellisPath.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisPath.scala
@@ -53,20 +53,18 @@ object GeoTrellisPath {
     val zoomLevelParam: String = "zoom"
     val bandCountParam: String = "band_count"
 
-    // try to parse it, otherwise it is a path
-    val uri = UrlWithAuthority.parseOption(path).fold(Url().withPath(UrlPath.fromRaw(path)): Url)(identity)
+    val uri = UrlWithAuthority.parseOption(path).fold(Url.parse(path))(identity)
     val queryString = uri.query
 
+    val scheme = uri.schemeOption.getOrElse("file")
     val catalogPath: Option[String] = {
-      uri.schemeOption.fold(uri.toStringRaw.some) { scheme =>
-        val authority =
-          uri match {
-            case url: UrlWithAuthority => url.authority.toString
-            case _ => ""
-          }
+      val authority =
+        uri match {
+          case url: UrlWithAuthority => url.authority.toString
+          case _ => ""
+        }
 
-        s"${scheme.split("\\+").last}://$authority${uri.path}".some
-      }
+      s"${scheme.split("\\+").last}://$authority${uri.path}".some
     }
 
     catalogPath.fold(Option.empty[GeoTrellisPath]) { catalogPath =>

--- a/store/src/test/scala/geotrellis/store/GeoTrellisPathSpec.scala
+++ b/store/src/test/scala/geotrellis/store/GeoTrellisPathSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.store
+
+import org.scalatest._
+
+class GeoTrellisPathSpec extends FunSpec {
+  describe("GeoTrellisPathSpec") {
+
+    it("should fail to parse without a layer") {
+      val path = GeoTrellisPath.parseOption("file:///foo/bar")
+      assert(path == None)
+    }
+
+    it("should parse a local absolute file path without scheme") {
+      val path = GeoTrellisPath.parse("/absolute/path?layer=baz")
+      assert(path.value == "file:///absolute/path")
+      assert(path.layerName == "baz")
+    }
+
+    it("should parse a local absolute file path with scheme") {
+      val path = GeoTrellisPath.parse("file:///absolute/path?layer=baz")
+      assert(path.value == "file:///absolute/path")
+      assert(path.layerName == "baz")
+    }
+
+    it("should parse a local relative file path with scheme") {
+      val path = GeoTrellisPath.parse("file://relative/path?layer=baz")
+      assert(path.value == "file://relative/path")
+      assert(path.layerName == "baz")
+    }
+
+    it("should parse a local relative file path without scheme") {
+      val path = GeoTrellisPath.parse("relative/path?layer=baz")
+      assert(path.value == "file://relative/path")
+      assert(path.layerName == "baz")
+    }
+
+    it("should parse params") {
+      val path = GeoTrellisPath.parse("file:///foo/bar?layer=baz&band_count=1&zoom=10")
+      assert(path.layerName == "baz")
+      assert(path.bandCount == Some(1))
+      assert(path.zoomLevel == Some(10))
+    }
+
+    it("should parse hdfs scheme") {
+      val path = GeoTrellisPath.parse("hdfs://path/to?layer=foo")
+      assert(path.value == "hdfs://path/to")
+      assert(path.layerName == "foo")
+    }
+
+    it("should parse s3 scheme") {
+      val path = GeoTrellisPath.parse("s3://bucket/path?layer=foo")
+      assert(path.value == "s3://bucket/path")
+      assert(path.layerName == "foo")
+    }
+
+    it("should parse absolute file scheme with gt+ prefix") {
+      val path = GeoTrellisPath.parse("gt+file:///absolute/path?layer=foo")
+      assert(path.value == "file:///absolute/path")
+      assert(path.layerName == "foo")
+    }
+
+    it("should parse relative file scheme with gt+ prefix") {
+      val path = GeoTrellisPath.parse("gt+file://relative/path?layer=foo")
+      assert(path.value == "file://relative/path")
+      assert(path.layerName == "foo")
+    }
+
+    it("should parse s3 scheme with gt+ prefix") {
+      val path = GeoTrellisPath.parse("gt+s3://bucket/path?layer=foo")
+      assert(path.value == "s3://bucket/path")
+      assert(path.layerName == "foo")
+    }
+
+    it("should ignore invalid parameters") {
+      val path = GeoTrellisPath.parse("file:///foo/bar?layer=baz&invalid=not&nope=1")
+      assert(path == GeoTrellisPath("file:///foo/bar", "baz", None, None))
+    }
+  }
+}

--- a/store/src/test/scala/geotrellis/store/GeoTrellisPathSpec.scala
+++ b/store/src/test/scala/geotrellis/store/GeoTrellisPathSpec.scala
@@ -22,30 +22,35 @@ class GeoTrellisPathSpec extends FunSpec {
   describe("GeoTrellisPathSpec") {
 
     it("should fail to parse without a layer") {
-      val path = GeoTrellisPath.parseOption("file:///foo/bar")
+      val path = GeoTrellisPath.parseOption("file:///foo/bar?zoom=1")
+      assert(path == None)
+    }
+
+    it("should fail to parse without a zoom") {
+      val path = GeoTrellisPath.parseOption("file:///foo/bar?layer=baz")
       assert(path == None)
     }
 
     it("should parse a local absolute file path without scheme") {
-      val path = GeoTrellisPath.parse("/absolute/path?layer=baz")
+      val path = GeoTrellisPath.parse("/absolute/path?layer=baz&zoom=1")
       assert(path.value == "file:///absolute/path")
       assert(path.layerName == "baz")
     }
 
     it("should parse a local absolute file path with scheme") {
-      val path = GeoTrellisPath.parse("file:///absolute/path?layer=baz")
+      val path = GeoTrellisPath.parse("file:///absolute/path?layer=baz&zoom=1")
       assert(path.value == "file:///absolute/path")
       assert(path.layerName == "baz")
     }
 
     it("should parse a local relative file path with scheme") {
-      val path = GeoTrellisPath.parse("file://relative/path?layer=baz")
+      val path = GeoTrellisPath.parse("file://relative/path?layer=baz&zoom=1")
       assert(path.value == "file://relative/path")
       assert(path.layerName == "baz")
     }
 
     it("should parse a local relative file path without scheme") {
-      val path = GeoTrellisPath.parse("relative/path?layer=baz")
+      val path = GeoTrellisPath.parse("relative/path?layer=baz&zoom=1")
       assert(path.value == "file://relative/path")
       assert(path.layerName == "baz")
     }
@@ -53,43 +58,43 @@ class GeoTrellisPathSpec extends FunSpec {
     it("should parse params") {
       val path = GeoTrellisPath.parse("file:///foo/bar?layer=baz&band_count=1&zoom=10")
       assert(path.layerName == "baz")
+      assert(path.zoomLevel == 10)
       assert(path.bandCount == Some(1))
-      assert(path.zoomLevel == Some(10))
     }
 
     it("should parse hdfs scheme") {
-      val path = GeoTrellisPath.parse("hdfs://path/to?layer=foo")
+      val path = GeoTrellisPath.parse("hdfs://path/to?layer=foo&zoom=1")
       assert(path.value == "hdfs://path/to")
       assert(path.layerName == "foo")
     }
 
     it("should parse s3 scheme") {
-      val path = GeoTrellisPath.parse("s3://bucket/path?layer=foo")
+      val path = GeoTrellisPath.parse("s3://bucket/path?layer=foo&zoom=1")
       assert(path.value == "s3://bucket/path")
       assert(path.layerName == "foo")
     }
 
     it("should parse absolute file scheme with gt+ prefix") {
-      val path = GeoTrellisPath.parse("gt+file:///absolute/path?layer=foo")
+      val path = GeoTrellisPath.parse("gt+file:///absolute/path?layer=foo&zoom=1")
       assert(path.value == "file:///absolute/path")
       assert(path.layerName == "foo")
     }
 
     it("should parse relative file scheme with gt+ prefix") {
-      val path = GeoTrellisPath.parse("gt+file://relative/path?layer=foo")
+      val path = GeoTrellisPath.parse("gt+file://relative/path?layer=foo&zoom=1")
       assert(path.value == "file://relative/path")
       assert(path.layerName == "foo")
     }
 
     it("should parse s3 scheme with gt+ prefix") {
-      val path = GeoTrellisPath.parse("gt+s3://bucket/path?layer=foo")
+      val path = GeoTrellisPath.parse("gt+s3://bucket/path?layer=foo&zoom=1")
       assert(path.value == "s3://bucket/path")
       assert(path.layerName == "foo")
     }
 
     it("should ignore invalid parameters") {
-      val path = GeoTrellisPath.parse("file:///foo/bar?layer=baz&invalid=not&nope=1")
-      assert(path == GeoTrellisPath("file:///foo/bar", "baz", None, None))
+      val path = GeoTrellisPath.parse("file:///foo/bar?layer=baz&zoom=1&invalid=not&nope=1")
+      assert(path == GeoTrellisPath("file:///foo/bar", "baz", 1, None))
     }
   }
 }


### PR DESCRIPTION
# Overview

Parsing of url authority was bad. This should fix that. This PR also opened a discussion around whether absolute and relative urls without scheme should be valid as well so there's tests for those here that currently fail. If we want to support this, I can add a fix for that here as well, where scheme-less urls assume `file://`.

Before fix, 7 of new tests fail. After, only the scheme-less tests fail.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [ ] [Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature
