### PR TITLE
Fix URI parsing error in windows

### DIFF
--- a/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala
+++ b/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala
@@ -16,9 +16,10 @@
 
 package geotrellis.util
 
+import org.apache.hadoop.util.Shell
+
 import java.net.URI
 import java.nio.file.Paths
-
 
 class FileRangeReaderProvider extends RangeReaderProvider {
   def canProcess(uri: URI): Boolean = uri.getScheme match {
@@ -35,11 +36,13 @@ class FileRangeReaderProvider extends RangeReaderProvider {
     val targetPath: String = {
       val uriString = uri.toString
 
-      if (uriString.startsWith("file://"))
-        uriString.slice("file://".size, uriString.size + 1)
-      else if (uriString.startsWith("file:"))
-        uriString.slice("file:".size, uriString.size + 1)
-      else
+      if (uriString.startsWith("file://")) {
+        val from = if (Shell.WINDOWS) "file:///" else "file://"
+        uriString.slice(from.size, uriString.size + 1)
+      } else if (uriString.startsWith("file:")) {
+        val from = if (Shell.WINDOWS) "file:/" else "file:"
+        uriString.slice(from.size, uriString.size + 1)
+      } else
         uriString
     }
 


### PR DESCRIPTION
Fix the problem that Paths.get cannot be recognized correctly after URI parsing in windows

# Overview

Brief description of what this PR does, and why it is needed.

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [ ] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #XXX
