### PR TITLE
liftCompletableFuture function fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Cassandra up to 4.x [#3382](https://github.com/locationtech/geotrellis/issues/3382)
 - Accumulo update up to 1.10.x [#3476](https://github.com/locationtech/geotrellis/pull/3476)
 - Fixed Extent.translate [#3480](https://github.com/locationtech/geotrellis/pull/3480)
+- liftCompletableFuture function fix [#3483](https://github.com/locationtech/geotrellis/pull/3483)
 
 ## [3.6.3] - 2022-07-12
 

--- a/cassandra/src/main/scala/geotrellis/store/cassandra/package.scala
+++ b/cassandra/src/main/scala/geotrellis/store/cassandra/package.scala
@@ -16,30 +16,22 @@
 
 package geotrellis.store
 
+import geotrellis.store.util._
 import cats.effect.Async
 import cats.syntax.functor._
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, Statement}
 
 import java.math.BigInteger
-import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 package object cassandra extends Serializable {
   implicit class BigIntOps(val self: BigInt) extends AnyVal {
     def asJava: BigInteger = new BigInteger(self.toByteArray)
   }
 
-  implicit class CompletableFutureOps[T](val self: CompletableFuture[T]) extends AnyVal {
-    def liftTo[F[_]: Async]: F[T] = Async[F].fromCompletableFuture(Async[F].delay(self))
-  }
-
-  implicit class CompletionStageOps[T](val self: CompletionStage[T]) extends AnyVal {
-    def liftTo[F[_]: Async]: F[T] = self.toCompletableFuture.liftTo
-  }
-
   implicit class CqlSessionOps(val self: CqlSession) extends AnyVal {
-    def closeF[F[_]: Async]: F[Unit] = self.closeAsync().liftTo.void
-    def executeF[F[_]: Async](statement: Statement[_]): F[AsyncResultSet] = self.executeAsync(statement).liftTo
+    def closeF[F[_]: Async]: F[Unit] = Async[F].liftCompletableFuture(self.closeAsync().toCompletableFuture).void
+    def executeF[F[_]: Async](statement: Statement[_]): F[AsyncResultSet] = Async[F].liftCompletableFuture(self.executeAsync(statement).toCompletableFuture)
   }
 
   implicit class AsyncResultSetOps(val self: AsyncResultSet) extends AnyVal {

--- a/store/src/main/scala/geotrellis/store/util/package.scala
+++ b/store/src/main/scala/geotrellis/store/util/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.store
+
+import cats.effect.Async
+
+import java.util.concurrent.CompletableFuture
+
+package object util {
+  implicit class AsyncOps[F[_]](val self: Async[F]) extends AnyVal {
+    def liftCompletableFuture[T](thunk: => CompletableFuture[T]): F[T] = self.fromCompletableFuture(self.delay(thunk))
+  }
+}


### PR DESCRIPTION
# Overview

This PR fixes the liftCompletableFuture function implementation. It should accept Future as a by name parameter to ensure wrapping happens before the Future is executed.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
