### PR TITLE
resolve amgiguity in spark and raster Implicits classes with explicit imports shadowing local identifiers

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/Implicits.scala
@@ -17,13 +17,13 @@
 package geotrellis.raster
 
 import geotrellis.vector.Point
-import geotrellis.vector._
+import geotrellis.vector.withExtraPointMethods
 import geotrellis.util.{MethodExtensions, np}
 
 object Implicits extends Implicits
 
 trait Implicits
-    extends costdistance.Implicits
+    extends geotrellis.raster.costdistance.Implicits
     with geotrellis.raster.crop.Implicits
     with geotrellis.raster.density.Implicits
     with geotrellis.raster.distance.Implicits

--- a/raster/src/main/scala/geotrellis/raster/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/Implicits.scala
@@ -24,33 +24,33 @@ object Implicits extends Implicits
 
 trait Implicits
     extends costdistance.Implicits
-    with crop.Implicits
-    with density.Implicits
-    with distance.Implicits
-    with equalization.Implicits
-    with hydrology.Implicits
-    with interpolation.Implicits
-    with io.json.Implicits
-    with mapalgebra.focal.Implicits
-    with mapalgebra.focal.hillshade.Implicits
-    with mapalgebra.local.Implicits
-    with mapalgebra.zonal.Implicits
-    with mask.Implicits
-    with matching.Implicits
-    with merge.Implicits
-    with prototype.Implicits
-    with rasterize.Implicits
-    with regiongroup.Implicits
-    with render.Implicits
-    with reproject.Implicits
-    with resample.Implicits
-    with sigmoidal.Implicits
-    with split.Implicits
-    with summary.Implicits
-    with summary.polygonal.Implicits
-    with transform.Implicits
-    with vectorize.Implicits
-    with viewshed.Implicits {
+    with geotrellis.raster.crop.Implicits
+    with geotrellis.raster.density.Implicits
+    with geotrellis.raster.distance.Implicits
+    with geotrellis.raster.equalization.Implicits
+    with geotrellis.raster.hydrology.Implicits
+    with geotrellis.raster.interpolation.Implicits
+    with geotrellis.raster.io.json.Implicits
+    with geotrellis.raster.mapalgebra.focal.Implicits
+    with geotrellis.raster.mapalgebra.focal.hillshade.Implicits
+    with geotrellis.raster.mapalgebra.local.Implicits
+    with geotrellis.raster.mapalgebra.zonal.Implicits
+    with geotrellis.raster.mask.Implicits
+    with geotrellis.raster.matching.Implicits
+    with geotrellis.raster.merge.Implicits
+    with geotrellis.raster.prototype.Implicits
+    with geotrellis.raster.rasterize.Implicits
+    with geotrellis.raster.regiongroup.Implicits
+    with geotrellis.raster.render.Implicits
+    with geotrellis.raster.reproject.Implicits
+    with geotrellis.raster.resample.Implicits
+    with geotrellis.raster.sigmoidal.Implicits
+    with geotrellis.raster.split.Implicits
+    with geotrellis.raster.summary.Implicits
+    with geotrellis.raster.summary.polygonal.Implicits
+    with geotrellis.raster.transform.Implicits
+    with geotrellis.raster.vectorize.Implicits
+    with geotrellis.raster.viewshed.Implicits {
 
   // Implicit method extension for core types
 
@@ -84,7 +84,7 @@ trait Implicits
     def assertEqualDimensions(): Unit =
       if(Set(rs.map(_.dimensions)).size != 1) {
         val dimensions = rs.map(_.dimensions).toSeq
-        throw new GeoAttrsError("Cannot combine tiles with different dimensions." +
+        throw GeoAttrsError("Cannot combine tiles with different dimensions." +
           s"$dimensions are not all equal")
       }
   }
@@ -92,7 +92,7 @@ trait Implicits
   implicit class TileTupleExtensions(t: (Tile, Tile)) {
     def assertEqualDimensions(): Unit =
       if(t._1.dimensions != t._2.dimensions) {
-        throw new GeoAttrsError("Cannot combine rasters with different dimensions." +
+        throw GeoAttrsError("Cannot combine rasters with different dimensions." +
           s"${t._1.dimensions} does not match ${t._2.dimensions}")
       }
   }

--- a/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/ColorMap.scala
@@ -16,11 +16,11 @@
 
 package geotrellis.raster.render
 
-import geotrellis.raster._
 import geotrellis.raster.histogram.Histogram
 import spire.syntax.cfor._
 import spire.std.any._
 import _root_.io.circe._
+import geotrellis.raster.{ArrayTile, IntCellType, Tile, d2i, i2d, isNoData}
 
 import scala.util.Try
 

--- a/raster/src/main/scala/geotrellis/raster/render/JpgRenderMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/render/JpgRenderMethods.scala
@@ -16,8 +16,8 @@
 
 package geotrellis.raster.render
 
-import geotrellis.raster._
-import geotrellis.raster.render.jpg._
+import geotrellis.raster.Tile
+import geotrellis.raster.render.jpg.{JpgEncoder, Settings}
 import geotrellis.util.MethodExtensions
 
 

--- a/spark/src/main/scala/geotrellis/spark/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/Implicits.scala
@@ -35,39 +35,39 @@ import scala.reflect.ClassTag
 object Implicits extends Implicits
 
 trait Implicits
-    extends buffer.Implicits
+    extends geotrellis.spark.buffer.Implicits
     with CrsFormats
     with StoreCodecs
-    with clip.Implicits
-    with costdistance.Implicits
-    with crop.Implicits
-    with density.Implicits
-    with distance.Implicits
-    with equalization.Implicits
-    with filter.Implicits
-    with join.Implicits
-    with knn.Implicits
-    with mapalgebra.focal.hillshade.Implicits
-    with mapalgebra.focal.Implicits
-    with mapalgebra.Implicits
-    with mapalgebra.local.Implicits
-    with mapalgebra.local.temporal.Implicits
-    with mapalgebra.zonal.Implicits
-    with mask.Implicits
-    with matching.Implicits
-    with merge.Implicits
-    with partition.Implicits
-    with regrid.Implicits
-    with reproject.Implicits
-    with resample.Implicits
-    with rasterize.Implicits
-    with sigmoidal.Implicits
-    with split.Implicits
-    with stitch.Implicits
-    with summary.Implicits
-    with tiling.Implicits
-    with timeseries.Implicits
-    with viewshed.Implicits
+    with geotrellis.spark.clip.Implicits
+    with geotrellis.spark.costdistance.Implicits
+    with geotrellis.spark.crop.Implicits
+    with geotrellis.spark.density.Implicits
+    with geotrellis.spark.distance.Implicits
+    with geotrellis.spark.equalization.Implicits
+    with geotrellis.spark.filter.Implicits
+    with geotrellis.spark.join.Implicits
+    with geotrellis.spark.knn.Implicits
+    with geotrellis.spark.mapalgebra.focal.hillshade.Implicits
+    with geotrellis.spark.mapalgebra.focal.Implicits
+    with geotrellis.spark.mapalgebra.Implicits
+    with geotrellis.spark.mapalgebra.local.Implicits
+    with geotrellis.spark.mapalgebra.local.temporal.Implicits
+    with geotrellis.spark.mapalgebra.zonal.Implicits
+    with geotrellis.spark.mask.Implicits
+    with geotrellis.spark.matching.Implicits
+    with geotrellis.spark.merge.Implicits
+    with geotrellis.spark.partition.Implicits
+    with geotrellis.spark.regrid.Implicits
+    with geotrellis.spark.reproject.Implicits
+    with geotrellis.spark.resample.Implicits
+    with geotrellis.spark.rasterize.Implicits
+    with geotrellis.spark.sigmoidal.Implicits
+    with geotrellis.spark.split.Implicits
+    with geotrellis.spark.stitch.Implicits
+    with geotrellis.spark.summary.Implicits
+    with geotrellis.spark.tiling.Implicits
+    with geotrellis.spark.timeseries.Implicits
+    with geotrellis.spark.viewshed.Implicits
     with Serializable {
 
   /** Auto wrap a partitioner when something is requestion an Option[Partitioner];

--- a/spark/src/main/scala/geotrellis/spark/mapalgebra/local/temporal/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/mapalgebra/local/temporal/package.scala
@@ -16,17 +16,17 @@
 
 package geotrellis.spark.mapalgebra.local
 
-import geotrellis.layer._
-import geotrellis.raster._
+import geotrellis.layer.{SpatialComponent, TemporalComponent, SpatialKey, TemporalKey}
 import geotrellis.layer.mapalgebra.local.temporal.LocalTemporalStatistics
+import geotrellis.raster.Tile
 import geotrellis.util._
 
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd.RDD
 
 import jp.ne.opt.chronoscala.Imports._
-import java.time._
 
+import java.time._
 import scala.reflect.ClassTag
 
 

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -17,8 +17,7 @@
 package geotrellis
 
 import geotrellis.layer.{Metadata, TileLayerMetadata}
-import geotrellis.raster._
-import geotrellis.layer._
+import geotrellis.raster.{Raster, Tile, MultibandTile}
 import org.apache.spark.rdd._
 
 package object spark extends Implicits {


### PR DESCRIPTION
# Overview

First off, this doesn't actually have anything to do with implicits -- it just happens to be a problem with spark and raster Implicits class and how it references all the other classes it extends.

The core of this is that prior to 2.13, the resolution between local identifiers (in this case, a relative reference to a class) and imported identifiers did not conform to the spec. The references to several classes resolved to the local package rather than an imported package. This was fixed in 2.13, so these two files no longer compile because the class identifiers resolve differently now.

For example, `interpolation.Implicits` resolved to the local `geotrellis.raster.interpolation.Implicits` rather than what it should have resolved to according to the spec, which is that the existence of `import geotrellis.vector._` results in it being `geotrellis.vector.interpolation.Implicits` -- this is a problem, because the package `geotrellis.vector.interpolation` exists, but not `geotrellis.vector.interpolation.Implicits`, so compilation fails. 

I thought through a few solutions to this, including explicitly importing only what's actually needed from other packages instead of `_`, but just changing this to the fqn of the Implicits classes seems the most obvious option. 

Also, fixed a couple of instances of unnecessary `new` with case classes.

## Checklist

- [ ] n/a [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] n/a New user API has useful Scaladoc strings
- [ ] n/a Unit tests added for bug-fix or new feature

## Demo

none

## Notes

Discussion:
https://github.com/scala/bug/issues/11593

Bug(s): 

https://github.com/scala/bug/issues/9552
https://github.com/scala/bug/issues/2458

Fix for Bug:
https://github.com/scala/scala/pull/6589

