### PR TITLE
Fix numerical errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Fix FileRangeReaderProvider parsing URI in windows [#3507](https://github.com/locationtech/geotrellis/pull/3507)
+- Fix rounding errors/numerical instability in GridExtent and LayoutTileSource [#3520](https://github.com/locationtech/geotrellis/pull/3520)
 
 ## [3.7.0] - 2023-02-26
 

--- a/layer/src/main/scala/geotrellis/layer/LayoutTileSource.scala
+++ b/layer/src/main/scala/geotrellis/layer/LayoutTileSource.scala
@@ -33,8 +33,8 @@ class LayoutTileSource[K: SpatialComponent](
 ) {
   LayoutTileSource.requireGridAligned(source.gridExtent, layout)
 
-  def sourceColOffset: Long = ((source.extent.xmin - layout.extent.xmin) / layout.cellwidth).toLong
-  def sourceRowOffset: Long = ((layout.extent.ymax - source.extent.ymax) / layout.cellheight).toLong
+  def sourceColOffset: Long = GridExtent.floorWithTolerance((source.extent.xmin - layout.extent.xmin) / layout.cellwidth).toLong
+  def sourceRowOffset: Long = GridExtent.floorWithTolerance((layout.extent.ymax - source.extent.ymax) / layout.cellheight).toLong
 
   def rasterRegionForKey(key: K): Option[RasterRegion] = {
     val spatialComponent = key.getComponent[SpatialKey]

--- a/raster/src/main/scala/geotrellis/raster/GridExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/GridExtent.scala
@@ -183,18 +183,18 @@ class GridExtent[@specialized(Int, Long) N: Integral](
       val colMaxDouble = mapXToGridDouble(subExtent.xmax)
 
       if (math.abs(colMaxDouble - floorWithTolerance(colMaxDouble)) < GridExtent.epsilon)
-        colMaxDouble.toLong - 1L
+        floorWithTolerance(colMaxDouble).toLong - 1L
       else
-        colMaxDouble.toLong
+        floorWithTolerance(colMaxDouble).toLong
     }
 
     val rowMax: N = Integral[N].fromLong {
       val rowMaxDouble = mapYToGridDouble(subExtent.ymin)
 
       if (math.abs(rowMaxDouble - floorWithTolerance(rowMaxDouble)) < GridExtent.epsilon)
-        rowMaxDouble.toLong - 1L
+        floorWithTolerance(rowMaxDouble).toLong - 1L
       else
-        rowMaxDouble.toLong
+        floorWithTolerance(rowMaxDouble).toLong
     }
 
     if (clamp)

--- a/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
@@ -191,8 +191,8 @@ class GridExtentSpec extends AnyFunSpec with Matchers {
       //gridextents have to be aligned for test to be valid
       val resultingBounds = ge2.gridBoundsFor(targetExtent)
 
-      assertEquals(targetBounds.height, resultingBounds.height)
-      assertEquals(targetBounds.width, resultingBounds.width)
+      targetBounds.height should be resultingBounds.height
+      targetBounds.width should be resultingBounds.width
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/GridExtentSpec.scala
@@ -179,5 +179,20 @@ class GridExtentSpec extends AnyFunSpec with Matchers {
       val actualGridExtent = gridExtent.withResolution(CellSize(1.4, 1.4))
       expectedGridExtent should be (actualGridExtent)
     }
+
+    it("should support roundtrip from grid bounds to raster extent and back") {
+      val targetBounds = GridBounds(55L, 103, 55 + 73, 103 + 111)
+      val ge = GridExtent[Long](Extent(1.8973214288275528, 49.352678585684544, 6.299107143119465, 51.7276785856839), CellSize(0.008928571428584, 0.008928571428568996))
+      val targetExtent = ge.extentFor(targetBounds)
+
+      //second, aligned extent based on a LayoutDefinition
+      val ge2 = GridExtent[Long](Extent(2.3883928573996727, 49.66517858568254, 3.5312500002584244, 50.80803572854129), CellSize(0.008928571428583998, 0.008928571428583998))
+
+      //gridextents have to be aligned for test to be valid
+      val resultingBounds = ge2.gridBoundsFor(targetExtent)
+
+      assertEquals(targetBounds.height, resultingBounds.height)
+      assertEquals(targetBounds.width, resultingBounds.width)
+    }
   }
 }


### PR DESCRIPTION
# Overview

When working in epsg:4326 coordinates, I recently observed separate bugs caused by the same problem. Basically transformations between geographical coordinates and grid coordinates where wrong due to floating point imprecision.
In both cases, grid coordinates were calculated as doubles and resulted in e.g. 4.9999999 but were done floored (toLong) resulting in 4.

This resulted in an actual pixel shift in one case, and in another case a missing row of pixels at the bottom of a saved geotiff.

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR. 
- [ ] Unit tests added for bug-fix or new feature


## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #XXX
