### PR TITLE
update scalastyle; add scapegoat and scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,7 @@
 version = 2.7.5
-align = more // For pretty alignment.
+align.preset = more // For pretty alignment.
 maxColumn = 120
 newlines.alwaysBeforeTopLevelStatements = true
+continuationIndent.callSite = 2
+continuationIndent.defnSite = 2
+continuationIndent.ctorSite = 2

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,4 @@
+version = 2.7.5
+align = more // For pretty alignment.
+maxColumn = 120
+newlines.alwaysBeforeTopLevelStatements = true

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,6 @@
 version = 2.7.5
-align.preset = more // For pretty alignment.
+align.preset = some
 maxColumn = 120
-newlines.alwaysBeforeTopLevelStatements = true
-continuationIndent.callSite = 2
+newlines.alwaysBeforeTopLevelStatements = false
 continuationIndent.defnSite = 2
-continuationIndent.ctorSite = 2
+# docstrings.style = Preserve

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 import sbt.Keys._
 
-ThisBuild / scalaVersion := "2.12.13"
+ThisBuild / scalaVersion := Version.scala211
 ThisBuild / organization := "org.locationtech.geotrellis"
-ThisBuild / crossScalaVersions := List("2.12.13", "2.11.12")
+ThisBuild / crossScalaVersions := List(Version.scala212, Version.scala211)
+ThisBuild / scapegoatVersion := Version.scapegoat
 
 lazy val root = Project("geotrellis", file("."))
   .aggregate(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbt.Keys._
 
-ThisBuild / scalaVersion := Version.scala211
+ThisBuild / scalaVersion := Version.scala212
 ThisBuild / organization := "org.locationtech.geotrellis"
 ThisBuild / crossScalaVersions := List(Version.scala212, Version.scala211)
 ThisBuild / scapegoatVersion := Version.scapegoat

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,11 @@
 import sbt._
 
 object Version {
+
+  val scala211 = "2.11.12"
+  val scala212 = "2.12.13"
+  val scala213 = "2.13.5"
+
   val geotools    = "24.2"
   val spire       = "0.13.0"
   val accumulo    = "1.9.3"
@@ -28,6 +33,7 @@ object Version {
   val spark       = "2.4.7"
   val gdal        = "3.1.0"
   val gdalWarp    = "1.1.1"
+  val scapegoat   = "1.4.8"
 
   val previousVersion = "3.5.0"
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -16,6 +16,7 @@
 
 import Dependencies._
 import GTBenchmarkPlugin.Keys._
+import com.sksamuel.scapegoat.sbt.ScapegoatSbtPlugin.autoImport.scapegoatDisabledInspections
 import sbt._
 import sbt.Keys._
 import sbtassembly.AssemblyPlugin.autoImport._
@@ -121,7 +122,8 @@ object Settings {
           existingText.flatMap(_ => existingText.map(_.trim)).getOrElse(newText)
         } }
       )
-    )
+    ),
+    scapegoatDisabledInspections := Seq("ObjectNames")
   )
 
   lazy val accumulo = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,9 +6,12 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.5.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle" % "1.5.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.26")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.18" )
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.1.0")
+
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.8"

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -114,4 +114,5 @@
  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
+ <check class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false"/>
 </scalastyle>


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

0. refactor scala versions out into variables
1. updates scalastyle dependency to the maintained 'beautiful-scala' package instead of the abandoned one
2. adds scapegoat configuration for static analysis (similar to config in stac4s)
3. add scalafmt (off by default-- maybe at some point all the code should be reformatted in one PR). The `.scalafmt.conf` was copied from stac4s

## Checklist

- [ ] n/a [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] n/a New user API has useful Scaladoc strings
- [ ] n/a Unit tests added for bug-fix or new feature

## Demo

none

## Notes

none