### PR TITLE
Upgrade up to Spark 3.1.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,7 @@ object Dependencies {
   }
 
   def apacheSpark(module: String) = Def.setting {
-    "org.apache.spark"  %% s"spark-$module" % ver("3.0.1", "3.2.0-SNAPSHOT").value
+    "org.apache.spark"  %% s"spark-$module" % ver("3.1.1", "3.2.0-SNAPSHOT").value
   }
 
   def scalaReflect(version: String) = "org.scala-lang" % "scala-reflect" % version


### PR DESCRIPTION
# Overview

Originally the Spark dep was upgraded to follow EMR versions. This month EMR 6.3.0 has been released with the Spark 3.1.1 support, so we're safe to upgrade the dep.

