### PR TITLE
Rasterizer.rasterize should be consistent with rasterizeWithValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move GDAL overview strategy logger to debug level [#3230](https://github.com/locationtech/geotrellis/pull/3230)
 - Fix S3RDDLayerReader partitioning [#3231](https://github.com/locationtech/geotrellis/pull/3231)
 - GDALRasterSource works inconsistenly with BitCellType and ByteCellType [#3232](https://github.com/locationtech/geotrellis/issues/3232)
-- rasterizeWithValue accepts only topologically valid polygons [#3236](https://github.com/locationtech/geotrellis/pull/3236) 
+- rasterizeWithValue accepts only topologically valid polygons [#3236](https://github.com/locationtech/geotrellis/pull/3236)
+- Rasterizer.rasterize should be consistent with rasterizeWithValue [#3238](https://github.com/locationtech/geotrellis/pull/3238) 
 
 ## [3.3.0] - 2020-04-07
 

--- a/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
@@ -75,14 +75,15 @@ object Rasterizer {
     * @param rasterExtent  Definition of raster to create
     * @param f             Function that takes col, row, feature and returns value to burn
     */
-  def rasterize(feature: Geometry, rasterExtent: RasterExtent)(f: (Int, Int) => Int) = {
-    val cols = rasterExtent.cols
-    val array = Array.ofDim[Int](rasterExtent.cols * rasterExtent.rows).fill(NODATA)
-    val f2 = (col: Int, row: Int) =>
-          array(row * cols + col) = f(col, row)
-    foreachCellByGeometry(feature, rasterExtent)(f2)
-    ArrayTile(array, rasterExtent.cols, rasterExtent.rows)
-  }
+  def rasterize(feature: Geometry, rasterExtent: RasterExtent)(f: (Int, Int) => Int) =
+    if(feature.isValid) {
+      val cols = rasterExtent.cols
+      val array = Array.ofDim[Int](rasterExtent.cols * rasterExtent.rows).fill(NODATA)
+      val f2 = (col: Int, row: Int) =>
+        array(row * cols + col) = f(col, row)
+      foreachCellByGeometry(feature, rasterExtent)(f2)
+      ArrayTile(array, rasterExtent.cols, rasterExtent.rows)
+    } else throw new IllegalArgumentException("Cannot rasterize an invalid polygon")
 
   /**
     * Given a Geometry and a [[RasterExtent]], call the function 'f'


### PR DESCRIPTION
# Overview

This PR fixes rasterize function to behave like rasterizeWithValue function

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
