### PR TITLE
Add toString and comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,10 @@ project/plugins/project
 project/plugins/target
 project/target
 target
-.ensime
+.ensime*
 .metals/
+.idea
+project/metals.sbt
 \#*#
 *~
 .#*
@@ -27,7 +29,6 @@ _SUCCESS
 .cache
 .settings
 .history
-.idea
 *.bloop
 .DS_Store
 *.iml
@@ -40,15 +41,7 @@ _SUCCESS
 scripts/emr/terraform/variables.tf*
 scripts/emr/terraform/terraform.tfstate*
 
-lib
-index.html
-index.js
-.ensime*
-
 nohup.out
-
-site/
-
 derby.log
 metastore_db/
 *.log

--- a/.travis/hbase-install.sh
+++ b/.travis/hbase-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-if [ ! -f $HOME/downloads/hbase-2.2.3-bin.tar.gz ]; then sudo wget -O $HOME/downloads/hbase-2.2.3-bin.tar.gz http://www-us.apache.org/dist/hbase/2.2.3/hbase-2.2.3-bin.tar.gz; fi
-sudo mv $HOME/downloads/hbase-2.2.3-bin.tar.gz hbase-2.2.3-bin.tar.gz && tar xzf hbase-2.2.3-bin.tar.gz
-sudo rm -f hbase-2.2.3/conf/hbase-site.xml && sudo mv .travis/hbase/hbase-site.xml hbase-2.2.3/conf
-sudo hbase-2.2.3/bin/start-hbase.sh
+if [ ! -f $HOME/downloads/hbase-2.2.4-bin.tar.gz ]; then sudo wget -O $HOME/downloads/hbase-2.2.4-bin.tar.gz http://www-us.apache.org/dist/hbase/2.2.4/hbase-2.2.4-bin.tar.gz; fi
+sudo mv $HOME/downloads/hbase-2.2.4-bin.tar.gz hbase-2.2.4-bin.tar.gz && tar xzf hbase-2.2.4-bin.tar.gz
+sudo rm -f hbase-2.2.4/conf/hbase-site.xml && sudo mv .travis/hbase/hbase-site.xml hbase-2.2.4/conf
+sudo hbase-2.2.4/bin/start-hbase.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - GeoTrellisPath assumes `file` scheme when none provided [#3191](https://github.com/locationtech/geotrellis/pull/3191)
+- toStrings overrides to common classes [#3217](https://github.com/locationtech/geotrellis/pull/3217)
 
 ### Changed
 

--- a/layer/src/main/scala/geotrellis/layer/LayoutDefinition.scala
+++ b/layer/src/main/scala/geotrellis/layer/LayoutDefinition.scala
@@ -17,10 +17,8 @@
 package geotrellis.layer
 
 import geotrellis.raster._
-import geotrellis.raster.rasterize._
 import geotrellis.vector._
 import spire.math.Integral
-import spire.implicits._
 import _root_.io.circe.generic.JsonCodec
 
 /**
@@ -30,12 +28,14 @@ import _root_.io.circe.generic.JsonCodec
  */
 @JsonCodec
 case class LayoutDefinition(override val extent: Extent, tileLayout: TileLayout) extends GridExtent[Long](extent, tileLayout.cellSize(extent)) {
+
+  /** Transformation between tile addressing and map coordinate addressing for for this layout */
   lazy val mapTransform = MapKeyTransform(extent, tileLayout.layoutDimensions)
 
-  def tileCols = tileLayout.tileCols
-  def tileRows = tileLayout.tileRows
-  def layoutCols = tileLayout.layoutCols
-  def layoutRows = tileLayout.layoutRows
+  def tileCols: Int = tileLayout.tileCols
+  def tileRows: Int = tileLayout.tileRows
+  def layoutCols: Int = tileLayout.layoutCols
+  def layoutRows: Int = tileLayout.layoutRows
 
   /** LayoutDefinition for tile bounds within this layout.
     * Resulting layout will line up with parent layout, but the (0,0) tile will be offset to region covered by bounds.
@@ -52,7 +52,7 @@ case class LayoutDefinition(override val extent: Extent, tileLayout: TileLayout)
   override def toString: String =
     s"""LayoutDefinition($extent,$cellSize,${layoutCols}x${layoutRows} tiles,${cols}x${rows} pixels)"""
 
-  override def canEqual(a: Any) = a.isInstanceOf[LayoutDefinition]
+  override def canEqual(a: Any): Boolean = a.isInstanceOf[LayoutDefinition]
 
   override def equals(that: Any): Boolean =
     that match {
@@ -63,7 +63,7 @@ case class LayoutDefinition(override val extent: Extent, tileLayout: TileLayout)
       case _ => false
   }
 
-  override def hashCode: Int =
+  override def hashCode(): Int =
     ((31 +
     (if (extent == null) 0 else extent.hashCode)) * 31 +
     (if (tileLayout == null) 0 else tileLayout.hashCode) * 31)

--- a/layer/src/main/scala/geotrellis/layer/ZoomedLayoutScheme.scala
+++ b/layer/src/main/scala/geotrellis/layer/ZoomedLayoutScheme.scala
@@ -144,4 +144,7 @@ class ZoomedLayoutScheme(val crs: CRS, val tileSize: Int, val resolutionThreshol
       )
     )
   }
+
+  override def toString: String = s"" +
+    s"ZoomedLayoutScheme($crs,$tileSize,$resolutionThreshold)"
 }

--- a/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayMultibandTile.scala
@@ -512,4 +512,6 @@ class ArrayMultibandTile(_bands: Array[Tile]) extends MultibandTile with MacroMu
     case _ =>
       false
   }
+
+  override def toString: String = s"ArrayMultibandTile($cols,$rows,$bandCount,$cellType)"
 }

--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -402,6 +402,8 @@ abstract class ArrayTile extends Tile with Serializable {
     }
     arr
   }
+
+  override def toString: String = s"ArrayTile($cols,$rows,$cellType)"
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/DelayedConversionMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DelayedConversionMultibandTile.scala
@@ -328,4 +328,6 @@ class DelayedConversionMultibandTile(inner: MultibandTile, override val targetCe
   }
 
   def toArrayTile: ArrayMultibandTile = inner.toArrayTile
+
+  override def toString: String = s"DelayedConversionMultibandTile($cols,$rows,$cellType)"
 }

--- a/raster/src/main/scala/geotrellis/raster/DelayedConversionTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DelayedConversionTile.scala
@@ -187,4 +187,6 @@ class DelayedConversionTile(inner: Tile, targetCellType: CellType)
 
     tile
   }
+
+  override def toString: String = s"DelayedConversionTile($cols,$rows,$cellType)"
 }

--- a/raster/src/main/scala/geotrellis/raster/DelegatingTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DelegatingTile.scala
@@ -98,4 +98,5 @@ abstract class DelegatingTile extends Tile {
   def mapDoubleMapper(mapper: DoubleTileMapper): Tile =
     delegate.mapDoubleMapper(mapper)
 
+  override def toString: String = s"DelegatingTile($cols,$rows,$cellType)"
 }

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
@@ -99,6 +99,8 @@ class GeoTiffRasterSource(
       convertRaster(Raster(tile, gridExtent.extentFor(gb.toGridType[Long], clamp = true)))
     }
   }
+
+  override def toString: String = s"GeoTiffRasterSource(${dataPath.value})"
 }
 
 object GeoTiffRasterSource {

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -155,6 +155,8 @@ class GeoTiffReprojectRasterSource(
 
   def convert(targetCellType: TargetCellType): RasterSource =
     GeoTiffReprojectRasterSource(dataPath, crs, resampleTarget, resampleMethod, strategy, targetCellType = Some(targetCellType))
+
+  override def toString: String = s"GeoTiffReprojectRasterSource(${dataPath.value},$crs,$resampleTarget,$resampleMethod)"
 }
 
 object GeoTiffReprojectRasterSource {

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -130,6 +130,8 @@ class GeoTiffResampleRasterSource(
       ).resample(targetRasterExtent.cols, targetRasterExtent.rows, method)
     }
   }
+
+  override def toString: String = s"GeoTiffResampleRasterSource(${dataPath.value},$resampleTarget,$method)"
 }
 
 object GeoTiffResampleRasterSource {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffMultibandTile.scala
@@ -1232,4 +1232,6 @@ abstract class GeoTiffMultibandTile(
       Some(bandType)
     )
   }
+
+  override def toString: String = s"GeoTiffMultibandTile($cols,$rows,$bandCount,$cellType)"
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
@@ -806,4 +806,6 @@ abstract class GeoTiffTile(
    */
   def toBytes(): Array[Byte] =
     toArrayTile.toBytes
+
+  override def toString: String = s"GeoTiffTile($cols,$rows,$cellType)"
 }


### PR DESCRIPTION
Added some `toString` overrides to commonly used classes that make the REPL output more readable.

## Demo
```scala
scala> val source = GeoTiffRasterSource("/tmp/aspect.tif")
source: geotrellis.raster.geotiff.GeoTiffRasterSource = GeoTiffRasterSource(/tmp/aspect.tif)

scala> val wm = source.reproject(WebMercator)
wm: geotrellis.raster.RasterSource = GeoTiffReprojectRasterSource(/tmp/aspect.tif,WebMercator,DefaultTarget,NearestNeighbor)

scala> val raster = wm.read(GridBounds(0L,0L,255L,255L)).get
raster: geotrellis.raster.Raster[geotrellis.raster.MultibandTile] = Raster(ArrayMultibandTile(256,256,1,float32ud-9999.0),Extent(-8769150.640916323, 4271288.442457698, -8765983.641700394, 4274455.441673627))

scala> raster.tile.band(0)
res0: geotrellis.raster.Tile = ArrayTile(256,256,float32ud-9999.0)
```