### PR TITLE
replace two uses of to[T] with equivalent toT

### DIFF
--- a/proj4/src/test/scala/geotrellis/proj4/GenerateTestCases.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/GenerateTestCases.scala
@@ -43,7 +43,7 @@ object GenerateTestCases {
           .filter { _ startsWith "<" }
           .map { s => s.tail.take(s.indexOf('>') - 1) }
           .filterNot { _ == "4326" }
-          .to[Vector]
+          .toVector
       }
     val output = new java.io.FileWriter("proj4/src/test/resources/proj4-epsg.csv");
 

--- a/proj4/src/test/scala/geotrellis/proj4/MetaCRSTestFileReader.scala
+++ b/proj4/src/test/scala/geotrellis/proj4/MetaCRSTestFileReader.scala
@@ -49,7 +49,7 @@ object MetaCRSTestFileReader {
       .filter(r => r.nonEmpty && !r.head.startsWith("#"))
       .drop(1)
       .map(parseTest)
-      .to[List]
+      .toList
   }
 
   private def parseTest(cols: Array[String]): MetaCRSTestCase = {

--- a/vector/src/main/scala/geotrellis/vector/SpatialIndex.scala
+++ b/vector/src/main/scala/geotrellis/vector/SpatialIndex.scala
@@ -100,7 +100,7 @@ class SpatialIndex[T](val measure: Measure = Measure.Euclidean) extends Serializ
     }
 
   def pointsInExtent(extent: Extent): Vector[T] =
-    pointsInExtentAsIterable(extent).to[Vector]
+    pointsInExtentAsIterable(extent).toVector
 
   def pointsInExtentAsJavaList(extent: Extent): java.util.List[T] =
     rtree.query(new Envelope(extent.xmin, extent.xmax, extent.ymin, extent.ymax)).asInstanceOf[java.util.List[T]]


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

There are two uses of `to[T]` methods in the proj4 module -- a `to[List]` and a ``to[Vector]`. These methods won't compile in 2.13, as to[Collection] method was replaced by the to(Collection) method, which is in the scala-collection-compat library. However, replacing these with `toList` and `toVector` is the simpler option, so doing that instead. 

## Checklist

- [ ] n/a [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] n/a New user API has useful Scaladoc strings
- [ ] n/a Unit tests added for bug-fix or new feature

## Demo

none

## Notes

none
