### PR TITLE
Fix GDALRasterSources BitCellType reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Deprecate method SpatialIndex#traversePointsInExtent [#3349](https://github.com/locationtech/geotrellis/issues/3349)
+- GDALRasterSource gives segmentation fault when reading rasters with NBITS=1 [#3300](https://github.com/locationtech/geotrellis/issues/3300)
 
 ## [3.5.2] - 2021-02-01
 

--- a/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
+++ b/gdal/src/test/scala/geotrellis/raster/gdal/GDALRasterSourceSpec.scala
@@ -194,8 +194,10 @@ class GDALRasterSourceSpec extends AnyFunSpec with RasterMatchers with GivenWhen
           val craster = raster.mapTile(_.convert(ct))
           GeoTiff(craster, LatLng).write(path)
 
-          GDALRasterSource(path).cellType shouldBe ct
-          GeoTiffRasterSource(path).cellType shouldBe ct
+          val (grs, rs) = GDALRasterSource(path) -> GeoTiffRasterSource(path)
+          grs.cellType shouldBe ct
+          rs.cellType shouldBe ct
+          assertEqual(grs.read().get, rs.read().get)
         }
       }
     }


### PR DESCRIPTION
# Overview

This PR addresses #3300 and allows reads of BitCellType TIFFs.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] Unit tests added for bug-fix or new feature

Closes #3300
