### PR TITLE
fix several issue of non-paren'ed method overrides paren'ed method

### DIFF
--- a/proj4/src/test/scala/geotrellis/proj4/GenerateTestCases.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/GenerateTestCases.scala
@@ -39,13 +39,12 @@ object GenerateTestCases {
   def main(args: Array[String]): Unit = {
     val knownCodes =
       loan(scala.io.Source.fromInputStream(getClass().getResourceAsStream("/proj4/nad/epsg"))) { source =>
-        source.getLines
+        source.getLines()
           .filter { _ startsWith "<" }
           .map { s => s.tail.take(s.indexOf('>') - 1) }
           .filterNot { _ == "4326" }
           .to[Vector]
       }
-
     val output = new java.io.FileWriter("proj4/src/test/resources/proj4-epsg.csv");
 
     val csvWriter = new com.opencsv.CSVWriter(output)

--- a/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/CompositeTile.scala
@@ -619,7 +619,7 @@ case class CompositeTile(tiles: Seq[Tile],
           }
           if(layoutCol != tileLayout.layoutCols - 1) {
             val pad = " " * 5
-            sb.append(s"$pad| ").r
+            sb.append(s"$pad| ").toString.r
           }
         }
         sb.append(s"\n")

--- a/raster/src/main/scala/geotrellis/raster/histogram/StreamingHistogram.scala
+++ b/raster/src/main/scala/geotrellis/raster/histogram/StreamingHistogram.scala
@@ -183,7 +183,7 @@ class StreamingHistogram(
     /* Add delta covering the whole range */
     if (left != None && right != None) {
       val delta = right.get._1 - left.get._1
-      _deltas.put(Delta(delta, left.get, right.get), Unit)
+      _deltas.put(Delta(delta, left.get, right.get), ())
     }
 
     /* Add the average of the two combined buckets */
@@ -230,14 +230,14 @@ class StreamingHistogram(
       if (larger != None) {
         val large = larger.get
         val delta = large._1 - b._1
-        _deltas.put(Delta(delta, b, large), Unit)
+        _deltas.put(Delta(delta, b, large), ())
       }
 
       /* Add delta between new bucket and next-smallest bucket */
       if (smaller != None) {
         val small = smaller.get
         val delta = b._1 - small._1
-        _deltas.put(Delta(delta, small, b), Unit)
+        _deltas.put(Delta(delta, small, b), ())
       }
     }
 

--- a/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
+++ b/spark/src/main/scala/geotrellis/spark/costdistance/IterativeCostDistance.scala
@@ -77,7 +77,7 @@ object IterativeCostDistance {
   class ChangesAccumulator extends AccumulatorV2[KeyCostPair, Changes] {
     private val list: Changes = mutable.ArrayBuffer.empty
 
-    def copy: ChangesAccumulator = {
+    def copy(): ChangesAccumulator = {
       val other = new ChangesAccumulator
       other.merge(this)
       other
@@ -88,7 +88,7 @@ object IterativeCostDistance {
     def isZero: Boolean = list.isEmpty
     def merge(other: AccumulatorV2[KeyCostPair, Changes]): Unit =
       this.synchronized { list ++= other.value }
-    def reset: Unit = this.synchronized { list.clear }
+    def reset(): Unit = this.synchronized { list.clear }
     def value: Changes = list
   }
 

--- a/spark/src/main/scala/geotrellis/spark/util/GroupIterator.scala
+++ b/spark/src/main/scala/geotrellis/spark/util/GroupIterator.scala
@@ -27,7 +27,7 @@ class GroupConsecutiveIterator[T, R](iter: Iterator[T])(f: T => R)
 
   def hasNext = remaining.hasNext
 
-  def next = {
+  def next() = {
     val cur = f(remaining.head)
     val (left, right) = remaining.span(x => f(x) == cur)
     remaining = right.buffered

--- a/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
+++ b/spark/src/main/scala/geotrellis/spark/viewshed/IterativeViewshed.scala
@@ -84,7 +84,7 @@ object IterativeViewshed {
   private class RayCatcher extends AccumulatorV2[Message, Messages] {
     private val messages = mutable.Map.empty[SpatialKey, List[Message]]
 
-    def copy: RayCatcher = {
+    def copy(): RayCatcher = {
       val other = new RayCatcher
       other.merge(this)
       other
@@ -116,7 +116,7 @@ object IterativeViewshed {
         messages ++= newMessages
      }
 
-    def reset: Unit = this.synchronized { messages.clear }
+    def reset(): Unit = this.synchronized { messages.clear }
 
     def value: Messages = messages.toMap
   }

--- a/store/src/main/scala/geotrellis/store/hadoop/util/HdfsUtils.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/util/HdfsUtils.scala
@@ -216,8 +216,8 @@ object HdfsUtils {
           val lineScanner =
             new LineScanner {
               def hasNext = scanner.hasNextLine
-              def next = scanner.nextLine
-              def close = scanner.close
+              def next() = scanner.nextLine
+              def close() = scanner.close
             }
 
           Some(lineScanner)
@@ -233,8 +233,8 @@ object HdfsUtils {
           val lineScanner =
             new LineScanner {
               def hasNext = scanner.hasNextLine
-              def next = scanner.nextLine
-              def close = { scanner.close; fdis.close }
+              def next() = scanner.nextLine
+              def close() = { scanner.close; fdis.close }
             }
 
           Some(lineScanner)


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

1. In 2.13, it is a compile error if a parent class method has a set of empty parens on it and an overriding method in a child class does **not** also have empty parens.  In 2.11 & 2.12, these are equivalent, so there's no change in behavior.
2. In 2.13, the `.r` syntax no longer works on StringBuilder, so an intermediate toString is required
3. Fix use of getLines without parens that gives an error or warning in 2.13
4. replace several more uses of `Unit` type as a value with `()`

## Checklist

- [ ] n/a [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] n/a New user API has useful Scaladoc strings
- [ ] n/a Unit tests added for bug-fix or new feature

## Demo

none

## Notes

none
