### PR TITLE
Move HttpRangeReader out of the spark package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ArrayTile equals method always returns true if first elements are NaN [#3242](https://github.com/locationtech/geotrellis/issues/3242)
 - Fixed resource issue with JpegDecompressor that was causing a "too many open files in the system" exception on many parallel reads of JPEG compressed GeoTiffs. [#3249](https://github.com/locationtech/geotrellis/pull/3249)
 - Fix MosaicRasterSource, GDALRasterSource and GeoTiffResampleRasterSource behavior [#3252](https://github.com/locationtech/geotrellis/pull/3252)
+- HttpRangeReader should live outside of the Spark package [#3254](https://github.com/locationtech/geotrellis/issues/3254)
 
 ## [3.3.0] - 2020-04-07
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -560,7 +560,6 @@ object Settings {
       sparkCore % Provided,
       hadoopClient % Provided,
       uzaygezenCore,
-      scalaj,
       avro,
       spire,
       chronoscala,
@@ -707,6 +706,7 @@ object Settings {
       uzaygezenCore,
       pureconfig,
       scalaXml,
+      scalaj,
       scalatest % Test
     )
   ) ++ commonSettings

--- a/spark/src/main/resources/META-INF/services/geotrellis.util.RangeReaderProvider
+++ b/spark/src/main/resources/META-INF/services/geotrellis.util.RangeReaderProvider
@@ -1,1 +1,0 @@
-geotrellis.spark.store.http.util.HttpRangeReaderProvider

--- a/store/src/main/resources/META-INF/services/geotrellis.util.RangeReaderProvider
+++ b/store/src/main/resources/META-INF/services/geotrellis.util.RangeReaderProvider
@@ -1,1 +1,2 @@
 geotrellis.store.hadoop.util.HdfsRangeReaderProvider
+geotrellis.store.http.util.HttpRangeReaderProvider

--- a/store/src/main/scala/geotrellis/store/http/util/HttpRangeReader.scala
+++ b/store/src/main/scala/geotrellis/store/http/util/HttpRangeReader.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.store.http.util
+package geotrellis.store.http.util
 
 import geotrellis.util.RangeReader
 
@@ -26,13 +26,13 @@ import scala.util.Try
 
 
 /**
- * This class extends [[RangeReader]] by reading chunks out of a GeoTiff at the
- * specified HTTP location.
- *
- * @throws [[HttpStatusException]] if the HTTP response code is 4xx or 5xx
- *
- * @param url: A [[URL]] pointing to the desired GeoTiff.
- */
+  * This class extends [[RangeReader]] by reading chunks out of a GeoTiff at the
+  * specified HTTP location.
+  *
+  * @throws [[HttpStatusException]] if the HTTP response code is 4xx or 5xx
+  *
+  * @param url: A [[URL]] pointing to the desired GeoTiff.
+  */
 class HttpRangeReader(url: URL, useHeadRequest: Boolean) extends RangeReader {
   @transient private[this] lazy val logger = getLogger
 
@@ -45,20 +45,20 @@ class HttpRangeReader(url: URL, useHeadRequest: Boolean) extends RangeReader {
       request.method("GET").execute { is => "" }
     }
     val contentLength = headers
-        .header("Content-Length")
-        .flatMap({ cl => Try(cl.toLong).toOption }) match {
-          case Some(num) => num
-          case None => -1L
-        }
+      .header("Content-Length")
+      .flatMap(cl => Try(cl.toLong).toOption) match {
+        case Some(num) => num
+        case None => -1L
+    }
     headers.throwError
 
     /**
-     * "The Accept-Ranges response HTTP header is a marker used by the server
-     *  to advertise its support of partial requests. The value of this field
-     *  indicates the unit that can be used to define a range."
-     * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges
-     */
-    require(headers.header("Accept-Ranges") == Some("bytes"),
+      * "The Accept-Ranges response HTTP header is a marker used by the server
+      *  to advertise its support of partial requests. The value of this field
+      *  indicates the unit that can be used to define a range."
+      * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges
+      */
+    require(headers.header("Accept-Ranges").contains("bytes"),
       "Server doesn't support ranged byte reads")
 
     require(contentLength > 0,
@@ -74,12 +74,12 @@ class HttpRangeReader(url: URL, useHeadRequest: Boolean) extends RangeReader {
       .asBytes
 
     /**
-     * "If the byte-range-set is unsatisfiable, the server SHOULD return
-     *  a response with a status of 416 (Requested range not satisfiable).
-     *  Otherwise, the server SHOULD return a response with a status of 206
-     *  (Partial Content) containing the satisfiable ranges of the entity-body."
-     * https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-     */
+      * "If the byte-range-set is unsatisfiable, the server SHOULD return
+      *  a response with a status of 416 (Requested range not satisfiable).
+      *  Otherwise, the server SHOULD return a response with a status of 206
+      *  (Partial Content) containing the satisfiable ranges of the entity-body."
+      * https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+      */
     require(res.code != 416,
       "Server unable to generate the byte range between ${start} and ${start + length}")
 
@@ -98,20 +98,20 @@ object HttpRangeReader {
   def apply(uri: URI): HttpRangeReader = apply(uri.toURL)
 
   /**
-   * Returns a new instance of HttpRangeReader.
-   *
-   * @param url: A [[URL]] pointing to the desired GeoTiff.
-   * @return A new instance of HttpRangeReader.
-   */
+    * Returns a new instance of HttpRangeReader.
+    *
+    * @param url: A [[URL]] pointing to the desired GeoTiff.
+    * @return A new instance of HttpRangeReader.
+    */
   def apply(url: URL): HttpRangeReader = new HttpRangeReader(url, true)
 
   /**
-   * Returns a new instance of HttpRangeReader which does not use HEAD
-   * to determine the totalLength.
-   *
-   * @param url: A [[URL]] pointing to the desired GeoTiff.
-   * @return A new instance of HttpRangeReader.
-   */
+    * Returns a new instance of HttpRangeReader which does not use HEAD
+    * to determine the totalLength.
+    *
+    * @param url: A [[URL]] pointing to the desired GeoTiff.
+    * @return A new instance of HttpRangeReader.
+    */
   def withoutHeadRequest(url: URL): HttpRangeReader = new HttpRangeReader(url, false)
 
   def withoutHeadRequest(address: String): HttpRangeReader = withoutHeadRequest(new URL(address))

--- a/store/src/main/scala/geotrellis/store/http/util/HttpRangeReaderProvider.scala
+++ b/store/src/main/scala/geotrellis/store/http/util/HttpRangeReaderProvider.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.store.http.util
+package geotrellis.store.http.util
 
 import geotrellis.util.RangeReaderProvider
 

--- a/store/src/test/scala/geotrellis/store/http/util/HttpRangeReaderProviderSpec.scala
+++ b/store/src/test/scala/geotrellis/store/http/util/HttpRangeReaderProviderSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.store.http.util
+package geotrellis.store.http.util
 
 import geotrellis.util.RangeReader
 

--- a/store/src/test/scala/geotrellis/store/http/util/HttpRangeReaderSpec.scala
+++ b/store/src/test/scala/geotrellis/store/http/util/HttpRangeReaderSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package geotrellis.spark.store.http.util
+package geotrellis.store.http.util
 
 import java.nio.file.{Files, Paths}
 import java.nio.ByteBuffer
@@ -97,7 +97,7 @@ class HttpRangeReaderSpec extends FunSpec with Matchers {
       }
 
       assertThrows[HttpStatusException] {
-       HttpRangeReader.withoutHeadRequest(uri)
+        HttpRangeReader.withoutHeadRequest(uri)
       }
     }
   }


### PR DESCRIPTION
# Overview

This PR moves HttpRangeReader into the store pacakge.

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary

Closes https://github.com/locationtech/geotrellis/issues/3254
