### PR TITLE
Backport GeoTrellisRasterSource updates from the GeoTrellis server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GeoTrellisPath assumes `file` scheme when none provided [#3191](https://github.com/locationtech/geotrellis/pull/3191)
 - toStrings overrides to common classes [#3217](https://github.com/locationtech/geotrellis/pull/3217)
+- GeoTrellisRasterSources legacy and temporal layers support [#3179](https://github.com/locationtech/geotrellis/issues/3179)
 
 ### Changed
 

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALRasterSource.scala
@@ -20,7 +20,7 @@ import geotrellis.raster.gdal.GDALDataset.DatasetType
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.OverviewStrategy
-import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
+import geotrellis.raster.resample.ResampleMethod
 import geotrellis.vector._
 
 class GDALRasterSource(
@@ -110,7 +110,7 @@ class GDALRasterSource(
       }
   }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     new GDALRasterSource(dataPath, options.reproject(gridExtent, crs, targetCRS, resampleTarget, method))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =

--- a/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
@@ -84,7 +84,7 @@ abstract class MosaicRasterSource extends RasterSource {
   def reprojection(
     targetCRS: CRS,
     resampleTarget: ResampleTarget = DefaultTarget,
-    method: ResampleMethod = NearestNeighbor,
+    method: ResampleMethod = ResampleMethod.DEFAULT,
     strategy: OverviewStrategy = OverviewStrategy.DEFAULT
   ): RasterSource =
     MosaicRasterSource(

--- a/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/MosaicRasterSource.scala
@@ -72,14 +72,14 @@ abstract class MosaicRasterSource extends RasterSource {
   /**
     * All available resolutions for all RasterSources in this MosaicRasterSource
     *
-    * @see [[geotrellis.contrib.vlm.RasterSource.resolutions]]
+    * @see [[geotrellis.raster.RasterSource.resolutions]]
     */
   def resolutions: List[CellSize] = sources.map { _.resolutions }.reduce
 
   /** Create a new MosaicRasterSource with sources transformed according to the provided
     * crs, options, and strategy, and a new crs
     *
-    * @see [[geotrellis.contrib.vlm.RasterSource.reproject]]
+    * @see [[geotrellis.raster.RasterSource.reproject]]
     */
   def reprojection(
     targetCRS: CRS,

--- a/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterMetadata.scala
@@ -40,7 +40,8 @@ trait RasterMetadata extends Serializable {
     * <li> For reprojected [[RasterSource]] these resolutions represent an estimate where
     *      each cell in target CRS has ''approximately'' the same geographic coverage as a cell in the source CRS.
     *
-    * For compatibility with [[OverviewStrategy]], this list should be sorted from smallest cell sizes to largest, as determined by `_.resolution`.
+    * For compatibility with [[OverviewStrategy]], this list should be sorted from the most resolute cell size to the least resolute cell size,
+    * as determined by `_.resolution`.
     *
     * When reading raster data the underlying implementation will have to sample from one of these resolutions.
     * It is possible that a read request for a small bounding box will results in significant IO request when the target

--- a/raster/src/main/scala/geotrellis/raster/RasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/RasterSource.scala
@@ -45,13 +45,13 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
   /** All available RasterSource metadata */
   def metadata: RasterMetadata
 
-  protected def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource
+  protected def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource
 
   /** Reproject to different CRS with explicit sampling reprojectOptions.
     * @see [[geotrellis.raster.reproject.Reproject]]
     * @group reproject
     */
-  def reproject(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
+  def reproject(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     if (targetCRS == this.crs) this
     else reprojection(targetCRS, resampleTarget, method, strategy)
 
@@ -61,7 +61,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     *   of the data footprint in the target grid.
     * @group reproject a
     */
-  def reprojectToGrid(targetCRS: CRS, grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
+  def reprojectToGrid(targetCRS: CRS, grid: GridExtent[Long], method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     if (targetCRS == this.crs && grid == this.gridExtent) this
     else if (targetCRS == this.crs) resampleToGrid(grid, method, strategy)
     else reprojection(targetCRS, TargetAlignment(grid), method, strategy)
@@ -71,7 +71,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     *   this region may be larger or smaller than the footprint of the data
     * @group reproject
     */
-  def reprojectToRegion(targetCRS: CRS, region: RasterExtent, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
+  def reprojectToRegion(targetCRS: CRS, region: RasterExtent, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     if (targetCRS == this.crs && region == this.gridExtent) this
     else if (targetCRS == this.crs) resampleToRegion(region.asInstanceOf[GridExtent[Long]], method, strategy)
     else reprojection(targetCRS, TargetRegion(region.toGridType[Long]), method, strategy)
@@ -81,7 +81,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
   /** Sampling grid is defined of the footprint of the data with resolution implied by column and row count.
     * @group resample
     */
-  def resample(targetCols: Long, targetRows: Long, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
+  def resample(targetCols: Long, targetRows: Long, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     resample(TargetDimensions(targetCols, targetRows), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[GridExtent]].
@@ -89,7 +89,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     *  of the data footprint in the target grid.
     * @group resample
     */
-  def resampleToGrid(grid: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
+  def resampleToGrid(grid: GridExtent[Long], method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     resample(TargetAlignment(grid), method, strategy)
 
   /** Sampling grid and resolution is defined by given [[RasterExtent]] region.
@@ -97,7 +97,7 @@ abstract class RasterSource extends CellGrid[Long] with RasterMetadata {
     *   this region may be larger or smaller than the footprint of the data
     * @group resample
     */
-  def resampleToRegion(region: GridExtent[Long], method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
+  def resampleToRegion(region: GridExtent[Long], method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     resample(TargetRegion(region), method, strategy)
 
   /** Reads a window for the extent.

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
@@ -19,7 +19,7 @@ package geotrellis.raster.geotiff
 import geotrellis.vector._
 import geotrellis.proj4._
 import geotrellis.raster._
-import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
+import geotrellis.raster.resample.ResampleMethod
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.util.RangeReader
@@ -55,7 +55,7 @@ class GeoTiffRasterSource(
   lazy val gridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
   lazy val resolutions: List[CellSize] = cellSize :: tiff.overviews.map(_.cellSize)
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTiffReprojectRasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTiffReprojectRasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTiffResampleRasterSource =

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -29,7 +29,7 @@ class GeoTiffReprojectRasterSource(
   val dataPath: GeoTiffPath,
   val crs: CRS,
   val resampleTarget: ResampleTarget = DefaultTarget,
-  val resampleMethod: ResampleMethod = NearestNeighbor,
+  val resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
   val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   val errorThreshold: Double = 0.125,
   private[raster] val targetCellType: Option[TargetCellType] = None,
@@ -147,7 +147,7 @@ class GeoTiffReprojectRasterSource(
     }.map { convertRaster }
   }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
@@ -164,7 +164,7 @@ object GeoTiffReprojectRasterSource {
     dataPath: GeoTiffPath,
     crs: CRS,
     resampleTarget: ResampleTarget = DefaultTarget,
-    resampleMethod: ResampleMethod = NearestNeighbor,
+    resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
     strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
     errorThreshold: Double = 0.125,
     targetCellType: Option[TargetCellType] = None,

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -21,14 +21,14 @@ import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.reproject.{Reproject, ReprojectRasterExtent}
-import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
+import geotrellis.raster.resample.ResampleMethod
 import geotrellis.raster.io.geotiff.{GeoTiff, GeoTiffMultibandTile, MultibandGeoTiff, OverviewStrategy, Tags}
 import geotrellis.util.RangeReader
 
 class GeoTiffResampleRasterSource(
   val dataPath: GeoTiffPath,
   val resampleTarget: ResampleTarget,
-  val method: ResampleMethod = NearestNeighbor,
+  val method: ResampleMethod = ResampleMethod.DEFAULT,
   val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   private[raster] val targetCellType: Option[TargetCellType] = None,
   @transient private[raster] val baseTiff: Option[MultibandGeoTiff] = None
@@ -64,7 +64,7 @@ class GeoTiffResampleRasterSource(
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(gridExtent.cellSize, strategy)
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTiffReprojectRasterSource =
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTiffReprojectRasterSource =
     new GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType) {
       override lazy val gridExtent: GridExtent[Long] = {
         val reprojectedRasterExtent =
@@ -138,7 +138,7 @@ object GeoTiffResampleRasterSource {
   def apply(
     dataPath: GeoTiffPath,
     resampleTarget: ResampleTarget,
-    method: ResampleMethod = NearestNeighbor,
+    method: ResampleMethod = ResampleMethod.DEFAULT,
     strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
     targetCellType: Option[TargetCellType] = None,
     baseTiff: Option[MultibandGeoTiff] = None

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/OverviewStrategy.scala
@@ -79,7 +79,7 @@ object OverviewStrategy {
 
   /**
     * This method is unsafe. It's up to the selectOverview method to handle each index OOB error.
-    * @param overviewCS        a sorted list of resolutions, otherwise it is not guaranteed that it would work with all the input strategies.
+    * @param overviewCS         a sorted list of resolutions, otherwise it is not guaranteed that it would work with all the input strategies.
     * @param desiredCS          cellSize that would be searched
     * @param proximityThreshold threshold to defined the search proximity
     * @return                   index of the closest cellSize. Returns -1 in case nothing was found or the input list was not sorted.

--- a/store/src/main/scala/geotrellis/store/AttributeStore.scala
+++ b/store/src/main/scala/geotrellis/store/AttributeStore.scala
@@ -18,7 +18,6 @@ package geotrellis.store
 
 import geotrellis.store.cog.ZoomRange
 import geotrellis.store.index._
-import geotrellis.store.json.Implicits._
 
 import org.apache.avro.Schema
 import io.circe._
@@ -28,7 +27,6 @@ import cats.syntax.either._
 import scala.reflect._
 import java.net.URI
 import java.util.ServiceLoader
-
 
 trait AttributeStore extends AttributeCaching with LayerAttributeStore {
   def read[T: Decoder](layerId: LayerId, attributeName: String): T

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -72,10 +72,7 @@ class GeoTrellisRasterSource(
   lazy val reader = CollectionLayerReader(attributeStore, dataPath.value)
 
   // read metadata directly instead of searching sourceLayers to avoid unneeded reads
-  lazy val layerMetadata: TileLayerMetadata[_] = {
-    logger.debug(s"RasterSource(${dataPath.value}): Reading layerMetadata")
-    reader.attributeStore.readTileLayerMetadataErased(layerId)
-  }
+  lazy val layerMetadata: TileLayerMetadata[_] = reader.attributeStore.readTileLayerMetadataErased(layerId)
 
   lazy val gridExtent: GridExtent[Long] = layerMetadata.layout.createAlignedGridExtent(layerMetadata.extent)
 

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -18,12 +18,18 @@ package geotrellis.store
 
 import geotrellis.proj4._
 import geotrellis.raster.io.geotiff.OverviewStrategy
-import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
+import geotrellis.raster.resample.ResampleMethod
 import geotrellis.raster._
 import geotrellis.layer._
+import geotrellis.layer.filter._
 import geotrellis.vector._
 
-case class Layer(id: LayerId, metadata: TileLayerMetadata[SpatialKey], bandCount: Int) {
+import jp.ne.opt.chronoscala.Imports._
+import org.log4s.getLogger
+
+import java.time.ZonedDateTime
+
+case class Layer(id: LayerId, metadata: TileLayerMetadata[_], bandCount: Int) {
   /** GridExtent of the data pixels in the layer */
   def gridExtent: GridExtent[Long] = metadata.layout.createAlignedGridExtent(metadata.extent)
 }
@@ -32,14 +38,22 @@ case class Layer(id: LayerId, metadata: TileLayerMetadata[SpatialKey], bandCount
   * Note: GeoTrellis AttributeStore does not store the band count for the layers by default,
   *       thus they need to be provided from application configuration.
   *
-  * @param dataPath geotrellis catalog DataPath
+  * @param attributeStore GeoTrellis attribute store
+  * @param dataPath       GeoTrellis catalog DataPath
+  * @param sourceLayers   List of source layers
+  * @param time           time slice, in case we're trying to read temporal layer slices
+  * @param targetCellType The target cellType
   */
 class GeoTrellisRasterSource(
   val attributeStore: AttributeStore,
   val dataPath: GeoTrellisPath,
   val sourceLayers: Stream[Layer],
-  val targetCellType: Option[TargetCellType]
+  val targetCellType: Option[TargetCellType],
+  val time: Option[ZonedDateTime],
+  val timeMetadataKey: String = "times"
 ) extends RasterSource {
+  @transient private[this] lazy val logger = getLogger
+
   def name: GeoTrellisPath = dataPath
 
   def this(attributeStore: AttributeStore, dataPath: GeoTrellisPath) =
@@ -47,6 +61,7 @@ class GeoTrellisRasterSource(
       attributeStore,
       dataPath,
       GeoTrellisRasterSource.getSourceLayersByName(attributeStore, dataPath.layerName, dataPath.bandCount.getOrElse(1)),
+      None,
       None
     )
 
@@ -57,7 +72,10 @@ class GeoTrellisRasterSource(
   lazy val reader = CollectionLayerReader(attributeStore, dataPath.value)
 
   // read metadata directly instead of searching sourceLayers to avoid unneeded reads
-  lazy val layerMetadata = reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](layerId)
+  lazy val layerMetadata: TileLayerMetadata[_] = {
+    logger.debug(s"RasterSource(${dataPath.value}): Reading layerMetadata")
+    reader.attributeStore.readTileLayerMetadataErased(layerId)
+  }
 
   lazy val gridExtent: GridExtent[Long] = layerMetadata.layout.createAlignedGridExtent(layerMetadata.extent)
 
@@ -72,7 +90,8 @@ class GeoTrellisRasterSource(
     "layerName"  -> layerId.name,
     "zoomLevel"  -> layerId.zoom.toString,
     "bandCount"  -> bandCount.toString
-  )
+  ) ++ time.map(t => ("time", t.toString)).toMap
+
   /** GeoTrellis metadata doesn't allow to query a per band metadata by default. */
   def attributesForBand(band: Int): Map[String, String] = Map.empty
 
@@ -81,9 +100,20 @@ class GeoTrellisRasterSource(
   // reference to this will fully initilze the sourceLayers stream
   lazy val resolutions: List[CellSize] = sourceLayers.map(_.gridExtent.cellSize).toList
 
-  def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
-    GeoTrellisRasterSource.read(reader, layerId, layerMetadata, extent, bands).map(convertRaster)
+  lazy val times: List[ZonedDateTime] = {
+    val layerId = dataPath.layerId
+    val header = attributeStore.readHeader[LayerHeader](layerId)
+    if (header.keyClass.contains("SpaceTimeKey")) {
+      attributeStore.read[List[ZonedDateTime]](layerId, "times").sorted
+    } else {
+      List.empty[ZonedDateTime]
+    }
   }
+
+  lazy val isTemporal: Boolean = times.nonEmpty
+
+  def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] =
+    GeoTrellisRasterSource.read(reader, layerId, layerMetadata, extent, bands).map(convertRaster)
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] =
     bounds
@@ -97,11 +127,11 @@ class GeoTrellisRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.dimensions).flatMap(read(_, bands)))
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource = {
     if (targetCRS != this.crs) {
       val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
       val (closestLayerId, targetGridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
-      new GeoTrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, targetGridExtent, targetCRS, resampleTarget, targetCellType = targetCellType)
+      new GeoTrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, targetGridExtent, targetCRS, resampleTarget, method, time = time, targetCellType = targetCellType)
     } else {
       // TODO: add unit tests for this in particular, the behavior feels murky
       resampleTarget match {
@@ -111,7 +141,7 @@ class GeoTrellisRasterSource(
         case resampleTarget =>
           val resampledGridExtent = resampleTarget(this.gridExtent)
           val closestLayerId = GeoTrellisRasterSource.getClosestResolution(sourceLayers.toList, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).id
-          new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, resampledGridExtent, method, targetCellType)
+          new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, resampledGridExtent, method, time, targetCellType)
       }
     }
   }
@@ -119,20 +149,20 @@ class GeoTrellisRasterSource(
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
     val resampledGridExtent = resampleTarget(this.gridExtent)
     val closestLayerId = GeoTrellisRasterSource.getClosestResolution(sourceLayers.toList, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize).id
-    new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, resampledGridExtent, method, targetCellType)
+    new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, resampledGridExtent, method, time, targetCellType)
   }
 
   def convert(targetCellType: TargetCellType): RasterSource =
-    new GeoTrellisRasterSource(attributeStore, dataPath, sourceLayers, Some(targetCellType))
+    new GeoTrellisRasterSource(attributeStore, dataPath, sourceLayers, Some(targetCellType), time)
 
-  override def toString: String =
-    s"GeoTrellisRasterSource($dataPath, $layerId)"
+  override def toString: String = s"GeoTrellisRasterSource($dataPath, $layerId)"
 }
 
 
 object GeoTrellisRasterSource {
   // stable identifiers to match in a readTiles function
   private val SpatialKeyClass    = classOf[SpatialKey]
+  private val SpaceTimeKeyClass  = classOf[SpaceTimeKey]
   private val TileClass          = classOf[Tile]
   private val MultibandTileClass = classOf[MultibandTile]
 
@@ -155,40 +185,86 @@ object GeoTrellisRasterSource {
       sortWith(_.zoom > _.zoom).
       toStream. // We will be lazy about fetching higher zoom levels
       map { id =>
-        val metadata = attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](id)
+        val metadata = attributeStore.readTileLayerMetadataErased(id)
         Layer(id, metadata, bandCount)
       }
   }
 
-  def readTiles(reader: CollectionLayerReader[LayerId], layerId: LayerId, extent: Extent, bands: Seq[Int]): Seq[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]] = {
+  def readTiles(
+    reader: CollectionLayerReader[LayerId],
+    layerId: LayerId,
+    extent: Extent,
+    bands: Seq[Int],
+    time: Option[ZonedDateTime] = None
+  ): Seq[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]] = {
+    def spatialTileRead =
+      reader.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId)
+        .where(Intersects(extent))
+        .result
+        .withContext { _.map { case (key, tile) => (key, MultibandTile(tile)) } }
+
+    def spatialMultibandTileRead =
+      reader.query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](layerId)
+        .where(Intersects(extent))
+        .result
+        .withContext { _.map { case (key, tile) => (key, tile.subsetBands(bands)) } }
+
+    def spaceTimeTileRead = {
+      val query =
+        reader
+          .query[SpaceTimeKey, Tile, TileLayerMetadata[SpaceTimeKey]](layerId)
+          .where(Intersects(extent))
+
+      time
+        .fold(query)(t => query.where(At(t)))
+        .result
+        .withContext { _.map { case (key, tile) => (key, MultibandTile(tile)) } }
+        .toSpatial
+    }
+
+    def spaceTimeMultibandTileRead = {
+      val query =
+        reader
+          .query[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]](layerId)
+          .where(Intersects(extent))
+
+      time
+        .fold(query)(t => query.where(At(t)))
+        .result
+        .withContext { _.map { case (key, tile) => (key, tile.subsetBands(bands)) } }
+        .toSpatial
+    }
+
     val header = reader.attributeStore.readHeader[LayerHeader](layerId)
-    (Class.forName(header.keyClass), Class.forName(header.valueClass)) match {
-      case (SpatialKeyClass, TileClass) =>
-        reader.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId)
-          .where(Intersects(extent))
-          .result
-          .withContext(tiles =>
-            // Convert single band tiles to multiband
-            tiles.map{ case(key, tile) => (key, MultibandTile(tile)) }
-          )
-      case (SpatialKeyClass, MultibandTileClass) =>
-        reader.query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](layerId)
-          .where(Intersects(extent))
-          .result
-          .withContext(tiles =>
-            tiles.map{ case(key, tile) => (key, tile.subsetBands(bands)) }
-          )
-      case _ =>
-        throw new Exception(s"Unable to read single or multiband tiles from file: ${(header.keyClass, header.valueClass)}")
+
+    if (!header.keyClass.contains("spark")) {
+      (Class.forName(header.keyClass), Class.forName(header.valueClass)) match {
+        case (SpatialKeyClass, TileClass)            => spatialTileRead
+        case (SpatialKeyClass, MultibandTileClass)   => spatialMultibandTileRead
+        case (SpaceTimeKeyClass, TileClass)          => spaceTimeTileRead
+        case (SpaceTimeKeyClass, MultibandTileClass) => spaceTimeMultibandTileRead
+        case _ =>
+          throw new Exception(s"Unable to read single or multiband tiles from file: ${(header.keyClass, header.valueClass)}")
+      }
+    } else {
+      /** Legacy GeoTrellis Layers compact */
+      (header.keyClass, header.valueClass) match {
+        case ("geotrellis.spark.SpatialKey", "geotrellis.raster.Tile")            => spatialTileRead
+        case ("geotrellis.spark.SpatialKey", "geotrellis.raster.MultibandTile")   => spatialMultibandTileRead
+        case ("geotrellis.spark.SpaceTimeKey", "geotrellis.raster.Tile")          => spaceTimeTileRead
+        case ("geotrellis.spark.SpaceTimeKey", "geotrellis.raster.MultibandTile") => spaceTimeMultibandTileRead
+        case _ =>
+          throw new Exception(s"Unable to read single or multiband tiles from file: ${(header.keyClass, header.valueClass)}")
+      }
     }
   }
 
-  def readIntersecting(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[SpatialKey], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+  def readIntersecting(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[_], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tiles = readTiles(reader, layerId, extent, bands)
     sparseStitch(tiles, extent)
   }
 
-  def read(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[SpatialKey], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+  def read(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[_], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tiles = readTiles(reader, layerId, extent, bands)
     metadata.extent.intersection(extent) flatMap { intersectionExtent =>
       sparseStitch(tiles, intersectionExtent).map(_.crop(intersectionExtent))
@@ -196,9 +272,9 @@ object GeoTrellisRasterSource {
   }
 
   /**
-   *  The stitch method in gtcore is unable to handle missing spatialkeys correctly.
-   *  This method works around that problem by attempting to infer any missing tiles
-   **/
+    *  The stitch method in gtcore is unable to handle missing spatialkeys correctly.
+    *  This method works around that problem by attempting to infer any missing tiles
+    **/
   def sparseStitch(
     tiles: Seq[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]],
     extent: Extent
@@ -220,5 +296,22 @@ object GeoTrellisRasterSource {
     }
     if (allTiles.isEmpty) None
     else Some(allTiles.stitch())
+  }
+
+  def apply(dataPath: GeoTrellisPath): GeoTrellisRasterSource = GeoTrellisRasterSource(dataPath, None, None)
+
+  def apply(dataPath: GeoTrellisPath, time: Option[ZonedDateTime]): GeoTrellisRasterSource = GeoTrellisRasterSource(dataPath, time, None)
+
+  def apply(dataPath: GeoTrellisPath, time: Option[ZonedDateTime], targetCellType: Option[TargetCellType]): GeoTrellisRasterSource = {
+    val attributeStore = AttributeStore(dataPath.value)
+    new GeoTrellisRasterSource(
+      attributeStore,
+      dataPath,
+      GeoTrellisRasterSource.getSourceLayersByName(
+        attributeStore, dataPath.layerName, dataPath.bandCount.getOrElse(1)
+      ),
+      targetCellType,
+      time
+    )
   }
 }

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -24,7 +24,9 @@ import geotrellis.proj4._
 import geotrellis.raster.io.geotiff.OverviewStrategy
 
 import org.log4s._
+
 import scala.io.AnsiColor._
+import java.time.ZonedDateTime
 
 class GeoTrellisReprojectRasterSource(
   val attributeStore: AttributeStore,
@@ -34,9 +36,10 @@ class GeoTrellisReprojectRasterSource(
   val gridExtent: GridExtent[Long],
   val crs: CRS,
   val resampleTarget: ResampleTarget = DefaultTarget,
-  val resampleMethod: ResampleMethod = NearestNeighbor,
+  val resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
   val strategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   val errorThreshold: Double = 0.125,
+  val time: Option[ZonedDateTime] = None,
   val targetCellType: Option[TargetCellType]
 ) extends RasterSource {
   @transient private[this] lazy val logger = getLogger
@@ -57,10 +60,11 @@ class GeoTrellisReprojectRasterSource(
 
   def attributes: Map[String, String] = Map(
     "catalogURI" -> dataPath.value,
-    "layerName"  -> layerId.name,
-    "zoomLevel"  -> layerId.zoom.toString,
-    "bandCount"  -> bandCount.toString
-  )
+    "layerName" -> layerId.name,
+    "zoomLevel" -> layerId.zoom.toString,
+    "bandCount" -> bandCount.toString
+  ) ++ time.map(t => ("time", t.toString)).toMap
+
   /** GeoTrellis metadata doesn't allow to query a per band metadata by default. */
   def attributesForBand(band: Int): Map[String, String] = Map.empty
 
@@ -78,17 +82,24 @@ class GeoTrellisReprojectRasterSource(
         lazy val tileBounds = sourceLayer.metadata.mapTransform.extentToBounds(sourceExtent)
         lazy val pixelsRead = (tileBounds.size * sourceLayer.metadata.layout.tileCols * sourceLayer.metadata.layout.tileRows).toDouble
         lazy val pixelsQueried = targetRasterExtent.cols.toDouble * targetRasterExtent.rows.toDouble
-        def msg = s"""
-          |${GREEN}Read($extent)${RESET} =
-          |\t${BOLD}FROM${RESET} ${dataPath.toString} ${sourceLayer.id}
-          |\t${BOLD}SOURCE${RESET} $sourceExtent ${sourceLayer.metadata.cellSize} @ ${sourceLayer.metadata.crs}
-          |\t${BOLD}TARGET${RESET} ${targetRasterExtent.extent} ${targetRasterExtent.cellSize} @ ${crs}
-          |\t${BOLD}READ${RESET} ${pixelsRead/pixelsQueried} read/query ratio for ${tileBounds.size} tiles
+
+        def msg =
+          s"""
+             |${GREEN}Read($extent)${RESET} =
+             |\t${BOLD}FROM${RESET} ${dataPath.toString} ${sourceLayer.id}
+
+             |\t${BOLD}SOURCE${RESET} $sourceExtent ${sourceLayer.metadata.cellSize} @ ${sourceLayer.metadata.crs}
+
+             |\t${BOLD}TARGET${RESET} ${targetRasterExtent.extent} ${
+            targetRasterExtent.cellSize}   @ ${crs}
+                     |\t${BOLD}READ${RESET} ${pixelsRead/pixelsQueried} rea
+
+        atio for ${tileBounds.size} tiles
         """.stripMargin
         if (tileBounds.size < 1024) // Assuming 256x256 tiles this would be a very large request
-          logger.debug(msg)
+        logger.debug(msg)
         else
-          logger.warn(msg + " (large read)")
+        logger.warn(msg + " (large read)")
       }
       raster <- GeoTrellisRasterSource.readIntersecting(reader, layerId, sourceLayer.metadata, sourceExtent, bands)
     } yield {
@@ -114,15 +125,15 @@ class GeoTrellisReprojectRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.dimensions).flatMap(read(_, bands)))
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): RasterSource = {
     if (targetCRS == sourceLayer.metadata.crs) {
       val resampledGridExtent = resampleTarget(this.sourceLayer.gridExtent)
       val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize)
       // TODO: if closestLayer is w/in some marging of desired CellSize, return GeoTrellisRasterSource instead
-      new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayer.id, sourceLayers, resampledGridExtent, resampleMethod, targetCellType)
+      new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayer.id, sourceLayers, resampledGridExtent, resampleMethod, time, targetCellType)
     } else {
       // Pick new layer ID
-      val (closestLayerId, gridExtent) =
+      val (_, gridExtent) =
         GeoTrellisReprojectRasterSource
           .getClosestSourceLayer(
             targetCRS,
@@ -139,6 +150,7 @@ class GeoTrellisReprojectRasterSource(
         targetCRS,
         resampleTarget,
         resampleMethod,
+        time = time,
         targetCellType = targetCellType
       )
     }
@@ -147,15 +159,13 @@ class GeoTrellisReprojectRasterSource(
   def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
     val newReprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
     val (closestLayerId, newGridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(crs, sourceLayers, newReprojectOptions, strategy)
-    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, newGridExtent, crs, resampleTarget, targetCellType = targetCellType)
+    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, newGridExtent, crs, resampleTarget, method, time = time, targetCellType = targetCellType)
   }
 
-  def convert(targetCellType: TargetCellType): RasterSource = {
-    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, crs, resampleTarget, targetCellType = Some(targetCellType))
-  }
+  def convert(targetCellType: TargetCellType): RasterSource =
+    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, crs, resampleTarget, resampleMethod, time = time, targetCellType = Some(targetCellType))
 
-  override def toString: String =
-    s"GeoTrellisReprojectRasterSource(${dataPath.value},$layerId,$crs,$gridExtent,${resampleMethod})"
+  override def toString: String = s"GeoTrellisReprojectRasterSource(${dataPath.value},$layerId,$crs,$gridExtent,$resampleMethod)"
 }
 
 object GeoTrellisReprojectRasterSource {

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -83,23 +83,17 @@ class GeoTrellisReprojectRasterSource(
         lazy val pixelsRead = (tileBounds.size * sourceLayer.metadata.layout.tileCols * sourceLayer.metadata.layout.tileRows).toDouble
         lazy val pixelsQueried = targetRasterExtent.cols.toDouble * targetRasterExtent.rows.toDouble
 
-        def msg =
-          s"""
-             |${GREEN}Read($extent)${RESET} =
-             |\t${BOLD}FROM${RESET} ${dataPath.toString} ${sourceLayer.id}
-
-             |\t${BOLD}SOURCE${RESET} $sourceExtent ${sourceLayer.metadata.cellSize} @ ${sourceLayer.metadata.crs}
-
-             |\t${BOLD}TARGET${RESET} ${targetRasterExtent.extent} ${
-            targetRasterExtent.cellSize}   @ ${crs}
-                     |\t${BOLD}READ${RESET} ${pixelsRead/pixelsQueried} rea
-
-        atio for ${tileBounds.size} tiles
+        def msg = s"""
+          |${GREEN}Read($extent)${RESET} =
+          |\t${BOLD}FROM${RESET} ${dataPath.toString} ${sourceLayer.id}
+          |\t${BOLD}SOURCE${RESET} $sourceExtent ${sourceLayer.metadata.cellSize} @ ${sourceLayer.metadata.crs}
+          |\t${BOLD}TARGET${RESET} ${targetRasterExtent.extent} ${targetRasterExtent.cellSize} @ ${crs}
+          |\t${BOLD}READ${RESET} ${pixelsRead/pixelsQueried} read/query ratio for ${tileBounds.size} tiles
         """.stripMargin
         if (tileBounds.size < 1024) // Assuming 256x256 tiles this would be a very large request
-        logger.debug(msg)
+          logger.debug(msg)
         else
-        logger.warn(msg + " (large read)")
+          logger.warn(msg + " (large read)")
       }
       raster <- GeoTrellisRasterSource.readIntersecting(reader, layerId, sourceLayer.metadata, sourceExtent, bands)
     } yield {

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -19,33 +19,37 @@ package geotrellis.store
 import geotrellis.vector._
 import geotrellis.proj4._
 import geotrellis.raster._
-import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
+import geotrellis.raster.resample.ResampleMethod
 import geotrellis.raster.io.geotiff.OverviewStrategy
 
 import org.log4s._
 
-/** RasterSource that resamples on read from underlying GeoTrellis layer.
- *
- * Note:
- * The constructor is unfriendly.
- * This class is not intended to constructed directly by the users.
- * Refer to [[GeoTrellisRasterSource]] for example of correct setup.
- * It is expected that the caller has significant pre-computed information  about the layers.
- *
- * @param attributeStore the source of metadata for the layers, used for reading
- * @param dataPath dataPath of the GeoTrellis catalog that can format a given path to be read in by a AttributeStore
- * @param layerId The specific layer we're sampling from
- * @param sourceLayers list of layers we can can sample from for futher resample
- * @param gridExtent the desired pixel grid for the layer
- * @param resampleMethod Resampling method used when fitting data to target grid
- */
+import java.time.ZonedDateTime
+
+/**
+  * RasterSource that resamples on read from underlying GeoTrellis layer.
+  *
+  * Note:
+  * The constructor is unfriendly.
+  * This class is not intended to constructed directly by the users.
+  * Refer to [[GeoTrellisRasterSource]] for example of correct setup.
+  * It is expected that the caller has significant pre-computed information  about the layers.
+  *
+  * @param attributeStore the source of metadata for the layers, used for reading
+  * @param dataPath dataPath of the GeoTrellis catalog that can format a given path to be read in by a AttributeStore
+  * @param layerId The specific layer we're sampling from
+  * @param sourceLayers list of layers we can can sample from for futher resample
+  * @param gridExtent the desired pixel grid for the layer
+  * @param resampleMethod Resampling method used when fitting data to target grid
+  */
 class GeoTrellisResampleRasterSource(
   val attributeStore: AttributeStore,
   val dataPath: GeoTrellisPath,
   val layerId: LayerId,
   val sourceLayers: Stream[Layer],
   val gridExtent: GridExtent[Long],
-  val resampleMethod: ResampleMethod = NearestNeighbor,
+  val resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
+  val time: Option[ZonedDateTime] = None,
   val targetCellType: Option[TargetCellType] = None
 ) extends RasterSource {
   @transient private[this] lazy val logger = getLogger
@@ -71,7 +75,7 @@ class GeoTrellisResampleRasterSource(
     "layerName"  -> layerId.name,
     "zoomLevel"  -> layerId.zoom.toString,
     "bandCount"  -> bandCount.toString
-  )
+  ) ++ time.map(t => ("time", t.toString)).toMap
   /** GeoTrellis metadata doesn't allow to query a per band metadata by default. */
   def attributesForBand(band: Int): Map[String, String] = Map.empty
 
@@ -83,9 +87,9 @@ class GeoTrellisResampleRasterSource(
     val tileBounds = sourceLayer.metadata.mapTransform.extentToBounds(extent)
     def msg = s"\u001b[32mread($extent)\u001b[0m = ${dataPath.toString} ${sourceLayer.id} ${sourceLayer.metadata.cellSize} @ ${sourceLayer.metadata.crs} TO $cellSize -- reading ${tileBounds.size} tiles"
     if (tileBounds.size < 1024) // Assuming 256x256 tiles this would be a very large request
-      logger.debug(msg)
+    logger.debug(msg)
     else
-      logger.warn(msg + " (large read)")
+    logger.warn(msg + " (large read)")
 
     GeoTrellisRasterSource.readIntersecting(reader, layerId, sourceLayer.metadata, extent, bands)
       .map { raster =>
@@ -95,31 +99,29 @@ class GeoTrellisResampleRasterSource(
       }
   }
 
-  def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+  def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] =
     bounds
       .intersection(this.dimensions)
       .map(gridExtent.extentFor(_).buffer(- cellSize.width / 2, - cellSize.height / 2))
       .flatMap(read(_, bands))
-  }
 
-  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTrellisReprojectRasterSource = {
+  def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTrellisReprojectRasterSource = {
     val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
-    val (closestLayerId, gridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
-    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, resampleTarget, targetCellType = targetCellType)
+    val (_, gridExtent) = GeoTrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
+    new GeoTrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, resampleTarget, method, time = time, targetCellType = targetCellType)
   }
   /** Resample underlying RasterSource to new grid extent
-   * Note: ResampleTarget will be applied to GridExtent of the source layer, not the GridExtent of this RasterSource
-   */
-  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTrellisResampleRasterSource = {
+    * Note: ResampleTarget will be applied to GridExtent of the source layer, not the GridExtent of this RasterSource
+    */
+  override def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTrellisResampleRasterSource = {
     val resampledGridExtent = resampleTarget(this.gridExtent)
     val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize)
     // TODO: if closestLayer is w/in some marging of desired CellSize, return GeoTrellisRasterSource instead
-    new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayer.id, sourceLayers, resampledGridExtent, method, targetCellType)
+    new GeoTrellisResampleRasterSource(attributeStore, dataPath, closestLayer.id, sourceLayers, resampledGridExtent, method, time, targetCellType)
   }
 
-  def convert(targetCellType: TargetCellType): GeoTrellisResampleRasterSource = {
-    new GeoTrellisResampleRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, resampleMethod, Some(targetCellType))
-  }
+  def convert(targetCellType: TargetCellType): GeoTrellisResampleRasterSource =
+    new GeoTrellisResampleRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, resampleMethod, time, Some(targetCellType))
 
   override def readExtents(extents: Traversable[Extent], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     extents.toIterator.flatMap(read(_, bands))

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -113,7 +113,7 @@ class GeoTrellisResampleRasterSource(
   /** Resample underlying RasterSource to new grid extent
     * Note: ResampleTarget will be applied to GridExtent of the source layer, not the GridExtent of this RasterSource
     */
-  override def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTrellisResampleRasterSource = {
+  def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): GeoTrellisResampleRasterSource = {
     val resampledGridExtent = resampleTarget(this.gridExtent)
     val closestLayer = GeoTrellisRasterSource.getClosestResolution(sourceLayers, resampledGridExtent.cellSize, strategy)(_.metadata.layout.cellSize)
     // TODO: if closestLayer is w/in some marging of desired CellSize, return GeoTrellisRasterSource instead

--- a/store/src/main/scala/geotrellis/store/Implicits.scala
+++ b/store/src/main/scala/geotrellis/store/Implicits.scala
@@ -16,12 +16,16 @@
 
 package geotrellis.store
 
-import geotrellis.raster.CellGrid
-import geotrellis.layer._
-import geotrellis.util._
-import java.time.Instant
-
+import geotrellis.layer.{SpaceTimeKey, SpatialKey, TileLayerMetadata}
 
 object Implicits extends Implicits
 
-trait Implicits extends avro.codecs.Implicits with json.Implicits
+trait Implicits extends avro.codecs.Implicits with json.Implicits {
+  implicit class AttributeStoreOps(attributeStore: AttributeStore) {
+    private [store] def readTileLayerMetadataErased(layerId: LayerId): TileLayerMetadata[_] = {
+      val header = attributeStore.readHeader[LayerHeader](layerId)
+      if(header.keyClass.contains("SpatialKey")) attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](layerId)
+      else attributeStore.readMetadata[TileLayerMetadata[SpaceTimeKey]](layerId)
+    }
+  }
+}


### PR DESCRIPTION
# Overview

This PR updates GeoTrellisRasterSource to work with GeoTrellis legacy (1.x and 2.x) layers
and with temporal layers.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary

## Demo

https://github.com/geotrellis/geotrellis-server#191
https://github.com/locationtech/geotrellis/pull/3180

Closes #3179
