### PR TITLE
Added check for Java 8 in build. Silenced sbt linting noise.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ nohup.out
 derby.log
 metastore_db/
 *.log
+.sdkmanrc

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,17 @@ lazy val root = Project("geotrellis", file("."))
   .settings(Settings.commonSettings)
   .settings(publish / skip := true)
   .settings(ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(mdoc))
+  .settings(
+    initialize := {
+      val curr = VersionNumber(sys.props("java.specification.version"))
+      val req = SemanticSelector("=1.8")
+      if (!curr.matchesSemVer(req)) {
+        val log = Keys.sLog.value
+        log.warn(s"Java $req required for GeoTools compatibility. Found Java $curr.\n" +
+          "Please change the version of Java running sbt.")
+      }
+    }
+  )
 
 lazy val mdoc = project
   .dependsOn(raster)

--- a/project/GTBenchmarkPlugin.scala
+++ b/project/GTBenchmarkPlugin.scala
@@ -38,15 +38,15 @@ object GTBenchmarkPlugin extends AutoPlugin {
   override def requires: Plugins = JmhPlugin
 
   object Keys {
-    val jmhOutputFormat = settingKey[String]("Output format: {text|csv|scsv|json|latex}")
-    val jmhOutputDir = settingKey[File]("Directory for writing JMH results")
+    val jmhOutputFormat = settingKey[String]("Output format: {text|csv|scsv|json|latex}").withRank(KeyRanks.Invisible)
+    val jmhOutputDir = settingKey[File]("Directory for writing JMH results").withRank(KeyRanks.Invisible)
     val jmhFileRegex = settingKey[Regex]("Filename regular expression for selecting files to benchmark")
-    val jmhThreads = settingKey[Option[Int]]("Number of JMH worker threads")
-    val jmhFork = settingKey[Option[Int]]("How many times to fork a single JMH benchmark")
+    val jmhThreads = settingKey[Option[Int]]("Number of JMH worker threads").withRank(KeyRanks.Invisible)
+    val jmhFork = settingKey[Option[Int]]("How many times to fork a single JMH benchmark").withRank(KeyRanks.Invisible)
     val jmhIterations = settingKey[Option[Int]]("Number of measurement iterations to do")
-    val jmhWarmupIterations = settingKey[Option[Int]]("Number of warmup iterations to do")
-    val jmhTimeUnit = settingKey[Option[String]]("Benchmark results time unit: {m|s|ms|us|ns}")
-    val jmhExtraOptions = settingKey[Option[String]]("Additional arguments to jmh:run before the filename regex")
+    val jmhWarmupIterations = settingKey[Option[Int]]("Number of warmup iterations to do").withRank(KeyRanks.Invisible)
+    val jmhTimeUnit = settingKey[Option[String]]("Benchmark results time unit: {m|s|ms|us|ns}").withRank(KeyRanks.Invisible)
+    val jmhExtraOptions = settingKey[Option[String]]("Additional arguments to jmh:run before the filename regex").withRank(KeyRanks.Invisible)
     val bench = taskKey[Unit]("Execute JMH benchmarks")
     val benchOnly = inputKey[Unit]("Execute JMH benchmarks on a single class")
   }


### PR DESCRIPTION
# Overview

* Added check for Java 8 in build.  Issues warning if not running under Java 8, required by GeoTools
* Silenced sbt linting noise from GTBenchmark plugin.

## Checklist

- [N/A] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [N/A] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [N/A] `docs` guides update, if necessary
- [N/A] New user API has useful Scaladoc strings
- [N/A] Unit tests added for bug-fix or new feature

