### PR TITLE
Add RasterizeRDD methods for keyed features RDD[(SpatialKey, F[G, D])]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - GeoTiffRasterSource is not threadsafe enough [#3265](https://github.com/locationtech/geotrellis/pull/3265)
 - Fix ShortArrayTileResult result ArrayTile fulfillment [#3268](https://github.com/locationtech/geotrellis/pull/3268)
+- Add alternative RasterizeRDD methods for keyed geometries or features [#3271](https://github.com/locationtech/geotrellis/pull/3271)
 
 ## [3.4.0] - 2020-06-19
 

--- a/spark/src/main/scala/geotrellis/spark/rasterize/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/rasterize/Implicits.scala
@@ -16,7 +16,8 @@
 
 package geotrellis.spark.rasterize
 
-import geotrellis.vector.{Geometry, Feature}
+import geotrellis.layer.SpatialKey
+import geotrellis.vector.{Feature, Geometry}
 import geotrellis.raster.rasterize.CellValue
 import org.apache.spark.rdd.RDD
 
@@ -31,4 +32,13 @@ trait Implicits {
 
   implicit class withCellValueFeatureRDDRasterizeMethods[G <: Geometry](val self: RDD[Feature[G, CellValue]])
       extends CellValueFeatureRDDRasterizeMethods[G]
+
+  implicit class withKeyedGeometryRDDRasterizeMethods[G <: Geometry](val self: RDD[(SpatialKey, G)])
+      extends KeyedGeometryRDDRasterizeMethods[G]
+
+  implicit class withKeyedFeatureRDDRasterizeMethods[G <: Geometry](val self: RDD[(SpatialKey, Feature[G, Double])])
+      extends KeyedFeatureRDDRasterizeMethods[G]
+
+  implicit class withKeyedCellValueFeatureRDDRasterizeMethods[G <: Geometry](val self: RDD[(SpatialKey, Feature[G, CellValue])])
+      extends KeyedCellValueFeatureRDDRasterizeMethods[G]
 }

--- a/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/rasterize/RasterizeRDDMethods.scala
@@ -32,16 +32,16 @@ import org.apache.spark.rdd._
 trait GeometryRDDRasterizeMethods[G <: Geometry] extends MethodExtensions[RDD[G]] {
 
   /**
-   * Rasterize an RDD of Geometry objects into a tiled raster RDD.
-   * Cells not intersecting any geometry will left as NODATA.
-   * Value will be converted to type matching specified [[CellType]].
-   *
-   * @param value Cell value for cells intersecting a geometry
-   * @param cellType [[CellType]] for creating raster tiles
-   * @param layout Raster layer layout for the result of rasterization
-   * @param options Rasterizer options for cell intersection rules
-   * @param partitioner Partitioner for result RDD
-   */
+    * Rasterize an RDD of Geometry objects into a tiled raster RDD.
+    * Cells not intersecting any geometry will left as NODATA.
+    * Value will be converted to type matching specified [[CellType]].
+    *
+    * @param value Cell value for cells intersecting a geometry
+    * @param cellType [[CellType]] for creating raster tiles
+    * @param layout Raster layer layout for the result of rasterization
+    * @param options Rasterizer options for cell intersection rules
+    * @param partitioner Partitioner for result RDD
+    */
   def rasterize(
     value: Double,
     cellType: CellType,
@@ -54,21 +54,21 @@ trait GeometryRDDRasterizeMethods[G <: Geometry] extends MethodExtensions[RDD[G]
 }
 
 /**
- * Extension methods for invoking the rasterizer on RDD of Feature objects.
- */
+  * Extension methods for invoking the rasterizer on RDD of Feature objects.
+  */
 trait FeatureRDDRasterizeMethods[G <: Geometry] extends MethodExtensions[RDD[Feature[G, Double]]] {
 
   /**
-   * Rasterize an RDD of Feature objects into a tiled raster RDD.
-   * Cells not intersecting any geometry will left as NODATA.
-   * Feature data will be converted to type matching specified [[CellType]].
-   * Feature rasterization order is undefined in this operation.
-   *
-   * @param cellType [[CellType]] for creating raster tiles
-   * @param layout Raster layer layout for the result of rasterization
-   * @param options Rasterizer options for cell intersection rules
-   * @param partitioner Partitioner for result RDD
-   */
+    * Rasterize an RDD of Feature objects into a tiled raster RDD.
+    * Cells not intersecting any geometry will left as NODATA.
+    * Feature data will be converted to type matching specified [[CellType]].
+    * Feature rasterization order is undefined in this operation.
+    *
+    * @param cellType [[CellType]] for creating raster tiles
+    * @param layout Raster layer layout for the result of rasterization
+    * @param options Rasterizer options for cell intersection rules
+    * @param partitioner Partitioner for result RDD
+    */
   def rasterize(
     cellType: CellType,
     layout: LayoutDefinition,
@@ -85,17 +85,17 @@ trait FeatureRDDRasterizeMethods[G <: Geometry] extends MethodExtensions[RDD[Fea
 trait CellValueFeatureRDDRasterizeMethods[G <: Geometry] extends MethodExtensions[RDD[Feature[G, CellValue]]] {
 
   /**
-   * Rasterize an RDD of Feature objects into a tiled raster RDD.
-   * Cells not intersecting any geometry will left as NODATA.
-   * Feature value will be converted to type matching specified [[CellType]].
-   * Z-Index from [[CellValue]] will be maintained per-cell during rasterization.
-   * A cell with greater zindex is always in front of a cell with a lower zinde.
-   *
-   * @param cellType [[CellType]] for creating raster tiles
-   * @param layout Raster layer layout for the result of rasterization
-   * @param options Rasterizer options for cell intersection rules
-   * @param partitioner Partitioner for result RDD
-   */
+    * Rasterize an RDD of Feature objects into a tiled raster RDD.
+    * Cells not intersecting any geometry will left as NODATA.
+    * Feature value will be converted to type matching specified [[CellType]].
+    * Z-Index from [[CellValue]] will be maintained per-cell during rasterization.
+    * A cell with greater zindex is always in front of a cell with a lower zinde.
+    *
+    * @param cellType [[CellType]] for creating raster tiles
+    * @param layout Raster layer layout for the result of rasterization
+    * @param options Rasterizer options for cell intersection rules
+    * @param partitioner Partitioner for result RDD
+    */
   def rasterize(
     cellType: CellType,
     layout: LayoutDefinition,
@@ -103,5 +103,82 @@ trait CellValueFeatureRDDRasterizeMethods[G <: Geometry] extends MethodExtension
     partitioner: Option[Partitioner] = None
   ): RDD[(SpatialKey, Tile)] with Metadata[LayoutDefinition] = {
     RasterizeRDD.fromFeatureWithZIndex(self, cellType, layout, options, partitioner)
+  }
+}
+
+/**
+  * Extension methods for invoking the rasterizer on RDD of Geometry objects keyed by the associated spatial key(s).
+  */
+trait KeyedGeometryRDDRasterizeMethods[G <: Geometry] extends MethodExtensions[RDD[(SpatialKey, G)]] {
+  /**
+    * Rasterize an RDD of Geometry objects keyed by the associated spatial key(s) into a tiled raster RDD.
+    * Cells not intersecting any geometry will left as NODATA.
+    * Value will be converted to type matching specified [[CellType]].
+    *
+    * @param value Cell value for cells intersecting a geometry
+    * @param cellType [[CellType]] for creating raster tiles
+    * @param layout Raster layer layout for the result of rasterization
+    * @param options Rasterizer options for cell intersection rules
+    * @param partitioner Partitioner for result RDD
+    */
+  def rasterize(
+    value: Double,
+    cellType: CellType,
+    layout: LayoutDefinition,
+    options: Rasterizer.Options = Rasterizer.Options.DEFAULT,
+    partitioner: Option[Partitioner] = None
+  ): RDD[(SpatialKey, Tile)] with Metadata[LayoutDefinition] = {
+    RasterizeRDD.fromKeyedGeometry(self, value, cellType, layout, options, partitioner)
+  }
+}
+
+/**
+  * Extension methods for invoking the rasterizer on RDD of Feature objects keyed by the associated spatial key(s).
+  */
+trait KeyedFeatureRDDRasterizeMethods[G <: Geometry] extends MethodExtensions[RDD[(SpatialKey, Feature[G, Double])]] {
+  /**
+    * Rasterize an RDD of Feature objects keyed by the associated spatial key(s) into a tiled raster RDD.
+    * Cells not intersecting any geometry will left as NODATA.
+    * Feature data will be converted to type matching specified [[CellType]].
+    * Feature rasterization order is undefined in this operation.
+    *
+    * @param cellType [[CellType]] for creating raster tiles
+    * @param layout Raster layer layout for the result of rasterization
+    * @param options Rasterizer options for cell intersection rules
+    * @param partitioner Partitioner for result RDD
+    */
+  def rasterize(
+    cellType: CellType,
+    layout: LayoutDefinition,
+    options: Rasterizer.Options = Rasterizer.Options.DEFAULT,
+    partitioner: Option[Partitioner] = None
+  ): RDD[(SpatialKey, Tile)] with Metadata[LayoutDefinition] = {
+    RasterizeRDD.fromKeyedFeature(self, cellType, layout, options, partitioner)
+  }
+}
+
+/**
+  * Extension methods for invoking the rasterizer on RDD of Feature objects keyed by the associated spatial key(s) and having CellValue data
+  */
+trait KeyedCellValueFeatureRDDRasterizeMethods[G <: Geometry] extends MethodExtensions[RDD[(SpatialKey, Feature[G, CellValue])]] {
+  /**
+    * Rasterize an RDD of Feature objects keyed by the associated spatial key(s) into a tiled raster RDD.
+    * Cells not intersecting any geometry will left as NODATA.
+    * Feature value will be converted to type matching specified [[CellType]].
+    * Z-Index from [[CellValue]] will be maintained per-cell during rasterization.
+    * A cell with greater zindex is always in front of a cell with a lower zinde.
+    *
+    * @param cellType [[CellType]] for creating raster tiles
+    * @param layout Raster layer layout for the result of rasterization
+    * @param options Rasterizer options for cell intersection rules
+    * @param partitioner Partitioner for result RDD
+    */
+  def rasterize(
+    cellType: CellType,
+    layout: LayoutDefinition,
+    options: Rasterizer.Options = Rasterizer.Options.DEFAULT,
+    partitioner: Option[Partitioner] = None
+  ): RDD[(SpatialKey, Tile)] with Metadata[LayoutDefinition] = {
+    RasterizeRDD.fromKeyedFeatureWithZIndex(self, cellType, layout, options, partitioner)
   }
 }


### PR DESCRIPTION
# Overview

Add RasterizeRDD methods for RDD of already-keyed features for types
- `RDD[(SpatialKey, Geometry)]`
- `RDD[(SpatialKey, Feature[Geometry, Double])]`
- `RDD[(SpatialKey, Feature[Geometry, CellValue])]`

This addition provides more convenient and more efficient alternatives to the current RasterizeRDD methods for use cases where the input RDD is already keyed by SpatialKey and doesn't need additional rasterization across the tile layout grid using `keysForGeometry`.

This was discussed in [gitter.im](https://gitter.im/geotrellis/geotrellis?at=5f057526a5ab931e4f713d49) with @pomadchin 

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.