### PR TITLE
Test storage method for tiff writes

### DIFF
--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -54,11 +54,35 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
       actual should be (expected)
     }
 
-    it("should write GeoTiff with correct layout (tiled vs striped)") {
-      // We need to make the tiff large enough for tiling to make sense
+    it("should write singleband geotiffs (tiled)") {
+      val tile = IntArrayTile.fill(7, 1000, 1000)
+      val sbGeoTiffTiled = SinglebandGeoTiff(
+        tile, Extent(0, 0, 1, 1), LatLng, Tags.empty,
+        GeoTiffOptions.DEFAULT.copy(storageMethod=Tiled(256, 256))
+      )
+      val sbtempTiled = File.createTempFile("geotiff-writer-tiled-sb", ".tif")
+      addToPurge(sbtempTiled.getPath)
+      GeoTiffWriter.write(sbGeoTiffTiled, sbtempTiled.getPath)
+      val sbactualTiled = SinglebandGeoTiff(sbtempTiled.getPath)
+      sbactualTiled.options.storageMethod shouldBe a [Tiled]
+    }
+
+    it("should write singleband geotiffs (striped)") {
+      val tile = IntArrayTile.fill(7, 1000, 1000)
+      val sbGeoTiffStriped = SinglebandGeoTiff(
+        tile, Extent(0, 0, 1, 1), LatLng, Tags.empty,
+        GeoTiffOptions.DEFAULT.copy(storageMethod=Striped())
+      )
+      val sbtempStriped = File.createTempFile("geotiff-writer-striped-sb", ".tif")
+      addToPurge(sbtempStriped.getPath)
+      GeoTiffWriter.write(sbGeoTiffStriped, sbtempStriped.getPath)
+      val sbactualStriped = SinglebandGeoTiff(sbtempStriped.getPath)
+      sbactualStriped.options.storageMethod shouldBe a [Striped]
+    }
+
+    it("should write multiband geotiffs (tiled)") {
       val tile = IntArrayTile.fill(7, 1000, 1000)
       val mbtile = ArrayMultibandTile(tile)
-
       val mbGeoTiffTiled = MultibandGeoTiff(
         mbtile, Extent(0, 0, 1, 1), LatLng, Tags.empty,
         GeoTiffOptions.DEFAULT.copy(storageMethod=Tiled(256, 256))
@@ -67,8 +91,12 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
       addToPurge(mbtempTiled.getPath)
       GeoTiffWriter.write(mbGeoTiffTiled, mbtempTiled.getPath)
       val mbactualTiled = MultibandGeoTiff(mbtempTiled.getPath)
-      mbactualTiled.options.storageMethod should be (Tiled(256, 256))
+      mbactualTiled.options.storageMethod shouldBe a [Tiled]
+    }
 
+    it("should write multiband geotiffs (striped)") {
+      val tile = IntArrayTile.fill(7, 1000, 1000)
+      val mbtile = ArrayMultibandTile(tile)
       val mbGeoTiffStriped = MultibandGeoTiff(
         mbtile, Extent(0, 0, 1, 1), LatLng, Tags.empty,
         GeoTiffOptions.DEFAULT.copy(storageMethod=Striped())
@@ -77,27 +105,7 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
       addToPurge(mbtempStriped.getPath)
       GeoTiffWriter.write(mbGeoTiffStriped, mbtempStriped.getPath)
       val mbactualStriped = MultibandGeoTiff(mbtempStriped.getPath)
-      assert(mbactualStriped.options.storageMethod.isInstanceOf[Striped])
-
-      val sbGeoTiffTiled = MultibandGeoTiff(
-        mbtile, Extent(0, 0, 1, 1), LatLng, Tags.empty,
-        GeoTiffOptions.DEFAULT.copy(storageMethod=Tiled(256, 256))
-      )
-      val sbtempTiled = File.createTempFile("geotiff-writer-tiled-sb", ".tif")
-      addToPurge(sbtempTiled.getPath)
-      GeoTiffWriter.write(sbGeoTiffTiled, sbtempTiled.getPath)
-      val sbactualTiled = SinglebandGeoTiff(sbtempTiled.getPath)
-      assert(sbactualTiled.options.storageMethod.isInstanceOf[Tiled])
-
-      val sbGeoTiffStriped = MultibandGeoTiff(
-        mbtile, Extent(0, 0, 1, 1), LatLng, Tags.empty,
-        GeoTiffOptions.DEFAULT.copy(storageMethod=Striped())
-      )
-      val sbtempStriped = File.createTempFile("geotiff-writer-striped-sb", ".tif")
-      println(sbtempStriped.getPath)
-      GeoTiffWriter.write(sbGeoTiffStriped, sbtempStriped.getPath)
-      val sbactualStriped = SinglebandGeoTiff(sbtempStriped.getPath)
-      assert(sbactualStriped.options.storageMethod.isInstanceOf[Striped])
+      mbactualStriped.options.storageMethod shouldBe a [Striped]
     }
 
     it("should write GeoTiff with oversized custom tags") {


### PR DESCRIPTION
# Overview

Add tests to demonstrate respect for `StorageMethod` on `GeoTiff` write options.

## Checklist

- [x] Unit tests added for bug-fix or new feature

## Notes

Couldn't reproduce bug; simply adding a test to ensure no regression from here

Closes #3335 
