### PR TITLE
Downgrade scaffeine to 3.1.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -95,8 +95,7 @@ object Dependencies {
   val cassandraDriverCore         = "com.datastax.oss" % "java-driver-core"          % Version.cassandra
   val cassandraDriverQueryBuilder = "com.datastax.oss" % "java-driver-query-builder" % Version.cassandra
 
-  val scaffeine = "com.github.blemale"           %% "scaffeine" % "4.1.0"
-  val caffeine  = "com.github.ben-manes.caffeine" % "caffeine"  % "2.9.3"
+  val scaffeine = "com.github.blemale"           %% "scaffeine" % "3.1.0"
 
   val geotoolsCoverage    = "org.geotools"                 % "gt-coverage"             % Version.geotools
   val geotoolsHsql        = "org.geotools"                 % "gt-epsg-hsql"            % Version.geotools

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -613,7 +613,6 @@ object Settings {
       hadoopClient % Provided,
       apacheIO,
       scaffeine,
-      caffeine,
       uzaygezenCore,
       scalaXml,
       apacheLang3,


### PR DESCRIPTION
This is the last version that has JDK 8 support

# Overview

Brief description of what this PR does, and why it is needed.

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

## Notes

Even the [latest Databricks runtime](https://docs.databricks.com/release-notes/runtime/12.0.html) runs on JDK 8. While EMR has moved on to support 12. There was no specific reason to bump this library so keeping it at this level reduced the number integration headaches.