### PR TITLE
Lazy init circe codecs in the vector module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Dependencies update [#3452](https://github.com/locationtech/geotrellis/pull/3452)
+- Lazy init circe codecs in the vector module [#3457](https://github.com/locationtech/geotrellis/pull/3457)
+
 ## [3.6.1] - 2022-03-12
 
 ### Added

--- a/vector/src/main/scala/geotrellis/vector/io/json/CrsFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/CrsFormats.scala
@@ -25,15 +25,15 @@ import geotrellis.proj4.CRS
 
 /** A trait specifying CRS/JSON conversion */
 trait CrsFormats {
-  implicit val crsEncoder: Encoder[CRS] =
+  implicit lazy val crsEncoder: Encoder[CRS] =
     Encoder.encodeString.contramap[CRS] { _.toProj4String }
 
-  implicit val crsDecoder: Decoder[CRS] =
+  implicit lazy val crsDecoder: Decoder[CRS] =
     Decoder.decodeString.emap { str =>
       Either.catchNonFatal(CRS.fromString(str)).leftMap(_ => "CRS must be a proj4 string.")
     }
 
-  implicit val linkedCRSEncoder: Encoder[LinkedCRS] =
+  implicit lazy val linkedCRSEncoder: Encoder[LinkedCRS] =
     Encoder.encodeJson.contramap[LinkedCRS] { obj =>
       Json.obj(
         "type" -> "link".asJson,
@@ -44,7 +44,7 @@ trait CrsFormats {
       )
     }
 
-  implicit val linkedCRSDecoder: Decoder[LinkedCRS] =
+  implicit lazy val linkedCRSDecoder: Decoder[LinkedCRS] =
     Decoder.decodeHCursor.emap { c: HCursor =>
       c.downField("type").as[String].flatMap {
         case "link" =>
@@ -59,7 +59,7 @@ trait CrsFormats {
       }.leftMap(_ => "Unable to parse LinkedCRS")
     }
 
-  implicit val namedCRSEncoder: Encoder[NamedCRS] =
+  implicit lazy val namedCRSEncoder: Encoder[NamedCRS] =
     Encoder.encodeJson.contramap[NamedCRS] { obj =>
       Json.obj(
         "type" -> "name".asJson,
@@ -67,7 +67,7 @@ trait CrsFormats {
       )
     }
 
-  implicit val namedCRSDecoder: Decoder[NamedCRS] =
+  implicit lazy val namedCRSDecoder: Decoder[NamedCRS] =
     Decoder.decodeHCursor.emap { c: HCursor =>
       c.downField("type").as[String].flatMap {
         case "name" =>
@@ -82,13 +82,13 @@ trait CrsFormats {
       }.leftMap(_ => "Unable to parse NamedCRS")
     }
 
-  implicit val jsonCrsEncoder: Encoder[JsonCRS] =
+  implicit lazy val jsonCrsEncoder: Encoder[JsonCRS] =
     Encoder.encodeJson.contramap[JsonCRS] {
       case crs: NamedCRS => crs.asJson
       case crs: LinkedCRS => crs.asJson
     }
 
-  implicit val jsonCrsDecoder: Decoder[JsonCRS] = {
+  implicit lazy val jsonCrsDecoder: Decoder[JsonCRS] = {
     Decoder.decodeHCursor.emap { c: HCursor =>
       c.downField("type").as[String].flatMap {
         case "name" => c.as[NamedCRS]

--- a/vector/src/main/scala/geotrellis/vector/io/json/FeatureFormats.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/FeatureFormats.scala
@@ -87,10 +87,10 @@ trait FeatureFormats {
   implicit def featureEncoder[G <: Geometry: Encoder, D: Encoder]: Encoder[Feature[G, D]] =
     Encoder.encodeJson.contramap[Feature[G, D]] { writeFeatureJson }
 
-  implicit val featureCollectionEncoder: Encoder[JsonFeatureCollection] =
+  implicit lazy val featureCollectionEncoder: Encoder[JsonFeatureCollection] =
     Encoder.encodeJson.contramap[JsonFeatureCollection] { _.asJson }
 
-  implicit val featureCollectionDecoder: Decoder[JsonFeatureCollection] =
+  implicit lazy val featureCollectionDecoder: Decoder[JsonFeatureCollection] =
     Decoder.decodeHCursor.emap { c: HCursor =>
       (c.downField("type").as[String], c.downField("features").focus) match {
         case (Right("FeatureCollection"), Some(features)) => Right(JsonFeatureCollection(features.asArray.toVector.flatten))
@@ -98,10 +98,10 @@ trait FeatureFormats {
       }
     }
 
-  implicit val featureCollectionMapEncoder: Encoder[JsonFeatureCollectionMap] =
+  implicit lazy val featureCollectionMapEncoder: Encoder[JsonFeatureCollectionMap] =
     Encoder.encodeJson.contramap[JsonFeatureCollectionMap] { _.asJson }
 
-  implicit val featureCollectionMapDecoder: Decoder[JsonFeatureCollectionMap] =
+  implicit lazy val featureCollectionMapDecoder: Decoder[JsonFeatureCollectionMap] =
     Decoder.decodeHCursor.emap { c: HCursor =>
       (c.downField("type").as[String], c.downField("features").focus) match {
         case (Right("FeatureCollection"), Some(features)) => Right(JsonFeatureCollectionMap(features.asArray.toVector.flatten))

--- a/vector/src/main/scala/geotrellis/vector/io/json/Style.scala
+++ b/vector/src/main/scala/geotrellis/vector/io/json/Style.scala
@@ -45,7 +45,7 @@ object Style {
       if (!java.lang.Double.isNaN(fillOpacity)) Some(fillOpacity) else None
     )
 
-  implicit val styleDecoder: Decoder[Style] =
+  implicit lazy val styleDecoder: Decoder[Style] =
     Decoder.decodeHCursor.emap { c: HCursor =>
       val strokeColor =
         c.downField("stroke").as[String] match {
@@ -80,7 +80,7 @@ object Style {
       Right(Style(strokeColor, strokeWidth, strokeOpacity, fillColor, fillOpacity))
     }
 
-  implicit val styleEncoder: Encoder[Style] =
+  implicit lazy val styleEncoder: Encoder[Style] =
     Encoder.encodeJson.contramap[Style] { style =>
       val l = mutable.ListBuffer[(String, Json)]()
       if (style.strokeColor.isDefined) l += (("stroke", style.strokeColor.get.asJson))


### PR DESCRIPTION
# Overview

Shapeless 2.3.7 in deps can cause runtime issues in case the codec is created, however, it is possible to work around it in case codecs are lazy.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
