### PR TITLE
Regrid: force crop to avoid going out of memory

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
+++ b/spark/src/main/scala/geotrellis/spark/regrid/Regrid.scala
@@ -118,11 +118,12 @@ object Regrid {
 
               val xSpan: Interval[Long] = oldXrange intersect newXrange
               val ySpan: Interval[Long] = oldYrange intersect newYrange
+              val forceCrop = newW < 0.6*oldW || newH < 0.6*oldH
               newKey ->
                 (oldTile.crop((xSpan.start - oldXstart).toInt,
                               (ySpan.start - oldYstart).toInt,
                               (xSpan.end - oldXstart).toInt,
-                              (ySpan.end - oldYstart).toInt),
+                              (ySpan.end - oldYstart).toInt),Crop.Options(force=forceCrop)),
                  ((xSpan.start - newXrange.start).toInt, (ySpan.start - newYrange.start).toInt)
                 )
             }


### PR DESCRIPTION
force cropping when regrid leads to much smaller tiles, to avoid memory multiplication in serialized rdd

# Overview
Issue: https://github.com/Open-EO/openeo-geotrellis-extensions/issues/191
Regrid uses cropping to create new tiles, but by default, cropping retains the original ArrayTile. So when regrid is used to go from large tile sizes (e.g. 1024 pixels) to smaller ones (e.g. 64 pixels) we get many cropped tiles all referencing these larger original tiles. When Spark then serializes these cropped tiles, the original arrays are all separately serialized, and we get a multiplication effect on the RDD size. Deserializing then can make executors go out of memory.

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [ ] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL


