### PR TITLE
Remove explicit unused Scaffeine dependency from projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Remove explicit unused Scaffeine dependency from projects [#3314](https://github.com/locationtech/geotrellis/pull/3314)
+
 ## [3.5.1] - 2020-11-23
 
 ### Changed

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ lazy val `cassandra-spark` = project
 lazy val hbase = project
   .dependsOn(store)
   .settings(Settings.hbase)
-  .settings(projectDependencies := { Seq((layer / projectID).value.exclude("com.google.protobuf", "protobuf-java")) })
+  .settings(projectDependencies := { Seq((store / projectID).value.exclude("com.google.protobuf", "protobuf-java")) })
 
 lazy val `hbase-spark` = project
   .dependsOn(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -484,7 +484,6 @@ object Settings {
     libraryDependencies ++= Seq(
       awsSdkS3 excludeAll ExclusionRule("com.fasterxml.jackson.core"),
       spire,
-      scaffeine,
       scalatest % Test
     ),
     /** https://github.com/lucidworks/spark-solr/issues/179 */
@@ -518,7 +517,6 @@ object Settings {
     libraryDependencies ++= Seq(
       sparkCore % Provided,
       spire,
-      scaffeine,
       sparkSql % Test,
       scalatest % Test
     ),
@@ -559,8 +557,7 @@ object Settings {
       chronoscala,
       sparkSql % Test,
       scalatest % Test,
-      logging,
-      scaffeine
+      logging
     ),
     mimaPreviousArtifacts := Set(
       "org.locationtech.geotrellis" %% "geotrellis-spark" % Version.previousVersion
@@ -671,7 +668,6 @@ object Settings {
       spire,
       chronoscala,
       logging,
-      scaffeine,
       uzaygezenCore,
       pureconfig,
       scalactic,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -433,8 +433,7 @@ object Settings {
       openCSV,
       parserCombinators,
       scalatest % Test,
-      scalacheck % Test,
-      scaffeine
+      scalacheck % Test
     ),
     // https://github.com/sbt/sbt/issues/4609
     Test / fork := true


### PR DESCRIPTION
# Overview

We need to review dependecnies usage in the project modules. A great example of an unused dependency is SCaffeine which is definitely not used in `geotrellis-proj4`. 

- [x] SCaffeine

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
