### PR TITLE
Use [ceil|floor]WithTolerance methods in GridExtent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed resource issue with JpegDecompressor that was causing a "too many open files in the system" exception on many parallel reads of JPEG compressed GeoTiffs. [#3249](https://github.com/locationtech/geotrellis/pull/3249)
 - Fix MosaicRasterSource, GDALRasterSource and GeoTiffResampleRasterSource behavior [#3252](https://github.com/locationtech/geotrellis/pull/3252)
 - HttpRangeReader should live outside of the Spark package [#3254](https://github.com/locationtech/geotrellis/issues/3254)
+- Consistently construct GridExtents with `math.round` [#3248](https://github.com/locationtech/geotrellis/issues/3248)
+
 
 ## [3.3.0] - 2020-04-07
 

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -70,8 +70,8 @@ class GridExtent[@specialized(Int, Long) N: Integral](
       throw GeoAttrsError(s"illegal cellheights: $cellheight and ${that.cellheight}")
 
     val newExtent = extent.combine(that.extent)
-    val newRows = ceil(newExtent.height / cellheight)
-    val newCols = ceil(newExtent.width / cellwidth)
+    val newRows = ceilWithTolerance(newExtent.height / cellheight)
+    val newCols = ceilWithTolerance(newExtent.width / cellwidth)
 
     new GridExtent[N](newExtent, cellwidth, cellheight,
       cols = Integral[N].fromDouble(newCols),
@@ -128,8 +128,8 @@ class GridExtent[@specialized(Int, Long) N: Integral](
   * width.
   */
   def withResolution(targetCellWidth: Double, targetCellHeight: Double): GridExtent[N] = {
-    val newCols = math.ceil((extent.xmax - extent.xmin) / targetCellWidth)
-    val newRows = math.ceil((extent.ymax - extent.ymin) / targetCellHeight)
+    val newCols = ceilWithTolerance((extent.xmax - extent.xmin) / targetCellWidth)
+    val newRows = ceilWithTolerance((extent.ymax - extent.ymin) / targetCellHeight)
     new GridExtent(extent, targetCellWidth, targetCellHeight,
       cols = Integral[N].fromDouble(newCols),
       rows = Integral[N].fromDouble(newRows))
@@ -247,8 +247,8 @@ class GridExtent[@specialized(Int, Long) N: Integral](
     * that lines up with the grid and also covers ``targetExtent``.
     */
   def createAlignedGridExtent(targetExtent: Extent, alignmentPoint: Point): GridExtent[N] = {
-    def left(reference: Double, actual: Double, unit: Double): Double = reference + math.floor((actual - reference) / unit) * unit
-    def right(reference: Double, actual: Double, unit: Double): Double = reference + math.ceil((actual - reference) / unit) * unit
+    def left(reference: Double, actual: Double, unit: Double): Double = reference + floorWithTolerance((actual - reference) / unit) * unit
+    def right(reference: Double, actual: Double, unit: Double): Double = reference + ceilWithTolerance((actual - reference) / unit) * unit
 
     val xmin = left(alignmentPoint.x, targetExtent.xmin, cellwidth)
     val xmax = right(alignmentPoint.x, targetExtent.xmax, cellwidth)
@@ -415,6 +415,12 @@ object GridExtent {
     val roundedValue = math.round(value)
     if (math.abs(value - roundedValue) < GridExtent.epsilon) roundedValue
     else math.floor(value)
+  }
+
+  def ceilWithTolerance(value: Double): Double = {
+    val roundedValue = math.round(value)
+    if(math.abs(value - roundedValue) < GridExtent.epsilon) roundedValue
+    else math.ceil(value)
   }
 
   implicit class gridExtentMethods[N: Integral](self: GridExtent[N]) {

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -128,11 +128,11 @@ class GridExtent[@specialized(Int, Long) N: Integral](
   * width.
   */
   def withResolution(targetCellWidth: Double, targetCellHeight: Double): GridExtent[N] = {
-    val newCols = ceilWithTolerance((extent.xmax - extent.xmin) / targetCellWidth)
-    val newRows = ceilWithTolerance((extent.ymax - extent.ymin) / targetCellHeight)
+    val newCols = math.round((extent.xmax - extent.xmin) / targetCellWidth)
+    val newRows = math.round((extent.ymax - extent.ymin) / targetCellHeight)
     new GridExtent(extent, targetCellWidth, targetCellHeight,
-      cols = Integral[N].fromDouble(newCols),
-      rows = Integral[N].fromDouble(newRows))
+      cols = Integral[N].fromLong(newCols),
+      rows = Integral[N].fromLong(newRows))
   }
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -29,6 +29,9 @@ import spire.implicits._
   * Represents an abstract grid over geographic extent.
   * Critically while the number of cell rows and columns is implied by the constructor arguments,
   * they are intentionally not expressed to avoid Int overflow for large grids.
+  *
+  * The constructor will throw [[java.lang.IllegalArgumentException]] if the provided extent and cell size do not match the
+  * provided cols and rows (dimensions).
   */
 class GridExtent[@specialized(Int, Long) N: Integral](
   val extent: Extent,
@@ -59,7 +62,7 @@ class GridExtent[@specialized(Int, Long) N: Integral](
   def cellSize = CellSize(cellwidth, cellheight)
 
   /**
-  * Combine two different [[GridExtent]]s (which must have the
+  * Combine two different GridExtents (which must have the
   * same cellsizes).  The result is a new extent at the same
   * resolution.
   */
@@ -107,21 +110,30 @@ class GridExtent[@specialized(Int, Long) N: Integral](
     (x, y)
   }
 
-  /** For a give column, find the corresponding x-coordinate in the grid of the present [[GridExtent]]. */
+  /** For a given column, find the corresponding x-coordinate in the grid of the present GridExtent. */
   final def gridColToMap(col: N): Double = {
     col.toDouble * cellwidth + extent.xmin + (cellwidth / 2)
   }
 
-  /** For a give row, find the corresponding y-coordinate in the grid of the present [[GridExtent]]. */
+  /** For a given row, find the corresponding y-coordinate in the grid of the present GridExtent. */
   final def gridRowToMap(row: N): Double = {
     extent.ymax - (row.toDouble * cellheight) - (cellheight / 2)
   }
 
   /**
-  * Returns a [[GridExtent]] with the same extent, but a modified
-  * number of columns and rows based on the given cell height and
-  * width.
-  */
+    * Returns a GridExtent with the same extent, but a modified
+    * number of columns and rows based on the given cell height and
+    * width.
+    *
+    * This method can construct a GridExtent where the number of
+    * columns and rows do not align closely with an integer boundary.
+    * The caller is responsible for verifying that the provided cell
+    * sizes are appropriate for the intended use case.
+    *
+    * See https://github.com/locationtech/geotrellis/issues/3261
+    * for details and an example. If you need a specific number of
+    * columns and rows, see [[geotrellis.raster.GridExtent#withDimensions(java.lang.Object, java.lang.Object) withDimensions(targetCols, targetRows)]]
+    */
   def withResolution(targetCellWidth: Double, targetCellHeight: Double): GridExtent[N] = {
     val newCols = math.round((extent.xmax - extent.xmin) / targetCellWidth)
     val newRows = math.round((extent.ymax - extent.ymin) / targetCellHeight)
@@ -131,15 +143,18 @@ class GridExtent[@specialized(Int, Long) N: Integral](
   }
 
   /**
-    * Returns a [[GridExtent]] with the same extent, but a modified
+    * Returns a GridExtent with the same extent, but a modified
     * number of columns and rows based on the given cell height and
     * width.
+    *
+    * See [[geotrellis.raster.GridExtent#withResolution(geotrellis.raster.CellSize) withResolution(cellSize)]]
+    * for more details.
     */
   def withResolution(cellSize: CellSize): GridExtent[N] =
     withResolution(cellSize.width, cellSize.height)
 
   /**
-   * Returns a [[GridExtent]] with the same extent and the given
+   * Returns a GridExtent with the same extent and the given
    * number of columns and rows.
    */
   def withDimensions(targetCols: N, targetRows: N): GridExtent[N] =
@@ -149,7 +164,7 @@ class GridExtent[@specialized(Int, Long) N: Integral](
     * Gets the GridBounds aligned with this GridExtent that is the
     * smallest subgrid containing all points within the extent. The
     * extent is considered inclusive on it's north and west borders,
-    * exclusive on it's east and south borders.  See [[RasterExtent]]
+    * exclusive on it's east and south borders.  See [[geotrellis.raster.RasterExtent]]
     * for a discussion of grid and extent boundary concepts.
     *
     * The 'clamp' flag determines whether or not to clamp the
@@ -268,7 +283,7 @@ class GridExtent[@specialized(Int, Long) N: Integral](
   }
 
   /**
-    * Returns a RasterExtent that lines up with this RasterExtent's
+    * Returns a [[geotrellis.raster.RasterExtent]] that lines up with this RasterExtent's
     * resolution, and grid layout.
     *
     * For example, the resulting RasterExtent will not have the given

--- a/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
@@ -17,11 +17,9 @@
 package geotrellis.raster
 
 import geotrellis.vector.{Extent, Point}
-import geotrellis.raster.testkit._
-
-import scala.math.{min, max}
-
 import org.scalatest._
+
+import scala.math.{max, min}
 
 class GridExtentSpec extends FunSpec with Matchers {
   def isWhole(x: Double): Boolean = (x.round - x).abs < geotrellis.util.Constants.FLOAT_EPSILON
@@ -135,6 +133,41 @@ class GridExtentSpec extends FunSpec with Matchers {
 
         result
       }).reduce(_ && _) should be (true)
+    }
+
+    it("should compute cols and rows in GridExtents with non integer cell sizes via withResolution") {
+      val cols: Long = 28017
+      val rows: Long = 22204
+      val resolutions = List(
+        CellSize(0.5047699668978283,0.5047699668978283),
+        CellSize(1.0095039019613432,1.0095399337956565),
+        CellSize(2.0188636920166245,2.019079867591313),
+        CellSize(4.037151059827706,4.037432400936376),
+        CellSize(8.071997809689758,8.074864801872751),
+        CellSize(16.143995619379517,16.149729603745502),
+        CellSize(32.287991238759034,32.299459207491005),
+        CellSize(64.57598247751807,64.41328933907688)
+      )
+      val extent = Extent(4114885.5876404666, -770072.0469938816, 4129027.727803043, -758864.1346488822)
+      val baseCellSize = resolutions.head
+      val baseGridExtent = GridExtent[Long](extent, baseCellSize)
+
+      val expectedGridExtents = List(
+        GridExtent(extent, cols, rows),
+        GridExtent(extent, 14009, 11102),
+        GridExtent(extent, 7005, 5551),
+        GridExtent(extent, 3503, 2776),
+        GridExtent(extent, 1752, 1388),
+        GridExtent(extent, 876, 694),
+        GridExtent(extent, 438, 347),
+        GridExtent(extent, 219, 174)
+      )
+
+      baseGridExtent.cols should be (cols)
+      baseGridExtent.rows should be (rows)
+      resolutions.zipWithIndex.foreach { case (r: CellSize, i: Int) =>
+        baseGridExtent.withResolution(r) should be(expectedGridExtents(i))
+      }
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
@@ -169,5 +169,13 @@ class GridExtentSpec extends FunSpec with Matchers {
         baseGridExtent.withResolution(r) should be(expectedGridExtents(i))
       }
     }
+
+    it("should compute withResolution even for CellSizes that don't cleanly divide the Extent") {
+      val extent = Extent(0, 0, 10, 10)
+      val gridExtent = GridExtent[Long](extent, CellSize(2, 2))
+      val expectedGridExtent = new GridExtent[Long](extent, 1.4, 1.4, 7, 7)
+      val actualGridExtent = gridExtent.withResolution(CellSize(1.4, 1.4))
+      expectedGridExtent should be (actualGridExtent)
+    }
   }
 }


### PR DESCRIPTION
~~Still waiting on an edge case test that allows us to consistently reproduce this issue~~, but as part of some other bugfixing/testing I updated GridExtent to use the tolerance methods consistently everywhere. This appears to have resolved the issue in the withResolution calls that caused mismatched grid extents.

They are _not_ used in `GridExtent.alignTargetPixels` because that method provides
a GDAL specific operation copied from GDAL source.

## Notes

The tolerance in GridExtent is 1e-7, in QGIS its 1e-6 and GDAL its 1e-5. Should we update our value to match one of the other projects? This could have the consequence of subtly breaking projects that rely on the current behavior for correctness. 

## Testing

Take a look at the first commit's CI build: https://app.circleci.com/pipelines/github/locationtech/geotrellis/28/workflows/e5506f7e-9024-4d1b-83b2-2a2f78945639/jobs/233

In there, you should find a test failure for the test `should compute cols and rows in GridExtents with non integer cell sizes` (use ctrl+f to find in page).

Then take a look at the HEAD of this branch's CI build: https://app.circleci.com/pipelines/github/locationtech/geotrellis/29/workflows/18bca2a1-c6b6-47d0-963c-e9ddbab9431d/jobs/246/steps

It should succeed with the new test now passing. Can search for the same passing test in the CI output.

Connects #3248 
