### PR TITLE
Exclude mdoc project from the unidoc generation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -183,6 +183,7 @@ lazy val util = project
 
 lazy val `doc-examples` = project
   .dependsOn(spark, `s3-spark`, `accumulo-spark`, `cassandra-spark`, `hbase-spark`, spark, `spark-testkit`, `spark-pipeline`)
+  .settings(publish / skip := true)
   .settings(Settings.`doc-examples`)
 
 lazy val bench = project

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val root = Project("geotrellis", file("."))
   .enablePlugins(ScalaUnidocPlugin)
   .settings(Settings.commonSettings)
   .settings(publish / skip := true)
-  .settings(unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject)
+  .settings(ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(mdoc))
 
 lazy val mdoc = project
   .dependsOn(raster)
@@ -56,7 +56,7 @@ lazy val vector = project
   .dependsOn(proj4, util)
   .settings(Settings.vector)
   .settings(
-    Test / unmanagedClasspath ++= (fullClasspath in (LocalProject("vector-testkit"), Compile)).value
+    Test / unmanagedClasspath ++= (LocalProject("vector-testkit") / Compile / fullClasspath).value
   )
 
 lazy val `vector-testkit` = project
@@ -71,10 +71,10 @@ lazy val raster = project
   .dependsOn(util, macros, vector)
   .settings(Settings.raster)
   .settings(
-    Test / unmanagedClasspath ++= (fullClasspath in (LocalProject("raster-testkit"), Compile)).value
+    Test / unmanagedClasspath ++= (LocalProject("raster-testkit") / Compile / fullClasspath).value
   )
   .settings(
-    Test / unmanagedClasspath ++= (fullClasspath in (LocalProject("vector-testkit"), Compile)).value
+    Test / unmanagedClasspath ++= (LocalProject("vector-testkit") / Compile / fullClasspath).value
   )
 
 lazy val `raster-testkit` = project
@@ -88,7 +88,7 @@ lazy val spark = project
     // This takes care of a pseudo-cyclic dependency between the `spark` test scope, `spark-testkit`,
     // and `spark` main (compile) scope. sbt is happy with this. IntelliJ requires that `spark-testkit`
     // be added to the `spark` module dependencies manually (via "Open Module Settings" context menu for "spark" module).
-    Test / unmanagedClasspath ++= (fullClasspath in (LocalProject("spark-testkit"), Compile)).value
+    Test / unmanagedClasspath ++= (LocalProject("spark-testkit") / Compile / fullClasspath).value
   )
 
 lazy val `spark-testkit` = project

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -224,7 +224,6 @@ object Settings {
 
   lazy val `doc-examples` = Seq(
     name := "geotrellis-doc-examples",
-    publish / skip := true,
     scalacOptions ++= commonScalacOptions,
     libraryDependencies ++= Seq(
       sparkCore,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -431,7 +431,6 @@ object Settings {
 
   lazy val mdoc = Seq(
     name := "geotrellis-mdoc",
-    libraryDependencies ++= Seq(),
     mdocIn := new File("docs-mdoc"),
     mdocOut := new File("website/docs"),
     mdocVariables := Map(

--- a/sbt
+++ b/sbt
@@ -34,10 +34,10 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.3.13"
-declare -r sbt_unreleased_version="1.4.0-M1"
+declare -r sbt_release_version="1.4.4"
+declare -r sbt_unreleased_version="1.4.4"
 
-declare -r latest_213="2.13.3"
+declare -r latest_213="2.13.4"
 declare -r latest_212="2.12.12"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
@@ -471,7 +471,7 @@ process_args() {
       -trace)       require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
       -debug-inc)   addJava "-Dxsbt.inc.debug=true" && shift ;;
 
-      -no-colors)   addJava "-Dsbt.log.noformat=true" && shift ;;
+      -no-colors)   addJava "-Dsbt.log.noformat=true" && addJava "-Dsbt.color=false" && shift ;;
       -sbt-create)  sbt_create=true && shift ;;
       -sbt-dir)     require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
       -sbt-boot)    require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;


### PR DESCRIPTION
# Overview

This PR fixes the project unidoc generation. It is interesting that the message generated by SBT is so confusing though.
It is a follow up to #3320. It looks like during the #3320 test no one could wait until the successful exit.

## Testing

`./sbt unidoc` -- it should not fail locally or in CI. It is not a fast command to test.

