### PR TITLE
refactor spire dependency to support using different versions between scala versions

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,6 @@ import sbt._
 
 object Version {
   val geotools    = "24.2"
-  val spire       = "0.13.0"
   val accumulo    = "1.9.3"
   val cassandra   = "3.7.2"
   val hbase       = "2.2.5"
@@ -34,11 +33,13 @@ object Version {
 import sbt.Keys._
 
 object Dependencies {
-  private def ver(for211: String, for212: String) = Def.setting {
+
+  private def ver(for211: String, for212: String, for213: Option[String] = None) = Def.setting {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 11)) => for211
       case Some((2, 12)) => for212
-      case _ => sys.error("not good")
+      case Some((2, 13)) => for213.getOrElse(for212)
+      case x => sys.error(s"Encountered unsupported Scala version ${x.getOrElse("undefined")}")
     }
   }
 
@@ -67,6 +68,15 @@ object Dependencies {
 
   def scalaReflect(version: String) = "org.scala-lang" % "scala-reflect" % version
 
+  def spire(module: String) = Def.setting {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 11)) => "org.spire-math" %% "spire" % "0.13.0"
+      case Some((2, 12)) => "org.spire-math" %% "spire" % "0.13.0" // 0.17.0 exists for 2.12
+      case Some((2, 13)) => "org.typelevel"  %% "spire" % "0.17.0"
+      case x => sys.error(s"Encountered unsupported Scala version ${x.getOrElse("undefined")}")
+    }
+  }
+
   val sparkCore           = "org.apache.spark"           %% "spark-core"               % Version.spark
   val sparkSql            = "org.apache.spark"           %% "spark-sql"                % Version.spark
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"               % "0.14.0"
@@ -77,8 +87,6 @@ object Dependencies {
   val jts                 = "org.locationtech.jts"        % "jts-core"                 % "1.17.1"
   val proj4j              = "org.locationtech.proj4j"     % "proj4j"                   % "1.1.1"
   val openCSV             = "com.opencsv"                 % "opencsv"                  % "5.3"
-  val spire               = "org.spire-math"             %% "spire"                    % Version.spire
-  val spireMacro          = "org.spire-math"             %% "spire-macros"             % Version.spire
   val apacheIO            = "commons-io"                  % "commons-io"               % "2.8.0"
   val apacheLang3         = "org.apache.commons"          % "commons-lang3"            % "3.12.0"
   val apacheMath          = "org.apache.commons"          % "commons-math3"            % "3.6.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -45,7 +45,7 @@ object Settings {
     Test / parallelExecution := false
   )
 
-  val commonScalacOptions = Seq(
+  lazy val commonScalacOptions = Seq(
     "-deprecation",
     "-unchecked",
     "-feature",
@@ -399,7 +399,7 @@ object Settings {
     name := "geotrellis-macros",
     Compile / sourceGenerators += (Compile / sourceManaged).map(Boilerplate.genMacro).taskValue,
     libraryDependencies ++= Seq(
-      spireMacro,
+      spire("spire-macros").value,
       scalaReflect(scalaVersion.value)
     )
   ) ++ commonSettings
@@ -430,7 +430,7 @@ object Settings {
     name := "geotrellis-raster",
     libraryDependencies ++= Seq(
       squants,
-      monocle("core").value, 
+      monocle("core").value,
       monocle("macro").value,
       scalaXml,
       scalaURI.value,
@@ -556,7 +556,7 @@ object Settings {
 
   lazy val `spark-pipeline` = Seq(
     name := "geotrellis-spark-pipeline",
-    libraryDependencies ++= Seq(   
+    libraryDependencies ++= Seq(
       circe("generic-extras").value,
       hadoopClient % Provided,
       sparkCore % Provided,
@@ -600,7 +600,7 @@ object Settings {
     libraryDependencies ++= Seq(
       log4s,
       scalaj,
-      spire,
+      spire("spire").value,
       scalatest % Test
     )
   ) ++ commonSettings
@@ -611,8 +611,8 @@ object Settings {
       jts,
       shapeless,
       pureconfig,
-      circe("core").value, 
-      circe("generic").value, 
+      circe("core").value,
+      circe("generic").value,
       circe("parser").value,
       cats("core").value,
       apacheMath,
@@ -669,7 +669,7 @@ object Settings {
       uzaygezenCore,
       scalaXml,
       apacheLang3,
-      fs2("core").value, 
+      fs2("core").value,
       fs2("io").value,
       cats("effect").value,
       scalatest % Test


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

1. Different versions of spire have different groupIds.  `org.spire-math %% spire % 0.13` is only available for 2.11 and 2.12, and `org.typelevel %% spire % 0.17` is only available for 2.12 and 2.13.  This changes allows those different versions to be expressed. 
2. It also extends `ver` to support a different dependency version for 2.13.
3. removes some stray whitespace

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

## Demo

none

## Notes

none
