### PR TITLE
Tile combine should union cellTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix combineDouble of ArrayTile and ConstantTile with non-commutative operator [#3257](https://github.com/locationtech/geotrellis/issues/3257)
 - Update GDAL up to 3.1 [#3279](https://github.com/locationtech/geotrellis/pull/3279)
 - Fix GeoTiff writer does not currently support WebMercator projection with no EPSG code set [#3281](https://github.com/locationtech/geotrellis/issues/3281)
+- Fix Tile combine should union cellTypes [#3284](https://github.com/locationtech/geotrellis/pull/3284)
 
 ## [3.4.1] - 2020-07-16
 

--- a/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
@@ -538,7 +538,7 @@ case class CompositeTile(tiles: Seq[Tile],
   def combine(other: Tile)(f: (Int, Int) => Int): Tile = {
     (this, other).assertEqualDimensions
 
-    val result = ArrayTile.alloc(cellType, cols, rows)
+    val result = ArrayTile.alloc(cellType.union(other.cellType), cols, rows)
     val layoutCols = tileLayout.layoutCols
     val layoutRows = tileLayout.layoutRows
     val tileCols = tileLayout.tileCols

--- a/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CroppedTile.scala
@@ -341,7 +341,7 @@ case class CroppedTile(
   def combine(other: Tile)(f: (Int, Int) => Int): Tile = {
     (this, other).assertEqualDimensions
 
-    val tile = ArrayTile.alloc(cellType, cols, rows)
+    val tile = ArrayTile.alloc(cellType.union(other.cellType), cols, rows)
     cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
         tile.set(col, row, f(get(col, row), other.get(col, row)))

--- a/raster/src/main/scala/geotrellis/raster/PaddedTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/PaddedTile.scala
@@ -175,7 +175,7 @@ case class PaddedTile(chunk: Tile, colOffset: Int, rowOffset: Int, cols: Int, ro
   def combine(other: Tile)(f: (Int, Int) => Int): Tile = {
     (this, other).assertEqualDimensions
 
-    val tile = ArrayTile.alloc(cellType, cols, rows)
+    val tile = ArrayTile.alloc(cellType.union(other.cellType), cols, rows)
     cfor(0)(_ < rows, _ + 1) { row =>
       cfor(0)(_ < cols, _ + 1) { col =>
         tile.set(col, row, f(get(col, row), other.get(col, row)))

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffTile.scala
@@ -613,7 +613,7 @@ abstract class GeoTiffTile(
           compressor.createDecompressor(),
           segmentLayout,
           compression,
-          cellType,
+          cellType.union(other.cellType),
           overviews = overviews
         )
       case _ =>

--- a/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
@@ -325,6 +325,15 @@ class ArrayTileSpec extends AnyFunSpec with Matchers with RasterMatchers with Ti
       assert(tile1 != tile2)
     }
   }
+
+  describe("ArrayTile cellType combine") {
+    it("should union cellTypes") {
+      val int = IntArrayTile(Array.ofDim[Int](2).fill(0), 1, 1)
+      val dt = DoubleArrayTile(Array.ofDim[Double](2).fill(0), 1, 1)
+
+      int.combine(dt)(_ + _).cellType shouldBe int.cellType.union(dt.cellType)
+    }
+  }
 }
 
 object ArrayTileSpec {

--- a/raster/src/test/scala/geotrellis/raster/CompositeTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/CompositeTileSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.funspec.AnyFunSpec
 import spire.syntax.cfor._
 
 class CompositeTileSpec extends AnyFunSpec with TileBuilders with RasterMatchers with TestFiles {
-  describe("wrap") {
+  describe("CompositeTileSpec wrap") {
     it("wraps a literal raster") {
       val r =
         createTile(
@@ -49,7 +49,7 @@ class CompositeTileSpec extends AnyFunSpec with TileBuilders with RasterMatchers
         arr.toSet.size should be (1)
         values += arr(0)
       }
-      values.toSeq.sorted.toSeq should be (Seq(1, 2, 3, 4, 5, 6))
+      values.toSeq.sorted should be (Seq(1, 2, 3, 4, 5, 6))
 
       assertEqual(r, tiled)
     }
@@ -150,6 +150,27 @@ class CompositeTileSpec extends AnyFunSpec with TileBuilders with RasterMatchers
       actualExtent should be (extent)
       assertEqual(actualTile, tile)
 
+    }
+  }
+
+  describe("CompositeTile cellType combine") {
+    it("should union cellTypes") {
+      val int = {
+        val r =
+          createTile(
+            Array(1, 1, 1, 2, 2, 2, 3, 3, 3,
+              1, 1, 1, 2, 2, 2, 3, 3, 3,
+
+              4, 4, 4, 5, 5, 5, 6, 6, 6,
+              4, 4, 4, 5, 5, 5, 6, 6, 6),
+            9, 4)
+
+        val tl = TileLayout(3, 2, 3, 2)
+        CompositeTile.wrap(r, tl)
+      }
+      val dt = int.convert(DoubleCellType)
+
+      int.combine(dt)(_ + _).cellType shouldBe int.cellType.union(dt.cellType)
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
@@ -83,6 +83,14 @@ class ConstantTileSpec extends AnyFunSpec with Matchers with RasterMatchers with
       val r1 = ConstantTile.fromBytes(t1.toBytes(), t1.cellType, cols, rows)
       assert(t1 === r1)
     }
+  }
 
+  describe("ConstantTile cellType combine") {
+    it("should union cellTypes") {
+      val int = IntConstantTile(-65536, 1, 1)
+      val dt = DoubleConstantTile(-Math.E, 1, 1)
+
+      int.combine(dt)(_ + _).cellType shouldBe int.cellType.union(dt.cellType)
+    }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/CroppedTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/CroppedTileSpec.scala
@@ -22,7 +22,6 @@ import geotrellis.vector.Extent
 import org.scalatest.funspec.AnyFunSpec
 
 class CroppedTileSpec extends AnyFunSpec with TileBuilders with RasterMatchers with TestFiles {
-
   describe("CroppedTileSpec") {
     it("should combine cropped tile") {
       val r = createTile(
@@ -41,6 +40,27 @@ class CroppedTileSpec extends AnyFunSpec with TileBuilders with RasterMatchers w
         4, 4, 4,
         4, 4, 4,
         4, 4, 4))
+    }
+  }
+
+  describe("CroppedTile cellType combine") {
+    it("should union cellTypes") {
+      val int = {
+        val r = createTile(
+          Array[Int](
+            1, 1, 1, 1, 1,
+            1, 2, 2, 2, 1,
+            1, 2, 2, 2, 1,
+            1, 2, 2, 2, 1,
+            1, 1, 1, 1, 1))
+
+        val sourceExtent = Extent(0, 0, 5, 5)
+        val targetExtent = Extent(1, 1, 4, 4)
+        CroppedTile(r, sourceExtent, targetExtent).toArrayTile
+      }
+      val dt = int.convert(DoubleCellType)
+
+      int.combine(dt)(_ + _).cellType shouldBe int.cellType.union(dt.cellType)
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/PaddedTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/PaddedTileSpec.scala
@@ -117,4 +117,13 @@ class PaddedTileSpec extends AnyFunSpec with Matchers with RasterMatchers {
 
     assertEqual(copy, expected)
   }
+
+  describe("PaddedTile cellType combine") {
+    it("should union cellTypes") {
+      val int = padded
+      val dt = padded.convert(DoubleCellType)
+
+      int.combine(dt)(_ + _).cellType shouldBe int.cellType.union(dt.cellType)
+    }
+  }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffTileSpec.scala
@@ -98,4 +98,13 @@ class GeoTiffTileSpec extends AnyFunSpec with RasterMatchers with TileBuilders w
       assertEqual(actual, expected)
     }
   }
+
+  describe("GeoTiffTile cellType combine") {
+    it("should union cellTypes") {
+      val int = IntArrayTile(Array.ofDim[Int](2).fill(0), 1, 1).toGeoTiffTile()
+      val dt = DoubleArrayTile(Array.ofDim[Double](2).fill(0), 1, 1).toGeoTiffTile()
+
+      int.combine(dt)(_ + _).cellType shouldBe int.cellType.union(dt.cellType)
+    }
+  }
 }


### PR DESCRIPTION
# Overview

This PR fixes an inconsistent API behavior and forces all combine function to behave like [ArrayTile.combine](https://github.com/locationtech/geotrellis/blob/v3.4.1/raster/src/main/scala/geotrellis/raster/ArrayTile.scala#L201)

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] Unit tests added for bug-fix or new feature

Closes #3170
