### PR TITLE
Pass baseTiff to new RasterSource on GeoTiffResampleRasterSource.reprojection/convert

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffReprojectRasterSource.scala
@@ -153,7 +153,7 @@ class GeoTiffReprojectRasterSource(
     GeoTiffReprojectRasterSource(dataPath, crs, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff = Some(tiff))
 
   def convert(targetCellType: TargetCellType): RasterSource =
-    GeoTiffReprojectRasterSource(dataPath, crs, resampleTarget, resampleMethod, strategy, targetCellType = Some(targetCellType))
+    GeoTiffReprojectRasterSource(dataPath, crs, resampleTarget, resampleMethod, strategy, targetCellType = Some(targetCellType), baseTiff=Some(tiff))
 
   override def toString: String = s"GeoTiffReprojectRasterSource(${dataPath.value}, $crs, $resampleTarget, $resampleMethod)"
 }

--- a/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
+++ b/raster/src/main/scala/geotrellis/raster/geotiff/GeoTiffResampleRasterSource.scala
@@ -65,7 +65,7 @@ class GeoTiffResampleRasterSource(
     tiff.getClosestOverview(gridExtent.cellSize, strategy)
 
   def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = ResampleMethod.DEFAULT, strategy: OverviewStrategy = OverviewStrategy.DEFAULT): GeoTiffReprojectRasterSource =
-    new GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType) {
+    new GeoTiffReprojectRasterSource(dataPath, targetCRS, resampleTarget, method, strategy, targetCellType = targetCellType, baseTiff=Some(tiff)) {
       override lazy val gridExtent: GridExtent[Long] = {
         val reprojectedRasterExtent =
           ReprojectRasterExtent(

--- a/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffRasterSourceSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/geotiff/GeoTiffRasterSourceSpec.scala
@@ -22,6 +22,7 @@ import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
 import geotrellis.raster.testkit._
 import geotrellis.vector._
+import geotrellis.proj4.WebMercator
 
 import org.scalatest.GivenWhenThen
 import org.scalatest.funspec.AnyFunSpec
@@ -83,6 +84,14 @@ class GeoTiffRasterSourceSpec extends AnyFunSpec with RasterMatchers with GivenW
     withGeoTiffClue(actual, expected, resampledSource.crs)  {
       assertRastersEqual(actual, expected)
     }
+  }
+
+  it("should preserve baseTiff on resample/reproject") {
+    val resampled = source.resample((source.cols * 0.95).toInt , (source.rows * 0.95).toInt, NearestNeighbor)
+    val reprojected = resampled.reproject(WebMercator)
+    assert(source.tiff == reprojected.asInstanceOf[GeoTiffReprojectRasterSource].tiff)
+    val converted = reprojected.convert(UShortCellType)
+    assert(source.tiff == converted.asInstanceOf[GeoTiffReprojectRasterSource].tiff)
   }
 
   it("resampleToRegion should produce an expected raster") {


### PR DESCRIPTION
# Overview

Before, when calling .convert or .reproject on a resampled GeoTiffRasterSource, a new baseTiff was created from the source path. Now, we preserve the baseTiff (like all other methods already do), avoiding creating a new one (and losing settings in the process)

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

