### PR TITLE
Remove an excessive close after the abort call in S3RangeReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Remove explicit unused Scaffeine dependency from projects [#3314](https://github.com/locationtech/geotrellis/pull/3314)
+- Remove an excessive close after the abort call in S3RangeReader [#3324](https://github.com/locationtech/geotrellis/pull/3324)
 
 ## [3.5.1] - 2020-11-23
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ GeoTrellis is currently available for Scala 2.11 and 2.12, using Spark 2.4.x.
 To get started with SBT, simply add the following to your build.sbt file:
 
 ```scala
-libraryDependencies += "org.locationtech.geotrellis" %% "geotrellis-raster" % "3.0.0"
+libraryDependencies += "org.locationtech.geotrellis" %% "geotrellis-raster" % "<latest version>"
 ```
 
 To grab the latest `SNAPSHOT`, `RC` or milestone build, add these resolvers:

--- a/s3/src/main/scala/geotrellis/store/s3/util/S3RangeReader.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/util/S3RangeReader.scala
@@ -55,8 +55,19 @@ class S3RangeReader(
       val responseStream = client.getObject(request)
       val length = responseStream.response.contentLength
 
+      /**
+        * The response stream is backed by [[org.apache.http.conn.EofSensorInputStream]].
+        * There is no need in closing the stream via close() after calling abort().
+        *
+        * abort() is a special version of close() which prevents
+        * re-use of the underlying connection, if any. Calling this method
+        * indicates that there should be no attempt to read until the end of
+        * the stream.
+        * * throws IOException in case of an IO problem on closing the underlying stream
+        *
+        * Source: https://github.com/apache/httpcomponents-core/blob/5.2.x/httpcore5/src/main/java/org/apache/hc/core5/http/io/EofSensorInputStream.java#L269-L283
+        */
       responseStream.abort()
-      responseStream.close()
       length
     }
   }


### PR DESCRIPTION
# Overview

This PR addresses the issue that happens on newer JVMs (it happened to me after upgrading up to `AdoptOpenJDK 1.8.0_275` from `1.8.0_265`). I'm surprised that this issue is JVM specific. This PR finishes https://github.com/locationtech/geotrellis/pull/3079 and adds explanations of the `abort()` function behavior.

This PR also converts https://github.com/locationtech/geotrellis/issues/3239 into a less pressing issue.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings

## Demo

```scala
import geotrellis.raster.geotiff._

val rs = GeoTiffRasterSource(
  "s3://geotrellis-test/daunnc/tiledb-benchmark/lc8-utm-1.tif"
)

rs.read() // should not fail
```

Without this PR the code snippet above fails with the following error:

```scala
org.apache.http.ConnectionClosedException: Premature end of Content-Length delimited message body (expected: 168,110; received: 0)
  at org.apache.http.impl.io.ContentLengthInputStream.read(ContentLengthInputStream.java:178)
  at org.apache.http.impl.io.ContentLengthInputStream.read(ContentLengthInputStream.java:198)
  at org.apache.http.impl.io.ContentLengthInputStream.close(ContentLengthInputStream.java:101)
  at org.apache.http.impl.execchain.ResponseEntityProxy.streamClosed(ResponseEntityProxy.java:142)
  at org.apache.http.conn.EofSensorInputStream.checkClose(EofSensorInputStream.java:228)
  at org.apache.http.conn.EofSensorInputStream.close(EofSensorInputStream.java:172)
  at java.io.FilterInputStream.close(FilterInputStream.java:181)
  at software.amazon.awssdk.services.s3.checksums.ChecksumValidatingInputStream.close(ChecksumValidatingInputStream.java:162)
  at java.io.FilterInputStream.close(FilterInputStream.java:181)
  at software.amazon.awssdk.core.io.SdkFilterInputStream.close(SdkFilterInputStream.java:83)
  at geotrellis.store.s3.util.S3RangeReader.totalLength$lzycompute(S3RangeReader.scala:59)
  at geotrellis.store.s3.util.S3RangeReader.totalLength(S3RangeReader.scala:44)
  at geotrellis.util.StreamingByteReader.ensureChunk(StreamingByteReader.scala:109)
  at geotrellis.util.StreamingByteReader.get(StreamingByteReader.scala:130)
  at geotrellis.raster.io.geotiff.reader.GeoTiffInfo$.read(GeoTiffInfo.scala:127)
  at geotrellis.raster.io.geotiff.reader.GeoTiffReader$.readMultiband(GeoTiffReader.scala:211)
  at geotrellis.raster.geotiff.GeoTiffRasterSource.$anonfun$tiff$1(GeoTiffRasterSource.scala:40)
  at scala.Option.getOrElse(Option.scala:189)
  at geotrellis.raster.geotiff.GeoTiffRasterSource.tiff$lzycompute(GeoTiffRasterSource.scala:37)
  at geotrellis.raster.geotiff.GeoTiffRasterSource.tiff(GeoTiffRasterSource.scala:34)
  at geotrellis.raster.geotiff.GeoTiffRasterSource.gridExtent$lzycompute(GeoTiffRasterSource.scala:55)
  at geotrellis.raster.geotiff.GeoTiffRasterSource.gridExtent(GeoTiffRasterSource.scala:55)
  at geotrellis.raster.RasterMetadata.extent(RasterMetadata.scala:52)
  at geotrellis.raster.RasterMetadata.extent$(RasterMetadata.scala:52)
  at geotrellis.raster.RasterSource.extent(RasterSource.scala:43)
  at geotrellis.raster.RasterSource.read(RasterSource.scala:134)
  ```
