### PR TITLE
Fix FileRangeReaderProvider parsing URI in windows

### DIFF
--- a/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala
+++ b/util/src/main/scala/geotrellis/util/FileRangeReaderProvider.scala
@@ -19,7 +19,6 @@ package geotrellis.util
 import java.net.URI
 import java.nio.file.Paths
 
-
 class FileRangeReaderProvider extends RangeReaderProvider {
   def canProcess(uri: URI): Boolean = uri.getScheme match {
     case str: String => if (str.toLowerCase == "file") true else false
@@ -32,14 +31,17 @@ class FileRangeReaderProvider extends RangeReaderProvider {
     // URIs that are correctly formatted from being used. To
     // get around this, we will pass in the URI as a String
     // instead without its Scheme (if it had one).
+    val isWindows = System.getProperty("os.name").toLowerCase().startsWith("win")
     val targetPath: String = {
       val uriString = uri.toString
 
-      if (uriString.startsWith("file://"))
-        uriString.slice("file://".size, uriString.size + 1)
-      else if (uriString.startsWith("file:"))
-        uriString.slice("file:".size, uriString.size + 1)
-      else
+      if (uriString.startsWith("file://")) {
+        val from = if (isWindows) "file:///" else "file://"
+        uriString.slice(from.size, uriString.size + 1)
+      } else if (uriString.startsWith("file:")) {
+        val from = if (isWindows) "file:/" else "file:"
+        uriString.slice(from.size, uriString.size + 1)
+      } else
         uriString
     }
 


### PR DESCRIPTION
# Overview

Fix the problem that Paths.get cannot be recognized correctly after URI parsing in windows.

## Notes

Use HadoopCOGLayerReader to read COGLayer and perform first operation on the result RDD.

Before repair:
![image](https://user-images.githubusercontent.com/97273184/222628861-56fcf85e-974e-42de-beec-806cb00cb86a.png)

After repair:
![image](https://user-images.githubusercontent.com/97273184/222629025-f2941ff9-e3dc-41ca-9a6f-0b200bd9f63d.png)