### PR TITLE
Fix GeometryCollection::getAll extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fix `Encoder[GeometryCollection]` including subclasses of GeometryCollection twice in the json
    (MultiPolygon, Multipoint,MultiLinestring) [#3167](https://github.com/locationtech/geotrellis/issues/3167)
--Fix `LayoutTileSource` buffer should only be 1/2 a cellsize to avoid going out of bounds and creating `NODATA` values [#3302](https://github.com/locationtech/geotrellis/pull/3302)
+- Fix `LayoutTileSource` buffer should only be 1/2 a cellsize to avoid going out of bounds and creating `NODATA` values [#3302](https://github.com/locationtech/geotrellis/pull/3302)
 - Remove unused allocation from CroppedTile [#3297](https://github.com/locationtech/geotrellis/pull/3297)
+- Fix GeometryCollection::getAll extension method [#3295](https://github.com/locationtech/geotrellis/pull/3295)
 
 ## [3.5.0] - 2020-08-18
 

--- a/vector/src/main/scala/geotrellis/vector/methods/GeometryCollectionMethods.scala
+++ b/vector/src/main/scala/geotrellis/vector/methods/GeometryCollectionMethods.scala
@@ -25,7 +25,7 @@ trait ExtraGeometryCollectionMethods extends MethodExtensions[GeometryCollection
   def getAll[G <: Geometry : ClassTag]: Seq[G] = {
     val lb = scala.collection.mutable.ListBuffer.empty[G]
     cfor(0)(_ < self.getNumGeometries, _ + 1){ i =>
-      if (classTag[G].runtimeClass.isInstance(self.getGeometryN(i)))
+      if (classTag[G].runtimeClass == self.getGeometryN(i).getClass)
         lb += self.getGeometryN(i).asInstanceOf[G]
     }
     lb.toSeq

--- a/vector/src/test/scala/spec/geotrellis/vector/GeometryCollectionSpec.scala
+++ b/vector/src/test/scala/spec/geotrellis/vector/GeometryCollectionSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.vector
+
+import geotrellis.proj4.{LatLng, WebMercator}
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funspec.AnyFunSpec
+
+class GeometryCollectionSpec extends AnyFunSpec with Matchers {
+  describe("GeometryCollection") {
+    it("should reproject without duplication") {
+      val p = Point(1,1)
+      val mp = MultiPoint(p, p)
+      val gc = GeometryCollection(multiPoints = Seq(mp))
+
+      val pp = p.reproject(LatLng, WebMercator)
+      val mpp = MultiPoint(pp, pp)
+      val gcp = GeometryCollection(multiPoints = Seq(mpp))
+
+      gc.reproject(LatLng, WebMercator) should be (gcp)
+    }
+
+    it("getAll should work right for all types") {
+      val p0 = Point(0, 0)
+      val p1 = Point(1, 0)
+      val p2 = Point(0, 1)
+      val ls = LineString(p0, p1)
+      val pg = Polygon(p0, p1, p2, p0)
+      val mp = MultiPoint(p0, p1, p2)
+      val mpg = MultiPolygon(pg)
+      val mls = MultiLineString(ls)
+      val gc = GeometryCollection(points = Seq(p0))
+
+      val gc1 = GeometryCollection(points = Seq(p0),
+                                   lines = Seq(ls),
+                                   polygons = Seq(pg),
+                                   multiPoints = Seq(mp),
+                                   multiLines = Seq(mls),
+                                   multiPolygons = Seq(mpg),
+                                   geometryCollections = Seq(gc))
+
+      gc1.getAll[Point] should be (Seq(p0))
+      gc1.getAll[LineString] should be (Seq(ls))
+      gc1.getAll[Polygon] should be (Seq(pg))
+      gc1.getAll[MultiPoint] should be (Seq(mp))
+      gc1.getAll[MultiLineString] should be (Seq(mls))
+      gc1.getAll[MultiPolygon] should be (Seq(mpg))
+      gc1.getAll[GeometryCollection] should be (Seq(gc))
+    }
+  }
+}


### PR DESCRIPTION
# Overview

As noted in #3289, we have some problems dealing with `GeometryCollection`s.  This bug was traced to the implementation of `getAll` which used reflection to extract the contained geometries that matched a desired type.  This was intended to be used to extract specific types or subclasses (`gc.getAll[Geometry]` would be useful).  The problem was with `gc.getAll(GeometryCollection)`, since `MultiPoint`, `MultiLineString`, and `MultiPolygon` are subclasses of `GeometryCollection`.  Therefore, `gc.getAll[GeometryCollection]` would return all `Multi*` and `GeometryCollection` entities.  This caused problems for methods like `reproject`, which would duplicate `Multi*` elements.

This PR, in it's first form, is for discussion purposes.  The simple solution presented here is that `getAll` loses it's subclass semantic.  This is the most straightforward, requiring no additional changes, but it does break the semantics, and therefore, technically must wait for GT 4.  A more laborious change could be implemented, keeping the subclass semantics of the old `getAll` implementation, but reimplementing `reproject` and other functions that don't correctly differentiate types.  This latter solution is more work, but may be preferred to maintain certain functionality.  

In all cases, GT 3 broke with the model of GT 2 and down where the contents of geometry collections were explicitly compartmentalized, so we might have some latitude for bending semver rules, as this PR's content can be seen as a bugfix of a broken API rather than a change of interface.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [X] Unit tests added for bug-fix or new feature

## Notes

Closes #3289 
