### PR TITLE
Fix Encoder[GeometryCollection]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Fix `Encoder[GeometryCollection]` including subclasses of GeometryCollection twice in the json
+   (MultiPolygon, Multipoint,MultiLinestring) [#3167](https://github.com/locationtech/geotrellis/issues/3167)
+
 ## [3.5.0] - 2020-08-18
 
 ### Added

--- a/vector/src/main/scala/geotrellis/vector/io/json/GeometryFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/GeometryFormats.scala
@@ -177,7 +177,7 @@ trait GeometryFormats {
       Json.obj(
         "type" -> "GeometryCollection".asJson,
         "geometries" -> 
-          obj.geometries.collect({
+          obj.geometries.collect {
             case geom: Point => geom.asJson
             case geom: LineString => geom.asJson
             case geom: Polygon => geom.asJson
@@ -185,7 +185,7 @@ trait GeometryFormats {
             case geom: MultiPoint => geom.asJson
             case geom: MultiLineString => geom.asJson
             case geom: GeometryCollection => geom.asJson
-          }).asJson
+          }.asJson
       )
     }
 

--- a/vector/src/main/scala/geotrellis/vector/io/json/GeometryFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/GeometryFormats.scala
@@ -176,15 +176,16 @@ trait GeometryFormats {
     Encoder.encodeJson.contramap[GeometryCollection] { obj =>
       Json.obj(
         "type" -> "GeometryCollection".asJson,
-        "geometries" -> Vector(
-          obj.getAll[Point].map(_.asJson),
-          obj.getAll[LineString].map(_.asJson),
-          obj.getAll[Polygon].map(_.asJson),
-          obj.getAll[MultiPoint].map(_.asJson),
-          obj.getAll[MultiLineString].map(_.asJson),
-          obj.getAll[MultiPolygon].map(_.asJson),
-          obj.getAll[GeometryCollection].map(_.asJson)
-        ).flatten.asJson
+        "geometries" -> 
+          obj.geometries.collect({
+            case geom: Point => geom.asJson
+            case geom: LineString => geom.asJson
+            case geom: Polygon => geom.asJson
+            case geom: MultiPolygon => geom.asJson
+            case geom: MultiPoint => geom.asJson
+            case geom: MultiLineString => geom.asJson
+            case geom: GeometryCollection => geom.asJson
+          }).asJson
       )
     }
 


### PR DESCRIPTION

# Overview
Encoding a GeometryCollection with a Multipolygon/MultiPoint/MultiLineString should serialize those geometries once

Current behavior encodes them in geometries as both `type: MultiX` and `type: GeometryCollection`

## Checklist

- [X] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [X] Unit tests added for bug-fix or new feature


Closes #3167 
