### PR TITLE
Update S3LayerDeleter to consider AWS SDK request limit

### DIFF
--- a/s3/src/main/scala/geotrellis/store/s3/S3LayerDeleter.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/S3LayerDeleter.scala
@@ -25,11 +25,14 @@ import org.log4s._
 import scala.collection.JavaConverters._
 
 class S3LayerDeleter(
-                      val attributeStore: AttributeStore,
-                      s3Client: => S3Client
-                    ) extends LayerDeleter[LayerId] {
+      val attributeStore: AttributeStore,
+      s3Client: => S3Client,
+      val requestLimit: Int = 1000
+    ) extends LayerDeleter[LayerId] {
   @transient private[this] lazy val logger = getLogger
-  @transient private[this] lazy val requestLimit = 1000
+
+  def apply(attributeStore: AttributeStore, s3Client: => S3Client, requestLimit: Int): S3LayerDeleter =
+    new S3LayerDeleter(attributeStore, s3Client, requestLimit)
 
   def delete(id: LayerId): Unit = {
     try {
@@ -48,23 +51,20 @@ class S3LayerDeleter(
 
       if (iter.isEmpty) throw new LayerDeleteError(id)
 
-      val objIdentifiers =
-        iter
-          .map { s3obj => ObjectIdentifier.builder.key(s3obj.key).build() }
-          .toList
-
-      for (objIdentifiersChunk <- objIdentifiers.grouped(requestLimit)) {
-        val deleteDefinition =
-          Delete.builder()
-            .objects(objIdentifiersChunk: _*)
-            .build()
-        val deleteRequest =
-          DeleteObjectsRequest.builder()
-            .bucket(bucket)
-            .delete(deleteDefinition)
-            .build()
-        s3Client.deleteObjects(deleteRequest)
-        attributeStore.delete(id)
+      iter
+        .map { s3obj => ObjectIdentifier.builder.key(s3obj.key).build() }
+        .grouped(requestLimit).foreach{ objIdentifiersChunk =>
+          val deleteDefinition =
+            Delete.builder()
+              .objects(objIdentifiersChunk.toSeq: _*)
+              .build()
+          val deleteRequest =
+            DeleteObjectsRequest.builder()
+              .bucket(bucket)
+              .delete(deleteDefinition)
+              .build()
+          s3Client.deleteObjects(deleteRequest)
+          attributeStore.delete(id)
       }
     } catch {
       case e: AttributeNotFoundError =>

--- a/s3/src/main/scala/geotrellis/store/s3/S3LayerDeleter.scala
+++ b/s3/src/main/scala/geotrellis/store/s3/S3LayerDeleter.scala
@@ -25,14 +25,11 @@ import org.log4s._
 import scala.collection.JavaConverters._
 
 class S3LayerDeleter(
-      val attributeStore: AttributeStore,
-      s3Client: => S3Client,
-      val requestLimit: Int = 1000
-    ) extends LayerDeleter[LayerId] {
+  val attributeStore: AttributeStore,
+  s3Client: => S3Client,
+  val requestLimit: Int = 1000
+  ) extends LayerDeleter[LayerId] {
   @transient private[this] lazy val logger = getLogger
-
-  def apply(attributeStore: AttributeStore, s3Client: => S3Client, requestLimit: Int): S3LayerDeleter =
-    new S3LayerDeleter(attributeStore, s3Client, requestLimit)
 
   def delete(id: LayerId): Unit = {
     try {
@@ -80,6 +77,9 @@ class S3LayerDeleter(
 object S3LayerDeleter {
   def apply(attributeStore: AttributeStore, s3Client: => S3Client): S3LayerDeleter =
     new S3LayerDeleter(attributeStore, s3Client)
+
+  def apply(attributeStore: AttributeStore, s3Client: => S3Client, requestLimit: Int): S3LayerDeleter =
+    new S3LayerDeleter(attributeStore, s3Client, requestLimit)
 
   def apply(bucket: String, prefix: String, s3Client: => S3Client): S3LayerDeleter = {
     val attStore = S3AttributeStore(bucket, prefix, s3Client)


### PR DESCRIPTION
# Overview

Very straightforward fix to deal with the delete request limit of the AWS SDK.

Simply chunks the `objectIdentifiers` list into lists of length smaller than the `requestLimit` and iteratively makes the delete call to the AWS SDK. 

## Checklist

- [ ]  [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings

## Demo

TODO

## Notes

Unsure of the testing strategies favored for S3 and if the changes should be included in the changelog.

Closes #3371 
