### PR TITLE
Add union to merge methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add RasterSourceRDD.tiledLayerRDD within the geometry intersection [#3474](https://github.com/locationtech/geotrellis/pull/3474)
 - Expose AWS_REQUEST_PAYER environment variable [#3479](https://github.com/locationtech/geotrellis/pull/3479)
+- Add union/outer join merger of tiles [#3482](https://github.com/locationtech/geotrellis/pull/3482)
 
 ### Changed
 - Migration to CE3 and other major dependencies upgrade [#3389](https://github.com/locationtech/geotrellis/pull/3389)

--- a/raster/src/main/scala/geotrellis/raster/merge/MultibandTileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/MultibandTileMergeMethods.scala
@@ -73,7 +73,7 @@ trait MultibandTileMergeMethods extends TileMergeMethods[MultibandTile] {
     * @param   otherExtent   The extent of the other MultiBandTile
     * @param   other         The other MultiBandTile
     * @param   method        The resampling method
-    * @param   unionF      The function which decides how values from rasters being combined will be transformed
+    * @param   unionFunc     The function which decides how values from rasters being combined will be transformed
     * @return                A new MultiBandTile, the result of the merge
     */
   def union(
@@ -81,7 +81,7 @@ trait MultibandTileMergeMethods extends TileMergeMethods[MultibandTile] {
     otherExtent: Extent,
     other: MultibandTile,
     method: ResampleMethod,
-    unionF: (Option[Double], Option[Double]) => Double
+    unionFunc: (Option[Double], Option[Double]) => Double
   ): MultibandTile = {
     val bands: Seq[Tile] =
       for {
@@ -89,7 +89,7 @@ trait MultibandTileMergeMethods extends TileMergeMethods[MultibandTile] {
       } yield {
         val thisBand = self.band(bandIndex)
         val thatBand = other.band(bandIndex)
-        thisBand.union(extent, otherExtent, thatBand, method, unionF)
+        thisBand.union(extent, otherExtent, thatBand, method, unionFunc)
       }
 
     ArrayMultibandTile(bands)

--- a/raster/src/main/scala/geotrellis/raster/merge/MultibandTileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/MultibandTileMergeMethods.scala
@@ -63,4 +63,35 @@ trait MultibandTileMergeMethods extends TileMergeMethods[MultibandTile] {
 
     ArrayMultibandTile(bands)
   }
+
+    /**
+    * Union this [[MultibandTile]] with the other one.  The output tile's
+    * extent will be the minimal extent which encompasses both input extents.
+    * A new MutlibandTile is returned.
+    *
+    * @param   extent        The extent of this MultiBandTile
+    * @param   otherExtent   The extent of the other MultiBandTile
+    * @param   other         The other MultiBandTile
+    * @param   method        The resampling method
+    * @param   unionF      The function which decides how values from rasters being combined will be transformed
+    * @return                A new MultiBandTile, the result of the merge
+    */
+  def union(
+    extent: Extent,
+    otherExtent: Extent,
+    other: MultibandTile,
+    method: ResampleMethod,
+    unionF: (Option[Double], Option[Double]) => Double
+  ): MultibandTile = {
+    val bands: Seq[Tile] =
+      for {
+        bandIndex <- 0 until self.bandCount
+      } yield {
+        val thisBand = self.band(bandIndex)
+        val thatBand = other.band(bandIndex)
+        thisBand.union(extent, otherExtent, thatBand, method, unionF)
+      }
+
+    ArrayMultibandTile(bands)
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/RasterMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/RasterMergeMethods.scala
@@ -50,4 +50,16 @@ abstract class RasterMergeMethods[
     */
   def merge(other: Raster[T]): Raster[T] =
     merge(other, NearestNeighbor)
+
+  /**
+    * Union this [[Raster]] with the other one.  All places in the
+    * present raster that contain NODATA are filled-in with data from
+    * the other raster.  A new Raster is returned.
+    *
+    * @param   other         The other Raster
+    * @param   method        The resampling method
+    * @return                A new Raster, the result of the merge
+    */
+  def union(other: Raster[T], method: ResampleMethod, unionF: (Option[Double], Option[Double]) => Double): Raster[T] =
+    Raster(self.tile.union(self.extent, other.extent, other.tile, method, unionF), self.extent.combine(other.extent))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/RasterMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/RasterMergeMethods.scala
@@ -60,6 +60,6 @@ abstract class RasterMergeMethods[
     * @param   method        The resampling method
     * @return                A new Raster, the result of the merge
     */
-  def union(other: Raster[T], method: ResampleMethod, unionF: (Option[Double], Option[Double]) => Double): Raster[T] =
-    Raster(self.tile.union(self.extent, other.extent, other.tile, method, unionF), self.extent.combine(other.extent))
+  def union(other: Raster[T], method: ResampleMethod, unionFunc: (Option[Double], Option[Double]) => Double): Raster[T] =
+    Raster(self.tile.union(self.extent, other.extent, other.tile, method, unionFunc), self.extent.combine(other.extent))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/RasterTileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/RasterTileFeatureMergeMethods.scala
@@ -33,6 +33,6 @@ abstract class RasterTileFeatureMergeMethods[
   def merge(other: TileFeature[Raster[T], D], method: ResampleMethod): TileFeature[Raster[T], D] =
     TileFeature(self.tile.merge(other.tile, method), Semigroup[D].combine(self.data, other.data))
 
-  def union(other: TileFeature[Raster[T], D], method: ResampleMethod, unionF: (Option[Double], Option[Double]) => Double): TileFeature[Raster[T], D] =
-    TileFeature(self.tile.union(other.tile, method, unionF), Semigroup[D].combine(self.data, other.data))
+  def union(other: TileFeature[Raster[T], D], method: ResampleMethod, unionFunc: (Option[Double], Option[Double]) => Double): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.union(other.tile, method, unionFunc), Semigroup[D].combine(self.data, other.data))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/RasterTileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/RasterTileFeatureMergeMethods.scala
@@ -32,4 +32,7 @@ abstract class RasterTileFeatureMergeMethods[
 
   def merge(other: TileFeature[Raster[T], D], method: ResampleMethod): TileFeature[Raster[T], D] =
     TileFeature(self.tile.merge(other.tile, method), Semigroup[D].combine(self.data, other.data))
+
+  def union(other: TileFeature[Raster[T], D], method: ResampleMethod, unionF: (Option[Double], Option[Double]) => Double): TileFeature[Raster[T], D] =
+    TileFeature(self.tile.union(other.tile, method, unionF), Semigroup[D].combine(self.data, other.data))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/SinglebandTileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/SinglebandTileMergeMethods.scala
@@ -151,6 +151,15 @@ trait SinglebandTileMergeMethods extends TileMergeMethods[Tile] {
         self
     }
 
+  /** Unions this tile with another tile, preserving the non-overlapping
+    * portions of each tile extent.
+    *
+    * This method requires a union function to be provided which decides
+    * how values will be added to the output raster. A `None` represents
+    * one of the two input rasters not having a value at the resampled location.
+    * Two `None` values mean that both tiles are missing values at the
+    * cell in question.
+    */
   def union(extent: Extent, otherExtent: Extent, other: Tile, method: ResampleMethod, unionFunc: (Option[Double], Option[Double]) => Double): Tile = {
     val unionInt: (Option[Int], Option[Int]) => Int =
       (l: Option[Int], r: Option[Int]) => {

--- a/raster/src/main/scala/geotrellis/raster/merge/SinglebandTileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/SinglebandTileMergeMethods.scala
@@ -212,7 +212,6 @@ trait SinglebandTileMergeMethods extends TileMergeMethods[Tile] {
             val maybeL = if (isNoData(l)) None else Some(l)
             val maybeR = if (isNoData(r)) None else Some(r)
             mutableTile.set(col, row, unionInt(maybeL, maybeR))
-            //if (l!=r) println(s"x => ${x}, y => ${y}, col => ${col}, row => ${row} | l,r => ${l}, ${r}")
           }
         }
     }

--- a/raster/src/main/scala/geotrellis/raster/merge/SinglebandTileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/SinglebandTileMergeMethods.scala
@@ -155,8 +155,8 @@ trait SinglebandTileMergeMethods extends TileMergeMethods[Tile] {
         self
     }
 
-  def union(extent: Extent, otherExtent: Extent, other: Tile, method: ResampleMethod, unionF: (Option[Double], Option[Double]) => Double): Tile = {
-    val unionInt = (l: Option[Double], r: Option[Double]) => unionF(l, r).toInt
+  def union(extent: Extent, otherExtent: Extent, other: Tile, method: ResampleMethod, unionFunc: (Option[Double], Option[Double]) => Double): Tile = {
+    val unionInt = (l: Option[Double], r: Option[Double]) => unionFunc(l, r).toInt
 
     val combinedExtent = otherExtent combine extent
     val re = RasterExtent(extent, self.cols, self.rows)
@@ -186,7 +186,7 @@ trait SinglebandTileMergeMethods extends TileMergeMethods[Tile] {
           cfor(0)(_ < targetRE.cols, _ + 1) { col =>
             val (x,y) = targetRE.gridToMap(col, row)
             val (l,r) = (interpolateLeft(x, y), interpolateRight(x, y))
-            mutableTile.setDouble(col, row, unionF(Some(l), Some(r)))
+            mutableTile.setDouble(col, row, unionFunc(Some(l), Some(r)))
           }
         }
       case x if x.isFloatingPoint =>
@@ -199,7 +199,7 @@ trait SinglebandTileMergeMethods extends TileMergeMethods[Tile] {
             val r = interpolateRight(x, y)
             val maybeL = if (isNoData(l)) None else Some(l)
             val maybeR = if (isNoData(r)) None else Some(r)
-            mutableTile.setDouble(col, row, unionF(maybeL, maybeR))
+            mutableTile.setDouble(col, row, unionFunc(maybeL, maybeR))
           }
         }
       case _ =>

--- a/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
@@ -37,7 +37,7 @@ abstract class TileFeatureMergeMethods[
     otherExtent: Extent,
     other: TileFeature[T, D],
     method: ResampleMethod,
-    unionF: (Option[Double], Option[Double]) => Double
+    unionFunc: (Option[Double], Option[Double]) => Double
   ): TileFeature[T, D] =
-    TileFeature(self.tile.union(extent, otherExtent, other.tile, method, unionF), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.union(extent, otherExtent, other.tile, method, unionFunc), Semigroup[D].combine(self.data, other.data))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
@@ -31,4 +31,13 @@ abstract class TileFeatureMergeMethods[
 
   def merge(extent: Extent, otherExtent: Extent, other: TileFeature[T, D], method: ResampleMethod): TileFeature[T, D] =
     TileFeature(self.tile.merge(extent, otherExtent, other.tile, method), Semigroup[D].combine(self.data, other.data))
+
+  def union(
+    extent: Extent,
+    otherExtent: Extent,
+    other: TileFeature[T, D],
+    method: ResampleMethod,
+    unionF: (Option[Double], Option[Double]) => Double
+  ): TileFeature[T, D] =
+    TileFeature(self.tile.union(extent, otherExtent, other.tile, method, unionF), Semigroup[D].combine(self.data, other.data))
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileFeatureMergeMethods.scala
@@ -19,7 +19,9 @@ package geotrellis.raster.merge
 import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.vector._
+
 import cats.Semigroup
+import cats.syntax.semigroup._ 
 
 
 abstract class TileFeatureMergeMethods[
@@ -27,10 +29,10 @@ abstract class TileFeatureMergeMethods[
   D: Semigroup
 ](val self: TileFeature[T, D]) extends TileMergeMethods[TileFeature[T, D]] {
   def merge(other: TileFeature[T, D], baseCol: Int, baseRow: Int): TileFeature[T, D] =
-    TileFeature(self.tile.merge(other.tile, baseCol, baseRow), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.merge(other.tile, baseCol, baseRow), self.data combine other.data)
 
   def merge(extent: Extent, otherExtent: Extent, other: TileFeature[T, D], method: ResampleMethod): TileFeature[T, D] =
-    TileFeature(self.tile.merge(extent, otherExtent, other.tile, method), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.merge(extent, otherExtent, other.tile, method), self.data combine other.data)
 
   def union(
     extent: Extent,
@@ -39,5 +41,5 @@ abstract class TileFeatureMergeMethods[
     method: ResampleMethod,
     unionFunc: (Option[Double], Option[Double]) => Double
   ): TileFeature[T, D] =
-    TileFeature(self.tile.union(extent, otherExtent, other.tile, method, unionFunc), Semigroup[D].combine(self.data, other.data))
+    TileFeature(self.tile.union(extent, otherExtent, other.tile, method, unionFunc), self.data combine other.data)
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/TileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileMergeMethods.scala
@@ -78,4 +78,9 @@ trait TileMergeMethods[T] extends MethodExtensions[T] {
   def merge(extent: Extent, otherExtent: Extent, other: T): T =
     merge(extent, otherExtent, other, NearestNeighbor)
 
+
+  def union(extent: Extent, otherExtent: Extent, other: T, method: ResampleMethod, unionF: (Option[Double], Option[Double]) => Double): T
+
+  def union(extent: Extent, otherExtent: Extent, other: T, unionF: (Option[Double], Option[Double]) => Double): T =
+    union(extent, otherExtent, other, NearestNeighbor, unionF)
 }

--- a/raster/src/main/scala/geotrellis/raster/merge/TileMergeMethods.scala
+++ b/raster/src/main/scala/geotrellis/raster/merge/TileMergeMethods.scala
@@ -79,8 +79,8 @@ trait TileMergeMethods[T] extends MethodExtensions[T] {
     merge(extent, otherExtent, other, NearestNeighbor)
 
 
-  def union(extent: Extent, otherExtent: Extent, other: T, method: ResampleMethod, unionF: (Option[Double], Option[Double]) => Double): T
+  def union(extent: Extent, otherExtent: Extent, other: T, method: ResampleMethod, unionFunc: (Option[Double], Option[Double]) => Double): T
 
-  def union(extent: Extent, otherExtent: Extent, other: T, unionF: (Option[Double], Option[Double]) => Double): T =
-    union(extent, otherExtent, other, NearestNeighbor, unionF)
+  def union(extent: Extent, otherExtent: Extent, other: T, unionFunc: (Option[Double], Option[Double]) => Double): T =
+    union(extent, otherExtent, other, NearestNeighbor, unionFunc)
 }

--- a/raster/src/test/scala/geotrellis/raster/merge/TileUnionMethodsSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/merge/TileUnionMethodsSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.raster.merge
+
+import geotrellis.raster._
+import geotrellis.raster.testkit._
+import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.vector.Extent
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funspec.AnyFunSpec
+
+class TileUnionMethodsSpec extends AnyFunSpec
+    with Matchers
+    with TileBuilders
+    with RasterMatchers {
+  describe("SinglebandTileMergeMethods") {
+
+    it("should union two tiles such that the extent of the output is equal to the minimum extent which covers both") {
+      val cellTypes: Seq[CellType] =
+        Seq(
+          BitCellType,
+          ByteCellType,
+          ByteConstantNoDataCellType,
+          ByteUserDefinedNoDataCellType(1.toByte),
+          UByteCellType,
+          UByteConstantNoDataCellType,
+          UByteUserDefinedNoDataCellType(1.toByte),
+          ShortCellType,
+          ShortConstantNoDataCellType,
+          ShortUserDefinedNoDataCellType(1.toShort),
+          UShortCellType,
+          UShortConstantNoDataCellType,
+          UShortUserDefinedNoDataCellType(1.toShort),
+          IntCellType,
+          IntConstantNoDataCellType,
+          IntUserDefinedNoDataCellType(1),
+          FloatCellType,
+          FloatConstantNoDataCellType,
+          FloatUserDefinedNoDataCellType(1.0f),
+          DoubleCellType,
+          DoubleConstantNoDataCellType,
+          DoubleUserDefinedNoDataCellType(1.0)
+        )
+
+      for(ct <- cellTypes) {
+        val arr = Array.ofDim[Double](100).fill(5.0)
+        arr(50) = 1.0
+        arr(55) = 0.0
+        arr(60) = Double.NaN
+
+        val tile1 =
+          DoubleArrayTile(arr, 10, 10).convert(ct)
+        val e1 = Extent(0, 0, 1, 1)
+        val tile2 =
+          tile1.prototype(ct, tile1.cols, tile1.rows)
+        val e2 = Extent(1, 1, 2, 2)
+        val unioned = tile1.union(e1, e2, tile2, NearestNeighbor, (d1, d2) => d1.getOrElse(4))
+        withClue(s"Failing on cell type $ct: ") {
+          unioned.rows shouldBe (20)
+          unioned.cols shouldBe (20)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Overview

This PR adds a tile merging function, `union` which combines two input tiles so as to preserve all non-overlapping regions.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

## Demo

Union of two tiles; tile 1 with extent 0,0,1,1 and tile2 with extent 2,2,2.2,2.2. Output tile with extent of 0,0,2.2,2.2:
<img width="616" alt="image" src="https://user-images.githubusercontent.com/1977405/182711914-096bfc76-af00-4959-8343-642f17b77da4.png">

Union of overlapping tiles with a function applied to average overlapping cell values:
<img width="448" alt="image" src="https://user-images.githubusercontent.com/1977405/182712053-005ea715-8c39-4c02-ae85-d043816f44c6.png">



Closes #3365
