### PR TITLE
Add a ZSpaceTimeLargeKeyIndex into specs

### DIFF
--- a/store/src/test/scala/geotrellis/store/index/zcurve/ZSpaceTimeLargeKeyIndex.scala
+++ b/store/src/test/scala/geotrellis/store/index/zcurve/ZSpaceTimeLargeKeyIndex.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.store.index.zcurve
+
+import geotrellis.layer._
+import geotrellis.store.index.KeyIndex
+
+import io.circe._
+import io.circe.syntax._
+
+object ZSpaceTimeLargeKeyIndex {
+  val NAME = "zorderlarge"
+
+  def byMilliseconds(keyBounds: KeyBounds[SpaceTimeKey], millis: Long, shift: Long = Long.MinValue / 2): ZSpaceTimeLargeKeyIndex =
+    new ZSpaceTimeLargeKeyIndex(keyBounds, millis, shift)
+
+  def bySecond(keyBounds: KeyBounds[SpaceTimeKey]): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L)
+
+  def bySeconds(keyBounds: KeyBounds[SpaceTimeKey], seconds: Int): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * seconds)
+
+  def byMinute(keyBounds: KeyBounds[SpaceTimeKey]): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60)
+
+  def byMinutes(keyBounds: KeyBounds[SpaceTimeKey], minutes: Int): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * minutes)
+
+  def byHour(keyBounds: KeyBounds[SpaceTimeKey]): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * 60)
+
+  def byHours(keyBounds: KeyBounds[SpaceTimeKey], hours: Int): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * hours)
+
+  def byDay(keyBounds: KeyBounds[SpaceTimeKey]): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24)
+
+  def byDays(keyBounds: KeyBounds[SpaceTimeKey], days: Int): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * days)
+
+  def byMonth(keyBounds: KeyBounds[SpaceTimeKey]): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * 30)
+
+  def byMonths(keyBounds: KeyBounds[SpaceTimeKey], months: Int): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * 30 * months)
+
+  def byYear(keyBounds: KeyBounds[SpaceTimeKey]): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * 365)
+
+  def byYears(keyBounds: KeyBounds[SpaceTimeKey], years: Int): ZSpaceTimeLargeKeyIndex =
+    byMilliseconds(keyBounds, 1000L * 60 * 60 * 24 * 365 * years)
+
+  implicit val zSpaceTimeKeyLargeIndexEncoder: Encoder[ZSpaceTimeLargeKeyIndex] =
+    Encoder.encodeJson.contramap[ZSpaceTimeLargeKeyIndex] { obj =>
+      Json.obj(
+        "type"   -> NAME.asJson,
+        "properties" -> Json.obj(
+          "keyBounds"   -> obj.keyBounds.asJson,
+          "temporalResolution" -> obj.temporalResolution.asJson,
+          "shift" -> obj.shift.asJson
+        )
+      )
+    }
+
+  implicit val zSpaceTimeKeyLargeIndexDecoder: Decoder[ZSpaceTimeLargeKeyIndex] =
+    Decoder.decodeHCursor.emap { c: HCursor =>
+      (c.downField("type").as[String], c.downField("properties")) match {
+        case (Right(typeName), properties) =>
+          if(typeName != NAME) Left(s"Wrong KeyIndex type: $NAME expected.")
+          else {
+            (properties.downField("keyBounds").as[KeyBounds[SpaceTimeKey]],
+              properties.downField("temporalResolution").as[Long],
+              properties.downField("shift").as[Long]) match {
+              case (Right(keyBounds), Right(tr), Right(s)) => Right(ZSpaceTimeLargeKeyIndex.byMilliseconds(keyBounds, tr, s))
+              case _ => Left("Wrong KeyIndex constructor arguments: ZSpaceTimeLargeKeyIndex constructor arguments expected.")
+            }
+          }
+
+        case _ => Left("Wrong KeyIndex type: ZSpaceTimeLargeKeyIndex expected.")
+      }
+    }
+}
+
+class ZSpaceTimeLargeKeyIndex(val keyBounds: KeyBounds[SpaceTimeKey], val temporalResolution: Long, val shift: Long = Long.MinValue / 2) extends KeyIndex[SpaceTimeKey] {
+  private def toZ(key: SpaceTimeKey): Z3 = Z3(key.col, key.row, ((key.instant - shift) / temporalResolution).toInt)
+
+  def toIndex(key: SpaceTimeKey): BigInt = toZ(key).z
+
+  def indexRanges(keyRange: (SpaceTimeKey, SpaceTimeKey)): Seq[(BigInt, BigInt)] =
+    Z3.zranges(toZ(keyRange._1), toZ(keyRange._2))
+}
+

--- a/store/src/test/scala/geotrellis/store/index/zcurve/ZSpaceTimeLargeKeyIndexSpec.scala
+++ b/store/src/test/scala/geotrellis/store/index/zcurve/ZSpaceTimeLargeKeyIndexSpec.scala
@@ -23,15 +23,15 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 import org.scalatest._
 
-class ZSpaceTimeKeyIndexSpec extends FunSpec with Matchers {
+class ZSpaceTimeLargeKeyIndexSpec extends FunSpec with Matchers {
   val y2k = ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
   val upperBound = 8
   val keyBounds = KeyBounds(SpaceTimeKey(0, 0, 0L), SpaceTimeKey(100, 100, 100L))
 
-  describe("ZSpaceTimeKeyIndex test") {
+  describe("ZSpaceTimeLargeKeyIndex test") {
 
     it("indexes time") {
-      val zst = ZSpaceTimeKeyIndex.byYear(keyBounds)
+      val zst = ZSpaceTimeLargeKeyIndex.byYear(keyBounds)
 
       val keys =
         for (col <- 0 until upperBound;
@@ -46,7 +46,7 @@ class ZSpaceTimeKeyIndexSpec extends FunSpec with Matchers {
     }
 
     it("generates indexes you can check by hand 2x2x2") {
-      val zst = ZSpaceTimeKeyIndex.byMilliseconds(keyBounds, 1)
+      val zst = ZSpaceTimeLargeKeyIndex.byMilliseconds(keyBounds, 1)
       val idx = List[SpaceTimeKey](
         SpaceTimeKey(0, 0, y2k),
         SpaceTimeKey(1, 0, y2k),
@@ -65,7 +65,7 @@ class ZSpaceTimeKeyIndexSpec extends FunSpec with Matchers {
     }
 
     it("generates a Seq[(Long,Long)] from a keyRange: (SpaceTimeKey, SpaceTimeKey)") {
-      val zst = ZSpaceTimeKeyIndex.byMilliseconds(keyBounds, 1)
+      val zst = ZSpaceTimeLargeKeyIndex.byMilliseconds(keyBounds, 1)
 
       //all sub cubes in a 2x2x2
       var idx = zst.indexRanges((SpaceTimeKey(0, 0, y2k), SpaceTimeKey(1, 1, y2k.plus(1, MILLIS))))
@@ -112,7 +112,7 @@ class ZSpaceTimeKeyIndexSpec extends FunSpec with Matchers {
     }
 
     it("generates indexes by month") {
-      val zst = ZSpaceTimeKeyIndex.byMonth(keyBounds)
+      val zst = ZSpaceTimeLargeKeyIndex.byMonth(keyBounds)
 
       val keys =
         for (col <- 0 until upperBound;
@@ -124,6 +124,31 @@ class ZSpaceTimeKeyIndexSpec extends FunSpec with Matchers {
       keys.distinct.size should be(upperBound * upperBound * upperBound)
       keys.min should be(zst.toIndex(SpaceTimeKey(0, 0, y2k)))
       keys.max should be(zst.toIndex(SpaceTimeKey(upperBound - 1, upperBound - 1, y2k.plusMonths(upperBound - 1))))
+    }
+
+    // https://github.com/geotrellis/geotrellis-server/issues/248
+    it("should generate correct ranges outside of the unix time bounds") {
+      // layer dates range
+      // ["1960-01-01T12:00Z","1974-01-01T12:00Z"]
+
+      // unix time is in [1 January 1970; 1 January 2038) bounds
+      val minDate = ZonedDateTime.parse("1960-01-01T12:00Z")
+      val maxDate = ZonedDateTime.parse("1974-01-01T12:00Z")
+
+      minDate.toInstant.toEpochMilli shouldBe -315576000000L
+      maxDate.toInstant.toEpochMilli shouldBe 126273600000L
+
+      // -315576000000L
+      val minKey = SpaceTimeKey(4577, 5960, instant = minDate.toInstant.toEpochMilli)
+      // 126273600000L
+      val maxKey = SpaceTimeKey(4590, 5971, instant = maxDate.toInstant.toEpochMilli)
+      val kb = KeyBounds(minKey, maxKey)
+
+      // val temporalResolution: Long = 31536000000L
+      val index = ZSpaceTimeLargeKeyIndex.byYear(kb)
+      index.temporalResolution shouldBe 31536000000L
+
+      index.indexRanges(minKey -> maxKey).length shouldBe 401
     }
   }
 }

--- a/store/src/test/scala/geotrellis/store/json/KeyIndexJsonFormatFactorySpec.scala
+++ b/store/src/test/scala/geotrellis/store/json/KeyIndexJsonFormatFactorySpec.scala
@@ -16,14 +16,14 @@
 
 package geotrellis.store.json
 
-import java.time.ZonedDateTime
-
 import geotrellis.layer._
 import geotrellis.store._
 import geotrellis.store.index._
+import geotrellis.store.index.zcurve.ZSpaceTimeLargeKeyIndex
+
 import io.circe.syntax._
 import cats.syntax.either._
-import geotrellis.store.index.zcurve.ZSpaceTimeLargeKeyIndex
+
 import org.scalatest._
 
 class KeyIndexJsonFormatFactorySpec extends FunSpec with Matchers {
@@ -39,28 +39,17 @@ class KeyIndexJsonFormatFactorySpec extends FunSpec with Matchers {
 
     // https://github.com/geotrellis/geotrellis-server/issues/248
     it("should be able to serialize and deserialize a ZSpaceTimeLargeKeyIndex key index set through application.conf") {
-      // layer dates range
+      // dates range
       // ["1960-01-01T12:00Z","1974-01-01T12:00Z"]
-
       // unix time is in [1 January 1970; 1 January 2038) bounds
-      val minDate = ZonedDateTime.parse("1960-01-01T12:00Z")
-      val maxDate = ZonedDateTime.parse("1974-01-01T12:00Z")
-
-      minDate.toInstant.toEpochMilli shouldBe -315576000000L
-      maxDate.toInstant.toEpochMilli shouldBe 126273600000L
-
       // -315576000000L
-      val minKey = SpaceTimeKey(4577, 5960, instant = minDate.toInstant.toEpochMilli)
+      val minKey = SpaceTimeKey(4577, 5960, instant = -315576000000L)
       // 126273600000L
-      val maxKey = SpaceTimeKey(4590, 5971, instant = maxDate.toInstant.toEpochMilli)
+      val maxKey = SpaceTimeKey(4590, 5971, instant = 126273600000L)
       val kb = KeyBounds(minKey, maxKey)
 
       // val temporalResolution: Long = 31536000000L
       val index = ZSpaceTimeLargeKeyIndex.byYear(kb)
-      index.temporalResolution shouldBe 31536000000L
-
-      index.indexRanges(minKey -> maxKey).length shouldBe 401
-
       val json = index.asJson
       val actual = json.as[KeyIndex[SpaceTimeKey]].valueOr(throw _)
       actual.keyBounds should be (kb)

--- a/store/src/test/scala/geotrellis/store/json/TestKeyIndexRegistrator.scala
+++ b/store/src/test/scala/geotrellis/store/json/TestKeyIndexRegistrator.scala
@@ -16,8 +16,8 @@
 
 package geotrellis.store.json
 
+import geotrellis.store.index.zcurve.ZSpaceTimeLargeKeyIndex
 import geotrellis.layer._
-import geotrellis.store._
 import geotrellis.store.index._
 
 import io.circe._
@@ -60,5 +60,6 @@ class TestKeyIndexRegistrator extends KeyIndexRegistrator {
 
   def register(keyIndexRegistry: KeyIndexRegistry): Unit = {
     keyIndexRegistry register KeyIndexFormatEntry[SpatialKey, TestKeyIndex](test)
+    keyIndexRegistry register KeyIndexFormatEntry[SpaceTimeKey, ZSpaceTimeLargeKeyIndex](ZSpaceTimeLargeKeyIndex.NAME)
   }
 }


### PR DESCRIPTION
# Overview

This PR proofs that https://github.com/geotrellis/geotrellis-server/issues/248 can be addressed by defining a different KeyIndexMethod.

