### PR TITLE
Fix S3RDDLayerReader partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Fix GeoTrellisRasterSources to properly pass time though all the internal functions [#3226](https://github.com/locationtech/geotrellis/pull/3226)
-- Move GDAL overview strategy logger to debug level [#3230](https://github.com/locationtech/geotrellis/pull/3230) 
+- Move GDAL overview strategy logger to debug level [#3230](https://github.com/locationtech/geotrellis/pull/3230)
+- Fix S3RDDLayerReader partitioning [#3231](https://github.com/locationtech/geotrellis/pull/3231) 
 
 ## [3.3.0] - 2020-04-07
 

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerReader.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3LayerReader.scala
@@ -75,7 +75,7 @@ class S3LayerReader(
     val maxWidth = Index.digits(keyIndex.toIndex(keyIndex.keyBounds.maxKey))
     val keyPath = (index: BigInt) => makePath(prefix, Index.encode(index, maxWidth))
     val decompose = (bounds: KeyBounds[K]) => keyIndex.indexRanges(bounds)
-    val rdd = rddReader.read[K, V](bucket, keyPath, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema), Some(3))
+    val rdd = rddReader.read[K, V](bucket, keyPath, queryKeyBounds, decompose, filterIndexOnly, Some(writerSchema), Some(numPartitions))
 
     new ContextRDD(rdd, layerMetadata)
   }


### PR DESCRIPTION
# Overview

Partitions never got used and for some reason are locked to `3`.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
