### PR TITLE
RasterSource instances overviews should be sorted

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffRasterSource.scala
@@ -53,7 +53,7 @@ class GeoTiffRasterSource(
   def crs: CRS = tiff.crs
 
   lazy val gridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
-  lazy val resolutions: List[CellSize] = cellSize :: tiff.overviews.map(_.cellSize)
+  lazy val resolutions: List[CellSize] = cellSize :: tiff.overviews.map(_.cellSize).sorted
 
   def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTiffReprojectRasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -82,7 +82,7 @@ class GeoTiffReprojectRasterSource(
 
   lazy val resolutions: List[CellSize] =
     ReprojectRasterExtent(tiff.rasterExtent, transform, Reproject.Options.DEFAULT).cellSize ::
-      tiff.overviews.map(ovr => ReprojectRasterExtent(ovr.rasterExtent, transform, Reproject.Options.DEFAULT).cellSize)
+      tiff.overviews.map(ovr => ReprojectRasterExtent(ovr.rasterExtent, transform, Reproject.Options.DEFAULT).cellSize).sorted
 
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] = {
     resampleTarget match {

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -59,7 +59,7 @@ class GeoTiffResampleRasterSource(
 
   override lazy val gridExtent: GridExtent[Long] = resampleTarget(tiff.rasterExtent.toGridType[Long])
 
-  lazy val resolutions: List[CellSize] = tiff.cellSize :: tiff.overviews.map(_.cellSize)
+  lazy val resolutions: List[CellSize] = tiff.cellSize :: tiff.overviews.map(_.cellSize).sorted
 
   @transient private[raster] lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(gridExtent.cellSize, strategy)

--- a/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisRasterSource.scala
@@ -52,8 +52,6 @@ class GeoTrellisRasterSource(
   val time: Option[ZonedDateTime],
   val timeMetadataKey: String = "times"
 ) extends RasterSource {
-  @transient private[this] lazy val logger = getLogger
-
   def name: GeoTrellisPath = dataPath
 
   def this(attributeStore: AttributeStore, dataPath: GeoTrellisPath) =
@@ -95,7 +93,7 @@ class GeoTrellisRasterSource(
   def metadata: GeoTrellisMetadata = GeoTrellisMetadata(name, crs, bandCount, cellType, gridExtent, resolutions, attributes)
 
   // reference to this will fully initilze the sourceLayers stream
-  lazy val resolutions: List[CellSize] = sourceLayers.map(_.gridExtent.cellSize).toList
+  lazy val resolutions: List[CellSize] = sourceLayers.map(_.gridExtent.cellSize).toList.sorted
 
   lazy val times: List[ZonedDateTime] = {
     val layerId = dataPath.layerId

--- a/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSource.scala
@@ -50,7 +50,7 @@ class GeoTrellisReprojectRasterSource(
 
   lazy val resolutions: List[CellSize] = sourceLayers.map { layer =>
     ReprojectRasterExtent(layer.gridExtent, Transform(layer.metadata.crs, crs), Reproject.Options.DEFAULT).cellSize
-  }.toList
+  }.toList.sorted
 
   lazy val sourceLayer: Layer = sourceLayers.find(_.id == layerId).get
 

--- a/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
+++ b/store/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSource.scala
@@ -81,7 +81,7 @@ class GeoTrellisResampleRasterSource(
 
   def metadata: GeoTrellisMetadata = GeoTrellisMetadata(name, crs, bandCount, cellType, gridExtent, resolutions, attributes)
 
-  lazy val resolutions: List[CellSize] = sourceLayers.map(_.gridExtent.cellSize).toList
+  lazy val resolutions: List[CellSize] = sourceLayers.map(_.gridExtent.cellSize).toList.sorted
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tileBounds = sourceLayer.metadata.mapTransform.extentToBounds(extent)


### PR DESCRIPTION
# Overview

This PR ensures that RasterSource overviews are sorted from the most resolute to the less resolute cellSize.

## Checklist

- [ ] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [ ] Unit tests added for bug-fix or new feature
