### PR TITLE
Disambiguate withBufferTileFocalMethods implicit preserving bin compatibility

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/BufferTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/BufferTile.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.raster
 
+import geotrellis.raster.mapalgebra.focal.BufferTileFocalMethods
 import spire.syntax.cfor._
 
 /**
@@ -437,4 +438,12 @@ case class BufferTile(
   def mapTile(f: Tile => Tile): BufferTile = BufferTile(f(sourceTile), gridBounds)
 
   override def toString: String = s"BufferTile(${sourceTile.dimensions}, $gridBounds, $cellType)"
+}
+
+object BufferTile {
+  /**
+   * This implicit class is not a part of the [[geotrellis.raster.mapalgebra.focal.Implicits]]
+   * to disambiguate implicit classes application.
+   */
+  implicit class withBufferTileFocalMethods(val self: BufferTile) extends BufferTileFocalMethods
 }

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Implicits.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/focal/Implicits.scala
@@ -16,27 +16,10 @@
 
 package geotrellis.raster.mapalgebra.focal
 
-import geotrellis.raster.{BufferTile, Tile}
-import shapeless.=:!=
+import geotrellis.raster.Tile
 
 object Implicits extends Implicits
 
 trait Implicits {
-  /**
-   * TODO: think of a better way of organizing implicits with regards to possible Tile successors
-   *
-   * Apply withTileFocalMethods to all successors of the [[Tile]] type excluding the [[BufferTile]].
-   * It is required to disambiguate withBufferTileFocalMethods implicit.
-   */
-  implicit class withTileFocalMethods[T](tile: T)(implicit t: T <:< Tile, nbt: T =:!= BufferTile) extends FocalMethods {
-    val self: Tile = t(tile)
-  }
-
-  /**
-   * [[BufferTile]] can't have successors (it is a case class).
-   * Limit this implicit to be applied to the [[BufferTile]] type only.
-   */
-  implicit class withBufferTileFocalMethods[T](tile: T)(implicit bt: T =:= BufferTile) extends BufferTileFocalMethods {
-    val self: BufferTile = bt(tile)
-  }
+  implicit class withTileFocalMethods(val self: Tile) extends FocalMethods
 }


### PR DESCRIPTION
# Overview

This PR reverts #3421 to preserve bin compatibility.