### PR TITLE
replace all unicode arrow operators with equivalent ascii (deprecated in 2.13)

### DIFF
--- a/bench/src/main/scala/geotrellis/bench/GeotrellisFlightRecordingProfiler.scala
+++ b/bench/src/main/scala/geotrellis/bench/GeotrellisFlightRecordingProfiler.scala
@@ -42,7 +42,7 @@ class GeotrellisFlightRecordingProfiler(initLine: String) extends FlightRecordin
   val settingsFile = getClass.getResource("/fine.jfc").getPath
 
   def optionString(opts: Map[String, String]) =
-    opts.map(p ⇒ s"${p._1}=${p._2}").mkString(",")
+    opts.map(p => s"${p._1}=${p._2}").mkString(",")
 
   val startOptions = Map(
     "name" -> getClass.getSimpleName,

--- a/bench/src/main/scala/geotrellis/raster/GenericRasterBench.scala
+++ b/bench/src/main/scala/geotrellis/raster/GenericRasterBench.scala
@@ -42,11 +42,11 @@ class GenericRasterBench  {
     // There may be a better way of doing this using separate `State` classes
     // that are injected on-demand by the framework.
     params.getBenchmark.split('.').last match {
-      case "genericRasterMap" ⇒
+      case "genericRasterMap" =>
         genericRaster = new GRaster(init(len)(Random.nextInt))
-      case "rasterMap" ⇒
+      case "rasterMap" =>
         tile = ArrayTile(init(len)(Random.nextInt), size, size)
-      case _ ⇒ throw new MatchError("Have a new benchmark without initialization?")
+      case _ => throw new MatchError("Have a new benchmark without initialization?")
     }
   }
 

--- a/bench/src/main/scala/geotrellis/raster/resample/ResampleBench.scala
+++ b/bench/src/main/scala/geotrellis/raster/resample/ResampleBench.scala
@@ -18,7 +18,7 @@ package geotrellis.raster.resample
 
 import geotrellis.proj4.{LatLng, Transform, WebMercator}
 import geotrellis.raster.{Raster, RasterExtent, SinglebandRaster, Tile}
-import org.openjdk.jmh.annotations.{Mode ⇒ JMHMode, _}
+import org.openjdk.jmh.annotations.{Mode => JMHMode, _}
 import geotrellis.bench._
 
 @BenchmarkMode(Array(JMHMode.AverageTime))
@@ -37,13 +37,13 @@ class ResampleBench {
   def setup(): Unit = {
     val geotiff = readSinglebandGeoTiff("aspect-tif.tif")
     method = methodName match {
-      case "NearestNeighbor" ⇒ NearestNeighbor
-      case "Bilinear" ⇒ Bilinear
-      case "CubicConvolution" ⇒ CubicConvolution
-      case "CubicSpline" ⇒ CubicSpline
-      case "Lanczos" ⇒ Lanczos
-      case "Average" ⇒ Average
-      case "Mode" ⇒ Mode
+      case "NearestNeighbor" => NearestNeighbor
+      case "Bilinear" => Bilinear
+      case "CubicConvolution" => CubicConvolution
+      case "CubicSpline" => CubicSpline
+      case "Lanczos" => Lanczos
+      case "Average" => Average
+      case "Mode" => Mode
     }
     trans = Transform(LatLng, WebMercator)
     invTrans = Transform(WebMercator, LatLng)

--- a/bench/src/main/scala/geotrellis/spark/store/index/MergeQueueBench.scala
+++ b/bench/src/main/scala/geotrellis/spark/store/index/MergeQueueBench.scala
@@ -44,7 +44,7 @@ class MergeQueueBench {
   def setupData(): Unit = {
     ranges = Vector.empty[(BigInt, BigInt)]
 
-    for (i ← 0 until size) {
+    for (i <- 0 until size) {
       val start: BigInt = BigInt(skip.toLong * i)
       val end: BigInt = start + span
       ranges = ranges :+ (start, end)

--- a/docs/architecture/004-spark-streaming.rst
+++ b/docs/architecture/004-spark-streaming.rst
@@ -22,9 +22,9 @@ API
 
 .. code:: scala
 
-  def foreachRDD(foreachFunc: (RDD[T]) ⇒ Unit): Unit
-  def transform[U](transformFunc: (RDD[T]) ⇒ RDD[U])(implicit arg0: ClassTag[U]): DStream[U]
-  def transformWith[U, V](other: DStream[U], transformFunc: (RDD[T], RDD[U]) ⇒ RDD[V])(implicit arg0: ClassTag[U], arg1: ClassTag[V]): DStream[V]
+  def foreachRDD(foreachFunc: (RDD[T]) => Unit): Unit
+  def transform[U](transformFunc: (RDD[T]) => RDD[U])(implicit arg0: ClassTag[U]): DStream[U]
+  def transformWith[U, V](other: DStream[U], transformFunc: (RDD[T], RDD[U]) => RDD[V])(implicit arg0: ClassTag[U], arg1: ClassTag[V]): DStream[V]
 
 
 And other higher ordered functions, which makes possible GeoTrellis ``RDD`` functions usage without reimplementing,

--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -117,7 +117,7 @@ object CRS {
     Option(crsFactory.readEpsgFromParameters(proj4String))
 
   /** Mix-in for singleton CRS implementations where distinguished string should be the name of the object. */
-  private[proj4] trait ObjectNameToString { self: CRS ⇒
+  private[proj4] trait ObjectNameToString { self: CRS =>
     override def toString: String = self.getClass.getSimpleName.replaceAllLiterally("$", "")
   }
 }

--- a/proj4/src/test/scala/geotrellis/proj4/CRSTest.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/CRSTest.scala
@@ -75,7 +75,7 @@ class CRSTest extends AnyFunSpec with Inspectors {
       LatLng, Sinusoidal, WebMercator, ConusAlbers
     )
 
-    forEvery(samples) { crs ⇒
+    forEvery(samples) { crs =>
       val str = crs.toString
       assert(!str.contains("$") && !str.contains("@"))
     }

--- a/proj4/src/test/scala/geotrellis/proj4/MetaCRSTest.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/MetaCRSTest.scala
@@ -70,8 +70,8 @@ object passing extends BeMatcher[MetaCRSTestCase] {
     val (success, x, y) = left.execute(crsFactory)
     MatchResult(
       success,
-      f"$srcCrsAuth:$srcCrs→$tgtCrsAuth:$tgtCrs ($srcOrd1, $srcOrd2, $srcOrd3) → ($tgtOrd1, $tgtOrd2, $tgtOrd3); got ($x, $y)",
-      f"$srcCrsAuth:$srcCrs→$tgtCrsAuth:$tgtCrs in tolerance")
+      f"$srcCrsAuth:$srcCrs->$tgtCrsAuth:$tgtCrs ($srcOrd1, $srcOrd2, $srcOrd3) -> ($tgtOrd1, $tgtOrd2, $tgtOrd3); got ($x, $y)",
+      f"$srcCrsAuth:$srcCrs->$tgtCrsAuth:$tgtCrs in tolerance")
   }
 }
 

--- a/project/GTBenchmarkPlugin.scala
+++ b/project/GTBenchmarkPlugin.scala
@@ -106,7 +106,7 @@ object GTBenchmarkPlugin extends AutoPlugin {
     )
 
     def benchFileParser(dir: File) = fileParser(dir)
-      .filter(f ⇒ pat.accept(f.name), s ⇒ "Not a benchmark file: " + s)
+      .filter(f => pat.accept(f.name), s => "Not a benchmark file: " + s)
 
     val parsers = dirs.map(benchFileParser)
 

--- a/raster-testkit/src/main/scala/geotrellis/raster/testkit/TileBuilders.scala
+++ b/raster-testkit/src/main/scala/geotrellis/raster/testkit/TileBuilders.scala
@@ -173,10 +173,10 @@ trait TileBuilders {
     def filter(c: Int, r: Int) = targeted.contains(r * t.cols + c)
 
     val injected = if(t.cellType.isFloatingPoint) {
-      t.mapDouble((c, r, v) ⇒ (if(filter(c,r)) doubleNODATA else v): Double)
+      t.mapDouble((c, r, v) => (if(filter(c,r)) doubleNODATA else v): Double)
     }
     else {
-      t.map((c, r, v) ⇒ if(filter(c, r)) NODATA else v)
+      t.map((c, r, v) => if(filter(c, r)) NODATA else v)
     }
 
     injected

--- a/raster/src/main/scala/geotrellis/raster/CellTypeEncoding.scala
+++ b/raster/src/main/scala/geotrellis/raster/CellTypeEncoding.scala
@@ -110,7 +110,7 @@ sealed trait FixedNoDataEncoding extends CellTypeEncoding {
 }
 
 /** Base trait for encoding CellTypes with user defined NoData values. */
-sealed trait UserDefinedNoDataEncoding extends CellTypeEncoding { self ⇒
+sealed trait UserDefinedNoDataEncoding extends CellTypeEncoding { self =>
   val name: String
   val isFloatingPoint = false
 

--- a/raster/src/main/scala/geotrellis/raster/DelegatingTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DelegatingTile.scala
@@ -68,22 +68,22 @@ abstract class DelegatingTile extends Tile {
   def toBytes(): Array[Byte] =
     delegate.toBytes()
 
-  def foreach(f: Int ⇒ Unit): Unit =
+  def foreach(f: Int => Unit): Unit =
     delegate.foreach(f)
 
-  def foreachDouble(f: Double ⇒ Unit): Unit =
+  def foreachDouble(f: Double => Unit): Unit =
     delegate.foreachDouble(f)
 
-  def map(f: Int ⇒ Int): Tile =
+  def map(f: Int => Int): Tile =
     delegate.map(f)
 
-  def combine(r2: Tile)(f: (Int, Int) ⇒ Int): Tile =
+  def combine(r2: Tile)(f: (Int, Int) => Int): Tile =
     delegate.combine(r2)(f)
 
-  def mapDouble(f: Double ⇒ Double): Tile =
+  def mapDouble(f: Double => Double): Tile =
     delegate.mapDouble(f)
 
-  def combineDouble(r2: Tile)(f: (Double, Double) ⇒ Double): Tile =
+  def combineDouble(r2: Tile)(f: (Double, Double) => Double): Tile =
     delegate.combineDouble(r2)(f)
 
   def foreachIntVisitor(visitor: IntTileVisitor): Unit =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/CoordinateSystemParser.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/CoordinateSystemParser.scala
@@ -161,7 +161,7 @@ class CoordinateSystemParser(val crs: CRS, val pixelSampleType: Option[PixelSamp
     case Some("utm") => utmProps
     case Some("lcc") => lccProps
     case Some("longlat") | Some("latlong") => longLatProps
-    case Some("sinu") ⇒ sinuProps
+    case Some("sinu") => sinuProps
     case Some("aea") => aeaProps
     case Some(p) => throw new GeoTiffWriterLimitationException(
       s"This GeoTiff writer does not currently support the projection $proj4String without an EPSG code associated with the CRS. You'll need to use a CRS that has an EPSG code, or reproject before writing to GeoTIFF."

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -116,7 +116,7 @@ object TiffTagFieldValue {
 
       val divider = 1 << bitsPerSample
 
-      for(cmap ← geoTiff.options.colorMap) {
+      for(cmap <- geoTiff.options.colorMap) {
         val palette = IndexedColorMap.toTiffPalette(cmap)
         val size = math.min(palette.size, divider)
         // Indexed color palette is stored as three consecutive arrays containing

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
@@ -348,10 +348,10 @@ class DoubleColorMap(breaksToColors: Map[Double, Int], val options: Options = Op
 /** A color map where the breaks are monotonically increasing integer values starting at zero.
  * Primarily used for capturing and persisting indexed color maps in GeoTIFFs. */
 class IndexedColorMap(indexedColors: Seq[Int]) extends IntColorMap(
-  indexedColors.zipWithIndex.map(p ⇒ p._2 -> p._1).toMap
+  indexedColors.zipWithIndex.map(p => p._2 -> p._1).toMap
 ) {
   override def toString = getClass.getSimpleName + "(" +
-    colors.map(c ⇒ f"0x$c%02x").mkString(", ") + ")"
+    colors.map(c => f"0x$c%02x").mkString(", ") + ")"
 }
 
 object IndexedColorMap {
@@ -364,11 +364,11 @@ object IndexedColorMap {
 
   /** Creates an IndexColorMap from sequence of RGB short values. */
   def fromTiffPalette(tiffPalette: Seq[(Short, Short, Short)]) = new IndexedColorMap(
-    tiffPalette.map { case (red, green, blue) ⇒ RGB(downsample(red), downsample(green), downsample(blue))}
+    tiffPalette.map { case (red, green, blue) => RGB(downsample(red), downsample(green), downsample(blue))}
   )
   /** Converts a ColorMap to sequence of short triplets in encoding expected by GeoTiff 'Palette' color space.*/
   def toTiffPalette(cm: ColorMap): Seq[(Short, Short, Short)] =
-    fromColorMap(cm).colors.map(c ⇒ (upsample(c.red), upsample(c.green), upsample(c.blue)))
+    fromColorMap(cm).colors.map(c => (upsample(c.red), upsample(c.green), upsample(c.blue)))
 
   /** Flattens the given colormap into an indexed variant, throwing away any defined boundaries. */
   def fromColorMap(cm: ColorMap) = new IndexedColorMap(cm.colors)

--- a/raster/src/main/scala/geotrellis/raster/render/ColorRamps.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorRamps.scala
@@ -113,7 +113,7 @@ object ColorRamps extends MatplotLibColorRamps {
   /** Constructs a greyscale [[ColorRamp]] with `stops` discrete values. */
   def greyscale(stops: Int): ColorRamp = {
     val colors = (0 to stops)
-      .map(i ⇒ {
+      .map(i => {
         val c = java.awt.Color.HSBtoRGB(0f, 0f, i / stops.toFloat)
         (c << 8) | 0xFF // Add alpha channel.
       })

--- a/raster/src/main/scala/geotrellis/raster/split/TileFeatureSplitMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/split/TileFeatureSplitMethods.scala
@@ -26,7 +26,7 @@ abstract class TileFeatureSplitMethods[
 
   def split(tileLayout: TileLayout, options: Options): Seq[TileFeature[T, D]] = {
     val results = self.tile.split(tileLayout, options)
-    results.map(t ⇒ TileFeature(t, self.data))
+    results.map(t => TileFeature(t, self.data))
   }
 }
 

--- a/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
+++ b/raster/src/main/scala/geotrellis/raster/stitch/Stitcher.scala
@@ -112,7 +112,7 @@ object Stitcher {
     D: Semigroup
   ]: Stitcher[TileFeature[T, D]] = new Stitcher[TileFeature[T, D]] {
     def stitch(pieces: Iterable[(TileFeature[T, D], (Int, Int))], cols: Int, rows: Int): TileFeature[T, D] = {
-      val newPieces = pieces.map{ piece ⇒ (piece._1.tile, piece._2) }
+      val newPieces = pieces.map{ piece => (piece._1.tile, piece._2) }
       val newData = pieces.map(_._1.data).reduce(Semigroup[D].combine)
       TileFeature(implicitly[Stitcher[T]].stitch(newPieces, cols, rows), newData)
     }
@@ -123,7 +123,7 @@ object Stitcher {
     D : Semigroup
   ](val self: TileFeature[T, D]) extends Stitcher[TileFeature[T, D]] {
     def stitch(pieces: Iterable[(TileFeature[T, D], (Int, Int))], cols: Int, rows: Int): TileFeature[T, D] = {
-      val newPieces = pieces.map{ piece ⇒ (piece._1.tile, piece._2) }
+      val newPieces = pieces.map{ piece => (piece._1.tile, piece._2) }
       val newData = pieces.map(_._1.data).reduce(Semigroup[D].combine)
       TileFeature(implicitly[Stitcher[T]].stitch(newPieces, cols, rows), newData)
     }

--- a/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ArrayTileSpec.scala
@@ -366,9 +366,9 @@ object ArrayTileSpec {
     def apply(t: Tile) = {
       var count: Long = 0
       t.dualForeach(
-        z ⇒ if(isData(z)) count = count + 1
+        z => if(isData(z)) count = count + 1
       ) (
-        z ⇒ if(isData(z)) count = count + 1
+        z => if(isData(z)) count = count + 1
       )
       count
     }

--- a/raster/src/test/scala/geotrellis/raster/CellTypeSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/CellTypeSpec.scala
@@ -154,18 +154,18 @@ class CellTypeSpec extends AnyFunSpec with Matchers with Inspectors {
       type PhantomCell = AnyVal
       type PhantomNoData = AnyVal
 
-      forEvery(CellDef.all) { cd ⇒
+      forEvery(CellDef.all) { cd =>
         val cellDef = cd.asInstanceOf[CellDef[PhantomCell, PhantomNoData]]
         withClue(s"for cell type '$cellDef'") {
-          forEvery(cellDef.range.testPoints) { nd ⇒
+          forEvery(cellDef.range.testPoints) { nd =>
             withClue(s"for no data '$nd'") {
               val ct = cellDef(nd)
               roundTrip(ct)
               roundTripTiff(ct)
               assert(cellDef.toCode(nd) === ct.name)
               ct.widenedNoData(cellDef.alg) match {
-                case WideIntNoData(wnd) ⇒ assert(wnd === nd)
-                case WideDoubleNoData(wnd) ⇒ assert(wnd === nd)
+                case WideIntNoData(wnd) => assert(wnd === nd)
+                case WideDoubleNoData(wnd) => assert(wnd === nd)
               }
               assert(TiffTagFieldValue.createNoDataString(ct) === Some(nd.toString))
             }
@@ -268,23 +268,23 @@ class CellTypeSpec extends AnyFunSpec with Matchers with Inspectors {
         .map(_.withNoData(Some(noData)))
 
       forEvery(userDefinedCelltypes) {
-        case c: UserDefinedNoData[_] ⇒ c.noDataValue match {
-          case n: Byte ⇒ assert(n === noData.toByte)
-          case n: Short ⇒ assert(n === noData.toShort)
-          case n: Int ⇒ assert(n === noData.toInt)
-          case n: Float ⇒ assert(n === noData.toFloat)
-          case n: Double ⇒ assert(n === noData.toDouble)
+        case c: UserDefinedNoData[_] => c.noDataValue match {
+          case n: Byte => assert(n === noData.toByte)
+          case n: Short => assert(n === noData.toShort)
+          case n: Int => assert(n === noData.toInt)
+          case n: Float => assert(n === noData.toFloat)
+          case n: Double => assert(n === noData.toDouble)
         }
         case _ => ???
       }
     }
     it("should report nodata value for ConstantNoData") {
       forEvery(CellType.constantNoDataCellTypes) { _.noDataValue match {
-        case n: Byte ⇒ assert(n === byteNODATA || n === ubyteNODATA)
-        case n: Short ⇒ assert(n === shortNODATA || n === ushortNODATA)
-        case n: Int ⇒ assert(isNoData(n))
-        case n: Float ⇒ assert(isNoData(n))
-        case n: Double ⇒ assert(isNoData(n))
+        case n: Byte => assert(n === byteNODATA || n === ubyteNODATA)
+        case n: Short => assert(n === shortNODATA || n === ushortNODATA)
+        case n: Int => assert(isNoData(n))
+        case n: Float => assert(isNoData(n))
+        case n: Double => assert(isNoData(n))
       }}
     }
   }

--- a/raster/src/test/scala/geotrellis/raster/histogram/HistogramSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/histogram/HistogramSpec.scala
@@ -70,7 +70,7 @@ class HistogramSpec extends AnyFunSpec with Matchers with Inspectors {
             (' ', 5)
           )
 
-          forAll(expected) { case (char, count) ⇒
+          forAll(expected) { case (char, count) =>
             h.itemCount(charToInt(char)) should be (count)
           }
 
@@ -80,7 +80,7 @@ class HistogramSpec extends AnyFunSpec with Matchers with Inspectors {
 
           bins.map(_._2).sum should be (s.length)
 
-          forAll(expected.filter(_._2 > 0)) { case (char, count) ⇒
+          forAll(expected.filter(_._2 > 0)) { case (char, count) =>
             val label = charToInt(char)
             bins.find(_._1 == label) should be ('nonEmpty)
           }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -509,7 +509,7 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
       val p1 = reread.options.colorMap.get.colors
       val p2 = indexed.options.colorMap.get.colors
 
-      Inspectors.forEvery(p1.zip(p2)) { case (c1, c2) ⇒
+      Inspectors.forEvery(p1.zip(p2)) { case (c1, c2) =>
         c1 should equal (c2)
       }
     }
@@ -525,7 +525,7 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
       val p1 = reread.options.colorMap.get.colors
       val p2 = base.options.colorMap.get.colors
 
-      Inspectors.forEvery(p1.zip(p2)) { case (c1, c2) ⇒
+      Inspectors.forEvery(p1.zip(p2)) { case (c1, c2) =>
         c1 should equal (c2)
       }
     }
@@ -534,7 +534,7 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
       val base = SinglebandGeoTiff(geoTiffPath("colormap.tif"))
       val illegal = Seq(FloatCellType, DoubleCellType, IntCellType)
 
-      Inspectors.forEvery(illegal) { cellType ⇒
+      Inspectors.forEvery(illegal) { cellType =>
         val naughty = base.copy(tile = base.tile.convert(cellType))
         intercept[IncompatibleGeoTiffOptionsException] {
           GeoTiffWriter.write(naughty, path)

--- a/raster/src/test/scala/geotrellis/raster/render/ascii/RenderAsciiTests.scala
+++ b/raster/src/test/scala/geotrellis/raster/render/ascii/RenderAsciiTests.scala
@@ -40,10 +40,10 @@ class RenderAsciiTests extends AnyFunSuite with Matchers with TileBuilders with 
       AsciiArtEncoder.Palette.STIPLED,
       AsciiArtEncoder.Palette.BINARY
     )
-    forEvery(palettes) { palette ⇒
+    forEvery(palettes) { palette =>
       val sample = createConsecutiveTile(palette.length)
       val render = sample.renderAscii(palette)
-      forAll(palette.values) { c ⇒
+      forAll(palette.values) { c =>
         assert(render.contains(c))
       }
     }
@@ -101,7 +101,7 @@ class RenderAsciiTests extends AnyFunSuite with Matchers with TileBuilders with 
 
     println(render)
 
-    forEvery(render.toCharArray.distinct.filter(_ != '\n'))(c ⇒
+    forEvery(render.toCharArray.distinct.filter(_ != '\n'))(c =>
       assert(c == palette.nodata || palette.values.contains(c))
     )
 

--- a/store/src/main/scala/geotrellis/store/avro/codecs/package.scala
+++ b/store/src/main/scala/geotrellis/store/avro/codecs/package.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 package object codecs {
   private[codecs] def injectFields(from: Schema, to: FieldAssembler[Schema]): FieldAssembler[Schema] = {
     from.getFields.asScala.foldLeft(to){
-      case (builder, field) ⇒
+      case (builder, field) =>
         builder.name(field.name()).`type`(field.schema()).noDefault()
     }
   }

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayStitcher.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayStitcher.scala
@@ -354,7 +354,7 @@ final class DelaunayStitcher(
     }
     setNext(getPrev(e), getFlip(base))
     setNext(base, e)
-    if (debug) println(s"Found base [$base]: [${getSrc(base)} ⇒ ${getDest(base)}], ${(getCoordinate(getSrc(base)), getCoordinate(getDest(base)))}")
+    if (debug) println(s"Found base [$base]: [${getSrc(base)} => ${getDest(base)}], ${(getCoordinate(getSrc(base)), getCoordinate(getDest(base)))}")
 
     if (isLinear && relativeTo(base, getDest(e)) == ON) {
       (base, true)
@@ -376,9 +376,9 @@ final class DelaunayStitcher(
           cand = hold
         }
 
-        if (debug) println(s"Found candidate [$cand]: [${getSrc(cand)} ⇒ ${getDest(cand)}], ${(getCoordinate(getSrc(cand)), getCoordinate(getDest(cand)))}")
+        if (debug) println(s"Found candidate [$cand]: [${getSrc(cand)} => ${getDest(cand)}], ${(getCoordinate(getSrc(cand)), getCoordinate(getDest(cand)))}")
         val added = createHalfEdges(getSrc(base), getDest(cand))
-        if (debug) println(s"Adding [$added]: [${getSrc(added)} ⇒ ${getDest(added)}]")
+        if (debug) println(s"Adding [$added]: [${getSrc(added)} => ${getDest(added)}]")
 
         setNext(rotCCWDest(cand), getFlip(added))
         setNext(added, getFlip(cand))


### PR DESCRIPTION
replace all unicode arrow operators with equivalent ascii (deprecated in 2.13)
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

Unicode arrow operators are deprecated in 2.13, so replacing them with ascii is one small step towards 2.13 support, as there will be fewer warnings. 

