### PR TITLE
update all methods to not use procedure syntax (via scalafix ProcedureSyntax)

### DIFF
--- a/layer/src/main/scala/geotrellis/layer/buffer/BufferTiles.scala
+++ b/layer/src/main/scala/geotrellis/layer/buffer/BufferTiles.scala
@@ -50,7 +50,7 @@ trait BufferTiles {
     val rows = tile.rows
 
     // ex: adding "TopLeft" corner of this tile to contribute to "TopLeft" tile at key
-    def addSlice(spatialKey: SpatialKey, direction: => raster.buffer.Direction) {
+    def addSlice(spatialKey: SpatialKey, direction: => raster.buffer.Direction): Unit = {
       if(includeKey(spatialKey)) {
         val bufferSizes = getBufferSizes(spatialKey)
 

--- a/raster-testkit/src/main/scala/geotrellis/raster/testkit/TileBuilders.scala
+++ b/raster-testkit/src/main/scala/geotrellis/raster/testkit/TileBuilders.scala
@@ -293,7 +293,7 @@ trait TileBuilders {
     ArrayTile(Array.fill(100)(n), 10, 10)
 
   /* prints out a raster to console */
-  def printR(tile: Tile) {
+  def printR(tile: Tile): Unit = {
     for(row <- 0 until tile.rows) {
       for(col <- 0 until tile.cols) {
         val v = tile.get(col, row)

--- a/raster-testkit/src/main/scala/geotrellis/raster/testkit/Utils.scala
+++ b/raster-testkit/src/main/scala/geotrellis/raster/testkit/Utils.scala
@@ -36,8 +36,8 @@ object Utils {
   }
 
   /** A dirty reflection function to modify object vals */
-  def modifyField(obj: AnyRef, name: String, value: Any) {
-    def impl(clazz: Class[_]) {
+  def modifyField(obj: AnyRef, name: String, value: Any): Unit = {
+    def impl(clazz: Class[_]): Unit = {
       Try(clazz.getDeclaredField(name)).toOption match {
         case Some(field) =>
           field.setAccessible(true)

--- a/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ByteArrayTile.scala
@@ -88,7 +88,7 @@ final case class ByteRawArrayTile(arr: Array[Byte], val cols: Int, val rows: Int
     * @param   i  The index of the datum
     * @param   z  The datum
     */
-  def update(i: Int, z: Int) { arr(i) = z.toByte }
+  def update(i: Int, z: Int): Unit = { arr(i) = z.toByte }
 
   /**
     * Update the datum at the specified index.
@@ -96,7 +96,7 @@ final case class ByteRawArrayTile(arr: Array[Byte], val cols: Int, val rows: Int
     * @param   i  The index of the datum
     * @param   z  The datum
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = z.toByte }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = z.toByte }
 }
 
 /**
@@ -133,7 +133,7 @@ final case class ByteConstantNoDataArrayTile(arr: Array[Byte], val cols: Int, va
     * @param   i  The index of the datum
     * @param   z  The datum
     */
-  def update(i: Int, z: Int) { arr(i) = i2b(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2b(z) }
 
   /**
     * Update the datum at the specified index.
@@ -141,7 +141,7 @@ final case class ByteConstantNoDataArrayTile(arr: Array[Byte], val cols: Int, va
     * @param   i  The index of the datum
     * @param   z  The datum
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2b(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2b(z) }
 }
 
 /**
@@ -180,7 +180,7 @@ final case class ByteUserDefinedNoDataArrayTile(arr: Array[Byte], val cols: Int,
     * @param   i  The index of the datum
     * @param   z  The datum
     */
-  def update(i: Int, z: Int) { arr(i) = i2udb(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2udb(z) }
 
   /**
     * Update the datum at the specified index.
@@ -188,7 +188,7 @@ final case class ByteUserDefinedNoDataArrayTile(arr: Array[Byte], val cols: Int,
     * @param   i  The index of the datum
     * @param   z  The datum
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2udb(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2udb(z) }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -95,7 +95,7 @@ abstract class ConstantTile extends Tile {
     *
     * @param  f  A function from Int to Unit
     */
-  def foreach(f: Int => Unit) {
+  def foreach(f: Int => Unit): Unit = {
     var i = 0
     val len = size
     while (i < len) { f(iVal); i += 1 }

--- a/raster/src/main/scala/geotrellis/raster/DoubleArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/DoubleArrayTile.scala
@@ -89,7 +89,7 @@ final case class DoubleRawArrayTile(arr: Array[Double], val cols: Int, val rows:
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = z.toDouble }
+  def update(i: Int, z: Int): Unit = { arr(i) = z.toDouble }
 
   /**
     * Update the datum at the given index in the array.
@@ -97,7 +97,7 @@ final case class DoubleRawArrayTile(arr: Array[Double], val cols: Int, val rows:
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = z.toDouble }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = z.toDouble }
 }
 
 /**
@@ -130,7 +130,7 @@ final case class DoubleConstantNoDataArrayTile(arr: Array[Double], val cols: Int
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2d(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2d(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -138,7 +138,7 @@ final case class DoubleConstantNoDataArrayTile(arr: Array[Double], val cols: Int
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = z }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = z }
 }
 
 /**
@@ -172,7 +172,7 @@ final case class DoubleUserDefinedNoDataArrayTile(arr: Array[Double], val cols: 
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2udd(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2udd(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -180,7 +180,7 @@ final case class DoubleUserDefinedNoDataArrayTile(arr: Array[Double], val cols: 
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2udd(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2udd(z) }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/FloatArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/FloatArrayTile.scala
@@ -86,7 +86,7 @@ final case class FloatRawArrayTile(arr: Array[Float], val cols: Int, val rows: I
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = z.toFloat }
+  def update(i: Int, z: Int): Unit = { arr(i) = z.toFloat }
 
   /**
     * Update the datum at the given index in the array.
@@ -94,7 +94,7 @@ final case class FloatRawArrayTile(arr: Array[Float], val cols: Int, val rows: I
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = z.toFloat }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = z.toFloat }
 }
 
 /**
@@ -127,7 +127,7 @@ final case class FloatConstantNoDataArrayTile(arr: Array[Float], val cols: Int, 
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2f(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2f(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -135,7 +135,7 @@ final case class FloatConstantNoDataArrayTile(arr: Array[Float], val cols: Int, 
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2f(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2f(z) }
 }
 
 /**
@@ -169,7 +169,7 @@ final case class FloatUserDefinedNoDataArrayTile(arr: Array[Float], val cols: In
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2udf(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2udf(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -177,7 +177,7 @@ final case class FloatUserDefinedNoDataArrayTile(arr: Array[Float], val cols: In
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2udf(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2udf(z) }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
@@ -90,7 +90,7 @@ final case class IntRawArrayTile(arr: Array[Int], val cols: Int, val rows: Int)
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = z }
+  def update(i: Int, z: Int): Unit = { arr(i) = z }
 
   /**
     * Update the datum at the given index in the array.
@@ -98,7 +98,7 @@ final case class IntRawArrayTile(arr: Array[Int], val cols: Int, val rows: Int)
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = z.toInt }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = z.toInt }
 }
 
 /**
@@ -130,7 +130,7 @@ final case class IntConstantNoDataArrayTile(arr: Array[Int], val cols: Int, val 
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = z }
+  def update(i: Int, z: Int): Unit = { arr(i) = z }
 
   /**
     * Update the datum at the given index in the array.
@@ -138,7 +138,7 @@ final case class IntConstantNoDataArrayTile(arr: Array[Int], val cols: Int, val 
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2i(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2i(z) }
 }
 
 /**
@@ -172,7 +172,7 @@ final case class IntUserDefinedNoDataArrayTile(arr: Array[Int], val cols: Int, v
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2udi(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2udi(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -180,7 +180,7 @@ final case class IntUserDefinedNoDataArrayTile(arr: Array[Int], val cols: Int, v
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2udi(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2udi(z) }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/MutableArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/MutableArrayTile.scala
@@ -50,7 +50,7 @@ abstract class MutableArrayTile extends ArrayTile {
     * @param  row    The row
     * @param  value  The value
     */
-  def set(col:Int, row:Int, value:Int) {
+  def set(col:Int, row:Int, value:Int): Unit = {
     update(row * cols + col, value)
   }
 
@@ -62,7 +62,7 @@ abstract class MutableArrayTile extends ArrayTile {
     * @param  row    The row
     * @param  value  The value
     */
-  def setDouble(col:Int, row:Int, value:Double) {
+  def setDouble(col:Int, row:Int, value:Double): Unit = {
     updateDouble(row * cols + col, value)
   }
 

--- a/raster/src/main/scala/geotrellis/raster/ShortArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ShortArrayTile.scala
@@ -88,7 +88,7 @@ final case class ShortRawArrayTile(arr: Array[Short], val cols: Int, val rows: I
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = z.toShort }
+  def update(i: Int, z: Int): Unit = { arr(i) = z.toShort }
 
   /**
     * Update the datum at the given index in the array.
@@ -96,7 +96,7 @@ final case class ShortRawArrayTile(arr: Array[Short], val cols: Int, val rows: I
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = z.toShort }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = z.toShort }
 }
 
 /**
@@ -170,7 +170,7 @@ final case class ShortUserDefinedNoDataArrayTile(arr: Array[Short], val cols: In
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2uds(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2uds(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -178,7 +178,7 @@ final case class ShortUserDefinedNoDataArrayTile(arr: Array[Short], val cols: In
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2uds(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2uds(z) }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/UByteArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/UByteArrayTile.scala
@@ -62,8 +62,8 @@ final case class UByteRawArrayTile(arr: Array[Byte], val cols: Int, val rows: In
   val cellType = UByteCellType
   def apply(i: Int): Int = arr(i) & 0xFF
   def applyDouble(i: Int): Double = (arr(i) & 0xFF).toDouble
-  def update(i: Int, z: Int) { arr(i) = z.toByte }
-  def updateDouble(i: Int, z: Double) { arr(i) = z.toByte }
+  def update(i: Int, z: Int): Unit = { arr(i) = z.toByte }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = z.toByte }
 }
 
 /**
@@ -95,7 +95,7 @@ final case class UByteConstantNoDataArrayTile(arr: Array[Byte], val cols: Int, v
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2ub(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2ub(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -103,7 +103,7 @@ final case class UByteConstantNoDataArrayTile(arr: Array[Byte], val cols: Int, v
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2ub(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2ub(z) }
 }
 
 /**
@@ -137,7 +137,7 @@ final case class UByteUserDefinedNoDataArrayTile(arr: Array[Byte], val cols: Int
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2udb(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2udb(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -145,7 +145,7 @@ final case class UByteUserDefinedNoDataArrayTile(arr: Array[Byte], val cols: Int
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2udb(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2udb(z) }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/UShortArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/UShortArrayTile.scala
@@ -87,7 +87,7 @@ class UShortRawArrayTile(arr: Array[Short], val cols: Int, val rows: Int)
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = z.toShort }
+  def update(i: Int, z: Int): Unit = { arr(i) = z.toShort }
 
   /**
     * Update the datum at the given index in the array.
@@ -95,7 +95,7 @@ class UShortRawArrayTile(arr: Array[Short], val cols: Int, val rows: Int)
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = z.toShort }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = z.toShort }
 }
 
 /**
@@ -127,7 +127,7 @@ class UShortConstantNoDataArrayTile(arr: Array[Short], val cols: Int, val rows: 
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2us(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2us(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -135,7 +135,7 @@ class UShortConstantNoDataArrayTile(arr: Array[Short], val cols: Int, val rows: 
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2us(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2us(z) }
 }
 
 /**
@@ -169,7 +169,7 @@ class UShortUserDefinedNoDataArrayTile(arr: Array[Short], val cols: Int, val row
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def update(i: Int, z: Int) { arr(i) = i2uds(z) }
+  def update(i: Int, z: Int): Unit = { arr(i) = i2uds(z) }
 
   /**
     * Update the datum at the given index in the array.
@@ -177,7 +177,7 @@ class UShortUserDefinedNoDataArrayTile(arr: Array[Short], val cols: Int, val row
     * @param   i  The index
     * @param   z  The value to place at that index
     */
-  def updateDouble(i: Int, z: Double) { arr(i) = d2uds(z) }
+  def updateDouble(i: Int, z: Double): Unit = { arr(i) = d2uds(z) }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/costdistance/CostDistance.scala
+++ b/raster/src/main/scala/geotrellis/raster/costdistance/CostDistance.scala
@@ -181,7 +181,7 @@ object CostDistance {
 
   type Cost = (Int, Int, Double)
 
-  private def calcNeighbors(c: Int, r: Int, cost: Tile, d: DoubleArrayTile, p: PriorityQueue[Cost]) {
+  private def calcNeighbors(c: Int, r: Int, cost: Tile, d: DoubleArrayTile, p: PriorityQueue[Cost]): Unit = {
     val l = dirs.length
     var z = 0
 

--- a/raster/src/main/scala/geotrellis/raster/histogram/FastMapHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/FastMapHistogram.scala
@@ -135,7 +135,7 @@ class FastMapHistogram(_size: Int, _buckets: Array[Int], _counts: Array[Long], _
     * Adjust the histogram so that that it is as if the given value
     * 'item' has been seen 'count' times.
     */
-  def setItem(item: Int, count: Long) {
+  def setItem(item: Int, count: Long): Unit = {
     // We use our hashing strategy to figure out which bucket this
     // item gets.  if the bucket is empty, we're adding the item,
     // whereas if its not we are just increasing the item's count.
@@ -177,7 +177,7 @@ class FastMapHistogram(_size: Int, _buckets: Array[Int], _counts: Array[Long], _
   /**
     * Forget any encounters with the value 'item'.
     */
-  def uncountItem(item: Int) {
+  def uncountItem(item: Int): Unit = {
     // We use our hashing strategy to figure out which bucket this
     // item gets.  if the bucket is empty, we never counted this
     // item. otherwise, we need to remove this value and its counts.
@@ -189,7 +189,7 @@ class FastMapHistogram(_size: Int, _buckets: Array[Int], _counts: Array[Long], _
     counts(i) = 0
   }
 
-  private def resize() {
+  private def resize(): Unit = {
     // It's important that size always be a power of 2. We grow our
     // hash table by x4 until it starts getting big, at which point we
     // only grow by x2.
@@ -264,7 +264,7 @@ class FastMapHistogram(_size: Int, _buckets: Array[Int], _counts: Array[Long], _
     *
     * @param  f  A unit function of one integer parameter
     */
-  def foreachValue(f: Int => Unit) {
+  def foreachValue(f: Int => Unit): Unit = {
     var i = 0
     while (i < size) {
       if (buckets(i) != UNSET) f(buckets(i))

--- a/raster/src/main/scala/geotrellis/raster/io/arg/ArgWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/arg/ArgWriter.scala
@@ -32,7 +32,7 @@ case class ArgWriter(cellType: CellType) {
   def cellTypeName = cellType.name
   def dataType = "arg"
 
-  def writeMetadataJSON(path: String, name: String, re: RasterExtent) {
+  def writeMetadataJSON(path: String, name: String, re: RasterExtent): Unit = {
     val metadata = s"""{
         |  "layer": "$name",
         |  "datatype": "$cellTypeName",
@@ -69,7 +69,7 @@ case class ArgWriter(cellType: CellType) {
    * @param tile: Tile to write to disk
    * @param metadataName: Name to be included in json metadata as 'layer', used in catalog
    */
-  def write(outputFilePath: String, tile: Tile, extent: Extent, metadataName: String) {
+  def write(outputFilePath: String, tile: Tile, extent: Extent, metadataName: String): Unit = {
     val path = outputFilePath
     val base: String = 
       if (path.endsWith(".arg") || path.endsWith(".json") || path.endsWith(".")) {
@@ -86,7 +86,7 @@ case class ArgWriter(cellType: CellType) {
     }
   }
 
-  def writeData(path: String, tile: Tile) {
+  def writeData(path: String, tile: Tile): Unit = {
     val dos = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path)))
     CellWriter.byType(cellType).writeCells(tile, dos)
     dos.close()

--- a/raster/src/main/scala/geotrellis/raster/io/arg/CellWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/arg/CellWriter.scala
@@ -33,9 +33,9 @@ object CellWriter {
 }
 
 trait CellWriter {
-  protected[this] def writeCell(raster: Tile, col: Int, row: Int, cols: Int, dos: DataOutputStream)
+  protected[this] def writeCell(raster: Tile, col: Int, row: Int, cols: Int, dos: DataOutputStream): Unit
 
-  def writeCells(raster: Tile, dos: DataOutputStream) {
+  def writeCells(raster: Tile, dos: DataOutputStream): Unit = {
     val cols = raster.cols
     val rows = raster.rows
 
@@ -52,7 +52,7 @@ trait CellWriter {
 }
 
 object BoolCellWriter extends CellWriter {
-  override def writeCells(raster: Tile, dos: DataOutputStream) {
+  override def writeCells(raster: Tile, dos: DataOutputStream): Unit = {
     val cols = raster.cols
     val rows = raster.rows
 
@@ -81,7 +81,7 @@ object BoolCellWriter extends CellWriter {
 trait IntCellWriter extends CellWriter {
   def noDataValue: Int
   def writeValue(z: Int, dos: DataOutputStream): Unit
-  @inline final def writeCell(raster: Tile, col: Int, row: Int, cols: Int, dos: DataOutputStream) {
+  @inline final def writeCell(raster: Tile, col: Int, row: Int, cols: Int, dos: DataOutputStream): Unit = {
     val z = raster.get(col, row)
     if (isNoData(z)) writeValue(noDataValue, dos) else writeValue(z, dos)
   }
@@ -89,30 +89,30 @@ trait IntCellWriter extends CellWriter {
 
 trait FloatCellWriter extends CellWriter {
   def writeValue(z: Double, dos: DataOutputStream): Unit
-  @inline final def writeCell(raster: Tile, col: Int, row: Int, cols: Int, dos: DataOutputStream) {
+  @inline final def writeCell(raster: Tile, col: Int, row: Int, cols: Int, dos: DataOutputStream): Unit = {
     writeValue(raster.getDouble(col, row), dos)
   }
 }
 
 object Int8CellWriter extends IntCellWriter {
   @inline final def noDataValue = Byte.MinValue
-  @inline final def writeValue(z: Int, dos: DataOutputStream) { dos.writeByte(z) }
+  @inline final def writeValue(z: Int, dos: DataOutputStream): Unit = { dos.writeByte(z) }
 }
 
 object Int16CellWriter extends IntCellWriter {
   @inline final def noDataValue = Short.MinValue
-  @inline final def writeValue(z: Int, dos: DataOutputStream) { dos.writeShort(z) }
+  @inline final def writeValue(z: Int, dos: DataOutputStream): Unit = { dos.writeShort(z) }
 }
 
 object Int32CellWriter extends IntCellWriter {
   @inline final def noDataValue = Int.MinValue
-  @inline final def writeValue(z: Int, dos: DataOutputStream) { dos.writeInt(z) }
+  @inline final def writeValue(z: Int, dos: DataOutputStream): Unit = { dos.writeInt(z) }
 }
 
 object Float32CellWriter extends FloatCellWriter {
-  @inline final def writeValue(z: Double, dos: DataOutputStream) { dos.writeFloat(z.toFloat) }
+  @inline final def writeValue(z: Double, dos: DataOutputStream): Unit = { dos.writeFloat(z.toFloat) }
 }
 
 object Float64CellWriter extends FloatCellWriter {
-  @inline final def writeValue(z: Double, dos: DataOutputStream) { dos.writeDouble(z) }
+  @inline final def writeValue(z: Double, dos: DataOutputStream): Unit = { dos.writeDouble(z) }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/ascii/AsciiReadState.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/ascii/AsciiReadState.scala
@@ -40,7 +40,7 @@ final class AsciiReadState(path: String,
     new BufferedReader(fr)
   }
 
-  def initSource(pos: Int, size: Int) {
+  def initSource(pos: Int, size: Int): Unit = {
     assert (pos == 0)
     assert (size == rasterExtent.cols * rasterExtent.rows)
 
@@ -80,7 +80,7 @@ final class AsciiReadState(path: String,
   }
 
   @inline
-  def assignFromSource(sourceIndex: Int, dest: MutableArrayTile, destIndex: Int) {
+  def assignFromSource(sourceIndex: Int, dest: MutableArrayTile, destIndex: Int): Unit = {
     dest(destIndex) = ints(sourceIndex)
   }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/ascii/AsciiWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/ascii/AsciiWriter.scala
@@ -27,11 +27,11 @@ object AsciiWriter {
   def cellType = "ascii"
   def dataType = ""
 
-  def write(path: String, raster: Tile, extent: Extent, name: String) {
+  def write(path: String, raster: Tile, extent: Extent, name: String): Unit = {
     write(path, raster, extent, name, NODATA)
   }
 
-  def write(path: String, raster: Tile, extent: Extent, name: String, noData: Int) {
+  def write(path: String, raster: Tile, extent: Extent, name: String, noData: Int): Unit = {
     val g = RasterExtent(extent, raster.cols, raster.rows)
     val e = extent
 

--- a/raster/src/main/scala/geotrellis/raster/io/ascii/IntReadState.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/ascii/IntReadState.scala
@@ -22,7 +22,7 @@ trait IntReadState extends ReadState {
   // must override
   def getNoDataValue: Int
 
-  protected[this] override def translate(tile: MutableArrayTile) {
+  protected[this] override def translate(tile: MutableArrayTile): Unit = {
     var i = 0
     val len = tile.size
     val nd = getNoDataValue

--- a/raster/src/main/scala/geotrellis/raster/io/ascii/ReadState.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/ascii/ReadState.scala
@@ -53,7 +53,7 @@ trait ReadState {
   /**
     * Called for cleanup after the ReadState is no longer used.
     */
-  def destroy() {}
+  def destroy(): Unit = {}
 
   /**
     * Overwrite this to translate data from source to destination,

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegmentLayout.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegmentLayout.scala
@@ -80,7 +80,7 @@ case class GeoTiffSegmentLayout(
     var partitionCount: Long = 0l
     val partitions = mutable.ArrayBuilder.make[Array[GridBounds[Int]]]
 
-    def finalizePartition() {
+    def finalizePartition(): Unit = {
       val res = partition.result
       if (res.nonEmpty) partitions += res
       partition.clear()
@@ -88,7 +88,7 @@ case class GeoTiffSegmentLayout(
       partitionCount = 0l
     }
 
-    def addToPartition(window: GridBounds[Int]) {
+    def addToPartition(window: GridBounds[Int]): Unit = {
       partition += window
       partitionSize += window.size
       partitionCount += 1

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/JpegDecompression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/JpegDecompression.scala
@@ -169,7 +169,7 @@ object YCbCrConverter {
     /**
      * Initializes tables for YCC->RGB color space conversion.
      */
-    private def buildYCCtoRGBtable() {
+    private def buildYCCtoRGBtable(): Unit = {
       var i = 0
       var x = -CENTERJSAMPLE
       while(i <= MAXJSAMPLE) {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffCSParser.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffCSParser.scala
@@ -269,7 +269,7 @@ class GeoTiffCSParser(geoKeyDirectory: GeoKeyDirectory) {
     gtgp
   }
 
-  private def getPCSData(pcs: Int, gtgp: GeoTiffCSParameters) {
+  private def getPCSData(pcs: Int, gtgp: GeoTiffCSParameters): Unit = {
     val (optDatum, optZone, optMapSystem) = pcsToDatumZoneAndMapSystem(pcs)
 
     val optDatumName = optMapSystem match {
@@ -661,7 +661,7 @@ class GeoTiffCSParser(geoKeyDirectory: GeoKeyDirectory) {
     }
     else angle
 
-  private def setProjectionParameters(gtgp: GeoTiffCSParameters) {
+  private def setProjectionParameters(gtgp: GeoTiffCSParameters): Unit = {
     var originLong, originLat, rectGridAngle = 0.0
     var falseEasting, falseNorthing = 0.0
     var originScale = 1.0

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Aspect.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Aspect.scala
@@ -45,7 +45,7 @@ object Aspect {
     new SurfacePointCalculation[Tile](tile, n, bounds, cs, target)
       with DoubleArrayTileResult
     {
-      def setValue(x: Int, y: Int, s: SurfacePoint) {
+      def setValue(x: Int, y: Int, s: SurfacePoint): Unit = {
         resultTile.setDouble(x, y, s.aspectAzimuth)
       }
     }

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/CursorMask.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/CursorMask.scala
@@ -152,7 +152,7 @@ class CursorMask(d:Int,f:(Int,Int)=>Boolean) {
     }
   }
 
-  def foreachMasked(mv:Movement)(f:(Int,Int)=>Unit) {
+  def foreachMasked(mv:Movement)(f:(Int,Int)=>Unit): Unit = {
     mv match {
       case Left => foreach(0,0,0,maskedAfterMoveLeft)(f)
       case Right => foreach(1,0,0,unmaskedAfterMoveLeft)(f)
@@ -162,7 +162,7 @@ class CursorMask(d:Int,f:(Int,Int)=>Boolean) {
     }
   }
 
-  def foreachUnmasked(mv:Movement)(f:(Int,Int)=>Unit) {
+  def foreachUnmasked(mv:Movement)(f:(Int,Int)=>Unit): Unit = {
     mv match {
       case Left => foreach(0,0,0,unmaskedAfterMoveLeft)(f)
       case Right => foreach(1,0,0,maskedAfterMoveLeft)(f)

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/FocalCalculation.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/FocalCalculation.scala
@@ -161,10 +161,10 @@ abstract class CellwiseCalculation[T] (
     case _ => sys.error("Cannot use cellwise calculation with this traversal strategy.")
   }
 
-  def add(r: Tile, x: Int, y: Int)
-  def remove(r: Tile, x: Int, y: Int)
+  def add(r: Tile, x: Int, y: Int): Unit
+  def remove(r: Tile, x: Int, y: Int): Unit
   def reset(): Unit
-  def setValue(x: Int, y: Int)
+  def setValue(x: Int, y: Int): Unit
 }
 
 trait CellwiseStrategyCalculation {

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Slope.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Slope.scala
@@ -50,7 +50,7 @@ object Slope {
     {
       val zFactor = z
 
-      def setValue(x: Int, y: Int, s: SurfacePoint) {
+      def setValue(x: Int, y: Int, s: SurfacePoint): Unit = {
         resultTile.setDouble(x, y, degrees(s.slope(zFactor)))
       }
     }

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/Hillshade.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/hillshade/Hillshade.scala
@@ -52,7 +52,7 @@ object Hillshade {
       val cosAz = cos(azimuth)
       val sinAz = sin(azimuth)
 
-      def setValue(x: Int, y: Int, s: SurfacePoint) {
+      def setValue(x: Int, y: Int, s: SurfacePoint): Unit = {
         s.`dz/dx` = s.`dz/dx` * zFactor
         s.`dz/dy` = s.`dz/dy` * zFactor
         val c = cosAz * s.cosAspect + sinAz * s.sinAspect // cos(azimuth - aspect)

--- a/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/Rasterizer.scala
@@ -145,7 +145,7 @@ object Rasterizer {
     * The function f is a closure that should alter a mutable variable
     * by side effect (to avoid boxing).
     */
-  def foreachCellByPoint(geom: Point, re: RasterExtent)(f: (Int, Int) => Unit) {
+  def foreachCellByPoint(geom: Point, re: RasterExtent)(f: (Int, Int) => Unit): Unit = {
     val col = re.mapXToGrid(geom.x)
     val row = re.mapYToGrid(geom.y)
     f(col, row)
@@ -156,14 +156,14 @@ object Rasterizer {
     * at each pixel in the raster extent covered by the geometry.  The
     * two arguments to the function 'f' are the column and row.
     */
-  def foreachCellByMultiPoint(p: MultiPoint, re: RasterExtent)(f: (Int, Int) => Unit) {
+  def foreachCellByMultiPoint(p: MultiPoint, re: RasterExtent)(f: (Int, Int) => Unit): Unit = {
     p.points.foreach(foreachCellByPoint(_, re)(f))
   }
 
   /**
     * Invoke a function on each point in a sequences of Points.
     */
-  def foreachCellByPointSeq(pSet: Seq[Point], re: RasterExtent)(f: (Int, Int) => Unit) {
+  def foreachCellByPointSeq(pSet: Seq[Point], re: RasterExtent)(f: (Int, Int) => Unit): Unit = {
     pSet.foreach(foreachCellByPoint(_, re)(f))
   }
 
@@ -174,7 +174,7 @@ object Rasterizer {
     * @param re  RasterExtent used to determine cols and rows
     * @param f   Function to apply: f(cols, row, feature)
     */
-  def foreachCellByMultiLineString(g: MultiLineString, re: RasterExtent)(f: (Int, Int) => Unit) {
+  def foreachCellByMultiLineString(g: MultiLineString, re: RasterExtent)(f: (Int, Int) => Unit): Unit = {
     g.lines.foreach(foreachCellByLineString(_, re)(f))
   }
 
@@ -190,7 +190,7 @@ object Rasterizer {
     g: MultiLineString,
     re: RasterExtent,
     c: Connectivity
-  )(f: (Int, Int) => Unit) {
+  )(f: (Int, Int) => Unit): Unit = {
     g.lines.foreach(foreachCellByLineString(_, re, c)(f))
   }
 
@@ -211,7 +211,7 @@ object Rasterizer {
     * @param options  The options parameter controls whether to treat pixels as points or areas and whether to report partially-intersected areas.
     * @param f        Function to apply: f(cols, row, feature)
     */
-  def foreachCellByPolygon(p: Polygon, re: RasterExtent, options: Options)(f: (Int, Int) => Unit) {
+  def foreachCellByPolygon(p: Polygon, re: RasterExtent, options: Options)(f: (Int, Int) => Unit): Unit = {
      PolygonRasterizer.foreachCellByPolygon(p, re, options)(f)
   }
 
@@ -231,7 +231,7 @@ object Rasterizer {
    * @param options  The options parameter controls whether to treat pixels as points or areas and whether to report partially-intersected areas.
    * @param f        Function to apply: f(cols, row, feature)
    */
-  def foreachCellByMultiPolygon[D](p: MultiPolygon, re: RasterExtent, options: Options)(f: (Int, Int) => Unit) {
+  def foreachCellByMultiPolygon[D](p: MultiPolygon, re: RasterExtent, options: Options)(f: (Int, Int) => Unit): Unit = {
     p.polygons.foreach(PolygonRasterizer.foreachCellByPolygon(_, re, options)(f))
   }
 
@@ -244,7 +244,7 @@ object Rasterizer {
     line: LineString,
     re: RasterExtent,
     c: Connectivity
-  )(f: (Int, Int) => Unit) {
+  )(f: (Int, Int) => Unit): Unit = {
     val coords = line.getCoordinates()
     var i = 1; while (i < coords.size) {
       val x1 = re.mapXToGrid(coords(i-1).x)
@@ -261,7 +261,7 @@ object Rasterizer {
     * LineString.  The iteration happens in the direction from the
     * first point to the last point.
     */
-  def foreachCellByLineString(line: LineString, re: RasterExtent)(f: (Int, Int) => Unit) {
+  def foreachCellByLineString(line: LineString, re: RasterExtent)(f: (Int, Int) => Unit): Unit = {
     val coords = line.getCoordinates()
     var i = 1; while (i < coords.size) {
       val x1 = re.mapXToGrid(coords(i-1).x)
@@ -350,7 +350,7 @@ object Rasterizer {
     * LineString.  The iteration happens in the direction from the
     * first point to the last point.
     */
-  def foreachCellByLineStringDouble(line: LineString, re: RasterExtent)(f: (Int, Int) => Unit) {
+  def foreachCellByLineStringDouble(line: LineString, re: RasterExtent)(f: (Int, Int) => Unit): Unit = {
     val coords = line.getCoordinates()
     var i = 1; while (i < coords.size) {
       foreachCellInGridLineDouble(coords(i-1).x, coords(i-1).y, coords(i+0).x, coords(i+0).y, re, line.isClosed || i != coords.size - 1)(f)

--- a/raster/src/main/scala/geotrellis/raster/render/jpg/JpgEncoder.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/jpg/JpgEncoder.scala
@@ -38,7 +38,7 @@ case class JpgEncoder(settings: Settings = Settings.DEFAULT) {
     writeParams
   }
 
-  def writeOutputStream(os: ImageOutputStream, raster: Tile) {
+  def writeOutputStream(os: ImageOutputStream, raster: Tile): Unit = {
     val img: BufferedImage = raster.toBufferedImage
 
     // Write to provided output stream

--- a/raster/src/main/scala/geotrellis/raster/render/png/Chunk.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/png/Chunk.scala
@@ -30,18 +30,18 @@ final class Chunk(chunkType:Int) {
   val cos = new CheckedOutputStream(baos, crc)
   writeInt(chunkType)
 
-  def writeInt(i:Int) {
+  def writeInt(i:Int): Unit = {
     cos.write(byte(i >> 24))
     cos.write(byte(i >> 16))
     cos.write(byte(i >> 8))
     cos.write(byte(i))
   }
 
-  def writeByte(b:Byte) {
+  def writeByte(b:Byte): Unit = {
     cos.write(b)
   }
 
-  def writeTo(out:DataOutputStream) {
+  def writeTo(out:DataOutputStream): Unit = {
     cos.flush()
     out.writeInt(baos.size() - 4)
     baos.writeTo(out)

--- a/raster/src/main/scala/geotrellis/raster/render/png/PngEncoder.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/png/PngEncoder.scala
@@ -49,7 +49,7 @@ case class PngEncoder(settings: Settings) {
   // how many bits to shift to get the uppermost byte.
   final val SHIFT: Int = (DEPTH - 1) * 8
 
-  def writeHeader(dos: DataOutputStream, raster: Tile) {
+  def writeHeader(dos: DataOutputStream, raster: Tile): Unit = {
     val width = raster.cols
     val height = raster.rows
 
@@ -67,7 +67,7 @@ case class PngEncoder(settings: Settings) {
     cIHDR.writeTo(dos)
   }
 
-  def writeBackgroundInfo(dos: DataOutputStream) {
+  def writeBackgroundInfo(dos: DataOutputStream): Unit = {
     settings.colorType match {
       case GreyPngEncoding(Some(ndColor)) =>
         // write a single 2-byte color value
@@ -124,7 +124,7 @@ case class PngEncoder(settings: Settings) {
   }
 
   // TODO: figure out how to share code without impacting performance
-  def writePixelData(dos: DataOutputStream, raster: Tile) {
+  def writePixelData(dos: DataOutputStream, raster: Tile): Unit = {
     settings.filter match {
       case PaethFilter => writePixelDataPaeth(dos, raster)
       case NoFilter => writePixelDataNoFilter(dos, raster)
@@ -132,7 +132,7 @@ case class PngEncoder(settings: Settings) {
     }
   }
 
-  def writePixelDataNoFilter(dos: DataOutputStream, raster: Tile) {
+  def writePixelDataNoFilter(dos: DataOutputStream, raster: Tile): Unit = {
     // dereference some useful information from the raster
     val cols = raster.cols
     val size = cols * raster.rows
@@ -172,7 +172,7 @@ case class PngEncoder(settings: Settings) {
     cIDAT.writeTo(dos)
   }
 
-  def writePixelDataPaeth(dos: DataOutputStream, raster: Tile) {
+  def writePixelDataPaeth(dos: DataOutputStream, raster: Tile): Unit = {
     // dereference some useful information from the raster
     val cols = raster.cols
     val size = cols * raster.rows
@@ -255,12 +255,12 @@ case class PngEncoder(settings: Settings) {
   }
 
   // signal the end of the PNG data
-  def writeEnd(dos: DataOutputStream) {
+  def writeEnd(dos: DataOutputStream): Unit = {
     val cIEND = new Chunk(IEND)
     cIEND.writeTo(dos)
   }
 
-  def writeOutputStream(os: OutputStream, raster: Tile) {
+  def writeOutputStream(os: OutputStream, raster: Tile): Unit = {
     // wrap our actual OutputStream to enable us to write bytes and such.
     val dos = new DataOutputStream(os)
 
@@ -284,7 +284,7 @@ case class PngEncoder(settings: Settings) {
     baos.toByteArray
   }
 
-  def writePath(path: String, raster: Tile) {
+  def writePath(path: String, raster: Tile): Unit = {
     val fos = new FileOutputStream(new File(path))
     writeOutputStream(fos, raster)
     fos.close()

--- a/raster/src/main/scala/geotrellis/raster/render/png/Util.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/png/Util.scala
@@ -26,7 +26,7 @@ object Util {
   /**
    * ByteBuffer boiler-plate stuff below.
    */
-  def initByteBuffer32(bb:ByteBuffer, d:Array[Int], size:Int) {
+  def initByteBuffer32(bb:ByteBuffer, d:Array[Int], size:Int): Unit = {
     var j = 0
     while (j < size) {
       val z = d(j)
@@ -38,7 +38,7 @@ object Util {
     }
   }
 
-  def initByteBuffer24(bb:ByteBuffer, d:Array[Int], size:Int) {
+  def initByteBuffer24(bb:ByteBuffer, d:Array[Int], size:Int): Unit = {
     var j = 0
     while (j < size) {
       val z = d(j)
@@ -49,7 +49,7 @@ object Util {
     }
   }
 
-  def initByteBuffer16(bb:ByteBuffer, d:Array[Int], size:Int) {
+  def initByteBuffer16(bb:ByteBuffer, d:Array[Int], size:Int): Unit = {
     var j = 0
     while (j < size) {
       val z = d(j)
@@ -59,7 +59,7 @@ object Util {
     }
   }
 
-  def initByteBuffer8(bb:ByteBuffer, d:Array[Int], size:Int) {
+  def initByteBuffer8(bb:ByteBuffer, d:Array[Int], size:Int): Unit = {
     var j = 0
     while (j < size) {
       bb.put(byte(d(j)))

--- a/spark/src/main/scala/geotrellis/spark/RasterSourceRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/RasterSourceRDD.scala
@@ -328,7 +328,7 @@ object RasterSourceRDD {
       var partitionCount: Long = 0l
       val partitions = ArrayBuilder.make[Array[T]]
 
-      def finalizePartition() {
+      def finalizePartition(): Unit = {
         val res = partition.result
         if (res.nonEmpty) partitions += res
         partition.clear()
@@ -336,7 +336,7 @@ object RasterSourceRDD {
         partitionCount = 0l
       }
 
-      def addToPartition(chunk: T) {
+      def addToPartition(chunk: T): Unit = {
         partition += chunk
         partitionSize += chunkSize(chunk)
         partitionCount += 1

--- a/spark/src/main/scala/geotrellis/spark/store/kryo/KryoRegistrator.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/kryo/KryoRegistrator.scala
@@ -26,7 +26,7 @@ import java.util.{Comparator, TreeMap}
 
 /** Account for a bug in Kryo < 2.22 for serializing TreeMaps */
 class XTreeMapSerializer extends MapSerializer {
-  override def write (kryo: Kryo, output: Output, map: java.util.Map[_, _]) {
+  override def write (kryo: Kryo, output: Output, map: java.util.Map[_, _]): Unit = {
     val treeMap = map.asInstanceOf[TreeMap[_, _]]
     kryo.writeClassAndObject(output, treeMap.comparator())
     super.write(kryo, output, map)
@@ -43,7 +43,7 @@ class XTreeMapSerializer extends MapSerializer {
 
 class KryoRegistrator extends SparkKryoRegistrator {
 
-  override def registerClasses(kryo: Kryo) {
+  override def registerClasses(kryo: Kryo): Unit = {
     // TreeMap serializaiton has a bug; we fix it here as we're stuck on low
     // Kryo versions due to Spark. Hack-tastic.
     kryo.register(classOf[TreeMap[_, _]], (new XTreeMapSerializer).asInstanceOf[com.esotericsoftware.kryo.Serializer[TreeMap[_, _]]])

--- a/spark/src/main/scala/geotrellis/spark/util/KryoWrapper.scala
+++ b/spark/src/main/scala/geotrellis/spark/util/KryoWrapper.scala
@@ -42,12 +42,12 @@ class KryoWrapper[T: ClassTag] extends Serializable {
   }
 
   // Used for Java serialization.
-  private def writeObject(out: java.io.ObjectOutputStream) {
+  private def writeObject(out: java.io.ObjectOutputStream): Unit = {
     getValueSerialized()
     out.defaultWriteObject()
   }
 
-  private def readObject(in: java.io.ObjectInputStream) {
+  private def readObject(in: java.io.ObjectInputStream): Unit = {
     in.defaultReadObject()
     setValueSerialized(valueSerialized)
     //println(s"Reading KryoWrapper $this - $value")

--- a/spark/src/main/scala/org/apache/spark/rdd/FilteredCartesianRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/rdd/FilteredCartesianRDD.scala
@@ -115,7 +115,7 @@ sealed class FilteredCartesianRDD[T: ClassTag, U: ClassTag, V: ClassTag](
     }
   )
 
-  override def clearDependencies() {
+  override def clearDependencies(): Unit = {
     super.clearDependencies()
     rdd1 = null
     rdd2 = null

--- a/store/src/main/scala/geotrellis/store/avro/AvroRecordCodec.scala
+++ b/store/src/main/scala/geotrellis/store/avro/AvroRecordCodec.scala
@@ -24,7 +24,7 @@ import scala.reflect.ClassTag
 @implicitNotFound("Cannot find AvroRecordCodec for ${T}. Try to import geotrellis.spark.io.avro.codecs.Implicits._")
 abstract class AvroRecordCodec[T: ClassTag] extends AvroCodec[T, GenericRecord] {
   def schema: Schema
-  def encode(thing: T, rec: GenericRecord)
+  def encode(thing: T, rec: GenericRecord): Unit
   def decode(rec: GenericRecord): T
 
   def encode(thing: T): GenericRecord = {

--- a/store/src/main/scala/geotrellis/store/hadoop/formats/FilterMapFileInputFormat.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/formats/FilterMapFileInputFormat.scala
@@ -275,6 +275,6 @@ class FilterMapFileInputFormat() extends FileInputFormat[BigIntWritable, BytesWr
     def getProgress(): Float = 0.0f // Not sure how to measure this, or if we need to.
 
     override
-    def close() { if(mapFile != null) { mapFile.close() } }
+    def close(): Unit = { if(mapFile != null) { mapFile.close() } }
   }
 }

--- a/store/src/main/scala/geotrellis/store/json/KeyIndexFormats.scala
+++ b/store/src/main/scala/geotrellis/store/json/KeyIndexFormats.scala
@@ -39,7 +39,7 @@ case class KeyIndexFormatEntry[K: Encoder: Decoder: ClassTag, T <: KeyIndex[K]: 
 }
 
 trait KeyIndexRegistrator {
-  def register(keyIndexRegistry: KeyIndexRegistry)
+  def register(keyIndexRegistry: KeyIndexRegistry): Unit
 }
 
 class KeyIndexEncoder[K](entries: Seq[KeyIndexFormatEntry[K, _]]) extends Encoder[KeyIndex[K]] {

--- a/vector/src/main/scala/geotrellis/vector/io/WKB/WKBWriter.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/WKB/WKBWriter.scala
@@ -85,7 +85,7 @@ class WKBWriter(outputDimension: Int, byteOrder: Int) {
     * @param os the out stream to write to
     * @throws IOException if an I/O error occurs
     */
-  private def write(geom: Geometry, os: OutStream) {
+  private def write(geom: Geometry, os: OutStream): Unit = {
     geom match {
       case g: Point => writePoint(g, os)
       case g: LineString => writeLineString(g, os)
@@ -98,7 +98,7 @@ class WKBWriter(outputDimension: Int, byteOrder: Int) {
     }
   }
 
-  private def writePoint(pt: Point, os: OutStream) {
+  private def writePoint(pt: Point, os: OutStream): Unit = {
     if (pt.getCoordinateSequence.size() == 0)
       throw new IllegalArgumentException("Empty Points cannot be represented in WKB")
     writeByteOrder(os)
@@ -106,13 +106,13 @@ class WKBWriter(outputDimension: Int, byteOrder: Int) {
     writeCoordinateSequence(pt.getCoordinateSequence, false, os)
   }
 
-  private def writeLineString(line: LineString, os: OutStream) {
+  private def writeLineString(line: LineString, os: OutStream): Unit = {
     writeByteOrder(os)
     writeGeometryType(WKBConstants.wkbLineString, line, os)
     writeCoordinateSequence(line.getCoordinateSequence, true, os)
   }
 
-  private def writePolygon(poly: Polygon, os: OutStream)
+  private def writePolygon(poly: Polygon, os: OutStream): Unit =
   {
     writeByteOrder(os)
     writeGeometryType(WKBConstants.wkbPolygon, poly, os)
@@ -123,7 +123,7 @@ class WKBWriter(outputDimension: Int, byteOrder: Int) {
     }
   }
 
-  private def writeGeometryCollection(geometryType: Int, gc: GeometryCollection, os: OutStream) {
+  private def writeGeometryCollection(geometryType: Int, gc: GeometryCollection, os: OutStream): Unit = {
     writeByteOrder(os)
     writeGeometryType(geometryType, gc, os)
     writeInt(gc.getNumGeometries, os)
@@ -131,7 +131,7 @@ class WKBWriter(outputDimension: Int, byteOrder: Int) {
       write(gc.getGeometryN(i), os)
   }
 
-  private def writeByteOrder(os: OutStream) {
+  private def writeByteOrder(os: OutStream): Unit = {
     if (byteOrder == ByteOrderValues.LITTLE_ENDIAN)
       buf(0) = WKBConstants.wkbNDR
     else
@@ -139,7 +139,7 @@ class WKBWriter(outputDimension: Int, byteOrder: Int) {
     os.write(buf, 1)
   }
 
-  private def writeGeometryType(geometryType: Int, g: Geometry, os: OutStream ) {
+  private def writeGeometryType(geometryType: Int, g: Geometry, os: OutStream ): Unit = {
     val flag3D = if (outputDimension == 3)  0x80000000 else 0
     srid match {
       case Some(srid: Int) =>
@@ -152,12 +152,12 @@ class WKBWriter(outputDimension: Int, byteOrder: Int) {
     }
   }
 
-  private def writeInt(intValue: Int, os: OutStream) {
+  private def writeInt(intValue: Int, os: OutStream): Unit = {
     ByteOrderValues.putInt(intValue, buf, byteOrder)
     os.write(buf, 4)
   }
 
-  private def writeCoordinate(seq: CoordinateSequence, index: Int, os: OutStream) {
+  private def writeCoordinate(seq: CoordinateSequence, index: Int, os: OutStream): Unit = {
     ByteOrderValues.putDouble(seq.getX(index), buf, byteOrder)
     os.write(buf, 8)
     ByteOrderValues.putDouble(seq.getY(index), buf, byteOrder)
@@ -174,7 +174,7 @@ class WKBWriter(outputDimension: Int, byteOrder: Int) {
     }
   }
 
-  private def writeCoordinateSequence(seq: CoordinateSequence, writeSize: Boolean, os: OutStream) {
+  private def writeCoordinateSequence(seq: CoordinateSequence, writeSize: Boolean, os: OutStream): Unit = {
     if (writeSize) writeInt(seq.size(), os)
     for (i <- 0 until seq.size()) writeCoordinate(seq, i, os)
   }

--- a/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeTable.scala
+++ b/vector/src/main/scala/geotrellis/vector/mesh/HalfEdgeTable.scala
@@ -421,7 +421,7 @@ class HalfEdgeTable(_size: Int) extends Serializable {
     repl
   }
 
-  private def resize() {
+  private def resize(): Unit = {
     // It's important that size always be a power of 2. We grow our
     // hash table by x4 until it starts getting big, at which point we
     // only grow by x2.


### PR DESCRIPTION
update all methods to not use procedure syntax (via scalafix ProcedureSyntax)

Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

Procedure syntax (a def without an `=` returning Unit) is deprecated in Scala 2, and is gone from Scala 3. This change updates all uses of this syntax with the equivalent `def f: Unit = {...}` syntax per `scalafix ProcedureSyntax`.
