### PR TITLE
Fix Monad instance for PolygonalSummaryResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Jackson dependencies [#3212](https://github.com/locationtech/geotrellis/issues/3212)
 - Fix Rasterizer for polygons containing concavities whith `PixelIsArea` option [#3192](https://github.com/locationtech/geotrellis/pull/3192)
 - Fix spatial join (Spark) when using different partitioning in left and right RDDs [#3175](https://github.com/locationtech/geotrellis/pull/3175)
+- Fix Monad instance for `PolygonalSummaryResult` [#3221](https://github.com/locationtech/geotrellis/pull/3221)
 
 ### Removed
 

--- a/raster/src/main/scala/geotrellis/raster/summary/polygonal/PolygonalSummaryResult.scala
+++ b/raster/src/main/scala/geotrellis/raster/summary/polygonal/PolygonalSummaryResult.scala
@@ -40,9 +40,11 @@ sealed trait PolygonalSummaryResult[+A] {
 
 object PolygonalSummaryResult {
   implicit val monad: Monad[PolygonalSummaryResult] = new Monad[PolygonalSummaryResult] {
-    def flatMap[A, B](fa: PolygonalSummaryResult[A])
-                     (f: A => PolygonalSummaryResult[B]): PolygonalSummaryResult[B] = {
-      flatten(map(fa)(f))
+    def flatMap[A, B](fa: PolygonalSummaryResult[A])(f: A => PolygonalSummaryResult[B]): PolygonalSummaryResult[B] = {
+      fa match {
+        case NoIntersection => NoIntersection
+        case Summary(value) => f(value)
+      }
     }
 
     def pure[A](x: A): PolygonalSummaryResult[A] = Summary(x)


### PR DESCRIPTION
This PR fixes the implementation of the Monad instance to avoid self-recursion

## Problem

```scala
scala> val s: PolygonalSummaryResult[Int] = Summary(3)
s: geotrellis.raster.summary.polygonal.PolygonalSummaryResult[Int] = Summary(3)

scala> s.map(x => x.toString)
java.lang.StackOverflowError
  at cats.Monad$$Lambda$6830/427965418.<init>(Unknown Source)
  at cats.Monad$$Lambda$6830/427965418.get$Lambda(Unknown Source)
  at cats.Monad.map(Monad.scala:16)
  at cats.Monad.map$(Monad.scala:14)
  at geotrellis.raster.summary.polygonal.PolygonalSummaryResult$$anon$1.map(PolygonalSummaryResult.scala:42)
  at geotrellis.raster.summary.polygonal.PolygonalSummaryResult$$anon$1.flatMap(PolygonalSummaryResult.scala:45)
  at geotrellis.raster.summary.polygonal.PolygonalSummaryResult$$anon$1.flatMap(PolygonalSummaryResult.scala:42)
  at cats.Monad.map(Monad.scala:16)
  at cats.Monad.map$(Monad.scala:14)
 ...
```

## Fixed

```scala
scala> import geotrellis.raster.summary.polygonal._
import geotrellis.raster.summary.polygonal._

scala> import cats.syntax.functor._
import cats.syntax.functor._

scala> (Summary(3): PolygonalSummaryResult[Int]).map( x => "asdf")
res2: geotrellis.raster.summary.polygonal.PolygonalSummaryResult[String] = Summary(asdf)
```

Note that the `Summary` instance has to be upcast to `PolygonalSummaryResult` in order for the provided `Monad` instance to be discovered. This looks weird in console but in practice its not much of an issue because the point of this ADT is that you don't know if the result will be `Summary` or `NoIntersection`. That is all polygonal summary functions actually have return type of `PoloygonalSummaryResult[A]` 