### PR TITLE
Add new shading rules to make GT work with Spark 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add method SpatialIndex#pointsInExtentAsIterable [#3349](https://github.com/locationtech/geotrellis/issues/3349)
 - Spark 3 & Hadoop 3 Support [#3218](https://github.com/locationtech/geotrellis/issues/3218)
 - Scala 2.13 cross compilation [#2893](https://github.com/locationtech/geotrellis/issues/2893)
+- Add new shading rules to make GT work with Spark 3.x [#3397](https://github.com/locationtech/geotrellis/pull/3397)
 
 ### Changed
 - Deprecate method SpatialIndex#traversePointsInExtent [#3349](https://github.com/locationtech/geotrellis/issues/3349)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -564,7 +564,8 @@ object Settings {
           .inLibrary("com.azavea.geotrellis" %% "geotrellis-hbase" % version.value).inAll,
         ShadeRule.rename("com.fasterxml.jackson.**" -> s"$shadePackage.com.fasterxml.jackson.@1")
           .inLibrary(jsonSchemaValidator).inAll,
-        ShadeRule.rename("shapeless.**" -> s"$shadePackage.shapeless.@1").inAll
+        ShadeRule.rename("shapeless.**" -> s"$shadePackage.shapeless.@1").inAll,
+        ShadeRule.rename("cats.kernel.**" -> s"$shadePackage.cats.kernel.@1").inAll
       )
     },
     assembly / assemblyMergeStrategy := {


### PR DESCRIPTION
# Overview

Spark depends on the [old cats.kernel](https://github.com/apache/spark/blob/d5868ebc398c7b69dbaaaa3218bc9b177252a3c8/dev/deps/spark-deps-hadoop-3.2-hive-2.3#L28) which requires us to shade it to avoid [binary incompatability runtime issues](https://github.com/typelevel/cats/issues/3628). 

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
