### PR TITLE
Add RasterSourceRDD.tiledLayerRDD within the geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add RasterSourceRDD.tiledLayerRDD within the geometry [#3474](https://github.com/locationtech/geotrellis/pull/3474)
+
 ## [3.6.3] - 2022-07-12
 
 ### Changed


### PR DESCRIPTION
# Overview

This PR expand the tiledLayerRDD API and makes it possible to tileToLayout within the given AOI without loading rasters into memory outside of it.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] Unit tests added for bug-fix or new feature

Closes https://github.com/locationtech/geotrellis/issues/3473
