### PR TITLE
Update Scala up to 2.13.6 and SBT 1.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ workflows:
       - common:
           matrix:
             parameters:
-              scala-version: ["2.12.13", "2.13.5"]
+              scala-version: ["2.12.13", "2.13.6"]
               test-set: ["1", "2"]
           filters:
             branches:
@@ -201,7 +201,7 @@ workflows:
       - cassandra:
           matrix:
             parameters:
-              scala-version: ["2.12.13", "2.13.5"]
+              scala-version: ["2.12.13", "2.13.6"]
           filters:
             branches:
               only: /.*/
@@ -211,7 +211,7 @@ workflows:
       - s3:
           matrix:
             parameters:
-              scala-version: ["2.12.13", "2.13.5"]
+              scala-version: ["2.12.13", "2.13.6"]
           filters:
             branches:
               only: /.*/
@@ -221,7 +221,7 @@ workflows:
       - hbase:
           matrix:
             parameters:
-              scala-version: ["2.12.13", "2.13.5"]
+              scala-version: ["2.12.13", "2.13.6"]
           filters:
             branches:
               only: /.*/
@@ -231,7 +231,7 @@ workflows:
       - accumulo:
           matrix:
             parameters:
-              scala-version: [ "2.12.13", "2.13.5" ]
+              scala-version: [ "2.12.13", "2.13.6" ]
           filters:
             branches:
               only: /.*/
@@ -241,7 +241,7 @@ workflows:
       - geowave:
           matrix:
             parameters:
-              scala-version: [ "2.12.13", "2.13.5" ]
+              scala-version: [ "2.12.13", "2.13.6" ]
           filters:
             branches:
               only: /.*/
@@ -264,7 +264,7 @@ workflows:
             - hbase
           matrix:
             parameters:
-              scala-version: ["2.12.13", "2.13.5"]
+              scala-version: ["2.12.13", "2.13.6"]
           filters:
             branches:
               only: master

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbt.Keys._
 
 ThisBuild / scalaVersion := "2.12.13"
 ThisBuild / organization := "org.locationtech.geotrellis"
-ThisBuild / crossScalaVersions := List("2.12.13", "2.13.5")
+ThisBuild / crossScalaVersions := List("2.12.13", "2.13.6")
 
 lazy val root = Project("geotrellis", file("."))
   .aggregate(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -94,8 +94,8 @@ object Settings {
       Path.userHome / ".sbt" / ".credentials"
     ).filter(_.asFile.canRead).map(Credentials(_)),
 
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full),
-    addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.4.14" cross CrossVersion.full),
+    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full),
+    addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.4.18" cross CrossVersion.full),
 
     libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) => Nil

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.1
+sbt.version=1.5.2

--- a/sbt
+++ b/sbt
@@ -34,10 +34,10 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.5.1"
-declare -r sbt_unreleased_version="1.5.1"
+declare -r sbt_release_version="1.5.2"
+declare -r sbt_unreleased_version="1.5.2"
 
-declare -r latest_213="2.13.5"
+declare -r latest_213="2.13.6"
 declare -r latest_212="2.12.13"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"

--- a/store/src/main/scala/geotrellis/store/cog/COGValueReader.scala
+++ b/store/src/main/scala/geotrellis/store/cog/COGValueReader.scala
@@ -49,7 +49,7 @@ trait COGValueReader[ID] {
     layerId: ID,
     keyPath: (K, Int, KeyIndex[K], ZoomRange) => String, // Key, maxWidth, toIndex, zoomRange
     fullPath: String => URI,
-    exceptionHandler: K => PartialFunction[Throwable, Nothing] = { key: K => { case e: Throwable => throw e }: PartialFunction[Throwable, Nothing] }
+    exceptionHandler: K => PartialFunction[Throwable, Nothing] = { key: K => ({ case e: Throwable => throw e }): PartialFunction[Throwable, Nothing] }
    ): COGReader[K, V] = new COGReader[K, V] {
     val COGLayerStorageMetadata(cogLayerMetadata, keyIndexes) =
       attributeStore.readMetadata[COGLayerStorageMetadata[K]](LayerId(layerId.name, 0))

--- a/vector/src/main/scala/geotrellis/vector/SpatialIndex.scala
+++ b/vector/src/main/scala/geotrellis/vector/SpatialIndex.scala
@@ -73,12 +73,7 @@ class SpatialIndex[T](val measure: Measure = Measure.Euclidean) extends Serializ
   def nearest(ex: Extent): T =
     rtree.nearestNeighbour(ex.jtsEnvelope, null, measure).asInstanceOf[T]
 
-  @deprecated(
-    """As of Scala 2.13, Iterable is preferred over Traversable, which will be removed in Scala 3.
-       Use pointsInExtentAsIterable instead.
-       """.stripMargin,
-    "3.5.3"
-  )
+  @deprecated("As of Scala 2.13, Iterable is preferred over Traversable, which will be removed in Scala 3. Use pointsInExtentAsIterable instead.", "3.5.3")
   def traversePointsInExtent(extent: Extent): Traversable[T] =
     new Traversable[T] {
       override def foreach[U](f: T => U): Unit = {


### PR DESCRIPTION
# Overview

This PR bumps the Scala version up as well as the SBT version.