### PR TITLE
Fix sbt unidoc build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val root = Project("geotrellis", file("."))
     `hbase-spark`,
     layer,
     macros,
+    mdoc,
     proj4,
     raster,
     `raster-testkit`,
@@ -41,6 +42,7 @@ lazy val root = Project("geotrellis", file("."))
 lazy val mdoc = project
   .dependsOn(raster)
   .enablePlugins(MdocPlugin)
+  .settings(publish / skip := true)
   .settings(Settings.mdoc)
 
 lazy val macros = project

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,6 @@ lazy val root = Project("geotrellis", file("."))
   .settings(unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject)
 
 lazy val mdoc = project
-  .in(file("."))
   .dependsOn(raster)
   .enablePlugins(MdocPlugin)
   .settings(Settings.mdoc)


### PR DESCRIPTION
# Overview

Fixes an erroneous commit in #3317 that wasn't caught by the PR build because the issue was in the scaladoc `unidoc` build.

## Demo

Here's a local run of `./sbt unidoc` moving past the error in the [CI build](https://app.circleci.com/pipelines/github/locationtech/geotrellis/150/workflows/d0a3c510-45a3-4218-837a-0c22c183e413/jobs/1601) where it couldn't find the `unidoc` task:

![Screen Shot 2020-12-16 at 12 58 10 PM](https://user-images.githubusercontent.com/1818302/102387423-5b0ea080-3f9e-11eb-9a5f-991a9d0349f1.png)

## Testing

Run `./sbt unidoc` on `master` -- it should fail with the error in CI. Switch to this branch and run `./sbt unidoc`. It should succeed.
