### PR TITLE
Exclude vectortile project from the unidoc generation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ lazy val root = Project("geotrellis", file("."))
   .enablePlugins(ScalaUnidocPlugin)
   .settings(Settings.commonSettings)
   .settings(publish / skip := true)
-  .settings(ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(mdoc))
+  // https://github.com/scalapb/ScalaPB/issues/1350
+  .settings(ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(mdoc, vectortile))
 
 lazy val mdoc = project
   .dependsOn(raster)


### PR DESCRIPTION
# Overview

Temporary (?) exclude vectortile from the unidoc generation due to the following error:

```scala
value readStringRequireUtf8 is not a member of com.google.protobuf.CodedInputStream
```

May be linked to: https://github.com/scalapb/ScalaPB/issues/1350