### PR TITLE
Fixed the issue that the generated vrt.xml is empty when writing out cog

### DIFF
--- a/store/src/main/scala/geotrellis/store/cog/vrt/VRT.scala
+++ b/store/src/main/scala/geotrellis/store/cog/vrt/VRT.scala
@@ -172,6 +172,7 @@ object VRT {
       doctype = null
     )
 
+    writer.flush()
     baos
   }
 


### PR DESCRIPTION
Add `writer.flush()` when writing xml to vrt, fix the problem of writing empty vrt.xml when writing out cog.