### PR TITLE
Review and cleanup build.sbt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Operating System Files
+
+*.DS_Store
+Thumbs.db
+
+# Docs
+
 index.html
 index.js
 package.html
@@ -5,49 +12,82 @@ lib
 site/
 docs/_build/
 
-project/boot
-project/plugins/project
-project/plugins/target
-project/target
-target
-.ensime*
-.metals/
-.idea
-project/metals.sbt
-\#*#
-*~
-.#*
-.lib
-*.aux.xml
-*.jar
-*.crc
-_SUCCESS
+# Build Files
 
-*.pyc
-.project
+bin
+target
+build/
+.gradle
+cmake-build-debug
+
+# Eclipse Project Files
+
 .classpath
-.cache
+.project
 .settings
-.history
-*.bloop
-.DS_Store
+
+# IntelliJ IDEA Files
+
 *.iml
-*.swp
-*.swo
-*.sublime-*
-.vagrant
+*.ipr
+*.iws
+*.idea
+
+# Spring Bootstrap artifacts
+
+dependency-reduced-pom.xml
+README.html
+
+# Sublime files
+
+*.sublime-workspace
+
+# VSCode files
+
+.vscode
+.history
+
+# Metals
+
+.metals
+.bloop
+metals.sbt
+
+# SBT
+
+.bsp
+
+# Terraform
 
 .terraform
 scripts/emr/terraform/variables.tf*
 scripts/emr/terraform/terraform.tfstate*
 
+# Vagrant
+
+.vagrant
+
+# Test files
+
+spark/src/test/resources/vlm/*catalog*
+
+# Other
+
+.#*
+.lib
+*.aux.xml
+*.jar
+*.crc
+
+_SUCCESS
+
+*.pyc
+.cache
+.settings
+*.swp
+*.swo
+
 nohup.out
 derby.log
 metastore_db/
 *.log
-
-spark/src/test/resources/vlm/*catalog*
-
-
-# vscode
-.vscode

--- a/build.sbt
+++ b/build.sbt
@@ -133,8 +133,8 @@ lazy val `cassandra-spark` = project
 
 lazy val hbase = project
   .dependsOn(store)
-  .settings(Settings.hbase)
   .settings(projectDependencies := { Seq((store / projectID).value.exclude("com.google.protobuf", "protobuf-java")) })
+  .settings(Settings.hbase)
 
 lazy val `hbase-spark` = project
   .dependsOn(
@@ -142,8 +142,8 @@ lazy val `hbase-spark` = project
     spark % "compile->compile;test->test", // <-- spark-testkit update should simplify this
     `spark-testkit` % Test
   )
+  .settings(projectDependencies := { Seq((hbase / projectID).value, (spark / projectID).value.exclude("com.google.protobuf", "protobuf-java")) })
   .settings(Settings.`hbase-spark`)
-  .settings(projectDependencies := { Seq((spark / projectID).value.exclude("com.google.protobuf", "protobuf-java")) })
 
 lazy val `spark-pipeline` = Project(id = "spark-pipeline", base = file("spark-pipeline")).
   dependsOn(spark, `s3-spark`, `spark-testkit` % "test").

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,8 +48,8 @@ object Dependencies {
 
   def cats(module: String) = Def.setting {
     module match {
-      case "core"   => "org.typelevel" %% s"cats-$module" % ver("1.6.1", "2.1.1").value
       case "effect" => "org.typelevel" %% s"cats-$module" % ver("1.3.1", "2.1.3").value
+      case _        => "org.typelevel" %% s"cats-$module" % ver("1.6.1", "2.1.1").value
     }
   }
 
@@ -65,10 +65,12 @@ object Dependencies {
     "io.lemonlabs" %% "scala-uri" % ver("1.4.10", "1.5.1").value
   }
 
+  def scalaReflect(version: String) = "org.scala-lang" % "scala-reflect" % version
+
   val sparkCore           = "org.apache.spark"           %% "spark-core"               % Version.spark
   val sparkSql            = "org.apache.spark"           %% "spark-sql"                % Version.spark
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"               % "0.13.0"
-  val logging             = "org.log4s"                  %% "log4s"                    % "1.8.2"
+  val log4s               = "org.log4s"                  %% "log4s"                    % "1.8.2"
   val scalatest           = "org.scalatest"              %% "scalatest"                % "3.2.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"               % "1.14.3"
   val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"                % "1.3.0"
@@ -78,6 +80,7 @@ object Dependencies {
   val spire               = "org.spire-math"             %% "spire"                    % Version.spire
   val spireMacro          = "org.spire-math"             %% "spire-macros"             % Version.spire
   val apacheIO            = "commons-io"                  % "commons-io"               % "2.7"
+  val apacheLang3         = "org.apache.commons"          % "commons-lang3"            % "3.10"
   val apacheMath          = "org.apache.commons"          % "commons-math3"            % "3.6.1"
   val chronoscala         = "jp.ne.opt"                  %% "chronoscala"              % "0.3.2"
   val awsSdkS3            = "software.amazon.awssdk"      % "s3"                       % "2.13.74"
@@ -85,14 +88,18 @@ object Dependencies {
   val avro                = "org.apache.avro"             % "avro"                     % "1.7.7"
   val parserCombinators   = "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.1.2"
   val jsonSchemaValidator = "com.networknt"               % "json-schema-validator"    % "0.1.23"
-  val scaffeine           = "com.github.blemale"         %% "scaffeine"                % "4.0.1"
   val accumuloCore        = "org.apache.accumulo"         % "accumulo-core"            % Version.accumulo
   val sl4jnop             = "org.slf4j"                   % "slf4j-nop"                % "1.7.25"
   val cassandraDriverCore = "com.datastax.cassandra"      % "cassandra-driver-core"    % Version.cassandra
+  val guava               = "com.google.guava"            % "guava"                    % "16.0.1"
+  
   val geomesaJobs              = "org.locationtech.geomesa" %% "geomesa-jobs"               % Version.geomesa
   val geomesaAccumuloJobs      = "org.locationtech.geomesa" %% "geomesa-accumulo-jobs"      % Version.geomesa
   val geomesaAccumuloDatastore = "org.locationtech.geomesa" %% "geomesa-accumulo-datastore" % Version.geomesa
   val geomesaUtils             = "org.locationtech.geomesa" %% "geomesa-utils"              % Version.geomesa
+
+  val scaffeine = "com.github.blemale"           %% "scaffeine" % "4.0.1"
+  val caffeine  = "com.github.ben-manes.caffeine" % "caffeine"  % "2.8.4"
 
   val geotoolsCoverage    = "org.geotools"                 % "gt-coverage"             % Version.geotools
   val geotoolsHsql        = "org.geotools"                 % "gt-epsg-hsql"            % Version.geotools
@@ -100,7 +107,12 @@ object Dependencies {
   val geotoolsReferencing = "org.geotools"                 % "gt-referencing"          % Version.geotools
   val geotoolsGeoTiff     = "org.geotools"                 % "gt-geotiff"              % Version.geotools
   val geotoolsShapefile   = "org.geotools"                 % "gt-shapefile"            % Version.geotools
+  val geotoolsMetadata    = "org.geotools"                 % "gt-metadata"             % Version.geotools
+  val geotoolsOpengis     = "org.geotools"                 % "gt-opengis"              % Version.geotools
 
+  val imageioExtUtilities = "it.geosolutions.imageio-ext"      % "imageio-ext-utilities" % "1.3.2"
+  val jtUtilities         = "it.geosolutions.jaiext.utilities" % "jt-utilities"          % "1.1.15"
+  
   // located in the OSGeo repo: https://repo.osgeo.org/repository/release/
   val jaiCore             = "javax.media" % "jai_core"     % "1.1.3"
 
@@ -132,6 +144,8 @@ object Dependencies {
   val scalaj              = "org.scalaj"                  %% "scalaj-http"             % "2.4.2"
 
   val scalapbRuntime      = "com.thesamet.scalapb"        %% "scalapb-runtime"         % scalapb.compiler.Version.scalapbVersion
+  val scalapbLenses       = "com.thesamet.scalapb"        %% "lenses"                  % scalapb.compiler.Version.scalapbVersion
+  val protobufJava        = "com.google.protobuf"          % "protobuf-java"           % "3.8.0"
 
   val squants             = "org.typelevel"               %% "squants"                 % "1.7.0"
   val scalactic           = "org.scalactic"               %% "scalactic"               % "3.2.1"
@@ -143,4 +157,8 @@ object Dependencies {
   val jacksonDatabind     = "com.fasterxml.jackson.core"    % "jackson-databind"         % "2.6.7"
   val jacksonAnnotations  = "com.fasterxml.jackson.core"    % "jackson-annotations"      % "2.6.7"
   val jacksonModuleScala  = "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.6.7"
+
+  val shapeless           = "com.chuusai"  %% "shapeless" % "2.3.3"
+  
+  val unitApi             = "javax.measure" % "unit-api"  % "1.0"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -101,8 +101,8 @@ object Dependencies {
   val geotoolsGeoTiff     = "org.geotools"                 % "gt-geotiff"              % Version.geotools
   val geotoolsShapefile   = "org.geotools"                 % "gt-shapefile"            % Version.geotools
 
-  // This is one finicky dependency. Being explicit in hopes it will stop hurting Travis.
-  val jaiCore             = "javax.media" % "jai_core"     % "1.1.3" from "https://repo.osgeo.org/repository/release/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar"
+  // located in the OSGeo repo: https://repo.osgeo.org/repository/release/
+  val jaiCore             = "javax.media" % "jai_core"     % "1.1.3"
 
   val geowaveRaster       = "mil.nga.giat"                 % "geowave-adapter-raster"     % Version.geowave
   val geowaveVector       = "mil.nga.giat"                 % "geowave-adapter-vector"     % Version.geowave

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -89,7 +89,7 @@ object Settings {
 
     credentials ++= List(Path.userHome / ".ivy2" / ".credentials").filter(_.asFile.canRead).map(Credentials(_)),
 
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
+    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.2" cross CrossVersion.full),
     addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.full),
     addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.3.20" cross CrossVersion.full),
 
@@ -127,8 +127,6 @@ object Settings {
       accumuloCore
         exclude("org.jboss.netty", "netty")
         exclude("org.apache.hadoop", "hadoop-client"),
-      spire,
-      scalatest % Test,
       hadoopClient % Provided
     ),
     console / initialCommands :=
@@ -147,8 +145,9 @@ object Settings {
       accumuloCore
         exclude("org.jboss.netty", "netty")
         exclude("org.apache.hadoop", "hadoop-client"),
-      sparkCore % Provided, sparkSql % Test,
-      spire,
+      hadoopClient % Provided,
+      sparkCore % Provided,
+      sparkSql % Test,
       scalatest % Test
     ),
     console / initialCommands :=
@@ -179,9 +178,7 @@ object Settings {
         excludeAll(
         ExclusionRule("org.jboss.netty"), ExclusionRule("io.netty"),
         ExclusionRule("org.slf4j"), ExclusionRule("com.typesafe.akka")
-      ) exclude("org.apache.hadoop", "hadoop-client"),
-      spire,
-      scalatest % Test
+      ) exclude("org.apache.hadoop", "hadoop-client")
     ),
     console / initialCommands :=
       """
@@ -199,11 +196,12 @@ object Settings {
     libraryDependencies ++= Seq(
       cassandraDriverCore
         excludeAll(
-        ExclusionRule("org.jboss.netty"), ExclusionRule("io.netty"),
-        ExclusionRule("org.slf4j"), ExclusionRule("com.typesafe.akka")
-      ) exclude("org.apache.hadoop", "hadoop-client"),
-      sparkCore % Provided, sparkSql % Test,
-      spire,
+          ExclusionRule("org.jboss.netty"), ExclusionRule("io.netty"),
+          ExclusionRule("org.slf4j"), ExclusionRule("com.typesafe.akka")
+        ) exclude("org.apache.hadoop", "hadoop-client"),
+      hadoopClient % Provided,
+      sparkCore % Provided,
+      sparkSql % Test,
       scalatest % Test
     ),
     console / initialCommands :=
@@ -225,7 +223,6 @@ object Settings {
     scalacOptions ++= commonScalacOptions,
     libraryDependencies ++= Seq(
       sparkCore,
-      logging,
       scalatest % Test,
       sparkSql % Test
     )
@@ -237,7 +234,6 @@ object Settings {
       geomesaAccumuloJobs,
       geomesaAccumuloDatastore,
       geomesaUtils,
-      spire,
       scalatest % Test
     ),
     console / initialCommands :=
@@ -256,12 +252,15 @@ object Settings {
     name := "geotrellis-geotools",
     libraryDependencies ++= Seq(
       jaiCore,
-      jts,
-      spire,
+      unitApi,
       geotoolsCoverage,
       geotoolsHsql,
       geotoolsMain,
       geotoolsReferencing,
+      geotoolsMetadata,
+      geotoolsOpengis,
+      imageioExtUtilities,
+      jtUtilities,
       geotoolsGeoTiff % Test,
       geotoolsShapefile % Test,
       scalatest % Test
@@ -319,7 +318,6 @@ object Settings {
       kryoSerializers exclude("com.esotericsoftware", "kryo"),
       kryoShaded,
       sparkCore % Provided,
-      spire,
       sparkSql % Test,
       scalatest % Test
     ),
@@ -351,20 +349,17 @@ object Settings {
   lazy val hbase = Seq(
     name := "geotrellis-hbase",
     libraryDependencies ++= Seq(
-      hbaseCommon exclude("javax.servlet", "servlet-api"),
-      hbaseClient exclude("javax.servlet", "servlet-api"),
-      hbaseMapReduce exclude("javax.servlet", "servlet-api"),
-      hbaseServer exclude("org.mortbay.jetty", "servlet-api-2.5"),
-      hbaseHadoopCompact exclude("javax.servlet", "servlet-api"),
-      hbaseHadoop2Compact exclude("javax.servlet", "servlet-api"),
-      hbaseMetrics exclude("javax.servlet", "servlet-api"),
-      hbaseMetricsApi exclude("javax.servlet", "servlet-api"),
-      hbaseZooKeeper exclude("javax.servlet", "servlet-api"),
-      jacksonCoreAsl,
-      spire,
-      sparkSql % Test,
-      scalatest % Test
-    ),
+      hbaseCommon,
+      hbaseClient,
+      hbaseMapReduce,
+      hbaseServer,
+      hbaseHadoopCompact,
+      hbaseHadoop2Compact,
+      hbaseMetrics,
+      hbaseMetricsApi,
+      hbaseZooKeeper
+    ).map(_ exclude("javax.servlet", "servlet-api") exclude("org.mortbay.jetty", "servlet-api-2.5")),
+    libraryDependencies += jacksonCoreAsl,
     console / initialCommands :=
       """
       import geotrellis.raster._
@@ -379,18 +374,8 @@ object Settings {
   lazy val `hbase-spark` = Seq(
     name := "geotrellis-hbase-spark",
     libraryDependencies ++= Seq(
-      hbaseCommon exclude("javax.servlet", "servlet-api"),
-      hbaseClient exclude("javax.servlet", "servlet-api"),
-      hbaseMapReduce exclude("javax.servlet", "servlet-api"),
-      hbaseServer exclude("org.mortbay.jetty", "servlet-api-2.5"),
-      hbaseHadoopCompact exclude("javax.servlet", "servlet-api"),
-      hbaseHadoop2Compact exclude("javax.servlet", "servlet-api"),
-      hbaseMetrics exclude("javax.servlet", "servlet-api"),
-      hbaseMetricsApi exclude("javax.servlet", "servlet-api"),
-      hbaseZooKeeper exclude("javax.servlet", "servlet-api"),
-      jacksonCoreAsl,
+      hadoopClient % Provided,
       sparkCore % Provided,
-      spire,
       sparkSql % Test,
       scalatest % Test
     ),
@@ -412,7 +397,7 @@ object Settings {
     Compile / sourceGenerators += (Compile / sourceManaged).map(Boilerplate.genMacro).taskValue,
     libraryDependencies ++= Seq(
       spireMacro,
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value
+      scalaReflect(scalaVersion.value)
     )
   ) ++ commonSettings
 
@@ -441,12 +426,9 @@ object Settings {
   lazy val raster = Seq(
     name := "geotrellis-raster",
     libraryDependencies ++= Seq(
-      pureconfig,
-      jts,
-      cats("core").value,
-      spire,
       squants,
-      monocle("core").value, monocle("macro").value,
+      monocle("core").value, 
+      monocle("macro").value,
       scalaXml,
       scalaURI.value,
       scalatest % Test,
@@ -482,7 +464,6 @@ object Settings {
     name := "geotrellis-s3",
     libraryDependencies ++= Seq(
       awsSdkS3 excludeAll ExclusionRule("com.fasterxml.jackson.core"),
-      spire,
       scalatest % Test
     ),
     /** https://github.com/lucidworks/spark-solr/issues/179 */
@@ -514,8 +495,8 @@ object Settings {
   lazy val `s3-spark` = Seq(
     name := "geotrellis-s3-spark",
     libraryDependencies ++= Seq(
+      hadoopClient % Provided,
       sparkCore % Provided,
-      spire,
       sparkSql % Test,
       scalatest % Test
     ),
@@ -539,7 +520,10 @@ object Settings {
     name := "geotrellis-shapefile",
     libraryDependencies ++= Seq(
       jaiCore,
-      geotoolsShapefile
+      geotoolsMain,
+      geotoolsOpengis,
+      geotoolsShapefile,
+      scalatest % Test
     ),
     Test / fork := false
   ) ++ commonSettings
@@ -549,13 +533,8 @@ object Settings {
     libraryDependencies ++= Seq(
       sparkCore % Provided,
       hadoopClient % Provided,
-      uzaygezenCore,
-      avro,
-      spire,
-      chronoscala,
       sparkSql % Test,
-      scalatest % Test,
-      logging
+      scalatest % Test
     ),
     mimaPreviousArtifacts := Set(
       "org.locationtech.geotrellis" %% "geotrellis-spark" % Version.previousVersion
@@ -574,11 +553,9 @@ object Settings {
 
   lazy val `spark-pipeline` = Seq(
     name := "geotrellis-spark-pipeline",
-    libraryDependencies ++= Seq(
-      circe("core").value,
-      circe("generic").value,
+    libraryDependencies ++= Seq(   
       circe("generic-extras").value,
-      circe("parser").value,
+      hadoopClient % Provided,
       sparkCore % Provided,
       sparkSql % Test,
       scalatest % Test
@@ -608,19 +585,17 @@ object Settings {
   lazy val `spark-testkit` = Seq(
     name := "geotrellis-spark-testkit",
     libraryDependencies ++= Seq(
+      hadoopClient % Provided,
       sparkCore % Provided,
       sparkSql % Provided,
-      hadoopClient % Provided,
-      scalatest,
-      chronoscala
+      scalatest
     )
   ) ++ commonSettings
 
   lazy val util = Seq(
     name := "geotrellis-util",
     libraryDependencies ++= Seq(
-      logging,
-      pureconfig,
+      log4s,
       scalaj,
       spire,
       scalatest % Test
@@ -631,10 +606,13 @@ object Settings {
     name := "geotrellis-vector",
     libraryDependencies ++= Seq(
       jts,
+      shapeless,
       pureconfig,
-      circe("core").value, circe("generic").value, circe("parser").value,
+      circe("core").value, 
+      circe("generic").value, 
+      circe("parser").value,
+      cats("core").value,
       apacheMath,
-      spire,
       scalatest % Test,
       scalacheck % Test
     )
@@ -648,8 +626,10 @@ object Settings {
   lazy val vectortile = Seq(
     name := "geotrellis-vectortile",
     libraryDependencies ++= Seq(
-      scalatest % Test,
-      scalapbRuntime % "protobuf"
+      scalapbRuntime % "protobuf",
+      scalapbLenses,
+      protobufJava,
+      scalatest % Test
     ),
     Compile / PB.protoSources:= Seq(file("vectortile/data")),
     Compile / PB.targets := Seq(
@@ -661,13 +641,8 @@ object Settings {
     name := "geotrellis-layer",
     libraryDependencies ++= Seq(
       hadoopClient % Provided,
-      apacheIO,
       avro,
-      spire,
       chronoscala,
-      logging,
-      uzaygezenCore,
-      pureconfig,
       scalactic,
       scalatest % Test
     ),
@@ -684,17 +659,16 @@ object Settings {
     name := "geotrellis-store",
     libraryDependencies ++= Seq(
       hadoopClient % Provided,
+      guava,
       apacheIO,
-      avro,
-      spire,
-      chronoscala,
-      spire,
-      fs2("core").value, fs2("io").value,
-      logging,
       scaffeine,
+      caffeine,
       uzaygezenCore,
-      pureconfig,
       scalaXml,
+      apacheLang3,
+      fs2("core").value, 
+      fs2("io").value,
+      cats("effect").value,
       scalatest % Test
     )
   ) ++ commonSettings
@@ -716,6 +690,7 @@ object Settings {
     name := "geotrellis-gdal-spark",
     libraryDependencies ++= Seq(
       gdalWarp,
+      hadoopClient % Provided,
       sparkCore % Provided,
       sparkSql % Test,
       scalatest % Test

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -34,7 +34,10 @@ object Settings {
     val geosolutions    = "geosolutions" at "https://maven.geo-solutions.it/"
     val ivy2Local       = Resolver.file("local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
     val mavenLocal      = Resolver.mavenLocal
+    val maven           = DefaultMavenRepository
     val local           = Seq(ivy2Local, mavenLocal)
+    val external        = Seq(osgeoReleases, maven, eclipseReleases, geosolutions)
+    val all             = external ++ local
   }
 
   lazy val noForkInTests = Seq(
@@ -105,12 +108,7 @@ object Settings {
       </developers>
     ),
 
-    resolvers ++= Seq(
-      Resolver.mavenLocal,
-      Settings.Repositories.geosolutions,
-      Settings.Repositories.osgeoReleases,
-      Settings.Repositories.eclipseReleases
-    ),
+    externalResolvers := Settings.Repositories.all,
     headerLicense := Some(HeaderLicense.ALv2(java.time.Year.now.getValue.toString, "Azavea")),
     headerMappings := Map(
       FileType.scala -> CommentStyle.cStyleBlockComment.copy(
@@ -242,10 +240,6 @@ object Settings {
       spire,
       scalatest % Test
     ),
-    resolvers ++= Seq(
-      Repositories.osgeoReleases,
-      Repositories.eclipseReleases
-    ),
     console / initialCommands :=
       """
       import geotrellis.raster._
@@ -264,16 +258,14 @@ object Settings {
       jaiCore,
       jts,
       spire,
-      scalatest % Test
-    ) ++ Seq(
       geotoolsCoverage,
       geotoolsHsql,
       geotoolsMain,
       geotoolsReferencing,
       geotoolsGeoTiff % Test,
-      geotoolsShapefile % Test
-    ).map(_ exclude("javax.media", "jai_core")),
-    externalResolvers += Settings.Repositories.osgeoReleases,
+      geotoolsShapefile % Test,
+      scalatest % Test
+    ),
     console / initialCommands :=
       """
       import geotrellis.geotools._
@@ -330,10 +322,6 @@ object Settings {
       spire,
       sparkSql % Test,
       scalatest % Test
-    ),
-    resolvers ++= Seq(
-      Repositories.osgeoReleases,
-      Repositories.geosolutions
     ),
     assembly / assemblyMergeStrategy := {
       case "reference.conf" => MergeStrategy.concat
@@ -551,9 +539,8 @@ object Settings {
     name := "geotrellis-shapefile",
     libraryDependencies ++= Seq(
       jaiCore,
-      geotoolsShapefile exclude("javax.media", "jai_core")
+      geotoolsShapefile
     ),
-    resolvers += Repositories.osgeoReleases,
     Test / fork := false
   ) ++ commonSettings
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.5

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.5
+sbt.version=1.3.13

--- a/s3/src/main/scala/geotrellis/store/s3/S3LayerCopier.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/S3LayerCopier.scala
@@ -42,8 +42,8 @@ class S3LayerCopier(
       val request =
         CopyObjectRequest.builder()
           .copySource(bucket + "/" + s3obj.key)
-          .bucket(bucket)
-          .key(s3obj.key.replace(s"${from.name}/${from.zoom}", s"${to.name}/${to.zoom}"))
+          .destinationBucket(bucket)
+          .destinationKey(s3obj.key.replace(s"${from.name}/${from.zoom}", s"${to.name}/${to.zoom}"))
           .build()
 
       s3Client.copyObject(request)


### PR DESCRIPTION
# Overview

This PR performs the review and cleanup of the entire build.sbt. It also ddresses `jai_core` resolution ordering by defining a strict dependencies resolution ordering.

P.S. These deps added into the build are not new, but just explicit for visibility.

Closes #3322
Closes #3315

#### Testing notes

The local couriser folder is located under `~/Library/Caches/Coursier/v1` on MacOS and under `~/.cache/coursier/v1` on linux, [see docs](https://get-coursier.io/docs/cache.html#default-location).