### PR TITLE
Update gdal-warp-bindings v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -Fix `LayoutTileSource` buffer should only be 1/2 a cellsize to avoid going out of bounds and creating `NODATA` values [#3302](https://github.com/locationtech/geotrellis/pull/3302)
 - Remove unused allocation from CroppedTile [#3297](https://github.com/locationtech/geotrellis/pull/3297)
 
+### Fixed
+- gdal-warp-bindings 1.1.1 bugfix release addresses a crash when initializing the bindings on MacOS. See https://github.com/geotrellis/gdal-warp-bindings#macos
+
 ## [3.5.0] - 2020-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    (MultiPolygon, Multipoint,MultiLinestring) [#3167](https://github.com/locationtech/geotrellis/issues/3167)
 -Fix `LayoutTileSource` buffer should only be 1/2 a cellsize to avoid going out of bounds and creating `NODATA` values [#3302](https://github.com/locationtech/geotrellis/pull/3302)
 - Remove unused allocation from CroppedTile [#3297](https://github.com/locationtech/geotrellis/pull/3297)
-
-### Fixed
 - gdal-warp-bindings 1.1.1 bugfix release addresses a crash when initializing the bindings on MacOS. See https://github.com/geotrellis/gdal-warp-bindings#macos
 
 ## [3.5.0] - 2020-08-18

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Version {
   val hadoop      = "2.8.5"
   val spark       = "2.4.4"
   val gdal        = "3.1.0"
-  val gdalWarp    = "1.1.0"
+  val gdalWarp    = "1.1.1"
 
   val previousVersion = "3.4.0"
 }


### PR DESCRIPTION
# Overview

Updates gdal-warp-bindings to the newly released 1.1.1 to address MacOS dylib issues.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] GDALWarp bindings 1.1.1 [CQ #22803](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22803)

