### PR TITLE
Disambiguate withBufferTileFocalMethods implicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new shading rules to make GT work with Spark 3.x [#3397](https://github.com/locationtech/geotrellis/pull/3397)
 - Add Buffer Tile [#3419](https://github.com/locationtech/geotrellis/pull/3419)
 
+### Changed
+- Disambiguate withBufferTileFocalMethods implicit [#3421](https://github.com/locationtech/geotrellis/pull/3421)
+
 ## [3.6.0] - 2021-04-30
 
 ### Added

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Implicits.scala
@@ -17,10 +17,26 @@
 package geotrellis.raster.mapalgebra.focal
 
 import geotrellis.raster.{BufferTile, Tile}
+import shapeless.=:!=
 
 object Implicits extends Implicits
 
 trait Implicits {
-  implicit class withTileFocalMethods(val self: Tile) extends FocalMethods
-  implicit class withBufferTileFocalMethods(val self: BufferTile) extends BufferTileFocalMethods
+  /**
+   * TODO: think of a better way of organizing implicits with regards to possible Tile successors
+   *
+   * Apply withTileFocalMethods to all successor of a [[Tile]] type but [[BufferTile]].
+   * It is required to disambiguate withBufferTileFocalMethods implicit.
+   */
+  implicit class withTileFocalMethods[T](tile: T)(implicit t: T <:< Tile, nbt: T =:!= BufferTile) extends FocalMethods {
+    val self: Tile = t(tile)
+  }
+
+  /**
+   * [[BufferTile]] can't have successors (it is a case class).
+   * Limit this implicit to be applied to the [[BufferTile]] type only.
+   */
+  implicit class withBufferTileFocalMethods[T](tile: T)(implicit bt: T =:= BufferTile) extends BufferTileFocalMethods {
+    val self: BufferTile = bt(tile)
+  }
 }


### PR DESCRIPTION
# Overview

This PR fixes a possible ambiguity of the to implicit classes

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
