### PR TITLE
Fix ShortArrayTileResult result ArrayTile fulfillment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - GeoTiffRasterSource is not threadsafe enough [#3265](https://github.com/locationtech/geotrellis/pull/3265)
+- Fix ShortArrayTileResult result ArrayTile fulfillment [#3268](https://github.com/locationtech/geotrellis/pull/3268)
 
 ## [3.4.0] - 2020-06-19
 

--- a/raster/src/main/scala/geotrellis/raster/ShortArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ShortArrayTile.scala
@@ -266,11 +266,11 @@ object ShortArrayTile {
   def ofDim(cols: Int, rows: Int, cellType: ShortCells with NoDataHandling): ShortArrayTile =
     cellType match {
       case ShortCellType =>
-        new ShortRawArrayTile(Array.ofDim[Short](cols * rows), cols, rows)
+        ShortRawArrayTile(Array.ofDim[Short](cols * rows), cols, rows)
       case ShortConstantNoDataCellType =>
-        new ShortConstantNoDataArrayTile(Array.ofDim[Short](cols * rows), cols, rows)
+        ShortConstantNoDataArrayTile(Array.ofDim[Short](cols * rows), cols, rows)
       case udct: ShortUserDefinedNoDataCellType =>
-        new ShortUserDefinedNoDataArrayTile(Array.ofDim[Short](cols * rows), cols, rows, udct)
+        ShortUserDefinedNoDataArrayTile(Array.ofDim[Short](cols * rows), cols, rows, udct)
     }
 
   /**
@@ -327,11 +327,11 @@ object ShortArrayTile {
   def fill(v: Short, cols: Int, rows: Int, cellType: ShortCells with NoDataHandling): ShortArrayTile =
     cellType match {
       case ShortCellType =>
-        new ShortRawArrayTile(Array.ofDim[Short](cols * rows).fill(v), cols, rows)
+        ShortRawArrayTile(Array.ofDim[Short](cols * rows).fill(v), cols, rows)
       case ShortConstantNoDataCellType =>
-        new ShortConstantNoDataArrayTile(Array.ofDim[Short](cols * rows).fill(v), cols, rows)
+        ShortConstantNoDataArrayTile(Array.ofDim[Short](cols * rows).fill(v), cols, rows)
       case udct: ShortUserDefinedNoDataCellType =>
-        new ShortUserDefinedNoDataArrayTile(Array.ofDim[Short](cols * rows).fill(v), cols, rows, udct)
+        ShortUserDefinedNoDataArrayTile(Array.ofDim[Short](cols * rows).fill(v), cols, rows, udct)
     }
 
   private def constructShortArray(bytes: Array[Byte]): Array[Short] = {
@@ -366,10 +366,10 @@ object ShortArrayTile {
   def fromBytes(bytes: Array[Byte], cols: Int, rows: Int, cellType: ShortCells with NoDataHandling): ShortArrayTile =
     cellType match {
       case ShortCellType =>
-        new ShortRawArrayTile(constructShortArray(bytes), cols, rows)
+        ShortRawArrayTile(constructShortArray(bytes), cols, rows)
       case ShortConstantNoDataCellType =>
-        new ShortConstantNoDataArrayTile(constructShortArray(bytes), cols, rows)
+        ShortConstantNoDataArrayTile(constructShortArray(bytes), cols, rows)
       case udct: ShortUserDefinedNoDataCellType =>
-        new ShortUserDefinedNoDataArrayTile(constructShortArray(bytes), cols, rows, udct)
+        ShortUserDefinedNoDataArrayTile(constructShortArray(bytes), cols, rows, udct)
     }
 }

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/FocalCalculation.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/FocalCalculation.scala
@@ -226,7 +226,7 @@ trait ShortArrayTileResult extends Resulting[Tile] { self: FocalCalculation[Tile
   /** [[ShortArrayTile]] that will be returned by the focal calculation */
   val cols: Int = bounds.width
   val rows: Int = bounds.height
-  val resultTile = ShortArrayTile(Array.ofDim[Short](cols * rows), cols, rows)
+  val resultTile = ShortArrayTile.empty(cols, rows)
 
   val copyOriginalValue: (Int, Int, Int, Int) => Unit = { (focusCol: Int, focusRow: Int, col: Int, row: Int) =>
     resultTile.set(col, row, r.get(focusCol, focusRow))


### PR DESCRIPTION
# Overview

This PR fixes an incorrect result array tile that is used i.e. in the FocalHillshade operation. 

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.

## Demo

Before (nodata around the scene is (0, 0, 0)):

![image](https://user-images.githubusercontent.com/4929546/87186301-458f9f00-c2b9-11ea-9674-f9dee473ad4c.png)

After (nodata around the scene is valid):

![image](https://user-images.githubusercontent.com/4929546/87186322-4f190700-c2b9-11ea-8d9e-35347d9790d9.png)
