### PR TITLE
Add GS in the list of supported URI schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add GS in the list of supported URI schemes [#3235](https://github.com/locationtech/geotrellis/pull/3235)
+
 ### Changed
 - Fix GeoTrellisRasterSources to properly pass time though all the internal functions [#3226](https://github.com/locationtech/geotrellis/pull/3226)
 - Move GDAL overview strategy logger to debug level [#3230](https://github.com/locationtech/geotrellis/pull/3230)

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -62,7 +62,7 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def getMetadata(domain: GDALMetadataDomain, band: Int): Map[String, String] = getMetadata(GDALDataset.SOURCE, domain, band)
 
-  def  getMetadata(datasetType: DatasetType, domain: GDALMetadataDomain, band: Int): Map[String, String] = {
+  def getMetadata(datasetType: DatasetType, domain: GDALMetadataDomain, band: Int): Map[String, String] = {
     val arr = Array.ofDim[Byte](100, 1 << 10)
     val returnValue = GDALWarp.get_metadata(token, datasetType.value, numberOfAttempts, band, domain.name, arr)
 

--- a/store/src/main/scala/geotrellis/store/hadoop/package.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/package.scala
@@ -19,7 +19,7 @@ package geotrellis.store
 import org.apache.hadoop.fs.Path
 
 package object hadoop extends Implicits {
-  final val SCHEMES: Array[String] = Array("hdfs", "hdfs+file", "s3n", "s3a", "wasb", "wasbs")
+  final val SCHEMES: Array[String] = Array("hdfs", "hdfs+file", "s3n", "s3a", "wasb", "wasbs", "gs")
 
   implicit def stringToPath(path: String): Path = new Path(path)
 }

--- a/store/src/main/scala/geotrellis/store/hadoop/util/HdfsRangeReader.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/util/HdfsRangeReader.scala
@@ -23,12 +23,10 @@ import org.apache.hadoop.fs.Path
 
 
 /**
- * This class extends [[RangeReader]] by reading chunks out of a GeoTiff on HDFS.
- *
- * @param request: A [[GetObjectRequest]] of the desired GeoTiff.
- * @param client: The [[S3Client]] that retrieves the data.
- * @return A new instance of S3RangeReader.
- */
+  * This class extends [[RangeReader]] by reading chunks out of a GeoTiff on HDFS.
+  * @param path [[Path]] to a file
+  * @param conf [[Configuration]]
+  */
 class HdfsRangeReader(
   path: Path,
   conf: Configuration


### PR DESCRIPTION
# Overview

This PR adds `gs://` into the list of supported URI by the HdfsRangeReaderLayerProvider

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
