### PR TITLE
change all long literals to use uppercase L instead of lowercase l

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegmentLayout.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiffSegmentLayout.scala
@@ -76,16 +76,16 @@ case class GeoTiffSegmentLayout(
   def partitionWindowsBySegments(windows: Seq[GridBounds[Int]], maxPartitionSize: Long): Array[Array[GridBounds[Int]]] = {
     val partition = mutable.ArrayBuilder.make[GridBounds[Int]]
     partition.sizeHintBounded(128, windows)
-    var partitionSize: Long = 0l
-    var partitionCount: Long = 0l
+    var partitionSize: Long = 0L
+    var partitionCount: Long = 0L
     val partitions = mutable.ArrayBuilder.make[Array[GridBounds[Int]]]
 
     def finalizePartition() {
       val res = partition.result
       if (res.nonEmpty) partitions += res
       partition.clear()
-      partitionSize = 0l
-      partitionCount = 0l
+      partitionSize = 0L
+      partitionCount = 0L
     }
 
     def addToPartition(window: GridBounds[Int]) {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/LazySegmentBytes.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/LazySegmentBytes.scala
@@ -78,7 +78,7 @@ class LazySegmentBytes(
       Segment(id, offset, offset + length - 1)
     }}.toSeq
       .sortBy(_.startOffset) // sort segments such that we inspect them in disk order
-      .foldLeft((0l, List(List.empty[Segment]))) { case ((chunkSize, headChunk :: commitedChunks), seg) =>
+      .foldLeft((0L, List(List.empty[Segment]))) { case ((chunkSize, headChunk :: commitedChunks), seg) =>
       // difference of offsets should be <= maxOffsetBetweenChunks
       // otherwise everything between these offsets would be read by reader
       // and the intention is to group segments by location and to limit groups by size

--- a/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3GeoTiffRDD.scala
+++ b/s3-spark/src/main/scala/geotrellis/spark/store/s3/S3GeoTiffRDD.scala
@@ -85,7 +85,7 @@ object S3GeoTiffRDD {
   ) extends RasterReader.Options
 
   private val DefaultMaxTileSize = 256
-  private val DefaultPartitionBytes = 128l * 1024 * 1024
+  private val DefaultPartitionBytes = 128L * 1024 * 1024
 
   object Options {
     def DEFAULT = Options()

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,6 +1,6 @@
 <scalastyle>
  <name>Scalastyle standard configuration</name>
- <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxFileLength"><![CDATA[800]]></parameter>
@@ -25,9 +25,9 @@
 // limitations under the License.]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxLineLength"><![CDATA[160]]></parameter>
@@ -49,7 +49,7 @@
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
   <parameters>
    <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
@@ -65,14 +65,14 @@
    <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[println]]></parameter>
@@ -88,8 +88,8 @@
    <parameter name="maximum"><![CDATA[10]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
   <parameters>
    <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
@@ -111,7 +111,7 @@
    <parameter name="maxMethods"><![CDATA[30]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
 </scalastyle>

--- a/spark/src/main/scala/geotrellis/spark/RasterSourceRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/RasterSourceRDD.scala
@@ -30,7 +30,7 @@ import scala.reflect.ClassTag
 import java.time.ZonedDateTime
 
 object RasterSourceRDD {
-  final val DEFAULT_PARTITION_BYTES: Long = 128l * 1024 * 1024
+  final val DEFAULT_PARTITION_BYTES: Long = 128L * 1024 * 1024
 
   def read(
     readingSources: Seq[ReadingSource],
@@ -318,22 +318,22 @@ object RasterSourceRDD {
   private def partition[T: ClassTag](
     chunks: Traversable[T],
     maxPartitionSize: Long
-  )(chunkSize: T => Long = { c: T => 1l }): Array[Array[T]] = {
+  )(chunkSize: T => Long = { c: T => 1L }): Array[Array[T]] = {
     if (chunks.isEmpty) {
       Array[Array[T]]()
     } else {
       val partition = ArrayBuilder.make[T]
       partition.sizeHintBounded(128, chunks)
-      var partitionSize: Long = 0l
-      var partitionCount: Long = 0l
+      var partitionSize: Long = 0L
+      var partitionCount: Long = 0L
       val partitions = ArrayBuilder.make[Array[T]]
 
       def finalizePartition() {
         val res = partition.result
         if (res.nonEmpty) partitions += res
         partition.clear()
-        partitionSize = 0l
-        partitionCount = 0l
+        partitionSize = 0L
+        partitionCount = 0L
       }
 
       def addToPartition(chunk: T) {

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopGeoTiffRDD.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopGeoTiffRDD.scala
@@ -80,7 +80,7 @@ object HadoopGeoTiffRDD {
   ) extends RasterReader.Options
 
   private val DefaultMaxTileSize = 256
-  private val DefaultPartitionBytes = 128l * 1024 * 1024
+  private val DefaultPartitionBytes = 128L * 1024 * 1024
 
   object Options {
     def DEFAULT = Options()

--- a/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopRDDWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/store/hadoop/HadoopRDDWriter.scala
@@ -53,7 +53,7 @@ object HadoopRDDWriter {
     */
   class MultiMapWriter(layerPath: String, partition: Int, blockSize: Long, indexInterval: Int) {
     private var writer: MapFile.Writer = null // avoids creating a MapFile for empty partitions
-    private var bytesRemaining = 0l
+    private var bytesRemaining = 0L
 
     private def getWriter(firstIndex: BigInt) = {
       val path = new Path(layerPath, f"part-r-${partition}%05d-${firstIndex}")

--- a/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
@@ -84,9 +84,9 @@ class TileLayerRDDFilterMethodsSpec extends AnyFunSpec with TestEnvironment {
     val (_, rdd) = createTileLayerRDD(originalRaster, 5, 5, gt.crs)
     val temporalRdd =
       rdd
-        .withContext { _.map { case (k, v) => SpaceTimeKey(k, TemporalKey(1000l)) -> v } }
+        .withContext { _.map { case (k, v) => SpaceTimeKey(k, TemporalKey(1000L)) -> v } }
         .mapContext { md => md.copy(bounds = md.bounds match {
-          case KeyBounds(minKey, maxKey) => KeyBounds(SpaceTimeKey(minKey, TemporalKey(1000l)), SpaceTimeKey(maxKey, TemporalKey(1000l)))
+          case KeyBounds(minKey, maxKey) => KeyBounds(SpaceTimeKey(minKey, TemporalKey(1000L)), SpaceTimeKey(maxKey, TemporalKey(1000L)))
           case _ => EmptyBounds
         }) }
     val allKeys = KeyBounds(SpatialKey(0,0), SpatialKey(4,4))

--- a/store/src/main/scala/geotrellis/store/index/IndexRanges.scala
+++ b/store/src/main/scala/geotrellis/store/index/IndexRanges.scala
@@ -50,7 +50,7 @@ object IndexRanges {
       }
 
       if (sum >= binWidth) {
-        sum = 0l
+        sum = 0L
         i += 1
       }
     }

--- a/util/src/main/scala/geotrellis/util/StreamingByteReader.scala
+++ b/util/src/main/scala/geotrellis/util/StreamingByteReader.scala
@@ -42,8 +42,8 @@ class StreamingByteReader(rangeReader: RangeReader, chunkSize: Int = 45876) exte
 
   private var chunkBytes: Array[Byte] = _
   private var chunkBuffer: ByteBuffer = _
-  private var chunkRange: NumericRange[Long] = 1l to 0l // empty
-  private var filePosition: Long = 0l
+  private var chunkRange: NumericRange[Long] = 1L to 0L // empty
+  private var filePosition: Long = 0L
   private var byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
 
   def position: Long = filePosition


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

1. change all long literals to use uppercase `L` instead of lowercase `l` . This was outputting a warning during compilation (at least in 2.13)
2. change scalastyle config to make this an error instead of a warning

