### PR TITLE
minor fixes for compilation errors under 2.13 (backwards-compatible with 2.11 and 2.12)

### DIFF
--- a/proj4/src/main/scala/geotrellis/proj4/CRS.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/CRS.scala
@@ -118,7 +118,7 @@ object CRS {
 
   /** Mix-in for singleton CRS implementations where distinguished string should be the name of the object. */
   private[proj4] trait ObjectNameToString { self: CRS =>
-    override def toString: String = self.getClass.getSimpleName.replaceAllLiterally("$", "")
+    override def toString: String = self.getClass.getSimpleName.replace("$", "")
   }
 }
 

--- a/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
@@ -619,7 +619,7 @@ case class CompositeTile(tiles: Seq[Tile],
           }
           if(layoutCol != tileLayout.layoutCols - 1) {
             val pad = " " * 5
-            sb.append(s"$pad| ")r
+            sb.append(s"$pad| ").r
           }
         }
         sb.append(s"\n")

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffCSParser.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffCSParser.scala
@@ -242,7 +242,7 @@ class GeoTiffCSParser(geoKeyDirectory: GeoKeyDirectory) {
         gtgp.zone = zone
         gtgp.mapSystem = mapSystem
       }
-      case None => Unit
+      case None => ()
     }
 
     if ((gtgp.mapSystem == MapSys_UTM_North || gtgp.mapSystem == MapSys_UTM_South)
@@ -470,7 +470,7 @@ class GeoTiffCSParser(geoKeyDirectory: GeoKeyDirectory) {
       projParms(5) = (ProjFalseEastingGeoKey, getValueIfNotNull(projParms(5)))
       projParms(6) = (ProjFalseNorthingGeoKey, getValueIfNotNull(projParms(6)))
     }
-    case _ => Unit
+    case _ => ()
   }
 
   private def getValueIfNotNull(tuple: (Int, Double)) =
@@ -923,7 +923,7 @@ class GeoTiffCSParser(geoKeyDirectory: GeoKeyDirectory) {
         gtgp.projectionParameters(5) = (ProjFalseEastingGeoKey, falseEasting)
         gtgp.projectionParameters(6) = (ProjFalseNorthingGeoKey, falseNorthing)
       }
-      case _ => Unit
+      case _ => ()
     }
 
     for (i <- 0 until gtgp.projectionParameters.size) {
@@ -936,7 +936,7 @@ class GeoTiffCSParser(geoKeyDirectory: GeoKeyDirectory) {
           if (gtgp.lengthInMeters != 0.0 && gtgp.lengthInMeters != 1.0) {
             gtgp.projectionParameters(i) = (v._1, v._2 * gtgp.lengthInMeters)
           }
-        case _ => Unit
+        case _ => ()
       }
     }
   }

--- a/util/src/main/scala/geotrellis/util/ByteReader.scala
+++ b/util/src/main/scala/geotrellis/util/ByteReader.scala
@@ -36,7 +36,7 @@ trait ByteReader {
   def getDouble: Double
   def getLong: Long
 
-  def order: ByteOrder
+  def order(): ByteOrder
   def order(byteOrder: ByteOrder): Unit
 }
 
@@ -47,7 +47,7 @@ trait ByteReader {
 object ByteReader {
   implicit def byteBuffer2ByteReader(byteBuffer: ByteBuffer): ByteReader = {
     new ByteReader() {
-      def position: Long = byteBuffer.position.toLong
+      def position(): Long = byteBuffer.position().toLong
       def position(i: Long): ByteReader = { byteBuffer.position(i.toInt) ; this }
 
       def getBytes(length: Int): Array[Byte] = {

--- a/util/src/main/scala/geotrellis/util/StreamingByteReader.scala
+++ b/util/src/main/scala/geotrellis/util/StreamingByteReader.scala
@@ -112,7 +112,7 @@ class StreamingByteReader(rangeReader: RangeReader, chunkSize: Int = 45876) exte
       readChunk(filePosition to (filePosition + len - 1))
     }
 
-    if (filePosition != chunkRange.start + chunkBuffer.position)
+    if (filePosition != chunkRange.start + chunkBuffer.position())
       chunkBuffer.position((filePosition - chunkRange.start).toInt)
 
     trimmed.toInt

--- a/vectortile/src/main/scala/geotrellis/vectortile/Layer.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/Layer.scala
@@ -387,7 +387,7 @@ object StrictLayer {
         case POINT => points += f
         case LINESTRING => lines += f
         case POLYGON => polys += f
-        case _ => Unit // `UNKNOWN` or `Unrecognized`.
+        case _ => () // `UNKNOWN` or `Unrecognized`.
       }
     }
 


### PR DESCRIPTION

Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

1. fix regex literal missing `.` before r
2. replace use of type Unit with instance `()`
3. replace use of replaceAllLiterally with replace
4. fix several ambiguous nullary arg references that no longer compile in 2.13

## Checklist

- [ ] n/a [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] n/a New user API has useful Scaladoc strings
- [ ] n/a Unit tests added for bug-fix or new feature

## Demo

none

## Notes

none
