### PR TITLE
Fix WebMercator projection TIFF CoordinateSystemParser logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix renderJpg() color is bluer than expected [#3203](https://github.com/locationtech/geotrellis/issues/3203)
 - Fix combineDouble of ArrayTile and ConstantTile with non-commutative operator [#3257](https://github.com/locationtech/geotrellis/issues/3257)
 - Update GDAL up to 3.1 [#3279](https://github.com/locationtech/geotrellis/pull/3279)
+- Fix GeoTiff writer does not currently support WebMercator projection with no EPSG code set [#3281](https://github.com/locationtech/geotrellis/issues/3281)
 
 ## [3.4.1] - 2020-07-16
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/CoordinateSystemParser.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/CoordinateSystemParser.scala
@@ -157,6 +157,7 @@ class CoordinateSystemParser(val crs: CRS, val pixelSampleType: Option[PixelSamp
   // that this code is taken from. We need to be able to write out more projections.
   private lazy val projProps = proj4Map.get("proj") match {
     case Some("tmerc") => tmercProps
+    case Some("merc") => mercProps
     case Some("utm") => utmProps
     case Some("lcc") => lccProps
     case Some("longlat") | Some("latlong") => longLatProps
@@ -180,6 +181,27 @@ class CoordinateSystemParser(val crs: CRS, val pixelSampleType: Option[PixelSamp
     val doubles = List(
       (ProjNatOriginLatGeoKey, getDouble("lat_0")),
       (ProjNatOriginLongGeoKey, getDouble("lon_0")),
+      (ProjScaleAtNatOriginGeoKey, getK(1.0)),
+      (ProjFalseEastingGeoKey, getDouble("x_0")),
+      (ProjFalseNorthingGeoKey, getDouble("y_0"))
+    )
+
+    (geoKeysInt, doubles)
+  }
+
+  // MERCATOR_2SP & MERCATOR_1SP
+  private lazy val mercProps = {
+    val geoKeysInt = List(
+      (GTModelTypeGeoKey, ModelTypeProjected),
+      (ProjectedCSTypeGeoKey, UserDefinedCPV),
+      (ProjectionGeoKey, UserDefinedCPV),
+      (ProjCoordTransGeoKey, CT_Mercator)
+    )
+
+    val doubles = List(
+      (ProjNatOriginLatGeoKey, getDouble("lat_0")),
+      (ProjNatOriginLongGeoKey, getDouble("lon_0")),
+      (ProjStdParallel1GeoKey, getDouble("lat_ts")),
       (ProjScaleAtNatOriginGeoKey, getK(1.0)),
       (ProjFalseEastingGeoKey, getDouble("x_0")),
       (ProjFalseNorthingGeoKey, getDouble("y_0"))

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -147,6 +147,16 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
       actualCRS.toProj4String should be (geoTiff.crs.toProj4String)
     }
 
+    it ("should write web mercator with no epsg code correctly") {
+      val geoTiff = MultibandGeoTiff(geoTiffPath("ndvi-web-mercator.tif"))
+
+      addToPurge(path)
+      GeoTiff(geoTiff.raster, CRS.fromString(geoTiff.crs.toProj4String)).write(path)
+      val actualCRS = SinglebandGeoTiff(path).crs
+
+      actualCRS.toProj4String should be (geoTiff.crs.toProj4String)
+    }
+
     it("should write floating point rasters correctly") {
       val t = DoubleArrayTile(Array(11.0, 22.0, 33.0, 44.0), 2, 2)
 


### PR DESCRIPTION
# Overview

This PR fixes GeoTiff.write logic when the CRS is web mercator but it had no the EPSG code data.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] Unit tests added for bug-fix or new feature

Closes https://github.com/locationtech/geotrellis/issues/3281
