### PR TITLE
Add a graceful JtsConfig fallback in case of a shapeless versions mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Dependencies update [#3452](https://github.com/locationtech/geotrellis/pull/3452)
 - Lazy init Circe codecs in the vector module [#3457](https://github.com/locationtech/geotrellis/pull/3457)
-- Lazy init Extent and ProjectedExtent Circe codecs [#3458](https://github.com/locationtech/geotrellis/pull/3457)
+- Lazy init Extent and ProjectedExtent Circe codecs [#3458](https://github.com/locationtech/geotrellis/pull/3458)
+- Add a graceful JtsConfig fallback in case of a shapeless versions mismatch [#3459](https://github.com/locationtech/geotrellis/pull/3459)
 
 ## [3.6.1] - 2022-03-12
 

--- a/vector/src/main/scala/geotrellis/vector/conf/JtsConfig.scala
+++ b/vector/src/main/scala/geotrellis/vector/conf/JtsConfig.scala
@@ -21,6 +21,7 @@ import org.locationtech.jts.precision.GeometryPrecisionReducer
 
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
+import org.log4s._
 
 case class Simplification(scale: Double = 1e12) {
   // 12 digits is maximum to avoid [[TopologyException]], see https://web.archive.org/web/20160226031453/http://tsusiatsoftware.net/jts/jts-faq/jts-faq.html#D9
@@ -39,6 +40,15 @@ case class JtsConfig(precision: Precision = Precision(), simplification: Simplif
 }
 
 object JtsConfig {
-  lazy val conf: JtsConfig = ConfigSource.default.at("geotrellis.jts").loadOrThrow[JtsConfig]
+  @transient private[this] lazy val logger = getLogger
+
+  lazy val conf: JtsConfig = try {
+    ConfigSource.default.at("geotrellis.jts").loadOrThrow[JtsConfig]
+  } catch {
+    // Shapeless 2.3.3 compatibility
+    case e: NoSuchMethodError =>
+      logger.warn(e)("NoSuchMethodError happened, probably due to the Shapeless versions mismatch, using the default configuration.")
+      JtsConfig()
+  }
   implicit def jtsConfigToClass(obj: JtsConfig.type): JtsConfig = conf
 }


### PR DESCRIPTION
# Overview

This PR allows to use GeoTrellis vector as a package on a Spark cluster with Shapeless 2.3.3

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
