### PR TITLE
Make JTSConfig load lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Deprecate method SpatialIndex#traversePointsInExtent [#3349](https://github.com/locationtech/geotrellis/issues/3349)
 - GDALRasterSource gives segmentation fault when reading rasters with NBITS=1 [#3300](https://github.com/locationtech/geotrellis/issues/3300)
+- Make JTSConfig load lazy [#3369](https://github.com/locationtech/geotrellis/pull/3369)
 
 ## [3.5.2] - 2021-02-01
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.4.9

--- a/sbt
+++ b/sbt
@@ -34,11 +34,11 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.4.7"
-declare -r sbt_unreleased_version="1.5.0-M2"
+declare -r sbt_release_version="1.4.9"
+declare -r sbt_unreleased_version="1.5.0-RC2"
 
 declare -r latest_213="2.13.5"
-declare -r latest_212="2.12.12"
+declare -r latest_212="2.12.13"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"

--- a/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
+++ b/vector/src/main/scala/geotrellis/vector/GeomFactory.scala
@@ -23,9 +23,9 @@ import org.locationtech.jts.geom.{GeometryFactory, PrecisionModel}
 import org.locationtech.jts.precision.GeometryPrecisionReducer
 
 object GeomFactory {
-  val precisionType: String = JtsConfig.precisionType
-  val precisionModel: PrecisionModel = JtsConfig.precisionModel
+  lazy val precisionType: String = JtsConfig.precisionType
+  lazy val precisionModel: PrecisionModel = JtsConfig.precisionModel
   lazy val simplifier: GeometryPrecisionReducer = JtsConfig.simplifier
 
-  val factory: GeometryFactory = new geom.GeometryFactory(precisionModel)
+  lazy val factory: GeometryFactory = new geom.GeometryFactory(precisionModel)
 }


### PR DESCRIPTION
# Overview

This PR fixes the JTS config loading ordering. That could cause bad JTS factories init, since sometimes the `reference.conf` file could be loaded into memory _after_ the call to the config. That could cause following errors:

```scala
Caused by: pureconfig.error.ConfigReaderException: Cannot convert configuration to a geotrellis.vector.conf.JtsConfig. Failures are:
  at the root:
    - (merge of system properties,reference.conf @ jar:file:/.../sbt/1.4.9/ssl-config-core_2.12-0.4.0.jar!/reference.conf: 1) Key not found: 'geotrellis'.
``` 

For the context: this could only happen in runs through SBT. 
I did a little bit of tracing down the history of this bug and it turned out that it appeared in `1.4.0` and all `1.4.x` versions are affected. However, in `1.5.x` (checked with `RC2`) this issue is gone. 

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
