### PR TITLE
GDALRasterSource should behave consistent across other RasterSources

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ To grab the latest `SNAPSHOT`, `RC` or milestone build, add these resolvers:
 
 ```scala
 resolvers ++= Seq(
-  "locationtech-releases" at "https://repo.locationtech.org/content/groups/releases",
-  "locationtech-snapshots" at "https://repo.locationtech.org/content/groups/snapshots"
+  "eclipse-releases" at "https://repo.eclipse.org/content/groups/releases",
+  "eclipse-snapshots" at "https://repo.eclipse.org/content/groups/snapshots"
 )
 ```
 

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -27,7 +27,7 @@ class GDALRasterSource(
   val dataPath: GDALPath,
   val options: GDALWarpOptions = GDALWarpOptions.EMPTY,
   private[raster] val targetCellType: Option[TargetCellType] = None
-) extends RasterSource {
+) extends RasterSource { self =>
 
   /**
     * All the information received from the JNI side should be cached on the JVM side,
@@ -114,7 +114,9 @@ class GDALRasterSource(
     new GDALRasterSource(dataPath, options.reproject(gridExtent, crs, targetCRS, resampleTarget, method))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
-    new GDALRasterSource(dataPath, options.copy(resampleMethod = Some(method)).resample(gridExtent, resampleTarget))
+    new GDALRasterSource(dataPath, options.copy(resampleMethod = Some(method)).resample(gridExtent, resampleTarget)) {
+      override lazy val resolutions: List[CellSize] = self.resolutions
+    }
 
   /** Converts the contents of the GDALRasterSource to the [[TargetCellType]].
    *

--- a/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
+++ b/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
@@ -43,7 +43,6 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhenThe
       )
     }
 
-    // no resampling is implemented there
     it("should be able to resample") {
       // read in the whole file and resample the pixels in memory
       val etiff = GeoTiffReader.readMultiband(uri, streaming = false)
@@ -64,12 +63,12 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhenThe
       source.resolutions.length shouldBe (etiff.overviews.length + 1)
       source.resolutions.length shouldBe resampledSource.resolutions.length
 
-      // calculated expected resolutions of overviews
-      // it's a rough approximation there as we're not calculating resolutions like GDAL
-      val ratio = resampledSource.cellSize.resolution / source.cellSize.resolution
-      resampledSource.resolutions.zip (source.resolutions.map { case CellSize(cw, ch) =>
-        CellSize(cw * ratio, ch * ratio)
-      }).map { case (rea, ree) => rea.resolution shouldBe ree.resolution +- 3e-1 }
+      source.resolutions.length shouldBe (etiff.overviews.length + 1)
+      source.resolutions.length shouldBe resampledSource.resolutions.length
+
+      resampledSource.resolutions.zip(source.resolutions).map { case (rea, ree) =>
+        rea.resolution shouldBe ree.resolution +- 1e-7
+      }
 
       val actual: Raster[MultibandTile] =
         resampledSource.read(GridBounds(0, 0, resampledSource.cols - 1, resampledSource.rows - 1)).get

--- a/layer/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
+++ b/layer/src/test/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSourceSpec.scala
@@ -49,6 +49,14 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with RasterMatchers with 
     it("should select correct overview to sample from with a GeoTiffReprojectRasterSource") {
       // we choose LatLng to switch scales, the source projection is in meters
       val baseReproject = rasterSource.reproject(LatLng).asInstanceOf[GeoTiffReprojectRasterSource]
+
+      // checking that list of resolutions is resampled
+      val transform = Transform(rasterSource.crs, baseReproject.crs)
+      baseReproject.resolutions.size shouldBe rasterSource.resolutions.size
+      rasterSource.resolutions.zip(baseReproject.resolutions).map { case (scz, ecz) =>
+        ReprojectRasterExtent(GridExtent[Long](rasterSource.extent, scz), transform, Reproject.Options.DEFAULT).cellSize shouldBe ecz
+      }
+
       // known good start, CellSize(10, 10) is the base resolution of source
       baseReproject.closestTiffOverview.cellSize shouldBe CellSize(10, 10)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -28,16 +28,16 @@ import sbtprotoc.ProtocPlugin.autoImport.PB
 
 object Settings {
   object Repositories {
-    val locationtechReleases  = "locationtech-releases" at "https://repo.locationtech.org/content/repositories/releases/"
-    val locationtechSnapshots = "locationtech-snapshots" at "https://repo.locationtech.org/content/repositories/snapshots/"
-    val boundlessgeo          = "boundlessgeo" at "https://repo.boundlessgeo.com/main/"
-    val boundlessgeoRelease   = "boundless" at "https://repo.boundlessgeo.com/release"
-    val geosolutions          = "geosolutions" at "https://maven.geo-solutions.it/"
-    val osgeo                 = "osgeo" at "https://download.osgeo.org/webdav/geotools/"
-    val ivy2Local             = Resolver.file("local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
-    val mavenLocal            = Resolver.mavenLocal
-    val local                 = Seq(ivy2Local, mavenLocal)
-    val azaveaBintray         = Resolver.bintrayRepo("azavea", "geotrellis")
+    val eclipseReleases     = "eclipse-releases" at "https://repo.eclipse.org/content/groups/releases"
+    val eclipseSnapshots    = "eclipse-snapshots" at "https://repo.eclipse.org/content/groups/snapshots"
+    val boundlessgeo        = "boundlessgeo" at "https://repo.boundlessgeo.com/main/"
+    val boundlessgeoRelease = "boundless" at "https://repo.boundlessgeo.com/release"
+    val geosolutions        = "geosolutions" at "https://maven.geo-solutions.it/"
+    val osgeo               = "osgeo" at "https://download.osgeo.org/webdav/geotools/"
+    val ivy2Local           = Resolver.file("local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
+    val mavenLocal          = Resolver.mavenLocal
+    val local               = Seq(ivy2Local, mavenLocal)
+    val azaveaBintray       = Resolver.bintrayRepo("azavea", "geotrellis")
   }
 
   lazy val noForkInTests = Seq(
@@ -110,7 +110,7 @@ object Settings {
       Resolver.mavenLocal,
       Settings.Repositories.geosolutions,
       Settings.Repositories.osgeo,
-      Settings.Repositories.locationtechReleases
+      Settings.Repositories.eclipseReleases
     ),
     headerLicense := Some(HeaderLicense.ALv2(java.time.Year.now.getValue.toString, "Azavea")),
     headerMappings := Map(
@@ -251,7 +251,7 @@ object Settings {
     ),
     resolvers ++= Seq(
       Repositories.boundlessgeo,
-      Repositories.locationtechReleases
+      Repositories.eclipseReleases
     ),
     console / initialCommands :=
       """

--- a/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
@@ -43,8 +43,6 @@ trait RasterMetadata extends Serializable {
     * When reading raster data the underlying implementation will have to sample from one of these resolutions.
     * It is possible that a read request for a small bounding box will results in significant IO request when the target
     * cell size is much larger than closest available resolution.
-    *
-    * Warning: the behavior of this function may slightly vary, depending on the implementation.
     */
   def resolutions: List[CellSize]
 


### PR DESCRIPTION
# Overview

This PR makes `GDALRasterSource` behave like all other RasterSources.
It also adds extra tests to test that `GeoTrellisReprojectRasterSource` behaves similar to other `RasterSources`.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary (it was already added)
- [x] Unit tests added for bug-fix or new feature

Closes #3210
