### PR TITLE
Add initial GDAL Transform rotation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add initial GDAL Transform rotation support [#3331](https://github.com/locationtech/geotrellis/pull/3331)
+
 ### Changed
 - Remove explicit unused Scaffeine dependency from projects [#3314](https://github.com/locationtech/geotrellis/pull/3314)
 - Remove an excessive close after the abort call in S3RangeReader [#3324](https://github.com/locationtech/geotrellis/pull/3324)

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -23,9 +23,10 @@ import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.vector.Extent
 
 import com.azavea.gdal.GDALWarp
+import cats.syntax.option._
 
 case class GDALDataset(token: Long) extends AnyVal {
-  def getAllMetadataFlatten(): Map[String, String] = getAllMetadataFlatten(GDALDataset.SOURCE)
+  def getAllMetadataFlatten: Map[String, String] = getAllMetadataFlatten(GDALDataset.SOURCE)
 
   def getAllMetadataFlatten(datasetType: DatasetType): Map[String, String] =
     (0 until bandCount(datasetType)).map(getAllMetadata(datasetType, _).flatMap(_._2)).reduce(_ ++ _)
@@ -43,13 +44,12 @@ case class GDALDataset(token: Long) extends AnyVal {
     val arr = Array.ofDim[Byte](100, 1 << 10)
     val returnValue = GDALWarp.get_metadata_domain_list(token, datasetType.value, numberOfAttempts, band, arr)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedProjectionException(
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataException(
         s"Unable to get the metadata domain list. GDAL Error Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
     (GDALMetadataDomain.ALL ++ arr.map(new String(_, "UTF-8").trim).filter(_.nonEmpty).toList.map(UserDefinedDomain)).distinct
   }
@@ -66,13 +66,12 @@ case class GDALDataset(token: Long) extends AnyVal {
     val arr = Array.ofDim[Byte](100, 1 << 10)
     val returnValue = GDALWarp.get_metadata(token, datasetType.value, numberOfAttempts, band, domain.name, arr)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedProjectionException(
-        s"Unable to get the metadata. GDAL Error Code: $positiveValue",
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataException(
+        s"Unable to get the metadata domain list. GDAL Error Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
     arr
       .map(new String(_, "UTF-8").trim)
@@ -81,8 +80,8 @@ case class GDALDataset(token: Long) extends AnyVal {
         val arr = str.split("=")
         if(arr.length == 2) {
           val Array(key, value) = str.split("=")
-          Some(key -> value)
-        } else Some("" -> str)
+          (key, value).some
+        } else ("", str).some
       }.toMap
   }
 
@@ -92,13 +91,12 @@ case class GDALDataset(token: Long) extends AnyVal {
     val arr = Array.ofDim[Byte](1 << 10)
     val returnValue = GDALWarp.get_metadata_item(token, datasetType.value, numberOfAttempts, band, key, domain.name, arr)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedProjectionException(
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataException(
         s"Unable to get the metadata item. GDAL Error Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
     new String(arr, "UTF-8").trim
   }
@@ -110,80 +108,103 @@ case class GDALDataset(token: Long) extends AnyVal {
     val crs = Array.ofDim[Byte](1 << 10)
     val returnValue = GDALWarp.get_crs_wkt(token, datasetType.value, numberOfAttempts, crs)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedProjectionException(
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedProjectionException(
         s"Unable to parse projection as WKT String. GDAL Error Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
-    Some(new String(crs, "UTF-8"))
+    new String(crs, "UTF-8").some
+  }
+
+  def overviewDimensions: List[Dimensions[Int]] = overviewDimensions(GDALDataset.WARPED)
+
+  def overviewDimensions(datasetType: DatasetType): List[Dimensions[Int]] = {
+    val N = 1 << 8
+    val widths = Array.ofDim[Int](N)
+    val heights = Array.ofDim[Int](N)
+
+    val returnValue = GDALWarp.get_overview_widths_heights(token, datasetType.value, numberOfAttempts, 1, widths, heights)
+
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataException(
+        s"Unable to construct overview dimensions. GDAL Error Code: $positiveValue",
+        positiveValue
+      )
+    })
+
+    widths.zip(heights).flatMap({ case (w, h) => if (w > 0 && h > 0) Dimensions(cols = w, rows = h).some else None }).toList
+  }
+
+  def dimensions: Dimensions[Int] = dimensions(GDALDataset.WARPED)
+
+  def dimensions(datasetType: DatasetType): Dimensions[Int] = {
+    val dimensions = Array.ofDim[Int](2)
+    val returnValue = GDALWarp.get_width_height(token, datasetType.value, numberOfAttempts, dimensions)
+
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataException(
+        s"Unable to construct dataset dimensions. GDAL Error Code: $positiveValue",
+        positiveValue
+      )
+    })
+
+    Dimensions(dimensions(0), dimensions(1))
+  }
+
+  def getTransform: Array[Double] = getTransform(GDALDataset.WARPED)
+
+  def getTransform(datasetType: DatasetType): Array[Double] = {
+    val transform = Array.ofDim[Double](6)
+    val returnValue = GDALWarp.get_transform(token, datasetType.value, numberOfAttempts, transform)
+
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataException(
+        s"Unable to construct a RasterExtent from the Transformation given. GDAL Error Code: $positiveValue",
+        positiveValue
+      )
+    })
+
+    transform
   }
 
   def rasterExtent: RasterExtent = rasterExtent(GDALDataset.WARPED)
 
-  def dimensions: Dimensions[Int] = rasterExtent.dimensions
-
+  /**
+    * Even though GeoTrellis doesn't support rotation fully, we still can properly compute the Dataset Extent.
+    *
+    * https://gdal.org/user/raster_data_model.html#affine-geotransform
+    * https://github.com/mapbox/rasterio/blob/1.2b1/rasterio/_base.pyx#L865-L895
+    * Previous revision code reference: https://github.com/locationtech/geotrellis/blob/v3.5.1/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala#L128
+    * */
   def rasterExtent(datasetType: DatasetType): RasterExtent = {
     require(acceptableDatasets contains datasetType)
-    val transform = Array.ofDim[Double](6)
-    val width_height = Array.ofDim[Int](2)
 
-    val transformReturnValue = GDALWarp.get_transform(token, datasetType.value, numberOfAttempts, transform)
-    val dimensionReturnValue = GDALWarp.get_width_height(token, datasetType.value, numberOfAttempts, width_height)
+    val Dimensions(cols, rows) = dimensions(datasetType)
+    val transform @ Array(_, _, xskew, _, yskew, _) = getTransform(datasetType)
+    val ext = extent(transform, cols, rows)
 
-    val returnValue =
-      if (transformReturnValue < 0) transformReturnValue
-      else if (dimensionReturnValue < 0) dimensionReturnValue
-      else 0
-
-    if (returnValue < 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedDataException(
-        s"Unable to construct a RasterExtent from the Transformation given. GDAL Error Code: $positiveValue",
-        positiveValue
-      )
-    }
-
-    val x1 = transform(0)
-    val y1 = transform(3)
-    val x2 = x1 + transform(1) * width_height(0)
-    val y2 = y1 + transform(5) * width_height(1)
-    val e = Extent(
-      math.min(x1, x2),
-      math.min(y1, y2),
-      math.max(x1, x2),
-      math.max(y1, y2)
-    )
-
-    RasterExtent(e, math.abs(transform(1)), math.abs(transform(5)), width_height(0), width_height(1))
+    /**
+      * RasterExtent doesn't support rotated AffineTransform.
+      * In case of rotation, it would throw since the cellSize would not match RasterExtent expectations.
+      *
+      * This if-statement aligns GDAL RasterExtent computation behavior with the Java RasterExtent computation.
+      *
+      * TODO: fix rotated rasters support: https://github.com/locationtech/geotrellis/issues/3332
+      */
+    if(xskew == 0d && yskew == 0d) {
+      val cs = cellSize(transform)
+      RasterExtent(ext, cs.width, cs.height, cols, rows)
+    } else RasterExtent(ext, cols, rows)
   }
 
-  def resolutions(): List[RasterExtent] = resolutions(GDALDataset.WARPED)
+  def resolutions: List[RasterExtent] = resolutions(GDALDataset.WARPED)
 
   def resolutions(datasetType: DatasetType): List[RasterExtent] = {
     require(acceptableDatasets contains datasetType)
-    val N = 1 << 8
-    val widths = Array.ofDim[Int](N)
-    val heights = Array.ofDim[Int](N)
-    val extent = this.extent(datasetType)
-
-    val returnValue =
-      GDALWarp.get_overview_widths_heights(token, datasetType.value, numberOfAttempts, 1, widths, heights)
-
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedDataException(
-        s"Unable to construct the overview RasterExtents for the resample. GDAL Error Code: $positiveValue",
-        positiveValue
-      )
-    }
-
-    widths.zip(heights).flatMap({ case (w, h) =>
-      if (w > 0 && h > 0) Some(RasterExtent(extent, cols = w, rows = h))
-      else None
-    }).toList
+    val ext = extent(datasetType)
+    overviewDimensions(datasetType).map { case Dimensions(cols, rows) => RasterExtent(ext, cols, rows) }
   }
 
   def extent: Extent = extent(GDALDataset.WARPED)
@@ -191,6 +212,39 @@ case class GDALDataset(token: Long) extends AnyVal {
   def extent(datasetType: DatasetType): Extent = {
     require(acceptableDatasets contains datasetType)
     this.rasterExtent(datasetType).extent
+  }
+
+  /**
+    * Compute extent, takes into account a possible rotation.
+    *
+    * https://github.com/mapbox/rasterio/blob/1.2b1/rasterio/_base.pyx#L865-L895
+    *
+    * Note for a reader:
+    * affine.Affine(a, b, c, d, e, f)
+    * GDALTransform(c, a, b, f, d, e)
+    *
+    * https://gdal.org/user/raster_data_model.html#affine-geotransform
+    * https://github.com/mapbox/rasterio/blob/1.2b1/rasterio/_base.pyx#L865-L895
+    */
+  private def extent(transform: Array[Double], cols: Int, rows: Int): Extent = {
+    val Array(upx, xres, xskew, upy, yskew, yres) = transform
+
+    val ulx = upx + 0 * xres + 0 * xskew
+    val uly = upy + 0 * yskew + 0 * yres
+
+    val llx = upx + 0 * xres + rows * xskew
+    val lly = upy + 0 * yskew + rows * yres
+
+    val lrx = upx + cols * xres + rows * xskew
+    val lry = upy + cols * yskew + rows * yres
+
+    val urx = upx + cols * xres + 0 * xskew
+    val ury = upy + cols * yskew + 0 * yres
+
+    val xs = List(ulx, llx, lrx, urx)
+    val ys = List(uly, lly, lry, ury)
+
+    Extent(xs.min, ys.min, xs.max, ys.max)
   }
 
   def bandCount: Int = bandCount(GDALDataset.WARPED)
@@ -201,13 +255,12 @@ case class GDALDataset(token: Long) extends AnyVal {
 
     val returnValue = GDALWarp.get_band_count(token, datasetType.value, numberOfAttempts, count)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedDataException(
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataException(
         s"A bandCount of <= 0 was found. GDAL Error Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
     count(0)
   }
@@ -220,17 +273,15 @@ case class GDALDataset(token: Long) extends AnyVal {
 
     val returnValue = GDALWarp.get_crs_proj4(token, datasetType.value, numberOfAttempts, crs)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedProjectionException(
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedProjectionException(
         s"Unable to parse projection as CRS. GDAL Error Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
-    val proj4String: String = new String(crs, "UTF-8").trim
-    if (proj4String.length > 0) CRS.fromString(proj4String.trim)
-    else LatLng
+    val proj4String = new String(crs, "UTF-8").trim
+    if (proj4String.nonEmpty) CRS.fromString(proj4String.trim) else LatLng
   }
 
   def noDataValue: Option[Double] = noDataValue(GDALDataset.WARPED)
@@ -242,16 +293,14 @@ case class GDALDataset(token: Long) extends AnyVal {
 
     val returnValue = GDALWarp.get_band_nodata(token, datasetType.value, numberOfAttempts, 1, nodata, success)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedDataTypeException(
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataTypeException(
         s"Unable to determine NoData value. GDAL Exception Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
-    if (success(0) == 0) None
-    else Some(nodata(0))
+    if (success(0) == 0) None else nodata(0).some
   }
 
   def dataType: Int = dataType(GDALDataset.WARPED)
@@ -262,24 +311,37 @@ case class GDALDataset(token: Long) extends AnyVal {
 
     val returnValue = GDALWarp.get_band_data_type(token, datasetType.value, numberOfAttempts, 1, dataType)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new MalformedDataTypeException(
+    errorHandler(returnValue, { positiveValue =>
+      new MalformedDataTypeException(
         s"Unable to determine DataType. GDAL Error Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
     dataType(0)
   }
 
   def cellSize: CellSize = cellSize(GDALDataset.WARPED)
 
+  /**
+    * https://github.com/mapbox/rasterio/blob/1.2b1/rasterio/_base.pyx#L865-L895
+    *
+    * Note for a reader:
+    * affine.Affine(a, b, c, d, e, f)
+    * GDALTransform(c, a, b, f, d, e)
+    *
+    * See https://rasterio.readthedocs.io/en/latest/topics/migrating-to-v1.html?highlight=Affine#affine-affine-vs-gdal-style-geotransforms
+    * */
   def cellSize(datasetType: DatasetType): CellSize = {
     require(acceptableDatasets contains datasetType)
-    val transform = Array.ofDim[Double](6)
-    GDALWarp.get_transform(token, datasetType.value, numberOfAttempts, transform)
-    CellSize(transform(1), transform(5))
+    cellSize(getTransform(datasetType))
+  }
+
+  private def cellSize(transform: Array[Double]): CellSize = {
+    val Array(_, xres, xskew, _, yskew, yres) = transform
+
+    if(xskew == 0d && yskew == 0d) CellSize(math.abs(xres), math.abs(yres))
+    else CellSize(math.sqrt(xres * xres + yskew * yskew), math.sqrt(xskew * xskew + yres * yres))
   }
 
   def cellType: CellType = cellType(GDALDataset.WARPED)
@@ -308,13 +370,12 @@ case class GDALDataset(token: Long) extends AnyVal {
 
     val returnValue = GDALWarp.get_data(token, datasetType.value, numberOfAttempts, srcWindow, dstWindow, band, dt, bytes)
 
-    if (returnValue <= 0) {
-      val positiveValue = math.abs(returnValue)
-      throw new GDALIOException(
+    errorHandler(returnValue, { positiveValue =>
+      new GDALIOException(
         s"Unable to read in data. GDAL Error Code: $positiveValue",
         positiveValue
       )
-    }
+    })
 
     ArrayTile.fromBytes(bytes, ct, dstWindow(0), dstWindow(1))
   }
@@ -324,6 +385,9 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def readMultibandRaster(gb: GridBounds[Int] = GridBounds(dimensions), bands: Seq[Int] = 1 to bandCount, datasetType: DatasetType = GDALDataset.WARPED): Raster[MultibandTile] =
     Raster(readMultibandTile(gb, bands, datasetType), rasterExtent.rasterExtentFor(gb).extent)
+
+  private def errorHandler(returnValue: Int, exception: Int => Throwable): Unit =
+    if (returnValue <= 0) throw exception(math.abs(returnValue))
 }
 
 object GDALDataset {

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -41,6 +41,8 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   /** https://github.com/OSGeo/gdal/blob/b1c9c12ad373e40b955162b45d704070d4ebf7b0/gdal/doc/source/development/rfc/rfc43_getmetadatadomainlist.rst */
   def getMetadataDomainList(datasetType: DatasetType, band: Int): List[GDALMetadataDomain] = {
+    require(acceptableDatasets contains datasetType)
+
     val arr = Array.ofDim[Byte](100, 1 << 10)
     val returnValue = GDALWarp.get_metadata_domain_list(token, datasetType.value, numberOfAttempts, band, arr)
 
@@ -63,6 +65,8 @@ case class GDALDataset(token: Long) extends AnyVal {
   def getMetadata(domain: GDALMetadataDomain, band: Int): Map[String, String] = getMetadata(GDALDataset.SOURCE, domain, band)
 
   def getMetadata(datasetType: DatasetType, domain: GDALMetadataDomain, band: Int): Map[String, String] = {
+    require(acceptableDatasets contains datasetType)
+
     val arr = Array.ofDim[Byte](100, 1 << 10)
     val returnValue = GDALWarp.get_metadata(token, datasetType.value, numberOfAttempts, band, domain.name, arr)
 
@@ -88,6 +92,8 @@ case class GDALDataset(token: Long) extends AnyVal {
   def getMetadataItem(key: String, domain: GDALMetadataDomain, band: Int): String = getMetadataItem(GDALDataset.WARPED, key, domain, band)
 
   def getMetadataItem(datasetType: DatasetType, key: String, domain: GDALMetadataDomain, band: Int): String = {
+    require(acceptableDatasets contains datasetType)
+
     val arr = Array.ofDim[Byte](1 << 10)
     val returnValue = GDALWarp.get_metadata_item(token, datasetType.value, numberOfAttempts, band, key, domain.name, arr)
 
@@ -105,6 +111,7 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def getProjection(datasetType: DatasetType): Option[String] = {
     require(acceptableDatasets contains datasetType)
+
     val crs = Array.ofDim[Byte](1 << 10)
     val returnValue = GDALWarp.get_crs_wkt(token, datasetType.value, numberOfAttempts, crs)
 
@@ -121,6 +128,8 @@ case class GDALDataset(token: Long) extends AnyVal {
   def overviewDimensions: List[Dimensions[Int]] = overviewDimensions(GDALDataset.WARPED)
 
   def overviewDimensions(datasetType: DatasetType): List[Dimensions[Int]] = {
+    require(acceptableDatasets contains datasetType)
+
     val N = 1 << 8
     val widths = Array.ofDim[Int](N)
     val heights = Array.ofDim[Int](N)
@@ -140,6 +149,8 @@ case class GDALDataset(token: Long) extends AnyVal {
   def dimensions: Dimensions[Int] = dimensions(GDALDataset.WARPED)
 
   def dimensions(datasetType: DatasetType): Dimensions[Int] = {
+    require(acceptableDatasets contains datasetType)
+
     val dimensions = Array.ofDim[Int](2)
     val returnValue = GDALWarp.get_width_height(token, datasetType.value, numberOfAttempts, dimensions)
 
@@ -156,6 +167,8 @@ case class GDALDataset(token: Long) extends AnyVal {
   def getTransform: Array[Double] = getTransform(GDALDataset.WARPED)
 
   def getTransform(datasetType: DatasetType): Array[Double] = {
+    require(acceptableDatasets contains datasetType)
+
     val transform = Array.ofDim[Double](6)
     val returnValue = GDALWarp.get_transform(token, datasetType.value, numberOfAttempts, transform)
 
@@ -203,6 +216,7 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def resolutions(datasetType: DatasetType): List[RasterExtent] = {
     require(acceptableDatasets contains datasetType)
+
     val ext = extent(datasetType)
     overviewDimensions(datasetType).map { case Dimensions(cols, rows) => RasterExtent(ext, cols, rows) }
   }
@@ -211,7 +225,7 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def extent(datasetType: DatasetType): Extent = {
     require(acceptableDatasets contains datasetType)
-    this.rasterExtent(datasetType).extent
+    rasterExtent(datasetType).extent
   }
 
   /**
@@ -251,8 +265,8 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def bandCount(datasetType: DatasetType): Int = {
     require(acceptableDatasets contains datasetType)
-    val count = Array.ofDim[Int](1)
 
+    val count = Array.ofDim[Int](1)
     val returnValue = GDALWarp.get_band_count(token, datasetType.value, numberOfAttempts, count)
 
     errorHandler(returnValue, { positiveValue =>
@@ -269,8 +283,8 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def crs(datasetType: DatasetType): CRS = {
     require(acceptableDatasets contains datasetType)
-    val crs = Array.ofDim[Byte](1 << 16)
 
+    val crs = Array.ofDim[Byte](1 << 16)
     val returnValue = GDALWarp.get_crs_proj4(token, datasetType.value, numberOfAttempts, crs)
 
     errorHandler(returnValue, { positiveValue =>
@@ -288,9 +302,9 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def noDataValue(datasetType: DatasetType): Option[Double] = {
     require(acceptableDatasets contains datasetType)
+
     val nodata = Array.ofDim[Double](1)
     val success = Array.ofDim[Int](1)
-
     val returnValue = GDALWarp.get_band_nodata(token, datasetType.value, numberOfAttempts, 1, nodata, success)
 
     errorHandler(returnValue, { positiveValue =>
@@ -307,8 +321,8 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def dataType(datasetType: DatasetType): Int = {
     require(acceptableDatasets contains datasetType)
-    val dataType = Array.ofDim[Int](1)
 
+    val dataType = Array.ofDim[Int](1)
     val returnValue = GDALWarp.get_band_data_type(token, datasetType.value, numberOfAttempts, 1, dataType)
 
     errorHandler(returnValue, { positiveValue =>
@@ -348,10 +362,11 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def cellType(datasetType: DatasetType): CellType = {
     require(acceptableDatasets contains datasetType)
+
     val nd = noDataValue(datasetType)
-    val dt = GDALDataType.intToGDALDataType(this.dataType(datasetType))
+    val dt = GDALDataType.intToGDALDataType(dataType(datasetType))
     /** The necessary metadata about the [[CellType]] is available only on the RasterBand metadata level, that is why band = 1 here. */
-    lazy val md = this.getMetadata(ImageStructureDomain, 1)
+    lazy val md = getMetadata(ImageStructureDomain, 1)
     /** To handle the [[BitCellType]] it is possible to fetch NBITS information from the RasterBand metadata, **/
     lazy val bitsPerSample = md.get("NBITS").map(_.toInt)
     /** To handle the [[ByteCellType]] it is possible to fetch information about the sampleFormat from the RasterBand metadata. **/
@@ -361,11 +376,12 @@ case class GDALDataset(token: Long) extends AnyVal {
 
   def readTile(gb: GridBounds[Int] = GridBounds(dimensions), band: Int, datasetType: DatasetType = GDALDataset.WARPED): Tile = {
     require(acceptableDatasets contains datasetType)
+
     val GridBounds(xmin, ymin, xmax, ymax) = gb
     val srcWindow: Array[Int] = Array(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1)
     val dstWindow: Array[Int] = Array(srcWindow(2), srcWindow(3))
-    val ct = this.cellType(datasetType)
-    val dt = this.dataType(datasetType)
+    val ct = cellType(datasetType)
+    val dt = dataType(datasetType)
     val bytes = Array.ofDim[Byte](dstWindow(0) * dstWindow(1) * ct.bytes)
 
     val returnValue = GDALWarp.get_data(token, datasetType.value, numberOfAttempts, srcWindow, dstWindow, band, dt, bytes)

--- a/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/raster/gdal/GDALDataset.scala
@@ -240,7 +240,7 @@ case class GDALDataset(token: Long) extends AnyVal {
     * https://gdal.org/user/raster_data_model.html#affine-geotransform
     * https://github.com/mapbox/rasterio/blob/1.2b1/rasterio/_base.pyx#L865-L895
     */
-  private def extent(transform: Array[Double], cols: Int, rows: Int): Extent = {
+  def extent(transform: Array[Double], cols: Int, rows: Int): Extent = {
     val Array(upx, xres, xskew, upy, yskew, yres) = transform
 
     val ulx = upx + 0 * xres + 0 * xskew
@@ -351,7 +351,7 @@ case class GDALDataset(token: Long) extends AnyVal {
     cellSize(getTransform(datasetType))
   }
 
-  private def cellSize(transform: Array[Double]): CellSize = {
+  def cellSize(transform: Array[Double]): CellSize = {
     val Array(_, xres, xskew, _, yskew, yres) = transform
 
     if(xskew == 0d && yskew == 0d) CellSize(math.abs(xres), math.abs(yres))


### PR DESCRIPTION
# Overview

This PR cleanups GDALDataset and adds initial GDAL Transform rotation support

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] New user API has useful Scaladoc strings
- [x] ~~Unit tests added for bug-fix or new feature~~ // I think the main test here is that the old logic is not broken, everything else should be covered by https://github.com/locationtech/geotrellis/issues/3332 

Related to https://github.com/locationtech/geotrellis/issues/3332