### PR TITLE
fix: The geotrellis-store module is missing dependency.

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -614,6 +614,8 @@ object Settings {
   lazy val store = Seq(
     name := "geotrellis-store",
     libraryDependencies ++= Seq(
+      guava,
+      uzaygezenCore,
       hadoopClient % Provided,
       apacheIO,
       scaffeine,


### PR DESCRIPTION
The module geotrellis-store is missing guava and uzaygezenCore dependency.
Without these two dependencies, the compilation will report the error as shown in the figure.
After the repair, the compile and test case are successful via sbt.
Unit tests can also run normally after the complete project is imported into IntelliJ Idea.

![image](https://user-images.githubusercontent.com/8111349/165355448-d02c6fd6-fee9-4789-8d07-0f5493476b84.png)
