### PR TITLE
SpatialIndex use of Traversable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add method SpatialIndex#pointsInExtentAsIterable [#3349](https://github.com/locationtech/geotrellis/issues/3349)
+
+### Changed
+- Deprecate method SpatialIndex#traversePointsInExtent [#3349](https://github.com/locationtech/geotrellis/issues/3349)
+
 ## [3.5.2] - 2021-02-01
 
 ### Added

--- a/vector/src/main/scala/geotrellis/vector/SpatialIndex.scala
+++ b/vector/src/main/scala/geotrellis/vector/SpatialIndex.scala
@@ -73,6 +73,12 @@ class SpatialIndex[T](val measure: Measure = Measure.Euclidean) extends Serializ
   def nearest(ex: Extent): T =
     rtree.nearestNeighbour(ex.jtsEnvelope, null, measure).asInstanceOf[T]
 
+  @deprecated(
+    """As of Scala 2.13, Iterable is preferred over Traversable, which will be removed in Scala 3.
+       Use pointsInExtentAsIterable instead.
+       """.stripMargin,
+    "3.5.3"
+  )
   def traversePointsInExtent(extent: Extent): Traversable[T] =
     new Traversable[T] {
       override def foreach[U](f: T => U): Unit = {
@@ -81,10 +87,20 @@ class SpatialIndex[T](val measure: Measure = Measure.Euclidean) extends Serializ
         }
         rtree.query(extent.jtsEnvelope, visitor)
       }
+
+      // Traversable implementations must override iterator in 2.13
+      def iterator: Iterator[T] =
+        rtree.query(extent.jtsEnvelope).asScala.map(_.asInstanceOf[T]).iterator
+    }
+
+  def pointsInExtentAsIterable(extent: Extent): Iterable[T] =
+    new Iterable[T] {
+      override def iterator: Iterator[T] =
+        rtree.query(extent.jtsEnvelope).asScala.map(_.asInstanceOf[T]).iterator
     }
 
   def pointsInExtent(extent: Extent): Vector[T] =
-    traversePointsInExtent(extent).to[Vector]
+    pointsInExtentAsIterable(extent).to[Vector]
 
   def pointsInExtentAsJavaList(extent: Extent): java.util.List[T] =
     rtree.query(new Envelope(extent.xmin, extent.xmax, extent.ymin, extent.ymax)).asInstanceOf[java.util.List[T]]


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

In `SpatialIndex`, the method `traversePointsInExtent` returns a Traversable. Traversable is being phased out in favor of Iterable. This method is only used within GT in the `pointsInExtent` method and has no direct unit tests, so it probably should have been a protected/private method. 

This change does the following:

1. Adds `pointsInExtentAsIterable` (named so as not to conflict with `pointsInExtent(...): Vector`) that returns an Iterable and uses this method in `pointsInExtent`
2. deprecates `traversePointsInExtent` in favor of `pointsInExtentAsIterable` (named so as not to conflict with `pointsInExtent(...): Vector`)
3. implements method `iterator` in Traversable as required by 2.13. This is backwards-compatible with 2.11 and 2.12. 

## Checklist

- [X] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

## Demo

none

## Notes

Closes #3349
