### PR TITLE
remove parens from unary prefix operator definitions, as they are deprecated in 2.13 and unnecessary

### DIFF
--- a/layer/src/main/scala/geotrellis/layer/mapalgebra/local/LocalTileCollectionMethods.scala
+++ b/layer/src/main/scala/geotrellis/layer/mapalgebra/local/LocalTileCollectionMethods.scala
@@ -131,7 +131,7 @@ trait LocalTileCollectionMethods[K] extends MethodExtensions[Seq[(K, Tile)]]
   /**
     * Negate (multiply by -1) each value in a raster.
     */
-  def unary_-() = localNegate()
+  def unary_- = localNegate()
 
   /**
     * Bitwise negation of Tile.

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/LocalMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/LocalMethods.scala
@@ -80,7 +80,7 @@ trait LocalMethods extends MethodExtensions[Tile]
     Negate(self)
 
   /** Negate (multiply by -1) each value in a raster. */
-  def unary_-(): Tile = localNegate()
+  def unary_- : Tile = localNegate()
 
   /**
     * Bitwise negation of Tile.
@@ -114,7 +114,7 @@ trait LocalMethods extends MethodExtensions[Tile]
    *  holds the x values. The arctan is calculated from y / x.
    *  @note               A double raster is always returned.
    */
-   def localAtan2(r: Tile): Tile =
+  def localAtan2(r: Tile): Tile =
     Atan2(self, r)
 
   /**

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/local/LocalTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/local/LocalTileRDDMethods.scala
@@ -131,7 +131,7 @@ trait LocalTileRDDMethods[K] extends TileRDDMethods[K]
   /**
     * Negate (multiply by -1) each value in a raster.
     */
-  def unary_-() = localNegate()
+  def unary_- = localNegate()
 
   /**
     * Bitwise negation of Tile.


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

1. Removes nullary parens from unary prefix operators, as they are deprecated in 2.13 and unnecessary anyway
2. remove stray indent

## Checklist

- [ ] n/a [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] n/a New user API has useful Scaladoc strings
- [ ] n/a Unit tests added for bug-fix or new feature

## Demo

none

## Notes

none
