### PR TITLE
fixing a typo in reading-geoTiffs.rst

### DIFF
--- a/docs/tutorials/reading-geoTiffs.rst
+++ b/docs/tutorials/reading-geoTiffs.rst
@@ -276,7 +276,7 @@ size of the file.
 Reading in Small Files
 ''''''''''''''''''''''
 
-Smaller files are GeoTiffs that are less than or equal to 4GB in isze.
+Smaller files are GeoTiffs that are less than or equal to 4GB in size.
 The way to best utilize the reader for these kinds of files differs from
 larger ones.
 


### PR DESCRIPTION
fixing a typo: isze -> size

# Overview

Brief description of what this PR does, and why it is needed.

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #XXX
