### PR TITLE
Move HttpRangeReader to geotrellis.util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed resource issue with JpegDecompressor that was causing a "too many open files in the system" exception on many parallel reads of JPEG compressed GeoTiffs. [#3249](https://github.com/locationtech/geotrellis/pull/3249)
 - Fix MosaicRasterSource, GDALRasterSource and GeoTiffResampleRasterSource behavior [#3252](https://github.com/locationtech/geotrellis/pull/3252)
 - HttpRangeReader should live outside of the Spark package [#3254](https://github.com/locationtech/geotrellis/issues/3254)
+- HttpRangeReader moved to `geotrellis.util [#3256](https://github.com/locationtech/geotrellis/issues/3256)
 
 ## [3.3.0] - 2020-04-07
 

--- a/docs/guide/module-hierarchy.rst
+++ b/docs/guide/module-hierarchy.rst
@@ -345,7 +345,8 @@ Plumbing for other GeoTrellis modules.
 -  Data structures missing from Scala, such as BTree
 -  Haversine implementation
 -  Lenses
--  RangeReader for reading contiguous subsets of data from a source
+-  RangeReaderProvider for reading contiguous subsets of data from a source
+  - Implementations for FileRangeReader and HttpRangeReader
 
 geotrellis-vector
 -----------------

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -632,6 +632,7 @@ object Settings {
     libraryDependencies ++= Seq(
       logging,
       pureconfig,
+      scalaj,
       spire,
       scalatest % Test
     )
@@ -706,7 +707,6 @@ object Settings {
       uzaygezenCore,
       pureconfig,
       scalaXml,
-      scalaj,
       scalatest % Test
     )
   ) ++ commonSettings

--- a/store/src/main/resources/META-INF/services/geotrellis.util.RangeReaderProvider
+++ b/store/src/main/resources/META-INF/services/geotrellis.util.RangeReaderProvider
@@ -1,2 +1,1 @@
 geotrellis.store.hadoop.util.HdfsRangeReaderProvider
-geotrellis.store.http.util.HttpRangeReaderProvider

--- a/util/src/main/resources/META-INF/services/geotrellis.util.RangeReaderProvider
+++ b/util/src/main/resources/META-INF/services/geotrellis.util.RangeReaderProvider
@@ -1,1 +1,2 @@
 geotrellis.util.FileRangeReaderProvider
+geotrellis.util.HttpRangeReaderProvider

--- a/util/src/main/scala/geotrellis/util/HttpRangeReader.scala
+++ b/util/src/main/scala/geotrellis/util/HttpRangeReader.scala
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package geotrellis.store.http.util
+package geotrellis.util
 
-import geotrellis.util.RangeReader
+import java.net.{URI, URL}
 
 import scalaj.http.Http
 import org.log4s._
 
-import java.net.{URL, URI}
 import scala.util.Try
-
 
 /**
   * This class extends [[RangeReader]] by reading chunks out of a GeoTiff at the

--- a/util/src/main/scala/geotrellis/util/HttpRangeReaderProvider.scala
+++ b/util/src/main/scala/geotrellis/util/HttpRangeReaderProvider.scala
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-package geotrellis.store.http.util
-
-import geotrellis.util.RangeReaderProvider
+package geotrellis.util
 
 import java.net.{URI, URL}
-
 
 class HttpRangeReaderProvider extends RangeReaderProvider {
   def canProcess(uri: URI): Boolean =

--- a/util/src/test/scala/geotrellis/util/HttpRangeReaderProviderSpec.scala
+++ b/util/src/test/scala/geotrellis/util/HttpRangeReaderProviderSpec.scala
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-package geotrellis.store.http.util
-
-import geotrellis.util.RangeReader
-
-import org.scalatest._
+package geotrellis.util
 
 import java.net.URI
+
+import org.scalatest._
 
 class HttpRangeReaderProviderSpec extends FunSpec with Matchers {
   describe("HttpRangeReaderProviderSpec") {

--- a/util/src/test/scala/geotrellis/util/HttpRangeReaderSpec.scala
+++ b/util/src/test/scala/geotrellis/util/HttpRangeReaderSpec.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package geotrellis.store.http.util
+package geotrellis.util
 
-import java.nio.file.{Files, Paths}
 import java.nio.ByteBuffer
+import java.nio.file.{Files, Paths}
 
 import org.scalatest._
 import scalaj.http.HttpStatusException


### PR DESCRIPTION
# Overview

A post-standup discussion made the decision
to move this class to geotrellis.util because:
- It's a generic enough util to be part of the
  base set of RangeReaders
- Allows users of geotrellis.raster.RasterSource
  to read remote public rasters without
  geotrellis.store
- Moves scalaj dep as far up the tree as possible
  making it easier to remove in the future for
  a more widely used lib

## Checklist

- [x] [docs/CHANGELOG.rst](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary
- [ ] [Module Hierarcy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

Closes #3256
