### PR TITLE
Create Ellipsoidal.scala

### DIFF
--- a/proj4/src/main/scala/geotrellis/proj4/Ellipsoidal.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/Ellipsoidal.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Astraea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.proj4
 
 import geotrellis.proj4.CRS

--- a/proj4/src/main/scala/geotrellis/proj4/Ellipsoidal.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/Ellipsoidal.scala
@@ -1,0 +1,10 @@
+package geotrellis.proj4
+
+import geotrellis.proj4.CRS
+import geotrellis.proj4.CRS.ObjectNameToString
+
+object Ellipsoidal extends CRS with ObjectNameToString {
+  lazy val proj4jCrs = factory.createFromName("EPSG:3785")
+
+  override val epsgCode: Option[Int] = Some(3785)
+}


### PR DESCRIPTION
Added  WGS84 of EPSG:3785 CRS projection support. This standard consider earth as a ellipsoid.

# Overview

Brief description of what this PR does, and why it is needed.

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #XXX
