### PR TITLE
ArrayTile.{cols | rows} calls boxing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specialize Grid for Int and Long [#3428](https://github.com/locationtech/geotrellis/pull/3428)
 - Move GeoWave and GeoMesa subproject to their own repositories [#3439](https://github.com/locationtech/geotrellis/pull/3439)
 - Use JTS 1.18, GeoTools 25.0 [#3437](https://github.com/locationtech/geotrellis/pull/3437)
+- ArrayTile.{cols | rows} calls boxing fix [#3441](https://github.com/locationtech/geotrellis/pull/3441)
 
 ## [3.6.0] - 2021-04-30
 

--- a/bench/src/main/scala/geotrellis/raster/GridBoxingBench.scala
+++ b/bench/src/main/scala/geotrellis/raster/GridBoxingBench.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Azavea & Astraea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.util.Random
+
+/** See issue https://github.com/locationtech/geotrellis/issues/3427 */
+@BenchmarkMode(Array(Mode.AverageTime))
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class GridBoxingBench {
+  val size = 1024
+
+  @Param(Array("short", "int"))
+  var cellType: String = _
+
+  var tile: MutableArrayTile = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    tile = cellType match {
+      case "short" =>
+        ShortArrayTile(
+          1 to size * size map (_.toShort) toArray, size, size
+        )
+      case "int" =>
+        IntArrayTile(
+          1 to size * size toArray, size, size
+        )
+    }
+  }
+
+  var row: Int = _
+  var col: Int = _
+  var value: Int = _
+  @Setup(Level.Invocation)
+  def selectCell(): Unit = {
+    row = Random.nextInt(size)
+    col = Random.nextInt(size)
+    value = Random.nextInt()
+  }
+
+  @Benchmark
+  def setCell(): Tile = {
+    tile.set(row, col, value)
+    tile
+  }
+}

--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -24,6 +24,13 @@ import spire.syntax.cfor._
   * cases.
   */
 abstract class ArrayTile extends Tile with Serializable {
+  /**
+   * cols and rows are explicitly defined to help with the Grid[N].{cols | rows} specialized functions dispatch.
+   * See https://github.com/locationtech/geotrellis/issues/3427
+   */
+  def cols: Int
+
+  def rows: Int
 
   /**
     * Return the [[ArrayTile]] equivalent of this ArrayTile.

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -28,6 +28,14 @@ import spire.syntax.cfor._
   */
 abstract class ConstantTile extends Tile {
 
+  /**
+   * cols and rows are explicitly defined to help with the Grid[N].{cols | rows} specialized functions dispatch.
+   * See https://github.com/locationtech/geotrellis/issues/3427
+   */
+  def cols: Int
+
+  def rows: Int
+
   /** Precomputed view of tile cells as seen by [[get]] method */
   protected val iVal: Int
 

--- a/raster/src/main/scala/geotrellis/raster/MutableArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/MutableArrayTile.scala
@@ -27,6 +27,14 @@ abstract class MutableArrayTile extends ArrayTile {
   def mutable = this
 
   /**
+   * cols and rows are explicitly defined to help with the Grid[N].{cols | rows} specialized functions dispatch.
+   * See https://github.com/locationtech/geotrellis/issues/3427
+   */
+  def cols: Int
+
+  def rows: Int
+
+  /**
     * Update the datum at the specified index.
     *
     * @param   i  The index of the datum

--- a/raster/src/main/scala/geotrellis/raster/Tile.scala
+++ b/raster/src/main/scala/geotrellis/raster/Tile.scala
@@ -21,6 +21,14 @@ package geotrellis.raster
   */
 abstract class Tile extends CellGrid[Int] with IterableTile with MappableTile[Tile] {
   /**
+   * cols and rows are explicitly defined to help with the Grid[N].{cols | rows} specialized functions dispatch.
+   * See https://github.com/locationtech/geotrellis/issues/3427
+   */
+  def cols: Int
+
+  def rows: Int
+
+  /**
     * Execute a function at each pixel of a [[Tile]].  Two functions
     * are given: an integer version which is used if the tile is an
     * integer-tile, and the other in the case of a floating-tile.


### PR DESCRIPTION
# Overview

Since GT 3.x we had a regression where all calls to cols / rows were boxed. This lead to regressions in `MutableArrayTile.{set / update / etc}` functions. For more details see #3427, #3428, #3429 and #3432

This PR clarifies Grid inheritors cols / rows function types to help with the specialized calls dispatch. 

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] Benchmark added for bug-fix or new feature

## Demo

Can be reproduced via:

```bash
$ sbt project bench; benchOnly geotrellis/raster/GridBoxingBench.scala
```

<img width="1395" alt="Screen Shot 2021-12-02 at 21 52 48" src="https://user-images.githubusercontent.com/4929546/144537167-70655edb-1e2c-4350-9561-7b195dca0f0e.png">

Closes #3427
Closes #3432
