### PR TITLE
GeoTrellisRasterSource should return None on empty reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix S3RDDLayerReader partitioning [#3231](https://github.com/locationtech/geotrellis/pull/3231)
 - GDALRasterSource works inconsistenly with BitCellType and ByteCellType [#3232](https://github.com/locationtech/geotrellis/issues/3232)
 - rasterizeWithValue accepts only topologically valid polygons [#3236](https://github.com/locationtech/geotrellis/pull/3236)
-- Rasterizer.rasterize should be consistent with rasterizeWithValue [#3238](https://github.com/locationtech/geotrellis/pull/3238) 
+- Rasterizer.rasterize should be consistent with rasterizeWithValue [#3238](https://github.com/locationtech/geotrellis/pull/3238)
+- GeoTrellisRasterSource should return None on empty reads [#3240](https://github.com/locationtech/geotrellis/pull/3240) 
 
 ## [3.3.0] - 2020-04-07
 

--- a/layer/src/main/scala/geotrellis/layer/stitch/StitchCollectionMethods.scala
+++ b/layer/src/main/scala/geotrellis/layer/stitch/StitchCollectionMethods.scala
@@ -47,7 +47,7 @@ abstract class SpatialTileLayoutCollectionStitchMethods[
     * @return The stitched Raster, otherwise None if the collection is empty or the extent does not intersect
     */
   def sparseStitch(extent: Extent): Option[Raster[V]] = {
-    if (self.headOption.isEmpty) {
+    if (self.isEmpty) {
       None
     } else {
       val tile = self.head._2

--- a/spark/src/main/scala/geotrellis/spark/stitch/StitchRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/stitch/StitchRDDMethods.scala
@@ -57,7 +57,7 @@ abstract class SpatialTileLayoutRDDStitchMethods[
     val tiles = self.toCollection
     // From here down, this code duplicates SpatialTileLayoutCollectionStitchMethods.sparseStitch,
     // replacing self with tiles
-    if (tiles.headOption.isEmpty) {
+    if (tiles.isEmpty) {
       None
     } else {
       val tile = tiles.head._2

--- a/spark/src/test/scala/geotrellis/spark/stitch/CollectionStitchMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/stitch/CollectionStitchMethodsSpec.scala
@@ -16,9 +16,10 @@
 
 package geotrellis.spark.stitch
 
+import geotrellis.layer._
+import geotrellis.proj4.LatLng
 import geotrellis.raster._
 import geotrellis.raster.testkit._
-import geotrellis.raster.io.geotiff.SinglebandGeoTiff
 import geotrellis.spark._
 import geotrellis.spark.testkit._
 import geotrellis.vector.Extent
@@ -174,5 +175,19 @@ class CollectionStitchMethodsSpec extends FunSpec
         TileLayout(4, 4, 1, 1)
       ).toCollection
     assertEqual(layer.sparseStitch.get.tile, tile)
+  }
+
+  it("should correctly sparse stitch an empty collection") {
+    val extent = Extent(0, 0, 4, 4)
+    val md = TileLayerMetadata(
+      IntConstantNoDataCellType,
+      LayoutDefinition(extent,TileLayout(4, 4, 1, 1)),
+      extent,
+      LatLng,
+      KeyBounds(SpatialKey(0,0), SpatialKey(3,3))
+    )
+    val layer = ContextCollection(Seq.empty[(SpatialKey, Tile)], md)
+
+    layer.sparseStitch shouldBe None
   }
 }


### PR DESCRIPTION
# Overview

This PR removes a duplicate `GeoTrellisRasterSource.sparseStitch` function that also was not safe enough and could work (incorrectly) with empty inputs.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary

## Notes

This bug was revelaed during [this issue](https://github.com/geotrellis/geotrellis-server/issues/258) investigation.