### PR TITLE
Add a safe WKTParser.parse function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GDAL up to 3.1 [#3279](https://github.com/locationtech/geotrellis/pull/3279)
 - Fix GeoTiff writer does not currently support WebMercator projection with no EPSG code set [#3281](https://github.com/locationtech/geotrellis/issues/3281)
 - Fix Tile combine should union cellTypes [#3284](https://github.com/locationtech/geotrellis/pull/3284)
+- Fix CRS.fromWKT function throws [#3209](https://github.com/locationtech/geotrellis/issues/3209)
 
 ## [3.4.1] - 2020-07-16
 

--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -68,7 +68,7 @@ object CRS {
   def fromWKT(wktString: String): Option[CRS] = {
     val fromEpsgCode = WKT.getEpsgStringCode(wktString).map(fromName)
     if(fromEpsgCode.isEmpty) {
-      WKTParser(wktString) match {
+      WKTParser.parse(wktString).toOption.flatMap {
         case wkt: ProjCS =>
           wkt.extension.flatMap {
             case ExtensionProj4(proj4String) =>

--- a/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKT.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKT.scala
@@ -51,19 +51,20 @@ object WKT {
     * @return
     */
   def getEpsgCode(wktString: String): Option[Int] = {
-    val wktParsed = WKTParser(wktString)
-    val db = parsed.find { case (_, wkt) => wkt == wktParsed }.map(_._1)
-    if(db.nonEmpty) db
-    else
-      wktParsed match {
-        case wkt: ProjCS =>
-          wkt.extension.flatMap {
-            case ExtensionProj4(proj4String) =>
-              CRS.fromString(proj4String).epsgCode
-            case _ => None
-          }
-        case _ => None
-      }
+    WKTParser.parse(wktString).toOption.flatMap { wktParsed =>
+      val db = parsed.find { case (_, wkt) => wkt == wktParsed }.map(_._1)
+      if (db.nonEmpty) db
+      else
+        wktParsed match {
+          case wkt: ProjCS =>
+            wkt.extension.flatMap {
+              case ExtensionProj4(proj4String) =>
+                CRS.fromString(proj4String).epsgCode
+              case _ => None
+            }
+          case _ => None
+        }
+    }
   }
 
   /**

--- a/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKTParser.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKTParser.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.proj4.io.wkt
 
+import scala.util.Try
 import scala.util.parsing.combinator.RegexParsers
 
 object WKTParser extends RegexParsers {
@@ -121,7 +122,7 @@ object WKTParser extends RegexParsers {
 
   def wktCS: Parser[WktCS] = localcs | projcs | geogcs | geoccs | compdcs | vertcs
 
-  def apply(wktString: String) : WktCS = {
+  def apply(wktString: String): WktCS = {
     val cleanWkt = wktString.replaceAll("\n", "")
     parseAll(wktCS, cleanWkt) match {
       case Success(wktObject, _) =>
@@ -134,4 +135,5 @@ object WKTParser extends RegexParsers {
     }
   }
 
+  def parse(wktString: String): Try[WktCS] = Try(apply(wktString))
 }

--- a/proj4/src/test/scala/geotrellis/proj4/CRSTest.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/CRSTest.scala
@@ -80,4 +80,8 @@ class CRSTest extends AnyFunSpec with Inspectors {
       assert(!str.contains("$") && !str.contains("@"))
     }
   }
+
+  it("CRS.fromWKT should not throw on an incorrect input") {
+    assert(CRS.fromWKT("") == Option.empty[CRS])
+  }
 }


### PR DESCRIPTION
# Overview

This PR fixes the `CRS.fromWKT` function behavior. It could throw, however, acording to its signature, it should handle the incorrect input.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] Unit tests added for bug-fix or new feature

Closes https://github.com/locationtech/geotrellis/issues/3209
