### PR TITLE
fixes for non-fqn Seq being immutable in Scala 2.13

### DIFF
--- a/layer/src/main/scala/geotrellis/layer/buffer/BufferTiles.scala
+++ b/layer/src/main/scala/geotrellis/layer/buffer/BufferTiles.scala
@@ -84,7 +84,7 @@ trait BufferTiles {
     addSlice(SpatialKey(col+1, row+1), TopLeft)
     addSlice(SpatialKey(col-1, row+1), TopRight)
 
-    parts
+    parts.toSeq
   }
 
   def bufferWithNeighbors[

--- a/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKT.scala
+++ b/proj4/src/main/scala/geotrellis/proj4/io/wkt/WKT.scala
@@ -22,7 +22,7 @@ import scala.io.Source
 
 object WKT {
   private val wktResourcePath = "/proj4/wkt/epsg.properties"
-  lazy val parsed: Map[Int, WktCS] = records.mapValues(WKTParser.apply)
+  lazy val parsed: Map[Int, WktCS] = records.mapValues(WKTParser.apply).toMap
   lazy val projections: Set[WktCS] = parsed.values.toSet
   lazy val records: Map[Int, String] = parseWktEpsgResource
 

--- a/raster/src/main/scala/geotrellis/raster/GridBounds.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridBounds.scala
@@ -162,7 +162,7 @@ case class GridBounds[@specialized(Int, Long) N: Integral](
       if(overlapRowMax < rowMax) {
         result += GridBounds(overlapColMin, overlapRowMax + 1, overlapColMax, rowMax)
       }
-      result
+      result.toSeq
     }
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/polygon/FractionalRasterizer.scala
@@ -30,7 +30,7 @@ object FractionalRasterizer {
 
   private type Segment = (Double, Double, Double, Double)
 
-  private def polygonToEdges(poly: Polygon, re: RasterExtent): Seq[Segment] = {
+  private def polygonToEdges(poly: Polygon, re: RasterExtent): mutable.ArrayBuffer[Segment] = {
 
     val arrayBuffer = mutable.ArrayBuffer.empty[Segment]
 

--- a/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
+++ b/raster/src/main/scala/geotrellis/raster/rasterize/polygon/PolygonRasterizer.scala
@@ -72,7 +72,7 @@ object PolygonRasterizer {
 
   private def intervalDifference(a : List[Interval], b: Interval) : List[Interval] = a.flatMap(intervalDifference(_,b))
 
-  private def mergeIntervals(sortedIntervals : Seq[Interval]) : Array[Double] = {
+  private def mergeIntervals(sortedIntervals : mutable.ListBuffer[Interval]) : Array[Double] = {
     if (sortedIntervals.length > 0) {
       val head = sortedIntervals.head
       val stack = mutable.Stack(head._1, head._2)

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -17,7 +17,8 @@
 package geotrellis
 
 import geotrellis.layer.{Metadata, TileLayerMetadata}
-import geotrellis.raster.{Raster, Tile, MultibandTile}
+import geotrellis.raster._
+import geotrellis.layer._
 import org.apache.spark.rdd._
 
 package object spark extends Implicits {

--- a/spark/src/main/scala/geotrellis/spark/package.scala
+++ b/spark/src/main/scala/geotrellis/spark/package.scala
@@ -17,8 +17,7 @@
 package geotrellis
 
 import geotrellis.layer.{Metadata, TileLayerMetadata}
-import geotrellis.raster._
-import geotrellis.layer._
+import geotrellis.raster.{Raster, Tile, MultibandTile}
 import org.apache.spark.rdd._
 
 package object spark extends Implicits {

--- a/store/src/main/scala/geotrellis/store/AttributeStore.scala
+++ b/store/src/main/scala/geotrellis/store/AttributeStore.scala
@@ -56,7 +56,7 @@ trait AttributeStore extends AttributeCaching with LayerAttributeStore {
    * This function should be re-implemented by AttributeStore subclasses so that
    * catalogs with large numbers of layers can be queried efficiently.
    */
-  def layersWithZoomLevels: Map[String, Seq[Int]] = layerIds.groupBy(_.name).mapValues(_.map(_.zoom))
+  def layersWithZoomLevels: Map[String, Seq[Int]] = layerIds.groupBy(_.name).mapValues(_.map(_.zoom)).toMap
 
   /** Return a sequence of available zoom levels for a named layer.
    *

--- a/store/src/main/scala/geotrellis/store/hadoop/formats/FilterMapFileInputFormat.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/formats/FilterMapFileInputFormat.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.input._
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 object FilterMapFileInputFormat {
   // Define some key names for Hadoop configuration

--- a/store/src/main/scala/geotrellis/store/hadoop/formats/FilterMapFileInputFormat.scala
+++ b/store/src/main/scala/geotrellis/store/hadoop/formats/FilterMapFileInputFormat.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.input._
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 object FilterMapFileInputFormat {
   // Define some key names for Hadoop configuration
@@ -115,8 +116,8 @@ class FilterMapFileInputFormat() extends FileInputFormat[BigIntWritable, BytesWr
 
     val possibleMatches =
       FilterMapFileInputFormat
-        .mapFileRanges(dataFileStatus.asScala.map(_.getPath.getParent), conf)
-        .filter { case (file, iMin, iMax) =>
+        .mapFileRanges(dataFileStatus.asScala.map(_.getPath.getParent).toSeq, conf)
+        .filter { case (_, iMin: BigInt, iMax: BigInt) =>
           // both file ranges and query ranges are sorted, use in-sync traversal
           while (it.hasNext && it.head._2 < iMin) it.next
           if (it.hasNext) iMin <= it.head._2 && (iMax == -1 || it.head._1 <= iMax)

--- a/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulation.scala
+++ b/vector/src/main/scala/geotrellis/vector/triangulation/DelaunayTriangulation.scala
@@ -501,7 +501,7 @@ case class DelaunayTriangulation(
     removeIncidentEdge(vi)
   }
 
-  private def removeVertexAndFill(vi: Int, tris: Map[(Int, Int, Int), HalfEdge[Int, Int]], bnd: Option[Int]): Seq[Int] = {
+  private def removeVertexAndFill(vi: Int, tris: Map[(Int, Int, Int), HalfEdge[Int, Int]], bnd: Option[Int]): ListBuffer[Int] = {
     val exteriorRing = ListBuffer.empty[Int]
 
     decoupleVertex(vi)

--- a/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
+++ b/vector/src/main/scala/geotrellis/vector/voronoi/VoronoiDiagram.scala
@@ -66,7 +66,7 @@ object VoronoiDiagram {
 
   private final val EPSILON = 1e-10
 
-  private def cellBoundsNew(het: HalfEdgeTable, verts: Int => Coordinate, extent: Extent)(incidentEdge: Int): Seq[CellBound] = {
+  private def cellBoundsNew(het: HalfEdgeTable, verts: Int => Coordinate, extent: Extent)(incidentEdge: Int): ListBuffer[CellBound] = {
     import het._
 
     var e = incidentEdge
@@ -118,7 +118,7 @@ object VoronoiDiagram {
     l
   }
 
-  private def cellExtentIntersection(het: HalfEdgeTable, verts: Int => Coordinate, incidentEdge: Int)(cell: Seq[CellBound], extent: Extent) = {
+  private def cellExtentIntersection(het: HalfEdgeTable, verts: Int => Coordinate, incidentEdge: Int)(cell: ListBuffer[CellBound], extent: Extent) = {
     val Extent(xmin, ymin, xmax, ymax) = extent
     val expts = ListBuffer((xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax)).map{ case (x, y) => new Coordinate(x, y) }
 
@@ -185,7 +185,7 @@ object VoronoiDiagram {
       None
     } else {
       clippedCorners += clippedCorners.head
-      val poly = Polygon(clippedCorners.map(Point(_)))
+      val poly = Polygon(clippedCorners.map(Point(_)).toSeq)
       Some(poly)
     }
   }

--- a/vectortile/src/main/scala/geotrellis/vectortile/internal/Command.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/internal/Command.scala
@@ -68,7 +68,7 @@ private[vectortile] case object ClosePath extends Command
 /** Contains convenience functions for handling [[Command]]s. */
 private[vectortile] object Command {
   /** Attempt to parse a list of Command/Parameter Integers. */
-  def commands(cmds: Seq[Int]): ListBuffer[Command] = {
+  def commands(cmds: Seq[Int]): Seq[Command] = {
     @tailrec def work(cmds: Seq[Int], curr: ListBuffer[Command]): ListBuffer[Command] = cmds match {
       case Nil => curr
       case ns => (parseCmd(ns.head): @unchecked) match {
@@ -102,7 +102,7 @@ private[vectortile] object Command {
       }
     }
 
-    work(cmds, new ListBuffer[Command])
+    work(cmds, new ListBuffer[Command]).toSeq
   }
 
   /** Convert a list of parsed Commands back into their original Command

--- a/vectortile/src/main/scala/geotrellis/vectortile/internal/package.scala
+++ b/vectortile/src/main/scala/geotrellis/vectortile/internal/package.scala
@@ -199,7 +199,7 @@ package object internal {
     ): Seq[Command] = {
       def work(lines: Array[LineString]): Seq[Command] = {
         var curs: (Int, Int) = (0, 0)
-        var buff = new ListBuffer[Command]
+        val buff = new ListBuffer[Command]
 
         lines.foreach({l =>
           val diffs: Array[(Int, Int)] = collapse(
@@ -313,7 +313,7 @@ package object internal {
           buff.appendAll(Seq(MoveTo(Array(diffs.head)), LineTo(diffs.tail), ClosePath))
         })
 
-        buff
+        buff.toSeq
       }
 
       poly match {


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

# Overview

These are the changes required to have the mutable/immutable Seq change in 2.13 work with cross-compilation.

**TODO** -- the changelog needs to be updated, since a couple of these involve public method signatures

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #XXX
