### PR TITLE
Make GDALRasterSource behavior consistent with other RasterSources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- RasterSources resolutions should be consistent across implementations [#3210](https://github.com/locationtech/geotrellis/issues/3210)
+- Bump gdal-warp-bindings version up to 1.0.0 [#3211](https://github.com/locationtech/geotrellis/pull/3211)
+- Fixed GDALRasterSource.resample method behavior to respect the passed resampleMethod [#3211](https://github.com/locationtech/geotrellis/pull/3211)
+
+### Changed
+
 - Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
 - Fix GeoTiff Byte and UByte CellType conversions [#3189](https://github.com/locationtech/geotrellis/issues/3189)
 - Fix incorrect parsing of authority in GeoTrellisPath [#3191](https://github.com/locationtech/geotrellis/pull/3191)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- RasterSources resolutions should be consistent across implementations [#3210](https://github.com/locationtech/geotrellis/issues/3210)
-- Bump gdal-warp-bindings version up to 1.0.0 [#3211](https://github.com/locationtech/geotrellis/pull/3211)
-- Fixed GDALRasterSource.resample method behavior to respect the passed resampleMethod [#3211](https://github.com/locationtech/geotrellis/pull/3211)
-
-### Changed
-
 - Fix `PolygonRasterizer` failure on some inputs [#3160](https://github.com/locationtech/geotrellis/issues/3160)
 - Fix GeoTiff Byte and UByte CellType conversions [#3189](https://github.com/locationtech/geotrellis/issues/3189)
 - Fix incorrect parsing of authority in GeoTrellisPath [#3191](https://github.com/locationtech/geotrellis/pull/3191)
 - GeoTrellisPath.zoomLevel is now `Option[Int]` -> `Int` to better indicate that it is a required parameter [#3191](https://github.com/locationtech/geotrellis/pull/3191)
 - Fix the length of one degree at the equator in metres [#3197](https://github.com/locationtech/geotrellis/pull/3197)
 - Fix Fix DelaunayRasterizer [#3202](https://github.com/locationtech/geotrellis/pull/3202)
+- RasterSources resolutions should be consistent across implementations [#3210](https://github.com/locationtech/geotrellis/issues/3210)
+- Bump gdal-warp-bindings version up to 1.0.0 [#3211](https://github.com/locationtech/geotrellis/pull/3211)
+- Fixed GDALRasterSource.resample method behavior to respect the passed resampleMethod [#3211](https://github.com/locationtech/geotrellis/pull/3211)
+- Fix Jackson dependencies [#3212](https://github.com/locationtech/geotrellis/issues/3212) 
 
 ### Removed
 

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -97,7 +97,7 @@ class GDALRasterSource(
     * These resolutions could represent actual overview as seen in source file
     * or overviews of VRT that was created as result of resample operations.
     */
-  lazy val resolutions: List[CellSize] = dataset.rasterExtent(GDALDataset.SOURCE).cellSize :: dataset.resolutions(datasetType).map(_.cellSize)
+  lazy val resolutions: List[CellSize] = gridExtent.cellSize :: dataset.resolutions(datasetType).map(_.cellSize)
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     bounds

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -97,7 +97,7 @@ class GDALRasterSource(
     * These resolutions could represent actual overview as seen in source file
     * or overviews of VRT that was created as result of resample operations.
     */
-  lazy val resolutions: List[CellSize] = dataset.resolutions(datasetType).map(_.cellSize)
+  lazy val resolutions: List[CellSize] = dataset.rasterExtent(GDALDataset.SOURCE).cellSize :: dataset.resolutions(datasetType).map(_.cellSize)
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     bounds
@@ -114,7 +114,7 @@ class GDALRasterSource(
     new GDALRasterSource(dataPath, options.reproject(gridExtent, crs, targetCRS, resampleTarget, method))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
-    new GDALRasterSource(dataPath, options.resample(gridExtent, resampleTarget))
+    new GDALRasterSource(dataPath, options.copy(resampleMethod = Some(method)).resample(gridExtent, resampleTarget))
 
   /** Converts the contents of the GDALRasterSource to the [[TargetCellType]].
    *

--- a/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
+++ b/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
@@ -46,9 +46,9 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhenThe
     // no resampling is implemented there
     it("should be able to resample") {
       // read in the whole file and resample the pixels in memory
+      val etiff = GeoTiffReader.readMultiband(uri, streaming = false)
       val expected: Raster[MultibandTile] =
-        GeoTiffReader
-          .readMultiband(uri, streaming = false)
+        etiff
           .raster
           .resample((source.cols * 0.95).toInt , (source.rows * 0.95).toInt, NearestNeighbor)
       // resample to 0.9 so we RasterSource picks the base layer and not an overview
@@ -60,6 +60,9 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhenThe
 
       info(s"Source CellSize: ${source.cellSize}")
       info(s"Target CellSize: ${resampledSource.cellSize}")
+
+      source.resolutions.length shouldBe (etiff.overviews.length + 1)
+      source.resolutions.length shouldBe resampledSource.resolutions.length
 
       // calculated expected resolutions of overviews
       // it's a rough approximation there as we're not calculating resolutions like GDAL

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Version {
   val hadoop      = "2.8.5"
   val spark       = "2.4.4"
   val gdal        = "2.4.0"
-  val gdalWarp    = "33.567d940"
+  val gdalWarp    = "1.0.0"
 
   val previousVersion = "3.0.0"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -138,9 +138,4 @@ object Dependencies {
 
   val gdalBindings        = "org.gdal"                     % "gdal"                    % Version.gdal
   val gdalWarp            = "com.azavea.geotrellis"        % "gdal-warp-bindings"      % Version.gdalWarp
-
-  val jacksonCore         = "com.fasterxml.jackson.core"    % "jackson-core"             % "2.6.7"
-  val jacksonDatabind     = "com.fasterxml.jackson.core"    % "jackson-databind"         % "2.6.7"
-  val jacksonAnnotations  = "com.fasterxml.jackson.core"    % "jackson-annotations"      % "2.6.7"
-  val jacksonModuleScala  = "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.6.7"
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -387,19 +387,6 @@ object Settings {
       sparkSql % Test,
       scalatest % Test
     ),
-    /** https://github.com/lucidworks/spark-solr/issues/179 */
-    dependencyOverrides ++= {
-      val deps = Seq(
-        "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
-        "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.7"
-      )
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        // if Scala 2.12+ is used
-        case Some((2, scalaMajor)) if scalaMajor >= 12 => deps
-        case _ => deps :+ "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
-      }
-    },
     console / initialCommands :=
       """
       import geotrellis.raster._
@@ -429,19 +416,6 @@ object Settings {
       sparkSql % Test,
       scalatest % Test
     ),
-    /** https://github.com/lucidworks/spark-solr/issues/179 */
-    dependencyOverrides ++= {
-      val deps = Seq(
-        "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
-        "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.7"
-      )
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        // if Scala 2.12+ is used
-        case Some((2, scalaMajor)) if scalaMajor >= 12 => deps
-        case _ => deps :+ "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
-      }
-    },
     console / initialCommands :=
       """
       import geotrellis.raster._
@@ -522,23 +496,12 @@ object Settings {
   lazy val s3 = Seq(
     name := "geotrellis-s3",
     libraryDependencies ++= Seq(
-      awsSdkS3,
+      /** https://github.com/lucidworks/spark-solr/issues/179 */
+      awsSdkS3 excludeAll ExclusionRule("com.fasterxml.jackson.core"),
       spire,
       scaffeine,
       scalatest % Test
     ),
-    dependencyOverrides ++= {
-      val deps = Seq(
-        "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
-        "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.7"
-      )
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        // if Scala 2.12+ is used
-        case Some((2, scalaMajor)) if scalaMajor >= 12 => deps
-        case _ => deps :+ "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
-      }
-    },
     mimaPreviousArtifacts := Set(
       "org.locationtech.geotrellis" %% "geotrellis-s3" % Version.previousVersion
     ),
@@ -556,24 +519,11 @@ object Settings {
     name := "geotrellis-s3-spark",
     libraryDependencies ++= Seq(
       sparkCore % Provided,
-      awsSdkS3,
       spire,
       scaffeine,
       sparkSql % Test,
       scalatest % Test
     ),
-    dependencyOverrides ++= {
-      val deps = Seq(
-        "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
-        "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.7"
-      )
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        // if Scala 2.12+ is used
-        case Some((2, scalaMajor)) if scalaMajor >= 12 => deps
-        case _ => deps :+ "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7"
-      }
-    },
     mimaPreviousArtifacts := Set(
       "org.locationtech.geotrellis" %% "geotrellis-s3" % Version.previousVersion
     ),
@@ -634,8 +584,12 @@ object Settings {
   lazy val `spark-pipeline` = Seq(
     name := "geotrellis-spark-pipeline",
     libraryDependencies ++= Seq(
-      circe("core").value, circe("generic").value, circe("generic-extras").value, circe("parser").value,
-      sparkCore % Provided, sparkSql % Test,
+      circe("core").value,
+      circe("generic").value,
+      circe("generic-extras").value,
+      circe("parser").value,
+      sparkCore % Provided,
+      sparkSql % Test,
       scalatest % Test
     ),
     assembly / test := {},
@@ -663,7 +617,8 @@ object Settings {
   lazy val `spark-testkit` = Seq(
     name := "geotrellis-spark-testkit",
     libraryDependencies ++= Seq(
-      sparkCore % Provided, sparkSql % Provided,
+      sparkCore % Provided,
+      sparkSql % Provided,
       hadoopClient % Provided,
       scalatest,
       chronoscala
@@ -771,22 +726,10 @@ object Settings {
     name := "geotrellis-gdal-spark",
     libraryDependencies ++= Seq(
       gdalWarp,
-      sparkCore % Provided, sparkSql % Test,
+      sparkCore % Provided,
+      sparkSql % Test,
       scalatest % Test
     ),
-    // caused by the AWS SDK v2
-    dependencyOverrides ++= {
-      val deps = Seq(
-        jacksonCore,
-        jacksonDatabind,
-        jacksonAnnotations
-      )
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        // if Scala 2.12+ is used
-        case Some((2, scalaMajor)) if scalaMajor >= 12 => deps
-        case _ => deps :+ jacksonModuleScala
-      }
-    },
     resolvers += Repositories.azaveaBintray,
     Test / fork := true,
     Test / parallelExecution := false,

--- a/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
@@ -36,7 +36,7 @@ trait RasterMetadata extends Serializable {
 
   /** All available overview resolutions for this raster source
     *
-    * <li> For base [[RasterSource]] instance this will be resolutions of available overviews.
+    * <li> For base [[RasterSource]] instance this will be resolutions of available overviews including the base resolution.
     * <li> For reprojected [[RasterSource]] these resolutions represent an estimate where
     *      each cell in target CRS has ''approximately'' the same geographic coverage as a cell in the source CRS.
     *

--- a/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
@@ -43,6 +43,8 @@ trait RasterMetadata extends Serializable {
     * When reading raster data the underlying implementation will have to sample from one of these resolutions.
     * It is possible that a read request for a small bounding box will results in significant IO request when the target
     * cell size is much larger than closest available resolution.
+    *
+    * Warning: the behavior of this function may slightly vary, depending on the implementation.
     */
   def resolutions: List[CellSize]
 

--- a/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffRasterSourceSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffRasterSourceSpec.scala
@@ -57,9 +57,9 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhen
 
   it("should be able to resample") {
     // read in the whole file and resample the pixels in memory
+    val etiff = GeoTiffReader.readMultiband(url, streaming = false)
     val expected: Raster[MultibandTile] =
-      GeoTiffReader
-        .readMultiband(url, streaming = false)
+      etiff
         .raster
         .resample((source.cols * 0.95).toInt , (source.rows * 0.95).toInt, NearestNeighbor)
         // resample to 0.9 so we RasterSource picks the base layer and not an overview
@@ -71,6 +71,9 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhen
 
     val actual: Raster[MultibandTile] =
       resampledSource.read(GridBounds(0, 0, resampledSource.cols - 1, resampledSource.rows - 1)).get
+
+    source.resolutions.length shouldBe (etiff.overviews.length + 1)
+    source.resolutions.length shouldBe resampledSource.resolutions.length
 
     resampledSource.resolutions.zip(source.resolutions).map { case (rea, ree) =>
       rea.resolution shouldBe ree.resolution +- 1e-7

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -45,10 +45,8 @@ class GeoTrellisReprojectRasterSource(
 
   lazy val reader = CollectionLayerReader(attributeStore, dataPath.value)
 
-  lazy val resolutions: List[CellSize] = {
-    sourceLayers.map { layer =>
-      ReprojectRasterExtent(layer.gridExtent, Transform(layer.metadata.crs, crs), Reproject.Options.DEFAULT).cellSize
-    }
+  lazy val resolutions: List[CellSize] = sourceLayers.map { layer =>
+    ReprojectRasterExtent(layer.gridExtent, Transform(layer.metadata.crs, crs), Reproject.Options.DEFAULT).cellSize
   }.toList
 
   lazy val sourceLayer: Layer = sourceLayers.find(_.id == layerId).get


### PR DESCRIPTION
# Overview

This PR: 

- [x] Adds the base cellSize to the list of resolutions to behave similar to other RasterSources.
- [x] Bumps GDALWarp version up to 1.0.0
- [x] Fixes Jackson dependencies

This issues makes `GDALRasterSource`, `GeoTiffRasterSource` and `DEMRasterSource` to behave more consistent.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary

Related to #3210
Closes #3212