### PR TITLE
Fix JDK deprecation to support JDK11 compilation

### DIFF
--- a/raster-testkit/src/main/scala/geotrellis/raster/testkit/RasterMatchers.scala
+++ b/raster-testkit/src/main/scala/geotrellis/raster/testkit/RasterMatchers.scala
@@ -283,7 +283,7 @@ trait RasterMatchers extends Matchers {
     val asciiDiffs = diffs.map(_.renderAscii(palette))
 
     val joinedDiffs: String = asciiDiffs
-      .map(_.lines.toSeq)
+      .map(_.linesIterator.toSeq)
       .transpose
       .map(_.mkString("\t"))
       .mkString("\n")


### PR DESCRIPTION
# Overview

This PR makes GT codebase JDK 11 friendly. In fact this issue was addressed mosltly via https://github.com/locationtech/geotrellis/pull/3294

Connects https://github.com/locationtech/geotrellis/issues/3301
