### PR TITLE
Fix issue with resource management in Jpeg compressed GeoTiffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rasterizer.rasterize should be consistent with rasterizeWithValue [#3238](https://github.com/locationtech/geotrellis/pull/3238)
 - GeoTrellisRasterSource should return None on empty reads [#3240](https://github.com/locationtech/geotrellis/pull/3240) 
 - ArrayTile equals method always returns true if first elements are NaN [#3242](https://github.com/locationtech/geotrellis/issues/3242)
+- Fixed resource issue with JpegDecompressor that was causing a "too many open files in the system" exception on many parallel reads of JPEG compressed GeoTiffs. [#3249](https://github.com/locationtech/geotrellis/pull/3249)
 
 ## [3.3.0] - 2020-04-07
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/compression/JpegCompressionSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/compression/JpegCompressionSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.io.geotiff.compression
+
+import geotrellis.raster._
+import geotrellis.raster.io.geotiff._
+import geotrellis.raster.testkit._
+import geotrellis.vector.Extent
+import java.nio.file.Files
+import java.net.URL
+import java.io.File
+import org.scalatest._
+import scala.collection.parallel._
+import scala.util.Random
+import sys.process._
+
+
+class JpegCompressionSpec extends FunSpec
+    with RasterMatchers
+    with BeforeAndAfterAll
+    with GeoTiffTestUtils {
+
+  override def afterAll = purge
+
+  describe("Reading GeoTiffs with JPEG compression") {
+    it("Does not cause Too many open files exception") {
+      /*
+       * Tests a resource closing issue that appeared in the JPEGDecompression logic.
+       * See https://github.com/locationtech/geotrellis/pull/3249 for details.
+       */
+
+      val url = "https://oin-hotosm.s3.amazonaws.com/5ed6406bb2d2d20005f78420/0/5ed6406bb2d2d20005f78421.tif"
+
+      val temp = File.createTempFile("oam-scene", ".tif")
+      val jpegRasterPath = temp.getPath
+
+      addToPurge(jpegRasterPath)
+
+      println(f"Downloading ${url}...")
+
+      new URL(url) #> new File(jpegRasterPath) !!
+
+      println(f"Starting test...")
+
+      val extent = RasterSource(jpegRasterPath).metadata.gridExtent.extent
+
+      val parList = (1 to 10000).toList.par
+      // TODO: Replace with java.util.concurrent.ForkJoinPool once we drop 2.11 support.
+      val forkJoinPool = new scala.concurrent.forkjoin.ForkJoinPool(50)
+      parList.tasksupport = new ForkJoinTaskSupport(forkJoinPool)
+
+      try {
+        parList.foreach { _ =>
+          val (xmin, ymin) = (
+            (Random.nextDouble * (extent.width - 1)) + extent.xmin,
+            (Random.nextDouble * (extent.height - 1)) + extent.ymin
+          )
+
+          val windowExtent = Extent(
+            xmin,
+            ymin,
+            xmin + 1,
+            ymin + 1
+          )
+
+          RasterSource(jpegRasterPath).read(windowExtent).map { r =>
+            // Do something to ensure the JVM doesn't optimize things away.
+            val m = r._1.band(1).mutable
+            m.set(0, 0, 1)
+          }
+
+          info("READ")
+        }
+      } finally {
+        forkJoinPool.shutdown()
+      }
+
+      println("DONE")
+
+    }
+  }
+}


### PR DESCRIPTION
# Overview

This PR fixes an issue with resource handling in JPEG compressed GeoTiffs.

Reading JPEGs with ImageIO is [known to cause issues](https://info.michael-simons.eu/2012/01/25/the-dangers-of-javas-imageio/). The way the JPEG decompression works does not close down resources sufficiently and can cause an error like this

```
Cause: java.nio.file.FileSystemException: /var/folders/sv/zr8j0t4j1f726nhlt3vb8c300000gn/T/imageio8791917777763522780.tmp: Too many open files in system
```

The first commit in this PR adds a unit test downloads a JPEG-compressed GeoTiff from OpenAerialMap. It then performs many parallel reads in a loop, causing a "too many files opened" exception with the current code.

The second commit modifies the `JpegDecompression` to always create and close the `ImageReader` resources as needed. This may cause the code to run slower, though I will note that the unit test running against a Deflate version of the GeoTiff ran successfully in 50 seconds, and it running against a (pre-downloaded) JPEG compressed version with the fix ran in 55 seconds.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [ ] ~~[Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary~~
- [ ] ~~`docs` guides update, if necessary~~
- [ ] ~~New user API has useful Scaladoc strings~~
- [x] Unit tests added for bug-fix or new feature

Related to https://github.com/raster-foundry/raster-foundry/issues/4658