### PR TITLE
GDALRasterSource should work consistent with BitCellType and ByteCellType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fix GeoTrellisRasterSources to properly pass time though all the internal functions [#3226](https://github.com/locationtech/geotrellis/pull/3226)
 - Move GDAL overview strategy logger to debug level [#3230](https://github.com/locationtech/geotrellis/pull/3230)
-- Fix S3RDDLayerReader partitioning [#3231](https://github.com/locationtech/geotrellis/pull/3231) 
+- Fix S3RDDLayerReader partitioning [#3231](https://github.com/locationtech/geotrellis/pull/3231)
+- GDALRasterSource works inconsistenly with BitCellType and ByteCellType [#3232](https://github.com/locationtech/geotrellis/issues/3232) 
 
 ## [3.3.0] - 2020-04-07
 

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -288,24 +288,7 @@ case class GDALDataset(token: Long) extends AnyVal {
     require(acceptableDatasets contains datasetType)
     val nd = noDataValue(datasetType)
     val dt = GDALDataType.intToGDALDataType(this.dataType(datasetType))
-    // This is declared lazy to avoid eval if the by-name param in GDALUtils.dataTypeToCellType is not needed
-    lazy val mm = {
-      val minmax = Array.ofDim[Double](2)
-      val success = Array.ofDim[Int](1)
-
-      val returnValue = GDALWarp.get_band_min_max(token, datasetType.value, numberOfAttempts, 1, true, minmax, success)
-
-      if (returnValue <= 0) {
-        val positiveValue = math.abs(returnValue)
-        throw new MalformedDataTypeException(
-          s"Unable to deterime the min/max values in order to calculate CellType. GDAL Error Code: $positiveValue",
-          positiveValue
-        )
-      }
-      if (success(0) != 0) Some(minmax(0), minmax(1))
-      else None
-    }
-    GDALUtils.dataTypeToCellType(datatype = dt, noDataValue = nd, minMaxValues = mm)
+    GDALUtils.dataTypeToCellType(datatype = dt, noDataValue = nd)
   }
 
   def readTile(gb: GridBounds[Int] = GridBounds(dimensions), band: Int, datasetType: DatasetType = GDALDataset.WARPED): Tile = {

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -62,7 +62,7 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def getMetadata(domain: GDALMetadataDomain, band: Int): Map[String, String] = getMetadata(GDALDataset.SOURCE, domain, band)
 
-  def getMetadata(datasetType: DatasetType, domain: GDALMetadataDomain, band: Int): Map[String, String] = {
+  def  getMetadata(datasetType: DatasetType, domain: GDALMetadataDomain, band: Int): Map[String, String] = {
     val arr = Array.ofDim[Byte](100, 1 << 10)
     val returnValue = GDALWarp.get_metadata(token, datasetType.value, numberOfAttempts, band, domain.name, arr)
 
@@ -288,11 +288,11 @@ case class GDALDataset(token: Long) extends AnyVal {
     require(acceptableDatasets contains datasetType)
     val nd = noDataValue(datasetType)
     val dt = GDALDataType.intToGDALDataType(this.dataType(datasetType))
-    /** The neccesary metadata about the [[CellType]] is available only on the RasterBand metadata level, that is why band = 1 here. */
+    /** The necessary metadata about the [[CellType]] is available only on the RasterBand metadata level, that is why band = 1 here. */
     lazy val md = this.getMetadata(ImageStructureDomain, 1)
     /** To handle the [[BitCellType]] it is possible to fetch NBITS information from the RasterBand metadata, **/
     lazy val bitsPerSample = md.get("NBITS").map(_.toInt)
-    /** To handle the [[ByteCellType]] it is possible to fetch information about the sampleFormat from the RasdterBand metadata. **/
+    /** To handle the [[ByteCellType]] it is possible to fetch information about the sampleFormat from the RasterBand metadata. **/
     lazy val signedByte = md.get("PIXELTYPE").contains("SIGNEDBYTE")
     GDALUtils.dataTypeToCellType(datatype = dt, noDataValue = nd, typeSizeInBits = bitsPerSample, signedByte = signedByte)
   }

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALUtils.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALUtils.scala
@@ -28,31 +28,34 @@ object GDALUtils {
 
   def deriveResampleMethodString(method: ResampleMethod): String =
     method match {
-      case NearestNeighbor => "near"
-      case Bilinear => "bilinear"
+      case NearestNeighbor  => "near"
+      case Bilinear         => "bilinear"
       case CubicConvolution => "cubic"
-      case CubicSpline => "cubicspline"
-      case Lanczos => "lanczos"
-      case Average => "average"
-      case Mode => "mode"
-      case Max => "max"
-      case Min => "min"
-      case Median => "med"
-      case _ => throw new Exception(s"Could not find equivalent GDALResampleMethod for: $method")
+      case CubicSpline      => "cubicspline"
+      case Lanczos          => "lanczos"
+      case Average          => "average"
+      case Mode             => "mode"
+      case Max              => "max"
+      case Min              => "min"
+      case Median           => "med"
+      case _                => throw new Exception(s"Could not find equivalent GDALResampleMethod for: $method")
     }
 
-  def dataTypeToCellType(datatype: GDALDataType, noDataValue: Option[Double] = None, typeSizeInBits: => Option[Int] = None): CellType =
+  def dataTypeToCellType(datatype: GDALDataType, noDataValue: Option[Double] = None, typeSizeInBits: => Option[Int] = None, signedByte: => Boolean = false): CellType =
     datatype match {
       case TypeByte =>
         typeSizeInBits match {
           case Some(bits) if bits == 1 => BitCellType
           case _ =>
-            noDataValue match {
+            if(!signedByte) noDataValue match {
               case Some(nd) if nd.toInt > 0 && nd <= 255 => UByteUserDefinedNoDataCellType(nd.toByte)
               case Some(nd) if nd.toInt == 0 => UByteConstantNoDataCellType
+              case _ => UByteCellType
+            }
+            else noDataValue match {
               case Some(nd) if nd.toInt > Byte.MinValue.toInt && nd <= Byte.MaxValue.toInt => ByteUserDefinedNoDataCellType(nd.toByte)
               case Some(nd) if nd.toInt == Byte.MinValue.toInt => ByteConstantNoDataCellType
-              case _ => UByteCellType
+              case _ => ByteCellType
             }
         }
       case TypeUInt16 =>
@@ -69,8 +72,8 @@ object GDALUtils {
         }
       case TypeUInt32 =>
         noDataValue match {
-          case Some(nd) if nd.toLong > 0l && nd.toLong <= 4294967295l => FloatUserDefinedNoDataCellType(nd.toFloat)
-          case Some(nd) if nd.toLong == 0l => FloatConstantNoDataCellType
+          case Some(nd) if nd.toLong > 0L && nd.toLong <= 4294967295L => FloatUserDefinedNoDataCellType(nd.toFloat)
+          case Some(nd) if nd.toLong == 0L => FloatConstantNoDataCellType
           case _ => FloatCellType
         }
       case TypeInt32 =>
@@ -82,13 +85,13 @@ object GDALUtils {
       case TypeFloat32 =>
         noDataValue match {
           case Some(nd) if isData(nd) && Float.MinValue.toDouble <= nd && Float.MaxValue.toDouble >= nd => FloatUserDefinedNoDataCellType(nd.toFloat)
-          case Some(nd) => FloatConstantNoDataCellType
+          case Some(_) => FloatConstantNoDataCellType
           case _ => FloatCellType
         }
       case TypeFloat64 =>
         noDataValue match {
           case Some(nd) if isData(nd) => DoubleUserDefinedNoDataCellType(nd)
-          case Some(nd) => DoubleConstantNoDataCellType
+          case Some(_) => DoubleConstantNoDataCellType
           case _ => DoubleCellType
         }
       case UnknownType =>
@@ -98,7 +101,7 @@ object GDALUtils {
     }
 
   def deriveOverviewStrategyString(strategy: OverviewStrategy): String = strategy match {
-    case Auto(n) if (n == 0) => "AUTO"
+    case Auto(n) if n == 0 => "AUTO"
     case Auto(n) => s"AUTO-$n"
     case Level(level) => s"$level"
     case Base => "NONE"

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALUtils.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALUtils.scala
@@ -41,25 +41,18 @@ object GDALUtils {
       case _ => throw new Exception(s"Could not find equivalent GDALResampleMethod for: $method")
     }
 
-  def dataTypeToCellType(datatype: GDALDataType, noDataValue: Option[Double] = None, typeSizeInBits: => Option[Int] = None, minMaxValues: => Option[(Double, Double)] = None): CellType =
+  def dataTypeToCellType(datatype: GDALDataType, noDataValue: Option[Double] = None, typeSizeInBits: => Option[Int] = None): CellType =
     datatype match {
       case TypeByte =>
         typeSizeInBits match {
           case Some(bits) if bits == 1 => BitCellType
           case _ =>
-            minMaxValues match {
-              case Some((mi, ma)) if (mi.toInt >= 0 && mi <= 255) && (ma.toInt >= 0 && ma <= 255) =>
-                noDataValue match {
-                  case Some(nd) if nd.toInt > 0 && nd <= 255 => UByteUserDefinedNoDataCellType(nd.toByte)
-                  case Some(nd) if nd.toInt == 0 => UByteConstantNoDataCellType
-                  case _ => UByteCellType
-                }
-              case _ =>
-                noDataValue match {
-                  case Some(nd) if nd.toInt > Byte.MinValue.toInt && nd <= Byte.MaxValue.toInt => ByteUserDefinedNoDataCellType(nd.toByte)
-                  case Some(nd) if nd.toInt == Byte.MinValue.toInt => ByteConstantNoDataCellType
-                  case _ => ByteCellType
-                }
+            noDataValue match {
+              case Some(nd) if nd.toInt > 0 && nd <= 255 => UByteUserDefinedNoDataCellType(nd.toByte)
+              case Some(nd) if nd.toInt == 0 => UByteConstantNoDataCellType
+              case Some(nd) if nd.toInt > Byte.MinValue.toInt && nd <= Byte.MaxValue.toInt => ByteUserDefinedNoDataCellType(nd.toByte)
+              case Some(nd) if nd.toInt == Byte.MinValue.toInt => ByteConstantNoDataCellType
+              case _ => UByteCellType
             }
         }
       case TypeUInt16 =>

--- a/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
+++ b/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
@@ -16,12 +16,14 @@
 
 package geotrellis.raster.gdal
 
+import geotrellis.proj4.LatLng
 import geotrellis.raster.geotiff.GeoTiffRasterSource
 import geotrellis.raster._
+import geotrellis.raster.io.geotiff.GeoTiff
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
 import geotrellis.raster.testkit._
-
+import geotrellis.vector.Extent
 import org.scalatest._
 
 class GDALRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhenThen {
@@ -109,6 +111,59 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with GivenWhenThe
     it("should read the same metadata as GeoTiffRasterSource") {
       lazy val tsource = GeoTiffRasterSource(uri)
       source.metadata.attributes.mapValues(_.toUpperCase) shouldBe tsource.metadata.attributes.mapValues(_.toUpperCase)
+    }
+
+    describe("should derive the cellType consistently with GeoTiffRasterSource") {
+      val ext = Extent(0.0, 0.0, 3.0, 3.0)
+      val data = Array(
+        Byte.MinValue, 2, 3,
+        4, 5, 6,
+        7, 8, Byte.MaxValue * 2
+      )
+
+      List(
+        BitCellType,
+        ByteCellType,
+        ByteConstantNoDataCellType,
+        ByteUserDefinedNoDataCellType((Byte.MinValue + 1).toByte),
+        UByteCellType,
+        UByteConstantNoDataCellType,
+        UByteUserDefinedNoDataCellType(1),
+        ShortCellType,
+        ShortConstantNoDataCellType,
+        ShortUserDefinedNoDataCellType((Short.MinValue + 1).toShort),
+        UShortCellType,
+        UShortConstantNoDataCellType,
+        UShortUserDefinedNoDataCellType(1),
+        IntCellType,
+        IntConstantNoDataCellType,
+        IntUserDefinedNoDataCellType(Int.MinValue + 1),
+        FloatCellType,
+        FloatConstantNoDataCellType,
+        FloatUserDefinedNoDataCellType(Float.MinValue + 1),
+        DoubleCellType,
+        DoubleConstantNoDataCellType,
+        DoubleUserDefinedNoDataCellType(Double.MinValue + 1)
+      ) map { ct =>
+        it(ct.getClass.getName.split("\\$").last.split("\\.").last) {
+          val path = s"/tmp/gdal-$ct-test.tiff"
+          val raster = Raster(ArrayTile(data, 3, 3).convert(ct), ext)
+          GeoTiff(raster, LatLng).write(path)
+
+          ct match {
+            case BitCellType =>
+              println("BitCellType requires a new GDALWarpBindings release")
+              // GDALRasterSource(path).cellType shouldBe UByteCellType
+              GeoTiffRasterSource(path).cellType shouldBe ct
+            case ByteCellType =>
+              GDALRasterSource(path).cellType shouldBe UByteCellType
+              GeoTiffRasterSource(path).cellType shouldBe ct
+            case _ =>
+              GDALRasterSource(path).cellType shouldBe ct
+              GeoTiffRasterSource(path).cellType shouldBe ct
+          }
+        }
+      }
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Version {
   val hadoop      = "2.8.5"
   val spark       = "2.4.4"
   val gdal        = "2.4.0"
-  val gdalWarp    = "1.0.0"
+  val gdalWarp    = "1.0.1"
 
   val previousVersion = "3.0.0"
 }


### PR DESCRIPTION
# Overview

This PR simplifies GDAL CellType derivation function and adds consistency specs

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [ ] [CQ 21987](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21987)

Closes #3232
