### PR TITLE
configure scalastyle to fail on error

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -24,6 +24,7 @@ import de.heikoseeberger.sbtheader.{CommentStyle, FileType}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{HeaderLicense, headerLicense, headerMappings}
 import sbtprotoc.ProtocPlugin.autoImport.PB
 import mdoc.MdocPlugin.autoImport._
+import org.scalastyle.sbt.ScalastylePlugin.autoImport.scalastyleFailOnError
 
 import java.io.File
 
@@ -72,6 +73,7 @@ object Settings {
     pomIncludeRepository := { _ => false },
     autoAPIMappings := true,
     Global / cancelable := true,
+    scalastyleFailOnError := true,
 
     publishTo := {
       val sonatype = "https://oss.sonatype.org/"


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

configure scalastyle to fail on error. The default is not to fail on an error, though that seems like it should be the purpose of the error level. This will also allow enforcement of error-level checks in CI.

