### PR TITLE
fix ambiguous relative paths for implicit imports between raster and vector

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/Implicits.scala
@@ -17,7 +17,6 @@
 package geotrellis.raster
 
 import geotrellis.vector.Point
-import geotrellis.vector._
 import geotrellis.util.{MethodExtensions, np}
 
 object Implicits extends Implicits
@@ -60,6 +59,8 @@ trait Implicits
   implicit class withMultibandTileMethods(val self: MultibandTile) extends MethodExtensions[MultibandTile]
       with DelayedConversionMultibandTileMethods
 
+  import geotrellis.vector.methods.Implicits.withExtraPointMethods
+
   implicit class SinglebandRasterAnyRefMethods(val self: SinglebandRaster) extends AnyRef {
     def getValueAtPoint(point: Point): Int =
       getValueAtPoint(point.x, point.y)
@@ -84,7 +85,7 @@ trait Implicits
     def assertEqualDimensions(): Unit =
       if(Set(rs.map(_.dimensions)).size != 1) {
         val dimensions = rs.map(_.dimensions).toSeq
-        throw new GeoAttrsError("Cannot combine tiles with different dimensions." +
+        throw GeoAttrsError("Cannot combine tiles with different dimensions." +
           s"$dimensions are not all equal")
       }
   }
@@ -92,7 +93,7 @@ trait Implicits
   implicit class TileTupleExtensions(t: (Tile, Tile)) {
     def assertEqualDimensions(): Unit =
       if(t._1.dimensions != t._2.dimensions) {
-        throw new GeoAttrsError("Cannot combine rasters with different dimensions." +
+        throw GeoAttrsError("Cannot combine rasters with different dimensions." +
           s"${t._1.dimensions} does not match ${t._2.dimensions}")
       }
   }


### PR DESCRIPTION
fix ambiguous relative paths for implicit imports between raster and vector

Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

This object extends many other objects named `Implicit` in the `raster` project. However, it also imported `geotrellis.vector._`, which also has objects `interpolation.Implicits`, `summary.Implicits`, and `summary.polygonal.Implicits`. In 2.11 and 2.12, these resolve to the `raster` objects in an sbt build, but still confuses IntelliJ using those versions. In 2.13, they are not resolved correctly even in the sbt build, resulting in compilation errors where the implicits are expected to exist.

This PR changes the `import geotrellis.vector._` to only import the single implicit class that's actually used from the package, so there's no ambiguous resolution of the 3 relative objects references previously mentioned.

Also, remove two unnecessary uses of `new` for case class construction.

## Checklist

- [ ] n/a [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] n/a New user API has useful Scaladoc strings
- [ ] n/a Unit tests added for bug-fix or new feature

## Demo

n/a

## Notes

n/a
