### PR TITLE
Fix GeoTrellisRasterSources to properly pass time though all the internal functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Fix GeoTrellisRasterSources to properly pass time though all the internal functions [#3226](https://github.com/locationtech/geotrellis/pull/3226) 
+
 ## [3.3.0] - 2020-04-07
 
 ### Added

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -110,7 +110,7 @@ class GeoTrellisRasterSource(
   lazy val isTemporal: Boolean = times.nonEmpty
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] =
-    GeoTrellisRasterSource.read(reader, layerId, layerMetadata, extent, bands).map(convertRaster)
+    GeoTrellisRasterSource.read(reader, layerId, layerMetadata, extent, bands, time).map(convertRaster)
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] =
     bounds
@@ -192,7 +192,7 @@ object GeoTrellisRasterSource {
     layerId: LayerId,
     extent: Extent,
     bands: Seq[Int],
-    time: Option[ZonedDateTime] = None
+    time: Option[ZonedDateTime]
   ): Seq[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]] = {
     def spatialTileRead =
       reader.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId)
@@ -256,13 +256,13 @@ object GeoTrellisRasterSource {
     }
   }
 
-  def readIntersecting(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[_], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
-    val tiles = readTiles(reader, layerId, extent, bands)
+  def readIntersecting(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[_], extent: Extent, bands: Seq[Int], time: Option[ZonedDateTime]): Option[Raster[MultibandTile]] = {
+    val tiles = readTiles(reader, layerId, extent, bands, time)
     sparseStitch(tiles, extent)
   }
 
-  def read(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[_], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
-    val tiles = readTiles(reader, layerId, extent, bands)
+  def read(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[_], extent: Extent, bands: Seq[Int], time: Option[ZonedDateTime]): Option[Raster[MultibandTile]] = {
+    val tiles = readTiles(reader, layerId, extent, bands, time)
     metadata.extent.intersection(extent) flatMap { intersectionExtent =>
       sparseStitch(tiles, intersectionExtent).map(_.crop(intersectionExtent))
     }

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -95,7 +95,7 @@ class GeoTrellisReprojectRasterSource(
         else
           logger.warn(msg + " (large read)")
       }
-      raster <- GeoTrellisRasterSource.readIntersecting(reader, layerId, sourceLayer.metadata, sourceExtent, bands)
+      raster <- GeoTrellisRasterSource.readIntersecting(reader, layerId, sourceLayer.metadata, sourceExtent, bands, time)
     } yield {
       val reprojected = raster.reproject(
         targetRasterExtent,

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -91,7 +91,7 @@ class GeoTrellisResampleRasterSource(
     else
     logger.warn(msg + " (large read)")
 
-    GeoTrellisRasterSource.readIntersecting(reader, layerId, sourceLayer.metadata, extent, bands)
+    GeoTrellisRasterSource.readIntersecting(reader, layerId, sourceLayer.metadata, extent, bands, time)
       .map { raster =>
         val targetRasterExtent = gridExtent.createAlignedRasterExtent(extent)
         logger.trace(s"\u001b[31mTargetRasterExtent\u001b[0m: ${targetRasterExtent} ${targetRasterExtent.dimensions}")


### PR DESCRIPTION
# Overview

We had a broken GeoTrellisRasterSources temporal support that was revelaed in terms of https://github.com/geotrellis/geotrellis-server/issues/248

This PR fixes the bad GeoTrellisRasterSoruces behavior.

Brief description of what this PR does, and why it is needed. The issue https://github.com/locationtech/geotrellis/issues/3225 is still valid. 

However, because GeoTrellisRasterSources work only with a single temporal slice. index overflows during the query ranges generation should never happen.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary

Addresses https://github.com/geotrellis/geotrellis-server/issues/248