### PR TITLE
potential fix for resamplemethod in reproject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump GeoTools version up to 30.x [#3521](https://github.com/locationtech/geotrellis/pull/3521)
 - Dependecies update & fix "not found: type Serializable" compiler bug [#3535](https://github.com/locationtech/geotrellis/pull/3535)
 - Update GDAL up to 3.9.x [#3540](https://github.com/locationtech/geotrellis/pull/3540)
+- Fix reprojection with downsampling for GeotiffRasterSource and tile RDDs. [#3541](https://github.com/locationtech/geotrellis/issues/3541)
 
 ## [3.7.1] - 2024-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump GeoTools version up to 30.x [#3521](https://github.com/locationtech/geotrellis/pull/3521)
 - Dependecies update & fix "not found: type Serializable" compiler bug [#3535](https://github.com/locationtech/geotrellis/pull/3535)
 - Update GDAL up to 3.9.x [#3540](https://github.com/locationtech/geotrellis/pull/3540)
-- Fix reprojection with downsampling for GeotiffRasterSource and tile RDDs. [#3541](https://github.com/locationtech/geotrellis/issues/3541)
+- Fix reprojection with downsampling for GeotiffRasterSource and tile RDDs. Reprojection outside the valid projection bounds may now throw a GeoAttrsError. [#3541](https://github.com/locationtech/geotrellis/issues/3541)
 
 ## [3.7.1] - 2024-01-08
 

--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
@@ -191,7 +191,8 @@ object RasterRegionReproject {
       errorThreshold: Double
     ): Unit = {
       val trans = Proj4Transform(dest, src)
-      val resampler = Resample(resampleMethod, raster.tile, raster.extent, CellSize(raster.rasterExtent.cellwidth, raster.rasterExtent.cellheight))
+      val targetCellSizeInSrcCRS = rasterExtent.reproject(dest,src).cellSize
+      val resampler = Resample(resampleMethod, raster.tile, raster.extent, targetCellSizeInSrcCRS))
       val rowcoords = rowCoords(region, rasterExtent, trans, errorThreshold)
 
       if (raster.cellType.isFloatingPoint) {
@@ -262,10 +263,11 @@ object RasterRegionReproject {
       val trans = Proj4Transform(dest, src)
       val rowcoords = rowCoords(region, rasterExtent, trans, errorThreshold)
       val resampler: Array[Resample] = Array.ofDim[Resample](raster.tile.bandCount)
+      val targetCellSizeInSrcCRS = rasterExtent.reproject(dest,src).cellSize
 
       for (b <- 0 until raster.tile.bandCount) {
         val band: Tile = raster.tile.bands(b)
-        resampler(b) = Resample(resampleMethod, band, raster.extent, raster.rasterExtent.cellSize)
+        resampler(b) = Resample(resampleMethod, band, raster.extent, targetCellSizeInSrcCRS)
       }
 
       if (raster.cellType.isFloatingPoint) {

--- a/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/RasterRegionReproject.scala
@@ -191,8 +191,15 @@ object RasterRegionReproject {
       errorThreshold: Double
     ): Unit = {
       val trans = Proj4Transform(dest, src)
-      val targetCellSizeInSrcCRS = rasterExtent.reproject(dest,src).cellSize
-      val resampler = Resample(resampleMethod, raster.tile, raster.extent, targetCellSizeInSrcCRS))
+
+      val targetCellSizeInSrcCRS =
+        try{
+          rasterExtent.reproject(dest,src).cellSize
+        }catch {
+          case e:Exception => //reprojection errors happen when going outside valid area of projection, need a better fix here
+            raster.rasterExtent.cellSize
+        }
+      val resampler = Resample(resampleMethod, raster.tile, raster.extent, targetCellSizeInSrcCRS)
       val rowcoords = rowCoords(region, rasterExtent, trans, errorThreshold)
 
       if (raster.cellType.isFloatingPoint) {
@@ -263,7 +270,14 @@ object RasterRegionReproject {
       val trans = Proj4Transform(dest, src)
       val rowcoords = rowCoords(region, rasterExtent, trans, errorThreshold)
       val resampler: Array[Resample] = Array.ofDim[Resample](raster.tile.bandCount)
-      val targetCellSizeInSrcCRS = rasterExtent.reproject(dest,src).cellSize
+
+      val targetCellSizeInSrcCRS =
+        try{
+          rasterExtent.reproject(dest,src).cellSize
+        }catch {
+          case e:Exception => //reprojection errors happen when going outside valid area of projection, need a better fix here
+            raster.rasterExtent.cellSize
+        }
 
       for (b <- 0 until raster.tile.bandCount) {
         val band: Tile = raster.tile.bands(b)


### PR DESCRIPTION
https://github.com/locationtech/geotrellis/issues/3541

# Overview

Proposed fix for a very important bug in reprojecting to lower resolution.
I think it's better (more correct) than previous behaviour, but not sure yet if it is 100% accurate.

It seems to me that the downsampling now happens in the original projection system, and then it is warping to the new CRS. This will work fine if the low resolution pixel is rectangular in both projection systems.


## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #XXX
