### PR TITLE
disable eviction warnings

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -121,7 +121,11 @@ object Settings {
           existingText.flatMap(_ => existingText.map(_.trim)).getOrElse(newText)
         } }
       )
-    )
+    ),
+    evictionWarningOptions in update := EvictionWarningOptions.default
+      .withWarnTransitiveEvictions(false)
+      .withWarnDirectEvictions(false)
+      .withWarnScalaVersionEviction(false)
   )
 
   lazy val accumulo = Seq(


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

There are many eviction warnings, given how complex the dependency tree is, and they just clutter up the build output. This explicitly turns them off.

## Checklist

- [ ] n/a [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] n/a [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] n/a `docs` guides update, if necessary
- [ ] n/a New user API has useful Scaladoc strings
- [ ] n/a Unit tests added for bug-fix or new feature

## Demo

none

## Notes

none