### PR TITLE
Fix Overviews Read Incorrectly when Per Dataset Masks Present bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GeoTiffRasterSource is not threadsafe enough [#3265](https://github.com/locationtech/geotrellis/pull/3265)
 - Fix ShortArrayTileResult result ArrayTile fulfillment [#3268](https://github.com/locationtech/geotrellis/pull/3268)
 - GeoTiffRasterSource TiledToLayout reads by SpatialKey can produce non-256x256 tiles [3267](https://github.com/locationtech/geotrellis/issues/3267)
+- Fix Overviews Read Incorrectly when Per Dataset Masks Present [#3269](https://github.com/locationtech/geotrellis/issues/3269)
 
 ## [3.4.0] - 2020-06-19
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/NewSubfileType.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/NewSubfileType.scala
@@ -32,15 +32,15 @@ case object Page extends NewSubfileType { val code = 2 }
 /** Transparency mask for another image in this TIFF file */
 case object Mask extends NewSubfileType { val code = 4 }
 /** Reduced-resolution version of a transparency mask */
-case object MaskReducedImage extends NewSubfileType { val code = 5 }
+case object ReducedImageMask extends NewSubfileType { val code = 5 }
 /** Transparency mask of multi-page image */
-case object MaskMultiPage extends NewSubfileType { val code = 6 }
+case object MultiPageMask extends NewSubfileType { val code = 6 }
 /** Transparency mask of reduced-resolution multi-page image */
-case object MaskMultiPageReducedImage extends NewSubfileType { val code = 7 }
+case object MultiPageReducedImageMask extends NewSubfileType { val code = 7 }
 /** Depth map */
 case object Depth extends NewSubfileType { val code = 8 }
 /** Depth map of reduced-resolution image */
-case object DepthReducedImage extends NewSubfileType { val code = 9 }
+case object ReducedImageDepth extends NewSubfileType { val code = 9 }
 /** Enhanced image data */
 case object Enhanced extends NewSubfileType { val code = 10 }
 
@@ -51,11 +51,11 @@ object NewSubfileType {
     case ReducedImage.code => Some(ReducedImage)
     case Page.code => Some(Page)
     case Mask.code => Some(Mask)
-    case MaskReducedImage.code => Some(MaskReducedImage)
-    case MaskMultiPage.code => Some(MaskMultiPage)
-    case MaskMultiPageReducedImage.code => Some(MaskMultiPageReducedImage)
+    case ReducedImage.code => Some(ReducedImage)
+    case MultiPageMask.code => Some(MultiPageMask)
+    case MultiPageReducedImageMask.code => Some(MultiPageReducedImageMask)
     case Depth.code => Some(Depth)
-    case DepthReducedImage.code => Some(DepthReducedImage)
+    case ReducedImageDepth.code => Some(ReducedImageDepth)
     case Enhanced.code => Some(Enhanced)
     case _ => None
   }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/NewSubfileType.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/NewSubfileType.scala
@@ -51,7 +51,7 @@ object NewSubfileType {
     case ReducedImage.code => Some(ReducedImage)
     case Page.code => Some(Page)
     case Mask.code => Some(Mask)
-    case ReducedImage.code => Some(ReducedImage)
+    case ReducedImageMask.code => Some(ReducedImageMask)
     case MultiPageMask.code => Some(MultiPageMask)
     case MultiPageReducedImageMask.code => Some(MultiPageReducedImageMask)
     case Depth.code => Some(Depth)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/NewSubfileType.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/NewSubfileType.scala
@@ -19,22 +19,44 @@ package geotrellis.raster.io.geotiff
 /**
   * A general indication of the kind of data contained in this subfile.
   * URL: https://www.awaresystems.be/imaging/tiff/tifftags/newsubfiletype.html
+  * URL #2: https://exiftool.org/TagNames/EXIF.html
   */
 abstract sealed class NewSubfileType extends Serializable { val code: Int }
 
+/** Full resolution image */
+case object FullResolutionImage extends NewSubfileType { val code = 0 }
 /** Reduced-resolution version of another image in this TIFF file */
 case object ReducedImage extends NewSubfileType { val code = 1 }
 /** Single page of a multi-page image (see the PageNumber field description) */
 case object Page extends NewSubfileType { val code = 2 }
 /** Transparency mask for another image in this TIFF file */
 case object Mask extends NewSubfileType { val code = 4 }
+/** Reduced-resolution version of a transparency mask */
+case object MaskReducedImage extends NewSubfileType { val code = 5 }
+/** Transparency mask of multi-page image */
+case object MaskMultiPage extends NewSubfileType { val code = 6 }
+/** Transparency mask of reduced-resolution multi-page image */
+case object MaskMultiPageReducedImage extends NewSubfileType { val code = 7 }
+/** Depth map */
+case object Depth extends NewSubfileType { val code = 8 }
+/** Depth map of reduced-resolution image */
+case object DepthReducedImage extends NewSubfileType { val code = 9 }
+/** Enhanced image data */
+case object Enhanced extends NewSubfileType { val code = 10 }
 
 object NewSubfileType {
   def fromCode(code: Long): Option[NewSubfileType] = fromCode(code.toInt)
   def fromCode(code: Int): Option[NewSubfileType] = code match {
+    case FullResolutionImage.code => Some(FullResolutionImage)
     case ReducedImage.code => Some(ReducedImage)
     case Page.code => Some(Page)
     case Mask.code => Some(Mask)
+    case MaskReducedImage.code => Some(MaskReducedImage)
+    case MaskMultiPage.code => Some(MaskMultiPage)
+    case MaskMultiPageReducedImage.code => Some(MaskMultiPageReducedImage)
+    case Depth.code => Some(Depth)
+    case DepthReducedImage.code => Some(DepthReducedImage)
+    case Enhanced.code => Some(Enhanced)
     case _ => None
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffInfo.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffInfo.scala
@@ -160,13 +160,21 @@ object GeoTiffInfo {
             case Tiff =>
               var ifdOffset = byteReader.getInt
               while (ifdOffset > 0) {
-                tiffTagsBuffer += TiffTags.read(byteReader, ifdOffset)(IntTiffTagOffsetSize)
+                val ifdTiffTags = TiffTags.read(byteReader, ifdOffset)(IntTiffTagOffsetSize)
+                // TIFF Reader supports only overviews at this point
+                // Overview is a reduced-resolution IFD
+                val subfileType = ifdTiffTags.nonBasicTags.newSubfileType.flatMap(NewSubfileType.fromCode)
+                if(subfileType.contains(ReducedImage)) tiffTagsBuffer += ifdTiffTags
                 ifdOffset = byteReader.getInt
               }
             case _ =>
               var ifdOffset = byteReader.getLong
               while (ifdOffset > 0) {
-                tiffTagsBuffer += TiffTags.read(byteReader, ifdOffset)(LongTiffTagOffsetSize)
+                val ifdTiffTags = TiffTags.read(byteReader, ifdOffset)(LongTiffTagOffsetSize)
+                // TIFF Reader supports only overviews at this point
+                // Overview is a reduced-resolution IFD
+                val subfileType = ifdTiffTags.nonBasicTags.newSubfileType.flatMap(NewSubfileType.fromCode)
+                if(subfileType.contains(ReducedImage)) tiffTagsBuffer += ifdTiffTags
                 ifdOffset = byteReader.getLong
               }
           }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyDirectory.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/GeoKeyDirectory.scala
@@ -18,9 +18,7 @@ package geotrellis.raster.io.geotiff.tags
 
 import ProjectionTypesMap._
 import geotrellis.raster.io.geotiff.reader.MalformedGeoTiffException
-import geotrellis.raster.io.geotiff.util._
 
-import monocle.syntax._
 import monocle.macros.Lenses
 import io.circe._
 import io.circe.generic.semiauto._


### PR DESCRIPTION
# Overview

With this PR GeoTiff reader will skip all IFDs that are not a `ReducedImage`.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] Unit tests added for bug-fix or new feature

Closes https://github.com/locationtech/geotrellis/issues/3269
