### PR TITLE
Bump Spark version up to 3.2.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
   }
 
   def apacheSpark(module: String) = Def.setting {
-    "org.apache.spark"  %% s"spark-$module" % ver("3.1.3", "3.2.1").value
+    "org.apache.spark"  %% s"spark-$module" % "3.2.0"
   }
 
   def scalaReflect(version: String) = "org.scala-lang" % "scala-reflect" % version


### PR DESCRIPTION
# Overview

This PR bumps GT Spark version up to be aligned with frameless and rasterframes. We want to cut one patch release before https://github.com/locationtech/geotrellis/pull/3389
