### PR TITLE
Fix: Mask preserves cell type of the masked tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Extent.translate [#3480](https://github.com/locationtech/geotrellis/pull/3480)
 - liftCompletableFuture function fix [#3483](https://github.com/locationtech/geotrellis/pull/3483)
 - Pass baseTiff to new RasterSource on GeoTiffResampleRasterSource.reproject/convert [#3485](https://github.com/locationtech/geotrellis/pull/3485)
+- `Mask` and `InverseMask` operations preserve tile cell type [#3494](https://github.com/locationtech/geotrellis/pull/3494)
 
 ## [3.6.3] - 2022-07-12
 

--- a/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ArrayTile.scala
@@ -535,6 +535,40 @@ object ArrayTile {
     * @return        The newly-created tile
     */
   def apply(arr: Array[Double], cols: Int, rows: Int): DoubleConstantNoDataArrayTile = new DoubleConstantNoDataArrayTile(arr, cols, rows)
+
+  /** Pixel-wise combine two of tiles given a function over Ints.
+    *
+    * @param left input tile
+    * @param right input tile
+    * @param out mutable result tile
+    * @param f combine function
+    */
+  def combine(left: Tile, right: Tile, out: MutableArrayTile, f: (Int, Int) => Int): Unit = {
+    cfor(0)(_ < left.rows, _ + 1) { row =>
+      cfor(0)(_ < left.cols, _ + 1) { col =>
+        val a = left.get(col, row)
+        val b = right.get(col, row)
+        out.set(col, row, f(a, b))
+      }
+    }
+  }
+
+  /** Pixel-wise combine two of tiles given a function over Doubles.
+    *
+    * @param left input tile
+    * @param right input tile
+    * @param out mutable result tile
+    * @param f combine function
+    */
+  def combineDouble(left: Tile, right: Tile, out: MutableArrayTile, f: (Double, Double) => Double): Unit = {
+    cfor(0)(_ < left.rows, _ + 1) { row =>
+      cfor(0)(_ < left.cols, _ + 1) { col =>
+        val a = left.getDouble(col, row)
+        val b = right.getDouble(col, row)
+        out.setDouble(col, row, f(a, b))
+      }
+    }
+  }
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/InverseMask.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/InverseMask.scala
@@ -27,7 +27,13 @@ object InverseMask extends Serializable {
     * For example, if *all* cells in the second raster are set to the readMask value,
     * the output raster will be identical to the first raster.
     */
-  def apply(r1: Tile, r2: Tile, readMask: Int, writeMask: Int): Tile =
-    r1.dualCombine(r2) { (z1: Int, z2: Int) => if (z2 == readMask) z1 else writeMask }
-  { (z1: Double, z2: Double) => if (d2i(z2) == readMask) z1 else i2d(writeMask) }
+  def apply(r1: Tile, r2: Tile, readMask: Int, writeMask: Int): Tile = {
+    val out = ArrayTile.alloc(r1.cellType, r1.cols, r1.rows)
+    if (r1.cellType.isFloatingPoint) {
+      ArrayTile.combineDouble(r1, r2, out, { (v: Double, m: Double) => if (d2i(m) == readMask.toDouble) v else i2d(writeMask) })
+    } else {
+      ArrayTile.combine(r1, r2, out, { (v: Int, m: Int) => if (m == readMask) v else writeMask })
+    }
+    out
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Mask.scala
+++ b/raster/src/main/scala/geotrellis/raster/mapalgebra/local/Mask.scala
@@ -27,7 +27,13 @@ object Mask extends Serializable {
    * For example, if *all* cells in the second raster are set to the readMask value,
    * the output raster will be empty -- all values set to NODATA.
    */
-  def apply(r1: Tile, r2: Tile, readMask: Int, writeMask: Int): Tile =
-    r1.dualCombine(r2) { (z1,z2) => if (z2 == readMask) writeMask else z1 }
-                       { (z1,z2) => if (d2i(z2) == readMask) i2d(writeMask) else z1 }
+  def apply(r1: Tile, r2: Tile, readMask: Int, writeMask: Int): Tile = {
+    val out = ArrayTile.alloc(r1.cellType, r1.cols, r1.rows)
+    if (r1.cellType.isFloatingPoint) {
+      ArrayTile.combineDouble(r1, r2, out, { (v: Double, m: Double) => if (d2i(m) == readMask) i2d(writeMask) else v })
+    } else {
+      ArrayTile.combine(r1, r2, out, { (v: Int, m: Int) => if (m == readMask) writeMask else v })
+    }
+    out
+  }
 }

--- a/raster/src/test/scala/geotrellis/raster/mask/SinglebandTileMaskMethodsSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/mask/SinglebandTileMaskMethodsSpec.scala
@@ -29,6 +29,14 @@ import org.scalatest.funspec.AnyFunSpec
 class SinglebandTileMaskMethodsSpec extends AnyFunSpec with Matchers with RasterMatchers with TileBuilders {
 
   describe("singleband tile mask") {
+    it("should preserve cellType") {
+      val r1 = createTile(Array(1,2,3,4)).convert(ByteCellType)
+      val r2 = createTile(Array(1,2,3,4)).convert(IntCellType)
+
+      val result = r1.localMask(r2, 2, NODATA)
+      result.cellType shouldBe ByteCellType
+    }
+
     it("should work with integers") {
       val r1 = createTile(
         Array( NODATA,1,1, 1,1,1, 1,1,1,


### PR DESCRIPTION
# Overview

`Mask` and `InverseMask` functions used `dualCombine` which used the union of cellTypes between tile and mask for result type. This mostly worked out fine but can produce bad results when either mask or tile had same byte width but different NODATA definitions. The correct behavior for mask operation is to always preserver the cell type of the input tile no matter how silly it or the mask cell type is. It's just better not to ask questions here.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

## Notes

Closes [#3488](https://github.com/locationtech/geotrellis/issues/3488)
