### PR TITLE
Fix gdal-warp -ovr ports

### DIFF
--- a/.travis/build-and-test-set-1.sh
+++ b/.travis/build-and-test-set-1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./sbt "++$TRAVIS_SCALA_VERSION" \
+./sbt -Dsbt.supershell=false "++$TRAVIS_SCALA_VERSION" \
   "project proj4" test \
   "project geotools" test \
   "project shapefile" test \

--- a/.travis/build-and-test-set-2.sh
+++ b/.travis/build-and-test-set-2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./sbt "++$TRAVIS_SCALA_VERSION" \
+./sbt -Dsbt.supershell=false "++$TRAVIS_SCALA_VERSION" \
   "project raster" test \
   "project accumulo" test \
   "project accumulo-spark" test \

--- a/.travis/build-and-test-set-3.sh
+++ b/.travis/build-and-test-set-3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./sbt "++$TRAVIS_SCALA_VERSION" \
+./sbt -Dsbt.supershell=false "++$TRAVIS_SCALA_VERSION" \
   "project spark" test \
   "project gdal-spark" test \
   "project spark-pipeline" test || { exit 1; }

--- a/.travis/build-set-1.sh
+++ b/.travis/build-set-1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./sbt "++$TRAVIS_SCALA_VERSION" \
+./sbt -Dsbt.supershell=false "++$TRAVIS_SCALA_VERSION" \
   "project proj4" test \
   "project geotools" test \
   "project shapefile" test \

--- a/.travis/build-set-2.sh
+++ b/.travis/build-set-2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./sbt "++$TRAVIS_SCALA_VERSION" \
+./sbt -Dsbt.supershell=false "++$TRAVIS_SCALA_VERSION" \
   "project raster" test \
   "project accumulo" test \
   "project accumulo-spark" test \

--- a/.travis/build-set-3.sh
+++ b/.travis/build-set-3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./sbt "++$TRAVIS_SCALA_VERSION" \
+./sbt -Dsbt.supershell=false "++$TRAVIS_SCALA_VERSION" \
   "project spark" test \
   "project gdal-spark" test \
   "project spark-pipeline" test || { exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - GeoTrellisPath assumes `file` scheme when none provided [#3191](https://github.com/locationtech/geotrellis/pull/3191)
+- toStrings overrides to common classes [#3217](https://github.com/locationtech/geotrellis/pull/3217)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix `OverviewStrategy` instances now define their own overview selection logic and more accurately port GDAL-Warp -ovr options [#3196](https://github.com/locationtech/geotrellis/issues/3196)
 - Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
 - Fix GeoTiff Byte and UByte CellType conversions [#3189](https://github.com/locationtech/geotrellis/issues/3189)
 - Fix incorrect parsing of authority in GeoTrellisPath [#3191](https://github.com/locationtech/geotrellis/pull/3191)

--- a/gdal-spark/src/test/resources/log4j.properties
+++ b/gdal-spark/src/test/resources/log4j.properties
@@ -1,0 +1,18 @@
+# Set everything to be logged to the console
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss} %c{1}: %m%n
+
+log4j.logger.geotrellis.spark=INFO
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.apache.spark=WARN
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=WARN
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=WARN
+
+log4j.logger.org.spark-project.jetty=WARN
+org.spark-project.jetty.LEVEL=WARN

--- a/gdal-spark/src/test/resources/log4j.properties
+++ b/gdal-spark/src/test/resources/log4j.properties
@@ -1,11 +1,9 @@
 # Set everything to be logged to the console
-log4j.rootCategory=WARN, console
+log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss} %c{1}: %m%n
-
-log4j.logger.geotrellis.spark=INFO
 
 # Settings to quiet third party logs that are too verbose
 log4j.logger.org.eclipse.jetty=WARN
@@ -16,3 +14,7 @@ log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=WARN
 
 log4j.logger.org.spark-project.jetty=WARN
 org.spark-project.jetty.LEVEL=WARN
+
+# Settings to silent GeoTrellis logs
+log4j.logger.geotrellis.spark=INFO
+log4j.logger.geotrellis.raster.gdal=ERROR

--- a/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
+++ b/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
@@ -143,9 +143,9 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
     }
 
     it("should reproduce tileToLayout followed by reproject") {
-      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout, strategy = AutoHigherResolution)
+      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout)
       val reprojectedSourceRDD: MultibandTileLayerRDD[SpatialKey] =
-        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout, strategy = AutoHigherResolution)
+        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout)
 
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedExpectedRDD.stitch, targetCRS).write("/tmp/expected.tif")
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedSourceRDD.stitch, targetCRS).write("/tmp/actual.tif")

--- a/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
+++ b/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
@@ -143,8 +143,9 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
     }
 
     it("should reproduce tileToLayout followed by reproject") {
+      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout, strategy = Base)
       val reprojectedSourceRDD: MultibandTileLayerRDD[SpatialKey] =
-        RasterSourceRDD.spatial(rasterSource.reprojectToGrid(targetCRS, layout), layout)
+        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout, strategy = Base)
 
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedExpectedRDD.stitch, targetCRS).write("/tmp/expected.tif")
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedSourceRDD.stitch, targetCRS).write("/tmp/actual.tif")

--- a/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
+++ b/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSourceRDDSpec.scala
@@ -143,9 +143,9 @@ class GDALRasterSourceRDDSpec extends FunSpec with TestEnvironment with BeforeAn
     }
 
     it("should reproduce tileToLayout followed by reproject") {
-      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout, strategy = Base)
+      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout, strategy = AutoHigherResolution)
       val reprojectedSourceRDD: MultibandTileLayerRDD[SpatialKey] =
-        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout, strategy = Base)
+        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout, strategy = AutoHigherResolution)
 
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedExpectedRDD.stitch, targetCRS).write("/tmp/expected.tif")
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedSourceRDD.stitch, targetCRS).write("/tmp/actual.tif")

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -19,7 +19,7 @@ package geotrellis.raster.gdal
 import geotrellis.raster.gdal.GDALDataset.DatasetType
 import geotrellis.proj4._
 import geotrellis.raster._
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
 import geotrellis.vector._
 
@@ -110,7 +110,7 @@ class GDALRasterSource(
       }
   }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     new GDALRasterSource(dataPath, options.reproject(gridExtent, crs, targetCRS, resampleTarget, method))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALUtils.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALUtils.scala
@@ -20,7 +20,12 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.resample._
 
+import org.log4s._
+
 object GDALUtils {
+
+  @transient private[this] lazy val logger = getLogger
+
   def deriveResampleMethodString(method: ResampleMethod): String =
     method match {
       case NearestNeighbor => "near"
@@ -100,8 +105,12 @@ object GDALUtils {
     }
 
   def deriveOverviewStrategyString(strategy: OverviewStrategy): String = strategy match {
+    case Auto(n) if (n == 0) => "AUTO"
     case Auto(n) => s"AUTO-$n"
-    case AutoHigherResolution => "AUTO"
+    case Level(level) => s"$level"
     case Base => "NONE"
+    case other =>
+      logger.warn(s"$other is not a valid GDALWarp -ovr argument; falling back to AUTO")
+      "AUTO"
   }
 }

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALWarpOptions.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALWarpOptions.scala
@@ -20,7 +20,7 @@ import geotrellis.raster.gdal.GDALDataset.DatasetType
 import geotrellis.raster.{ConvertTargetCellType, TargetCellType}
 import geotrellis.raster._
 import geotrellis.raster.resample._
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.proj4.CRS
 import geotrellis.vector.Extent
 
@@ -85,7 +85,7 @@ case class GDALWarpOptions(
     *        Specify AUTO-n where n is an integer greater or equal to 1, to select an overview level below the AUTO one.
     *        Or specify NONE to force the base resolution to be used (can be useful if overviews have been generated with a low quality resampling method, and the warping is done using a higher quality resampling method).
     */
-  ovr: Option[OverviewStrategy] = Some(AutoHigherResolution),
+  ovr: Option[OverviewStrategy] = Some(OverviewStrategy.DEFAULT),
   /** -to, set a transformer option suitable to pass to [GDALCreateGenImgProjTransformer2()](https://www.gdal.org/gdal__alg_8h.html#a94cd172f78dbc41d6f407d662914f2e3) */
   to: List[(String, String)] = Nil,
   /** -novshiftgrid, Disable the use of vertical datum shift grids when one of the source or target SRS has an explicit vertical datum, and the input dataset is a single band dataset. */

--- a/gdal/src/test/resources/log4j.properties
+++ b/gdal/src/test/resources/log4j.properties
@@ -5,8 +5,6 @@ log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss} %c{1}: %m%n
 
-log4j.logger.geotrellis.spark=INFO
-
 # Settings to quiet third party logs that are too verbose
 log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.apache.spark=WARN
@@ -16,3 +14,7 @@ log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=WARN
 
 log4j.logger.org.spark-project.jetty=WARN
 org.spark-project.jetty.LEVEL=WARN
+
+# Settings to silent GeoTrellis logs
+log4j.logger.geotrellis.spark=INFO
+log4j.logger.geotrellis.raster.gdal=ERROR

--- a/gdal/src/test/scala/geotrellis/raster/gdal/GDALWarpOptionsSpec.scala
+++ b/gdal/src/test/scala/geotrellis/raster/gdal/GDALWarpOptionsSpec.scala
@@ -18,7 +18,7 @@ package geotrellis.raster.gdal
 
 import geotrellis.proj4._
 import geotrellis.raster._
-import geotrellis.raster.io.geotiff.AutoHigherResolution
+import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.resample._
 import geotrellis.vector.Extent
 import geotrellis.raster.testkit._
@@ -143,7 +143,7 @@ class GDALWarpOptionsSpec extends FunSpec with RasterMatchers with GivenWhenThen
           .reproject(
             targetCRS    = WebMercator,
             resampleTarget = TargetCellSize(CellSize(10, 10)),
-            strategy     = AutoHigherResolution
+            strategy     = OverviewStrategy.DEFAULT
         )
         .resampleToRegion(
           region = GridExtent(Extent(-8769160.0, 4257700.0, -8750630.0, 4274460.0), CellSize(22, 22))
@@ -183,7 +183,7 @@ object GDALWarpOptionsSpec {
       None,
       List("-9999.0"),
       Nil,
-      Some(AutoHigherResolution),
+      Some(OverviewStrategy.DEFAULT),
       Nil, false, None, false, false, false, None, Nil, None, None, false, false,
       false, None, false, false, Nil, None, None, None, None, None, false, false, false, None, false, Nil, Nil, Nil, None
     )

--- a/layer/src/main/scala/geotrellis/layer/Implicits.scala
+++ b/layer/src/main/scala/geotrellis/layer/Implicits.scala
@@ -20,6 +20,7 @@ import geotrellis.raster.{CellGrid, RasterSource, ResampleMethod}
 import geotrellis.util._
 import java.time.Instant
 
+import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.vector.io.json.CrsFormats
 
@@ -60,9 +61,10 @@ trait Implicits extends merge.Implicits
     def tileToLayout[K: SpatialComponent](
       layout: LayoutDefinition,
       tileKeyTransform: SpatialKey => K,
-      resampleMethod: ResampleMethod = NearestNeighbor
+      resampleMethod: ResampleMethod = NearestNeighbor,
+      strategy: OverviewStrategy = OverviewStrategy.DEFAULT
     ): LayoutTileSource[K] =
-      LayoutTileSource(self.resampleToGrid(layout, resampleMethod), layout, tileKeyTransform)
+      LayoutTileSource(self.resampleToGrid(layout, resampleMethod, strategy), layout, tileKeyTransform)
 
     def tileToLayout(layout: LayoutDefinition, resampleMethod: ResampleMethod): LayoutTileSource[SpatialKey] =
       tileToLayout(layout, identity, resampleMethod)

--- a/layer/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
+++ b/layer/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
@@ -67,7 +67,7 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with RasterMatchers with 
       }
 
       val twiceFuzzySource = rasterSource.reprojectToGrid(LatLng, twiceFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
-      twiceFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(20,20)
+      twiceFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(20, 20)
 
       val thriceFuzzyLayout = {
         val CellSize(width, height) = baseReproject.cellSize
@@ -75,7 +75,8 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with RasterMatchers with 
       }
 
       val thriceFuzzySource = rasterSource.reprojectToGrid(LatLng, thriceFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
-      thriceFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(20,20)
+      thriceFuzzySource.closestTiffOverview.cellSize.width shouldBe 40.0 +- 0.1
+      thriceFuzzySource.closestTiffOverview.cellSize.height shouldBe 40.0 +- 0.1
 
       val quatroFuzzyLayout = {
         val CellSize(width, height) = baseReproject.cellSize
@@ -83,6 +84,7 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with RasterMatchers with 
       }
 
       val quatroTimesFuzzySource = rasterSource.reprojectToGrid(LatLng, quatroFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
+      println("TARGET", quatroFuzzyLayout.cellSize)
       quatroTimesFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(40.0,39.94082840236686)
 
     }

--- a/layer/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
+++ b/layer/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
@@ -22,6 +22,8 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.reproject._
 import geotrellis.raster.testkit.RasterMatchers
+import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.raster.io.geotiff.AutoHigherResolution
 
 import org.scalatest._
 
@@ -74,9 +76,12 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with RasterMatchers with 
         LayoutDefinition(RasterExtent(LatLng.worldExtent, CellSize(width*3.5, height*3.5)), tileSize = 256)
       }
 
-      val thriceFuzzySource = rasterSource.reprojectToGrid(LatLng, thriceFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
-      thriceFuzzySource.closestTiffOverview.cellSize.width shouldBe 40.0 +- 0.1
-      thriceFuzzySource.closestTiffOverview.cellSize.height shouldBe 40.0 +- 0.1
+      val thriceFuzzySourceAutoHigher = rasterSource.reprojectToGrid(LatLng, thriceFuzzyLayout, NearestNeighbor, AutoHigherResolution).asInstanceOf[GeoTiffReprojectRasterSource]
+      thriceFuzzySourceAutoHigher.closestTiffOverview.cellSize shouldBe CellSize(20, 20)
+
+      val thriceFuzzySourceAuto = rasterSource.reprojectToGrid(LatLng, thriceFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
+      thriceFuzzySourceAuto.closestTiffOverview.cellSize.width shouldBe 40.0 +- 0.1
+      thriceFuzzySourceAuto.closestTiffOverview.cellSize.height shouldBe 40.0 +- 0.1
 
       val quatroFuzzyLayout = {
         val CellSize(width, height) = baseReproject.cellSize
@@ -84,7 +89,6 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with RasterMatchers with 
       }
 
       val quatroTimesFuzzySource = rasterSource.reprojectToGrid(LatLng, quatroFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
-      println("TARGET", quatroFuzzyLayout.cellSize)
       quatroTimesFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(40.0,39.94082840236686)
 
     }

--- a/layer/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
+++ b/layer/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
@@ -22,8 +22,6 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.reproject._
 import geotrellis.raster.testkit.RasterMatchers
-import geotrellis.raster.resample.NearestNeighbor
-import geotrellis.raster.io.geotiff.AutoHigherResolution
 
 import org.scalatest._
 
@@ -76,12 +74,8 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with RasterMatchers with 
         LayoutDefinition(RasterExtent(LatLng.worldExtent, CellSize(width*3.5, height*3.5)), tileSize = 256)
       }
 
-      val thriceFuzzySourceAutoHigher = rasterSource.reprojectToGrid(LatLng, thriceFuzzyLayout, NearestNeighbor, AutoHigherResolution).asInstanceOf[GeoTiffReprojectRasterSource]
+      val thriceFuzzySourceAutoHigher = rasterSource.reprojectToGrid(LatLng, thriceFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
       thriceFuzzySourceAutoHigher.closestTiffOverview.cellSize shouldBe CellSize(20, 20)
-
-      val thriceFuzzySourceAuto = rasterSource.reprojectToGrid(LatLng, thriceFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
-      thriceFuzzySourceAuto.closestTiffOverview.cellSize.width shouldBe 40.0 +- 0.1
-      thriceFuzzySourceAuto.closestTiffOverview.cellSize.height shouldBe 40.0 +- 0.1
 
       val quatroFuzzyLayout = {
         val CellSize(width, height) = baseReproject.cellSize

--- a/raster/src/main/scala/geotrellis/raster/CellSize.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellSize.scala
@@ -20,6 +20,8 @@ import geotrellis.vector.Extent
 
 import _root_.io.circe.generic.JsonCodec
 
+import scala.math.Ordering
+
 /**
   * A case class containing the width and height of a cell.
   *
@@ -71,5 +73,10 @@ object CellSize {
   def fromString(s:String) = {
     val Array(width, height) = s.split(",").map(_.toDouble)
     CellSize(width, height)
+  }
+
+  implicit val cellsizeOrdering = new Ordering[CellSize] {
+    def compare(x: CellSize, y: CellSize): Int =
+    (x.resolution - y.resolution).toInt
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
@@ -21,7 +21,7 @@ import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.raster.reproject.Reproject
 import geotrellis.proj4.{CRS, WebMercator}
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 
 import cats.Semigroup
 import cats.implicits._
@@ -85,7 +85,7 @@ abstract class MosaicRasterSource extends RasterSource {
     targetCRS: CRS,
     resampleTarget: ResampleTarget = DefaultTarget,
     method: ResampleMethod = NearestNeighbor,
-    strategy: OverviewStrategy = AutoHigherResolution
+    strategy: OverviewStrategy = OverviewStrategy.DEFAULT
   ): RasterSource =
     MosaicRasterSource(
       sources map { _.reproject(targetCRS, resampleTarget, method, strategy) },

--- a/raster/src/main/scala/geotrellis/raster/RasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterSource.scala
@@ -20,7 +20,7 @@ import geotrellis.vector._
 import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.proj4._
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.util.GetComponent
 
 import java.util.ServiceLoader
@@ -45,13 +45,13 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
   /** All available RasterSource metadata */
   def metadata: RasterMetadata
 
-  protected def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource
+  protected def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource
 
   /** Reproject to different CRS with explicit sampling reprojectOptions.
     * @see [[geotrellis.raster.reproject.Reproject]]
     * @group reproject
     */
-  def reproject(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reproject(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     if (targetCRS == this.crs) this
     else reprojection(targetCRS, resampleTarget, method, strategy)
 
@@ -61,7 +61,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     *   of the data footprint in the target grid.
     * @group reproject a
     */
-  def reprojectToGrid(targetCRS: CRS, grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reprojectToGrid(targetCRS: CRS, grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     if (targetCRS == this.crs && grid == this.gridExtent) this
     else if (targetCRS == this.crs) resampleToGrid(grid, method)
     else reprojection(targetCRS, TargetAlignment(grid), method, strategy)
@@ -71,7 +71,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     *   this region may be larger or smaller than the footprint of the data
     * @group reproject
     */
-  def reprojectToRegion(targetCRS: CRS, region: RasterExtent, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reprojectToRegion(targetCRS: CRS, region: RasterExtent, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     if (targetCRS == this.crs && region == this.gridExtent) this
     else if (targetCRS == this.crs) resampleToRegion(region.asInstanceOf[GridExtent[Long]], method)
     else reprojection(targetCRS, TargetRegion(region.toGridType[Long]), method, strategy)
@@ -81,7 +81,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
   /** Sampling grid is defined of the footprint of the data with resolution implied by column and row count.
     * @group resample
     */
-  def resample(targetCols: Long, targetRows: Long, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def resample(targetCols: Long, targetRows: Long, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     resample(TargetDimensions(targetCols, targetRows), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[GridExtent]].
@@ -89,7 +89,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     *  of the data footprint in the target grid.
     * @group resample
     */
-  def resampleToGrid(grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def resampleToGrid(grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     resample(TargetAlignment(grid), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[RasterExtent]] region.
@@ -97,7 +97,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     *   this region may be larger or smaller than the footprint of the data
     * @group resample
     */
-  def resampleToRegion(region: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def resampleToRegion(region: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     resample(TargetRegion(region), method, strategy)
 
   /** Reads a window for the extent.

--- a/raster/src/main/scala/geotrellis/raster/RasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterSource.scala
@@ -73,7 +73,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     */
   def reprojectToRegion(targetCRS: CRS, region: RasterExtent, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     if (targetCRS == this.crs && region == this.gridExtent) this
-    else if (targetCRS == this.crs) resampleToRegion(region.asInstanceOf[GridExtent[Long]], method)
+    else if (targetCRS == this.crs) resampleToRegion(region.asInstanceOf[GridExtent[Long]], method, strategy)
     else reprojection(targetCRS, TargetRegion(region.toGridType[Long]), method, strategy)
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource

--- a/raster/src/main/scala/geotrellis/raster/RasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterSource.scala
@@ -63,7 +63,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     */
   def reprojectToGrid(targetCRS: CRS, grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     if (targetCRS == this.crs && grid == this.gridExtent) this
-    else if (targetCRS == this.crs) resampleToGrid(grid, method)
+    else if (targetCRS == this.crs) resampleToGrid(grid, method, strategy)
     else reprojection(targetCRS, TargetAlignment(grid), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[RasterExtent]] region.

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
@@ -55,7 +55,7 @@ class GeoTiffRasterSource(
   lazy val gridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
   lazy val resolutions: List[CellSize] = cellSize :: tiff.overviews.map(_.cellSize)
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTiffReprojectRasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTiffResampleRasterSource =

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -22,7 +22,7 @@ import geotrellis.raster.reproject._
 import geotrellis.raster.resample._
 import geotrellis.proj4._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, GeoTiff, GeoTiffMultibandTile, MultibandGeoTiff, OverviewStrategy, Tags}
+import geotrellis.raster.io.geotiff.{GeoTiff, GeoTiffMultibandTile, MultibandGeoTiff, OverviewStrategy, Tags}
 import geotrellis.util.RangeReader
 
 class GeoTiffReprojectRasterSource(
@@ -30,7 +30,7 @@ class GeoTiffReprojectRasterSource(
   val crs: CRS,
   val resampleTarget: ResampleTarget = DefaultTarget,
   val resampleMethod: ResampleMethod = NearestNeighbor,
-  val strategy: OverviewStrategy = AutoHigherResolution,
+  val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   val errorThreshold: Double = 0.125,
   private[raster] val targetCellType: Option[TargetCellType] = None,
   @transient private[raster] val baseTiff: Option[MultibandGeoTiff] = None
@@ -147,7 +147,7 @@ class GeoTiffReprojectRasterSource(
     }.map { convertRaster }
   }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
@@ -163,7 +163,7 @@ object GeoTiffReprojectRasterSource {
     crs: CRS,
     resampleTarget: ResampleTarget = DefaultTarget,
     resampleMethod: ResampleMethod = NearestNeighbor,
-    strategy: OverviewStrategy = AutoHigherResolution,
+    strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
     errorThreshold: Double = 0.125,
     targetCellType: Option[TargetCellType] = None,
     baseTiff: Option[MultibandGeoTiff] = None

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -22,14 +22,14 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.reproject.{Reproject, ReprojectRasterExtent}
 import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, GeoTiff, GeoTiffMultibandTile, MultibandGeoTiff, OverviewStrategy, Tags}
+import geotrellis.raster.io.geotiff.{GeoTiff, GeoTiffMultibandTile, MultibandGeoTiff, OverviewStrategy, Tags}
 import geotrellis.util.RangeReader
 
 class GeoTiffResampleRasterSource(
   val dataPath: GeoTiffPath,
   val resampleTarget: ResampleTarget,
   val method: ResampleMethod = NearestNeighbor,
-  val strategy: OverviewStrategy = AutoHigherResolution,
+  val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   private[raster] val targetCellType: Option[TargetCellType] = None,
   @transient private[raster] val baseTiff: Option[MultibandGeoTiff] = None
 ) extends RasterSource {
@@ -64,7 +64,7 @@ class GeoTiffResampleRasterSource(
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(gridExtent.cellSize, strategy)
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTiffReprojectRasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTiffReprojectRasterSource =
     new GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType) {
       override lazy val gridExtent: GridExtent[Long] = {
         val reprojectedRasterExtent =
@@ -137,7 +137,7 @@ object GeoTiffResampleRasterSource {
     dataPath: GeoTiffPath,
     resampleTarget: ResampleTarget,
     method: ResampleMethod = NearestNeighbor,
-    strategy: OverviewStrategy = AutoHigherResolution,
+    strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
     targetCellType: Option[TargetCellType] = None,
     baseTiff: Option[MultibandGeoTiff] = None
   ): GeoTiffResampleRasterSource = new GeoTiffResampleRasterSource(dataPath, resampleTarget, method, strategy, targetCellType, baseTiff)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
@@ -106,8 +106,9 @@ trait GeoTiff[T <: CellGrid[Int]] extends GeoTiffData {
     overviews match {
       case Nil => this
       case list =>
-        val sourceCS = OverviewStrategy.selectOverview(overviews.map(_.cellSize), cellSize, strategy)
-        list(list.indexOf(sourceCS))
+        val availableViews = this :: list
+        val sourceCS = OverviewStrategy.selectOverview(availableViews.map(_.cellSize), cellSize, strategy)
+        availableViews(sourceCS)
     }
   }
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
@@ -53,8 +53,9 @@ object OverviewStrategy {
         overviewCS.indexOf(overviewCS.min)
       case AutoHigherResolution =>
         val idx = selectIndexByProximity(overviewCS, desiredCS, 1.0)
-        // AutoHigherResolution defaults to Base if index out of bounds
-        if (idx >= overviewCS.size) overviewCS.indexOf(overviewCS.min) else idx
+        // AutoHigherResolution defaults to the closest level
+        // idx > overviewCS.size means, that idx = overviewCS.size (last idx + 1)
+        if (idx > overviewCS.size) idx - 1 else idx
     }
     if (maybeIndex < 0) 0
     else if (maybeIndex >= overviewCS.size) overviewCS.size - 1

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
@@ -27,7 +27,7 @@ import scala.collection.Searching._
 sealed trait OverviewStrategy
 
 object OverviewStrategy {
-  def DEFAULT = Auto(0)
+  def DEFAULT = AutoHigherResolution
 
   def selectOverview(
     overviewCS: List[CellSize],

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
@@ -33,15 +33,20 @@ object OverviewStrategy {
     overviewCS: List[CellSize],
     desiredCS: CellSize,
     strategy: OverviewStrategy
-  ): Int = strategy match {
-    case Level(overviewIdx) =>
-      overviewIdx
-    case Auto(n) =>
-      selectIndexByProximity(overviewCS, desiredCS, 0.5) + n
-    case Base =>
-      overviewCS.indexOf(overviewCS.min)
-    case AutoHigherResolution =>
-      selectIndexByProximity(overviewCS, desiredCS, 1.0)
+  ): Int = {
+    val maybeIndex = strategy match {
+      case Level(overviewIdx) =>
+        overviewIdx
+      case Auto(n) =>
+        selectIndexByProximity(overviewCS, desiredCS, 0.5) + n
+      case Base =>
+        overviewCS.indexOf(overviewCS.min)
+      case AutoHigherResolution =>
+        selectIndexByProximity(overviewCS, desiredCS, 1.0)
+    }
+    if (maybeIndex < 0) 0
+    else if (maybeIndex >= overviewCS.size) overviewCS.size - 1
+    else maybeIndex
   }
 
   def selectIndexByProximity(overviewCS: List[CellSize], desiredCS: CellSize, proximityThreshold: Double): Int =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
@@ -32,6 +32,8 @@ object OverviewStrategy {
   /**
     * Select appropriate overview given the strategy.
     *
+    * WARN: this function assumes that CellSizes are sorted. It interprets idx 0 as the position with the highest CellSize.
+    *
     * Unless a particular strategy suggests otherwise, this method will clamp the returned
     * index to the range of overviewCS.
     * @param overviewCS

--- a/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
@@ -16,15 +16,15 @@
 
 package geotrellis.raster.geotiff
 
-import java.io.File
-
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
 import geotrellis.raster.reproject._
 import geotrellis.raster.testkit.RasterMatchers
 import geotrellis.proj4._
-import geotrellis.raster.io.geotiff.GeoTiffTestUtils
+
+import java.io.File
+
 import org.scalatest._
 
 class GeoTiffReprojectRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhenThen {

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
@@ -15,58 +15,72 @@ class OverviewStrategySpec extends FunSpec with Matchers {
   describe("Auto") {
     it("auto0 should select the closest resolution") {
       val strategy = Auto(0)
-      val selected =
-        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      val selected = OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
       selected should be (2)
     }
     it("auto1 should select the one after the closest") {
       val strategy = Auto(1)
-      val selected =
-        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      val selected = OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
       selected should be (3)
     }
     it("auto2 should select the one after the one after closest") {
       val strategy = Auto(2)
-      val selected =
-        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      val selected = OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
       selected should be (4)
     }
     it ("should select the last overview if out of bounds high") {
       val strategy = Auto(8)
-      val selected =
-        OverviewStrategy.selectOverview(availableResolutions, CellSize(1,1), strategy)
+      val selected = OverviewStrategy.selectOverview(availableResolutions, CellSize(1,1), strategy)
       selected should be (4)
+    }
+
+    it("should select the base overview if the list is not sorted") {
+      val strategy = Auto(0)
+      val selected = OverviewStrategy.selectOverview(availableResolutions.reverse, CellSize(45,45), strategy)
+      selected should be (0)
     }
   }
   describe("Level") {
     it("should select the nth overview") {
       val strategy = Level(2)
-      val selected =
-        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      val selected = OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      selected should be (2)
+    }
+
+    it("should select the nth overview if the list is not sorted") {
+      val strategy = Level(2)
+      val selected = OverviewStrategy.selectOverview(availableResolutions.reverse, CellSize(5,5), strategy)
       selected should be (2)
     }
   }
   describe("Base") {
+    val strategy = Base
     it("should select the highest/base resolution overview") {
-      val strategy = Base
-      val selected =
-        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      val selected = OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
       selected should be (0)
+    }
+
+    it("hould select the highest/base resolution overview if the list is not sorted") {
+      val selected = OverviewStrategy.selectOverview(availableResolutions.reverse, CellSize(5,5), strategy)
+      selected should be (4)
     }
   }
   describe("AutoHigherResolution") {
     val strategy = AutoHigherResolution
 
     it("should select the nearest overview - without rounding down") {
-      val selected =
-        OverviewStrategy.selectOverview(availableResolutions, CellSize(7,7), strategy)
+      val selected = OverviewStrategy.selectOverview(availableResolutions, CellSize(7,7), strategy)
       selected should be (2)
     }
 
     it("should select the best matching overview if out of bounds") {
-      val selected =
-        OverviewStrategy.selectOverview(availableResolutions, CellSize(32,32), strategy)
+      val selected = OverviewStrategy.selectOverview(availableResolutions, CellSize(32,32), strategy)
       selected should be (4)
+    }
+
+    it("should select the base overview if the list is not sorted") {
+      val selected = OverviewStrategy.selectOverview(availableResolutions.reverse, CellSize(32,32), strategy)
+      selected should be (0)
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
@@ -17,19 +17,19 @@ class OverviewStrategySpec extends FunSpec with Matchers {
       val strategy = Auto(0)
       val selected =
         OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
-      selected should be (CellSize(4, 4))
+      selected should be (2)
     }
     it("auto1 should select the one after the closest") {
       val strategy = Auto(1)
       val selected =
         OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
-      selected should be (CellSize(8, 8))
+      selected should be (3)
     }
     it("auto2 should select the one after the one after closest") {
       val strategy = Auto(2)
       val selected =
         OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
-      selected should be (CellSize(16, 16))
+      selected should be (4)
     }
   }
   describe("Level") {
@@ -37,7 +37,7 @@ class OverviewStrategySpec extends FunSpec with Matchers {
       val strategy = Level(2)
       val selected =
         OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
-      selected should be (CellSize(4, 4))
+      selected should be (2)
     }
   }
   describe("Base") {
@@ -45,7 +45,7 @@ class OverviewStrategySpec extends FunSpec with Matchers {
       val strategy = Base
       val selected =
         OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
-      selected should be (CellSize(1, 1))
+      selected should be (0)
     }
   }
   describe("AutoHigherResolution") {
@@ -53,7 +53,7 @@ class OverviewStrategySpec extends FunSpec with Matchers {
       val strategy = AutoHigherResolution
       val selected =
         OverviewStrategy.selectOverview(availableResolutions, CellSize(7,7), strategy)
-      selected should be (CellSize(4, 4))
+      selected should be (2)
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
@@ -63,10 +63,10 @@ class OverviewStrategySpec extends FunSpec with Matchers {
       selected should be (2)
     }
 
-    it("should select the base overview if out of bounds") {
+    it("should select the best matching overview if out of bounds") {
       val selected =
         OverviewStrategy.selectOverview(availableResolutions, CellSize(32,32), strategy)
-      selected should be (0)
+      selected should be (4)
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
@@ -1,0 +1,59 @@
+package geotrellis.raster.io.geotiff
+
+import geotrellis.raster._
+
+import org.scalatest._
+
+class OverviewStrategySpec extends FunSpec with Matchers {
+  val availableResolutions = List(
+    CellSize(1, 1),
+    CellSize(2, 2),
+    CellSize(4, 4),
+    CellSize(8, 8),
+    CellSize(16, 16)
+  )
+  describe("Auto") {
+    it("auto0 should select the closest resolution") {
+      val strategy = Auto(0)
+      val selected =
+        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      selected should be (CellSize(4, 4))
+    }
+    it("auto1 should select the one after the closest") {
+      val strategy = Auto(1)
+      val selected =
+        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      selected should be (CellSize(8, 8))
+    }
+    it("auto2 should select the one after the one after closest") {
+      val strategy = Auto(2)
+      val selected =
+        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      selected should be (CellSize(16, 16))
+    }
+  }
+  describe("Level") {
+    it("should select the nth overview") {
+      val strategy = Level(2)
+      val selected =
+        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      selected should be (CellSize(4, 4))
+    }
+  }
+  describe("Base") {
+    it("should select the highest/base resolution overview") {
+      val strategy = Base
+      val selected =
+        OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
+      selected should be (CellSize(1, 1))
+    }
+  }
+  describe("AutoHigherResolution") {
+    it("should select the nearest overview - without rounding down") {
+      val strategy = AutoHigherResolution
+      val selected =
+        OverviewStrategy.selectOverview(availableResolutions, CellSize(7,7), strategy)
+      selected should be (CellSize(4, 4))
+    }
+  }
+}

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/OverviewStrategySpec.scala
@@ -31,6 +31,12 @@ class OverviewStrategySpec extends FunSpec with Matchers {
         OverviewStrategy.selectOverview(availableResolutions, CellSize(5,5), strategy)
       selected should be (4)
     }
+    it ("should select the last overview if out of bounds high") {
+      val strategy = Auto(8)
+      val selected =
+        OverviewStrategy.selectOverview(availableResolutions, CellSize(1,1), strategy)
+      selected should be (4)
+    }
   }
   describe("Level") {
     it("should select the nth overview") {
@@ -49,11 +55,18 @@ class OverviewStrategySpec extends FunSpec with Matchers {
     }
   }
   describe("AutoHigherResolution") {
+    val strategy = AutoHigherResolution
+
     it("should select the nearest overview - without rounding down") {
-      val strategy = AutoHigherResolution
       val selected =
         OverviewStrategy.selectOverview(availableResolutions, CellSize(7,7), strategy)
       selected should be (2)
+    }
+
+    it("should select the base overview if out of bounds") {
+      val selected =
+        OverviewStrategy.selectOverview(availableResolutions, CellSize(32,32), strategy)
+      selected should be (0)
     }
   }
 }

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/geotiff/S3GeoTiffLayerReader.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/geotiff/S3GeoTiffLayerReader.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.store.s3.geotiff
 
 import geotrellis.layer.ZoomedLayoutScheme
 import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.store.util._
 import geotrellis.store.s3.cog.byteReader
 import geotrellis.store.s3.S3ClientProducer
@@ -38,7 +38,7 @@ import scala.concurrent.ExecutionContext
   val attributeStore: AttributeStore[M, GeoTiffMetadata],
   val layoutScheme: ZoomedLayoutScheme,
   val resampleMethod: ResampleMethod = NearestNeighbor,
-  val strategy: OverviewStrategy = AutoHigherResolution,
+  val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   s3Client: => S3Client = S3ClientProducer.get(),
   executionContext: ExecutionContext = BlockingThreadPool.executionContext
 ) extends GeoTiffLayerReader[M] {
@@ -50,7 +50,7 @@ import scala.concurrent.ExecutionContext
     attributeStore: AttributeStore[M, GeoTiffMetadata],
     layoutScheme: ZoomedLayoutScheme,
     resampleMethod: ResampleMethod = NearestNeighbor,
-    strategy: OverviewStrategy = AutoHigherResolution,
+    strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
     s3Client: => S3Client = S3ClientProducer.get(),
     executionContext: => ExecutionContext = BlockingThreadPool.executionContext
   ): S3GeoTiffLayerReader[M] = new S3GeoTiffLayerReader[M](

--- a/spark/src/main/scala/geotrellis/spark/store/file/geotiff/FileGeoTiffLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/file/geotiff/FileGeoTiffLayerReader.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.store.file.geotiff
 
 import geotrellis.layer.ZoomedLayoutScheme
 import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.store.file.cog.byteReader
 import geotrellis.spark.store.hadoop.geotiff._
 import geotrellis.store.util.BlockingThreadPool
@@ -36,7 +36,7 @@ import scala.concurrent.ExecutionContext
   val attributeStore: AttributeStore[M, GeoTiffMetadata],
   val layoutScheme: ZoomedLayoutScheme,
   val resampleMethod: ResampleMethod = NearestNeighbor,
-  val strategy: OverviewStrategy = AutoHigherResolution,
+  val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
 ) extends GeoTiffLayerReader[M] {
   implicit lazy val ec: ExecutionContext = executionContext
@@ -47,7 +47,7 @@ import scala.concurrent.ExecutionContext
     attributeStore: AttributeStore[M, GeoTiffMetadata],
     layoutScheme: ZoomedLayoutScheme,
     resampleMethod: ResampleMethod = NearestNeighbor,
-    strategy: OverviewStrategy = AutoHigherResolution,
+    strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
     executionContext: => ExecutionContext = BlockingThreadPool.executionContext
   ): FileGeoTiffLayerReader[M] =
     new FileGeoTiffLayerReader(attributeStore, layoutScheme, resampleMethod, strategy, executionContext)

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/geotiff/HadoopGeoTiffLayerReader.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/geotiff/HadoopGeoTiffLayerReader.scala
@@ -18,7 +18,7 @@ package geotrellis.spark.store.hadoop.geotiff
 
 import geotrellis.layer.ZoomedLayoutScheme
 import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.store.util.BlockingThreadPool
 import geotrellis.store.hadoop.cog.byteReader
 import geotrellis.util.ByteReader
@@ -36,7 +36,7 @@ import scala.concurrent.ExecutionContext
   val attributeStore: AttributeStore[M, GeoTiffMetadata],
   val layoutScheme: ZoomedLayoutScheme,
   val resampleMethod: ResampleMethod = NearestNeighbor,
-  val strategy: OverviewStrategy = AutoHigherResolution,
+  val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   val conf: Configuration = new Configuration,
   executionContext: => ExecutionContext = BlockingThreadPool.executionContext
 ) extends GeoTiffLayerReader[M] {
@@ -48,7 +48,7 @@ import scala.concurrent.ExecutionContext
     attributeStore: AttributeStore[M, GeoTiffMetadata],
     layoutScheme: ZoomedLayoutScheme,
     resampleMethod: ResampleMethod = NearestNeighbor,
-    strategy: OverviewStrategy = AutoHigherResolution,
+    strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
     conf: Configuration = new Configuration,
     executionContext: => ExecutionContext = BlockingThreadPool.executionContext
   ): HadoopGeoTiffLayerReader[M] =

--- a/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
@@ -140,9 +140,9 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
     }
 
     it("should reproduce tileToLayout followed by reproject") {
-      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout, strategy = Base)
+      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout, strategy = AutoHigherResolution)
       val reprojectedSourceRDD: MultibandTileLayerRDD[SpatialKey] =
-        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout, strategy = Base)
+        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout, strategy = AutoHigherResolution)
 
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedExpectedRDD.stitch, targetCRS).write("/tmp/expected.tif")
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedSourceRDD.stitch, targetCRS).write("/tmp/actual.tif")

--- a/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
@@ -140,9 +140,8 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
     }
 
     it("should reproduce tileToLayout followed by reproject") {
-      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout)
       val reprojectedSourceRDD: MultibandTileLayerRDD[SpatialKey] =
-        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout)
+        RasterSourceRDD.spatial(rasterSource.reprojectToGrid(targetCRS, layout), layout)
 
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedExpectedRDD.stitch, targetCRS).write("/tmp/expected.tif")
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedSourceRDD.stitch, targetCRS).write("/tmp/actual.tif")

--- a/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
@@ -86,14 +86,13 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
     val geoTiffRDD = HadoopGeoTiffRDD.spatialMultiband(uri)
     val md = geoTiffRDD.collectMetadata[SpatialKey](floatingLayout)._2
 
-    val reprojectedExpectedRDD: MultibandTileLayerRDD[SpatialKey] = {
+    val reprojectedExpectedRDD: MultibandTileLayerRDD[SpatialKey] =
       geoTiffRDD
         .tileToLayout(md)
         .reproject(
           targetCRS,
           layout
         )._2.persist()
-    }
 
     def assertRDDLayersEqual(
       expected: MultibandTileLayerRDD[SpatialKey],
@@ -141,8 +140,9 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
     }
 
     it("should reproduce tileToLayout followed by reproject") {
+      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout, strategy = Base)
       val reprojectedSourceRDD: MultibandTileLayerRDD[SpatialKey] =
-        RasterSourceRDD.spatial(rasterSource.reprojectToGrid(targetCRS, layout), layout)
+        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout, strategy = Base)
 
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedExpectedRDD.stitch, targetCRS).write("/tmp/expected.tif")
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedSourceRDD.stitch, targetCRS).write("/tmp/actual.tif")

--- a/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/RasterSourceRDDSpec.scala
@@ -140,9 +140,9 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with RasterMatche
     }
 
     it("should reproduce tileToLayout followed by reproject") {
-      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout, strategy = AutoHigherResolution)
+      val reprojectedRasterSource = rasterSource.reprojectToGrid(targetCRS, layout)
       val reprojectedSourceRDD: MultibandTileLayerRDD[SpatialKey] =
-        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout, strategy = AutoHigherResolution)
+        RasterSourceRDD.spatial(Seq(reprojectedRasterSource), layout)
 
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedExpectedRDD.stitch, targetCRS).write("/tmp/expected.tif")
       // geotrellis.raster.io.geotiff.GeoTiff(reprojectedSourceRDD.stitch, targetCRS).write("/tmp/actual.tif")

--- a/spark/src/test/scala/geotrellis/store/GeoTrellisRasterSourceSpec.scala
+++ b/spark/src/test/scala/geotrellis/store/GeoTrellisRasterSourceSpec.scala
@@ -175,42 +175,19 @@ class GeoTrellisRasterSourceSpec extends FunSpec with RasterMatchers with GivenW
 
       implicit def getoce(ge: GridExtent[Long]): CellSize = ge.cellSize
 
-      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, AutoHigherResolution).get == rasterExtent1)
-      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize2, AutoHigherResolution).get == rasterExtent2)
+      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, AutoHigherResolution) == rasterExtent1)
+      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize2, AutoHigherResolution) == rasterExtent2)
 
-      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, Auto(0)).get == rasterExtent1)
-      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, Auto(1)).get == rasterExtent2)
-      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, Auto(2)).get == rasterExtent3)
+      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, Auto(0)) == rasterExtent1)
+      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, Auto(1)) == rasterExtent2)
+      assert(GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, Auto(2)) == rasterExtent3)
       // do the best we can, we can't get index 3, so we get the closest:
       val res = GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, Auto(3))
-      info (s"Auto(3): ${res.map(_.cellSize)}")
-      assert(res == Some(rasterExtent3))
+      assert(res == rasterExtent3)
 
       val resBase = GeoTrellisRasterSource.getClosestResolution(resolutions, cellSize1, Base)
-      info(s"Base: ${resBase.map(_.cellSize)}")
-      assert(resBase == Some(rasterExtent1))
+      assert(resBase == rasterExtent1)
     }
-
-    // it("should get the closest layer") {
-    //   val extent = Extent(0.0, 0.0, 10.0, 10.0)
-    //   val rasterExtent1 = new GridExtent[Long](extent, 1.0, 1.0, 10, 10)
-    //   val rasterExtent2 = new GridExtent[Long](extent, 2.0, 2.0, 10, 10)
-    //   val rasterExtent3 = new GridExtent[Long](extent, 4.0, 4.0, 10, 10)
-
-    //   val resolutions = List(rasterExtent1, rasterExtent2, rasterExtent3)
-
-    //   val layerId1 = LayerId("foo", 0)
-    //   val layerId2 = LayerId("foo", 1)
-    //   val layerId3 = LayerId("foo", 2)
-    //   val layerIds = List(layerId1, layerId2, layerId3)
-
-    //   val cellSize = CellSize(1.0, 1.0)
-
-    //   implicit def getoce(ge: GridExtent[Long]): CellSize = ge.cellSize
-    //   assert(GeoTrellisRasterSource.getClosestLayer(resolutions, layerIds, layerId3, cellSize) == layerId1)
-    //   assert(GeoTrellisRasterSource.getClosestLayer(List(), List(), layerId3, cellSize) == layerId3)
-    //   assert(GeoTrellisRasterSource.getClosestLayer(resolutions, List(), layerId3, cellSize) == layerId3)
-    // }
 
     it("should reproject") {
       val targetCRS = WebMercator

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -141,10 +141,10 @@ object GeoTrellisRasterSource {
     cellSize: CellSize,
     strategy: OverviewStrategy = OverviewStrategy.DEFAULT
   )(implicit f: T => CellSize): T = {
-    val resolutions = grids.map(f).toList
-    val sourceResolution =
-      OverviewStrategy.selectOverview(resolutions, cellSize, strategy)
-    grids(sourceResolution)
+    val sgrids = grids.sortBy(f(_))
+    val resolutions = sgrids.map(f).toList
+    val sourceResolution = OverviewStrategy.selectOverview(resolutions, cellSize, strategy)
+    sgrids(sourceResolution)
   }
 
   /** Read metadata for all layers that share a name and sort them by their resolution */

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -110,7 +110,7 @@ class GeoTrellisRasterSource(
           this
         case resampleTarget =>
           val resampledGridExtent = resampleTarget(this.gridExtent)
-          val closestLayerId = GeoTrellisRasterSource.getClosestResolution(sourceLayers.toList, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get.id
+          val closestLayerId = GeoTrellisRasterSource.getClosestResolution(sourceLayers.toList, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).id
           new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, resampledGridExtent, method, targetCellType)
       }
     }
@@ -118,7 +118,7 @@ class GeoTrellisRasterSource(
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
     val resampledGridExtent = resampleTarget(this.gridExtent)
-    val closestLayerId = GeoTrellisRasterSource.getClosestResolution(sourceLayers.toList, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get.id
+    val closestLayerId = GeoTrellisRasterSource.getClosestResolution(sourceLayers.toList, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).id
     new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, resampledGridExtent, method, targetCellType)
   }
 
@@ -140,12 +140,11 @@ object GeoTrellisRasterSource {
     grids: Seq[T],
     cellSize: CellSize,
     strategy: OverviewStrategy = OverviewStrategy.DEFAULT
-  )(implicit f: T => CellSize): Option[T] = {
-    val maxResultion = Some(grids.minBy(g => f(g).resolution))
+  )(implicit f: T => CellSize): T = {
     val resolutions = grids.map(f).toList
     val sourceResolution =
       OverviewStrategy.selectOverview(resolutions, cellSize, strategy)
-    grids.lift(resolutions.indexOf(sourceResolution))
+    grids(sourceResolution)
   }
 
   /** Read metadata for all layers that share a name and sort them by their resolution */

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -21,7 +21,7 @@ import geotrellis.raster._
 import geotrellis.raster.reproject._
 import geotrellis.raster.resample._
 import geotrellis.proj4._
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 
 import org.log4s._
 import scala.io.AnsiColor._
@@ -35,7 +35,7 @@ class GeoTrellisReprojectRasterSource(
   val crs: CRS,
   val resampleTarget: ResampleTarget = DefaultTarget,
   val resampleMethod: ResampleMethod = NearestNeighbor,
-  val strategy: OverviewStrategy = AutoHigherResolution,
+  val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   val errorThreshold: Double = 0.125,
   val targetCellType: Option[TargetCellType]
 ) extends RasterSource {
@@ -114,7 +114,7 @@ class GeoTrellisReprojectRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.dimensions).flatMap(read(_, bands)))
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): RasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource = {
     if (targetCRS == sourceLayer.metadata.crs) {
       val resampledGridExtent = resampleTarget(this.sourceLayer.gridExtent)
       val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -117,7 +117,7 @@ class GeoTrellisReprojectRasterSource(
   def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource = {
     if (targetCRS == sourceLayer.metadata.crs) {
       val resampledGridExtent = resampleTarget(this.sourceLayer.gridExtent)
-      val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get
+      val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize)
       // TODO: if closestLayer is w/in some marging of desired CellSize, return GeoTrellisRasterSource instead
       new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayer.id, sourceLayers, resampledGridExtent, resampleMethod, targetCellType)
     } else {
@@ -175,7 +175,7 @@ object GeoTrellisReprojectRasterSource {
     if (options.targetRasterExtent.isDefined) {
       val targetGrid: GridExtent[Long] = options.targetRasterExtent.get.toGridType[Long]
       val sourceGrid: GridExtent[Long] = ReprojectRasterExtent(targetGrid, targetCRS, sourceCRS)
-      val sourceLayer = GeoTrellisRasterSource.getClosestResolution(sourcePyramid, sourceGrid.cellSize, strategy)(_.metadata.layout.cellSize).get
+      val sourceLayer = GeoTrellisRasterSource.getClosestResolution(sourcePyramid, sourceGrid.cellSize, strategy)(_.metadata.layout.cellSize)
       (sourceLayer.id, targetGrid)
 
     } else if (options.parentGridExtent.isDefined) {
@@ -193,7 +193,7 @@ object GeoTrellisReprojectRasterSource {
           val pixelSize = distance / math.sqrt(cols * cols + rows * rows)
           CellSize(pixelSize, pixelSize)
         }
-        GeoTrellisRasterSource.getClosestResolution(sourcePyramid, aproximateSourceCellSize, strategy)(_.metadata.layout.cellSize).get
+        GeoTrellisRasterSource.getClosestResolution(sourcePyramid, aproximateSourceCellSize, strategy)(_.metadata.layout.cellSize)
       }
       val gridExtent: GridExtent[Long] = ReprojectRasterExtent(sourceLayer.gridExtent, sourceLayer.metadata.crs, targetCRS, options)
       (sourceLayer.id, gridExtent)
@@ -209,7 +209,7 @@ object GeoTrellisReprojectRasterSource {
         val pixelSize = distance / math.sqrt(cols * cols + rows * rows)
         CellSize(pixelSize, pixelSize)
       }
-      val sourceLayer = GeoTrellisRasterSource.getClosestResolution(sourcePyramid, aproximateSourceCellSize, strategy)(_.metadata.layout.cellSize).get
+      val sourceLayer = GeoTrellisRasterSource.getClosestResolution(sourcePyramid, aproximateSourceCellSize, strategy)(_.metadata.layout.cellSize)
       val gridExtent: GridExtent[Long] = ReprojectRasterExtent(sourceLayer.gridExtent, sourceLayer.metadata.crs, targetCRS, options)
       (sourceLayer.id, gridExtent)
 

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -112,7 +112,7 @@ class GeoTrellisResampleRasterSource(
    */
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTrellisResampleRasterSource = {
     val resampledGridExtent = resampleTarget(this.gridExtent)
-    val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).get
+    val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize)
     // TODO: if closestLayer is w/in some marging of desired CellSize, return GeoTrellisRasterSource instead
     new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayer.id, sourceLayers, resampledGridExtent, method, targetCellType)
   }

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -20,7 +20,7 @@ import geotrellis.vector._
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
-import geotrellis.raster.io.geotiff.{AutoHigherResolution, OverviewStrategy}
+import geotrellis.raster.io.geotiff.OverviewStrategy
 
 import org.log4s._
 
@@ -102,7 +102,7 @@ class GeoTrellisResampleRasterSource(
       .flatMap(read(_, bands))
   }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTrellisReprojectRasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTrellisReprojectRasterSource = {
     val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
     val (closestLayerId, gridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
     new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, resampleTarget, targetCellType = targetCellType)


### PR DESCRIPTION
# Overview

This PR exposes the overview selection logic implicit in each of the `OverviewStrategy` instances by way of a `selectOverview` method. Now, instead of matching and requiring users of the sum type to implement logic themselves, a call to `selectOverview` with the available `CellSizes` and the desired `CellSize` will yield a selection of the `CellSize` corresponding to the selected `Overview`

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature


## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #3196
