### PR TITLE
Add rasters S3 write methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add rasters S3 write methods [#3333](https://github.com/locationtech/geotrellis/pull/3333)
+
 ### Changed
 - Remove explicit unused Scaffeine dependency from projects [#3314](https://github.com/locationtech/geotrellis/pull/3314)
 - Remove an excessive close after the abort call in S3RangeReader [#3324](https://github.com/locationtech/geotrellis/pull/3324)

--- a/s3/src/main/scala/geotrellis/store/s3/S3RasterMethods.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/S3RasterMethods.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.store.s3
+
+import geotrellis.raster.CellGrid
+import geotrellis.raster.io.geotiff.GeoTiff
+import geotrellis.raster.render.{Jpg, Png}
+import geotrellis.util.MethodExtensions
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+trait S3RasterMethods[T] extends MethodExtensions[T] {
+  def write(uri: AmazonS3URI, client: S3Client = S3ClientProducer.get()): Unit
+
+  protected def writeArray(uri: AmazonS3URI, client: S3Client, bytes: Array[Byte]): Unit = {
+    val objectRequest = PutObjectRequest.builder
+      .bucket(uri.getBucket)
+      .key(uri.getKey)
+      .build
+
+    client.putObject(objectRequest, RequestBody.fromBytes(bytes))
+  }
+}
+
+abstract class JpgS3WriteMethods(self: Jpg) extends S3RasterMethods[Jpg] {
+  def write(uri: AmazonS3URI, client: S3Client = S3ClientProducer.get()): Unit =
+    writeArray(uri, client, self.bytes)
+}
+
+abstract class PngS3WriteMethods(self: Png) extends S3RasterMethods[Png] {
+  def write(uri: AmazonS3URI, client: S3Client = S3ClientProducer.get()): Unit =
+    writeArray(uri, client, self.bytes)
+}
+
+abstract class GeoTiffS3WriteMethods[T <: CellGrid[Int]](self: GeoTiff[T]) extends S3RasterMethods[GeoTiff[T]] {
+  def write(uri: AmazonS3URI, client: S3Client = S3ClientProducer.get()): Unit =
+    writeArray(uri, client, self.toCloudOptimizedByteArray)
+}

--- a/s3/src/main/scala/geotrellis/store/s3/package.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/package.scala
@@ -16,18 +16,21 @@
 
 package geotrellis.store
 
+import geotrellis.raster.CellGrid
+import geotrellis.raster.io.geotiff.GeoTiff
+import geotrellis.raster.render.{Jpg, Png}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.{NoSuchKeyException, HeadObjectRequest}
 
 import scala.util.{Try, Success, Failure}
 
 package object s3 {
-  private[geotrellis] def makePath(chunks: String*) =
+  private[geotrellis] def makePath(chunks: String*): String =
     chunks
       .collect { case str if str.nonEmpty => if(str.endsWith("/")) str.dropRight(1) else str }
       .mkString("/")
 
-  implicit class S3ClientExtension(client: S3Client) {
+  implicit class S3ClientExtension(val client: S3Client) extends AnyVal {
     def objectExists(bucket: String, key: String): Boolean = {
       val request = HeadObjectRequest.builder()
         .bucket(bucket)
@@ -50,4 +53,10 @@ package object s3 {
       client.objectExists(bucket, key)
     }
   }
+
+  implicit class withJpgS3WriteMethods(val self: Jpg) extends JpgS3WriteMethods(self)
+
+  implicit class withPngS3WriteMethods(val self: Png) extends PngS3WriteMethods(self)
+
+  implicit class withGeoTiffS3WriteMethods[T <: CellGrid[Int]](val self: GeoTiff[T]) extends GeoTiffS3WriteMethods[T](self)
 }


### PR DESCRIPTION
# Overview

This PR adds a specific to s3 overload that doesn't require having a hadoop dependency in the classpath.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.

## Demo

```scala
val tiff: MultibandGeoTiff = ???
tiff.write(new AmazonS3URI("s3://test/destination.tiff"))
```
