### PR TITLE
Bump dependencies up

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 ThisBuild / versionScheme := Some("semver-spec")
 ThisBuild / scalaVersion := "2.12.15"
 ThisBuild / organization := "org.locationtech.geotrellis"
-ThisBuild / crossScalaVersions := List("2.12.15", "2.13.7")
+ThisBuild / crossScalaVersions := List("2.12.15", "2.13.8")
 
 lazy val root = Project("geotrellis", file("."))
   .aggregate(

--- a/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSummarySpec.scala
+++ b/gdal-spark/src/test/scala/geotrellis/spark/gdal/GDALRasterSummarySpec.scala
@@ -152,7 +152,7 @@ class GDALRasterSummarySpec extends AnyFunSpec with TestEnvironment with GivenWh
     val targetCRS = WebMercator
     val method = Bilinear
     val layout = LayoutDefinition(GridExtent[Int](Extent(-2.0037508342789244E7, -2.0037508342789244E7, 2.0037508342789244E7, 2.0037508342789244E7), CellSize(9.554628535647032, 9.554628535647032)), 256)
-    val RasterExtent(Extent(exmin, eymin, exmax, eymax), ecw, ech, ecols, erows) = RasterExtent(Extent(-8769161.632988561, 4257685.794912352, -8750625.653629405, 4274482.8318780195), CellSize(9.554628535647412, 9.554628535646911))
+    val RasterExtent(Extent(exmin, eymin, exmax, eymax), ecw, ech, ecols, erows) = RasterExtent(Extent(-8769161.632988561, 4257685.794912352, -8750616.09900087, 4274482.8318780195), CellSize(9.554628535647412, 9.554628535646911))
 
     cfor(0)(_ < 11, _ + 1) { _ =>
       val reference = GDALRasterSource(inputPath).reproject(targetCRS, method = method).tileToLayout(layout, method)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,8 +45,8 @@ object Dependencies {
 
   def cats(module: String) = Def.setting {
     module match {
-      case "effect" => "org.typelevel" %% s"cats-$module" % "2.3.3"
-      case _        => "org.typelevel" %% s"cats-$module" % "2.4.2"
+      case "effect" => "org.typelevel" %% s"cats-$module" % "2.5.4"
+      case _        => "org.typelevel" %% s"cats-$module" % "2.6.1"
     }
   }
 
@@ -58,11 +58,11 @@ object Dependencies {
   }
 
   def fs2(module: String) = Def.setting {
-    "co.fs2" %% s"fs2-$module" % "2.5.3"
+    "co.fs2" %% s"fs2-$module" % "2.5.10"
   }
 
   def apacheSpark(module: String) = Def.setting {
-    "org.apache.spark"  %% s"spark-$module" % ver("3.1.2", "3.2.0").value
+    "org.apache.spark"  %% s"spark-$module" % ver("3.1.3", "3.2.0").value
   }
 
   def scalaReflect(version: String) = "org.scala-lang" % "scala-reflect" % version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
   val scalacheck          = "org.scalacheck"             %% "scalacheck"               % "1.15.4"
   val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"                % "1.3.0"
   val jts                 = "org.locationtech.jts"        % "jts-core"                 % "1.18.1"
-  val proj4j              = "org.locationtech.proj4j"     % "proj4j"                   % "1.1.3"
+  val proj4j              = "org.locationtech.proj4j"     % "proj4j"                   % "1.1.5"
   val openCSV             = "com.opencsv"                 % "opencsv"                  % "5.6"
   val spire               = "org.typelevel"              %% "spire"                    % Version.spire
   val spireMacro          = "org.typelevel"              %% "spire-macros"             % Version.spire

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
   def cats(module: String) = Def.setting {
     module match {
       case "effect" => "org.typelevel" %% s"cats-$module" % "2.5.4"
-      case _        => "org.typelevel" %% s"cats-$module" % "2.6.1"
+      case _        => "org.typelevel" %% s"cats-$module" % "2.7.0"
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,12 +21,12 @@ object Version {
   val spire       = "0.17.0"
   val accumulo    = "1.9.3"
   val cassandra   = "3.7.2"
-  val hbase       = "2.4.2"
-  val hadoop      = "3.2.1"
+  val hbase       = "2.4.11"
+  val hadoop      = "3.2.2"
   val gdal        = "3.1.0"
   val gdalWarp    = "1.1.1"
 
-  val previousVersion = "3.5.2"
+  val previousVersion = "3.6.0"
 }
 import sbt.Keys._
 
@@ -70,19 +70,19 @@ object Dependencies {
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"               % "0.14.0"
   val log4s               = "org.log4s"                  %% "log4s"                    % "1.10.0"
   val log4jbridge         = "org.apache.logging.log4j"    % "log4j-1.2-api"            % "2.17.0"
-  val scalatest           = "org.scalatest"              %% "scalatest"                % "3.2.5"
-  val scalacheck          = "org.scalacheck"             %% "scalacheck"               % "1.15.2"
+  val scalatest           = "org.scalatest"              %% "scalatest"                % "3.2.10"
+  val scalacheck          = "org.scalacheck"             %% "scalacheck"               % "1.15.4"
   val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"                % "1.3.0"
   val jts                 = "org.locationtech.jts"        % "jts-core"                 % "1.18.1"
-  val proj4j              = "org.locationtech.proj4j"     % "proj4j"                   % "1.1.3"
-  val openCSV             = "com.opencsv"                 % "opencsv"                  % "5.3"
+  val proj4j              = "org.locationtech.proj4j"     % "proj4j"                   % "1.1.4"
+  val openCSV             = "com.opencsv"                 % "opencsv"                  % "5.6"
   val spire               = "org.typelevel"              %% "spire"                    % Version.spire
   val spireMacro          = "org.typelevel"              %% "spire-macros"             % Version.spire
   val apacheIO            = "commons-io"                  % "commons-io"               % "2.8.0"
   val apacheLang3         = "org.apache.commons"          % "commons-lang3"            % "3.12.0"
   val apacheMath          = "org.apache.commons"          % "commons-math3"            % "3.6.1"
   val chronoscala         = "jp.ne.opt"                  %% "chronoscala"              % "1.0.0"
-  val awsSdkS3            = "software.amazon.awssdk"      % "s3"                       % "2.16.13"
+  val awsSdkS3            = "software.amazon.awssdk"      % "s3"                       % "2.17.156"
   val hadoopClient        = "org.apache.hadoop"           % "hadoop-client"            % Version.hadoop
   val avro                = "org.apache.avro"             % "avro"                     % "1.7.7"
   val parserCombinators   = "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.1.2"
@@ -93,8 +93,8 @@ object Dependencies {
   val cassandraDriverCore = "com.datastax.cassandra"      % "cassandra-driver-core"    % Version.cassandra
   val guava               = "com.google.guava"            % "guava"                    % "16.0.1"
 
-  val scaffeine = "com.github.blemale"           %% "scaffeine" % "4.0.2"
-  val caffeine  = "com.github.ben-manes.caffeine" % "caffeine"  % "2.8.5"
+  val scaffeine = "com.github.blemale"           %% "scaffeine" % "4.1.0"
+  val caffeine  = "com.github.ben-manes.caffeine" % "caffeine"  % "2.8.8"
 
   val geotoolsCoverage    = "org.geotools"                 % "gt-coverage"             % Version.geotools
   val geotoolsHsql        = "org.geotools"                 % "gt-epsg-hsql"            % Version.geotools
@@ -112,7 +112,7 @@ object Dependencies {
 
   val hbaseMapReduce      = "org.apache.hbase" % "hbase-mapreduce" % Version.hbase
 
-  val woodstoxCore          = "com.fasterxml.woodstox" % "woodstox-core"          % "6.2.5"
+  val woodstoxCore          = "com.fasterxml.woodstox" % "woodstox-core"          % "6.2.8"
   val stax2Api              = "org.codehaus.woodstox"  % "stax2-api"              % "4.2.1"
   val commonsConfiguration2 = "org.apache.commons"     % "commons-configuration2" % "2.7"
   val re2j                  = "com.google.re2j"        % "re2j"                   % "1.6"
@@ -127,7 +127,7 @@ object Dependencies {
   val scalapbLenses       = "com.thesamet.scalapb"        %% "lenses"                  % scalapb.compiler.Version.scalapbVersion
   val protobufJava        = "com.google.protobuf"          % "protobuf-java"           % "3.8.0"
 
-  val squants             = "org.typelevel"               %% "squants"                 % "1.7.0"
+  val squants             = "org.typelevel"               %% "squants"                 % "1.7.4"
   val scalactic           = "org.scalactic"               %% "scalactic"               % "3.2.5"
 
   val gdalBindings        = "org.gdal"                     % "gdal"                    % Version.gdal
@@ -153,7 +153,7 @@ object Dependencies {
   val jaiCodec            = "javax.media" % "jai_codec"    % "1.1.3"
   val imageIo             = "javax.media" % "jai_imageio"  % "1.1"
 
-  val imageioExtUtilities = "it.geosolutions.imageio-ext" % "imageio-ext-utilities" % "1.3.5"
+  val imageioExtUtilities = "it.geosolutions.imageio-ext" % "imageio-ext-utilities" % "1.3.11"
 
   val worksWithDependencies = Seq(jaiCore, jaiCodec, imageIo, imageioExtUtilities).map(_ % Provided)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,8 +52,8 @@ object Dependencies {
 
   def circe(module: String) = Def.setting {
     module match {
-      case "json-schema" => "io.circe" %% s"circe-$module" % "0.1.0"
-      case _             => "io.circe" %% s"circe-$module" % "0.13.0"
+      case "json-schema" => "io.circe" %% s"circe-$module" % "0.2.0"
+      case _             => "io.circe" %% s"circe-$module" % "0.14.1"
     }
   }
 
@@ -138,7 +138,7 @@ object Dependencies {
   val jacksonAnnotations  = "com.fasterxml.jackson.core"    % "jackson-annotations"      % "2.6.7"
   val jacksonModuleScala  = "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.6.7"
 
-  val shapeless           = "com.chuusai"  %% "shapeless" % "2.3.3"
+  val shapeless           = "com.chuusai"  %% "shapeless" % "2.3.7"
   val newtype             = "io.estatico"  %% "newtype"   % "0.4.4"
 
   // aligned with the GeoTools version, should be 2.1.2 for GeoTools 24.2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
   }
 
   def apacheSpark(module: String) = Def.setting {
-    "org.apache.spark"  %% s"spark-$module" % ver("3.1.3", "3.2.0").value
+    "org.apache.spark"  %% s"spark-$module" % ver("3.1.3", "3.2.1").value
   }
 
   def scalaReflect(version: String) = "org.scala-lang" % "scala-reflect" % version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
   val scalacheck          = "org.scalacheck"             %% "scalacheck"               % "1.15.4"
   val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"                % "1.3.0"
   val jts                 = "org.locationtech.jts"        % "jts-core"                 % "1.18.1"
-  val proj4j              = "org.locationtech.proj4j"     % "proj4j"                   % "1.1.4"
+  val proj4j              = "org.locationtech.proj4j"     % "proj4j"                   % "1.1.3"
   val openCSV             = "com.opencsv"                 % "opencsv"                  % "5.6"
   val spire               = "org.typelevel"              %% "spire"                    % Version.spire
   val spireMacro          = "org.typelevel"              %% "spire-macros"             % Version.spire

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -270,6 +270,7 @@ object Settings {
     scalacOptions ++= commonScalacOptions,
     libraryDependencies ++= Seq(
       apacheSpark("core").value,
+      log4jbridge, // CVE-2021-4104, CVE-2020-8908
       scalatest % Test,
       apacheSpark("sql").value % Test
     )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -116,7 +116,10 @@ object Settings {
         case x => sys.error(s"Encountered unsupported Scala version ${x.getOrElse("undefined")}")
     }),
 
-    libraryDependencies += scalaReflect(scalaVersion.value),
+    libraryDependencies ++= Seq(
+      scalaReflect(scalaVersion.value),
+      log4jbridge % Test // CVE-2021-4104, CVE-2020-8908
+    ),
 
     pomExtra := (
       <developers>
@@ -548,7 +551,6 @@ object Settings {
     name := "geotrellis-util",
     libraryDependencies ++= Seq(
       log4s,
-      log4jbridge, // CVE-2021-4104, CVE-2020-8908
       scalaj,
       spire,
       scalatest % Test

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -100,13 +100,13 @@ object Settings {
     ).filter(_.asFile.canRead).map(Credentials(_)),
 
     addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full),
-    addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.4.31" cross CrossVersion.full),
+    addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.5.1" cross CrossVersion.full),
 
     libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) => Nil
       case Some((2, 12)) => Seq(
         compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
-        "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2"
+        "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0"
       )
         case x => sys.error(s"Encountered unsupported Scala version ${x.getOrElse("undefined")}")
     }),
@@ -220,9 +220,9 @@ object Settings {
     libraryDependencies ++= Seq(
       cassandraDriverCore
         excludeAll(
-        ExclusionRule("org.jboss.netty"), ExclusionRule("io.netty"),
-        ExclusionRule("org.slf4j"), ExclusionRule("com.typesafe.akka")
-      ) exclude("org.apache.hadoop", "hadoop-client")
+          ExclusionRule("org.jboss.netty"), ExclusionRule("io.netty"),
+          ExclusionRule("org.slf4j"), ExclusionRule("com.typesafe.akka")
+        ) exclude("org.apache.hadoop", "hadoop-client")
     ),
     console / initialCommands :=
       """

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,14 @@
 resolvers += sbt.Resolver.bintrayIvyRepo("typesafe", "sbt-plugins")
 
 addDependencyTreePlugin
-addSbtPlugin("com.eed3si9n"       % "sbt-assembly"    % "1.0.0")
-addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"      % "0.4.3")
+addSbtPlugin("com.eed3si9n"       % "sbt-assembly"    % "1.2.0")
+addSbtPlugin("com.github.sbt"     % "sbt-unidoc"      % "0.5.0")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"     % "0.6.1")
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "5.6.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.4.0")
-addSbtPlugin("com.typesafe"       % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "5.6.5")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.4.2")
+addSbtPlugin("com.typesafe"       % "sbt-mima-plugin" % "1.0.1")
 addSbtPlugin("com.thesamet"       % "sbt-protoc"      % "0.99.34")
-addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"    % "0.9.29")
+addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"    % "0.9.34")
 addSbtPlugin("org.scalameta"      % "sbt-mdoc"        % "2.2.19" )
-addSbtPlugin("com.geirsson"       % "sbt-ci-release"  % "1.5.7")
+addSbtPlugin("com.github.sbt"     % "sbt-ci-release"  % "1.5.10")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.8"

--- a/sbt
+++ b/sbt
@@ -34,10 +34,10 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.5.8"
-declare -r sbt_unreleased_version="1.6.0-M1"
+declare -r sbt_release_version="1.6.2"
+declare -r sbt_unreleased_version="1.6.2"
 
-declare -r latest_213="2.13.7"
+declare -r latest_213="2.13.8"
 declare -r latest_212="2.12.15"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"


### PR DESCRIPTION
# Overview

We need to update critical deps version up to maintain cross libraries compatability.

- [ ] shapeless up to 2.3.7 (not 2.3.8, due to https://github.com/milessabin/shapeless/issues/1248)
- [ ] Cats 2.7.0
- [ ] Cats Effects 2.5.4
- [ ] FS2 2.5.10
- [ ] Circe 1.14.1 
- [ ] Circe Json Schema 0.2.0
- [ ] HBase 2.4.11
- [ ] opencsv 5.6
- [ ] AWS SDK S3 2.17.156
- [ ] Scaffeine 4.1.0
- [ ] Caffeine 2.8.8

Closes https://github.com/locationtech/geotrellis/issues/3451
Closes https://github.com/locationtech/geotrellis/pull/3453