### PR TITLE
Add GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,12 +13,13 @@ A clear and concise description of what the bug is.
 
 ## To Reproduce
 
-Steps to reproduce the behavior:
+Provide as able:
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+- Steps to reproduce the behavior
+- Code example
+- Inputs
+- Actual output
+- Expected output
 
 ## Expected behavior
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- Java version:
+- Scala version:
+- GeoTrellis version:
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GeoTrellis Community Support on Gitter
+    url: https://gitter.im/geotrellis/geotrellis 
+    about: Ask GeoTrellis questions on Gitter 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,6 +15,8 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 
 A clear and concise description of what you want to happen.
 
+Consider providing code examples, expected inputs and outputs, and a sample API if applicable.
+
 ## Describe alternatives you've considered
 
 A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,34 @@
+---
+name: Release
+about: Release checklist for maintainers
+title: 'Release X.Y.Z'
+labels: ''
+assignees: ''
+
+---
+
+[ ] Check out the `master` branch and ensure it contains all commits to be released
+
+[ ] Update CHANGELOG.md and version.sbt to the release version as a single commit to `master`. [Example](https://github.com/locationtech/geotrellis/commit/e8fbbe2668aa0e99b7a631e9dc7802bc270c2bda)
+
+[ ] Create a new tag at the previous commit with `git tag -a vX.Y.Z -m "vX.Y.Z"`
+
+[ ] Push the tag to `locationtech/geotrellis` with `git push --tags`
+
+[ ] Follow the instructions in the setup section of [publish/README.md](https://github.com/locationtech/geotrellis/blob/master/publish/README.md#setup) to ensure that your local environment is configured for publishing the release
+
+[ ] Set the `RELEASE_TAG` variable in `./publish/Makefile` to `vX.Y.Z`, substituting x/y/z for the current release version
+
+[ ] **Before Continuing:** Ensure you have pushed the tag you created in step 3 before continuing. Otherwise the next step will fail.
+
+[ ] Execute `make build` in `./publish` to build the release container
+
+[ ] Execute `make publish` in `./publish` to build and push release artifacts to Sonatype. This will take an hour or so.
+
+[ ] Go to https://oss.sonatype.org and follow the [Releasing the Deployment](https://central.sonatype.org/pages/releasing-the-deployment.html) instructions to actually publish the release to Maven. Before clicking "publish" ensure that artifacts were generated for each scala version + geotrellis package combination supported by the release.
+
+[ ] Update `version.sbt` with the new SNAPSHOT version to begin publishing and add an empty `[Unreleased]` section to the CHANGELOG.md. Commit as as a single commit directly to the `master` branch. Typically you only need to increment the bugfix version. [Example](https://github.com/locationtech/geotrellis/commit/be47659e533f771bf9ffba54d59fca3cdcb4bf16)
+
+[ ] Push the previous commit to `locationtech/geotrellis` directly.
+
+[ ] Create a new [GitHub Release](https://github.com/locationtech/geotrellis/releases/new). Include the CHANGELOG entries for the release in the release notes, and state if the release breaks binary compatibility. [Example](https://github.com/locationtech/geotrellis/releases/tag/v3.4.0)


### PR DESCRIPTION
For:
- Bug Reports
- Feature Requests
- New Releases

Mostly this was a way to document our release process and capture
it in issues, similar to other Azavea OSS projects, until we are able to
address https://github.com/locationtech/geotrellis/issues/3140

Bonus that we can begin iterating on a few other common issue
template types.

@pomadchin pay particular attention to the steps in the new release.md issue template. Please double-check that I didn't miss any of the key release steps.

