### PR TITLE
ConstantTile with NoData: support idempotent CellType conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependecies update & fix "not found: type Serializable" compiler bug [#3535](https://github.com/locationtech/geotrellis/pull/3535)
 - Update GDAL up to 3.9.x [#3540](https://github.com/locationtech/geotrellis/pull/3540)
 - Fix reprojection with downsampling for GeotiffRasterSource and tile RDDs. Reprojection outside the valid projection bounds may now throw a GeoAttrsError. [#3541](https://github.com/locationtech/geotrellis/issues/3541)
-- ConstantTile: fix 'convert' method when the constant value is nodata. [#3525](https://github.com/locationtech/geotrellis/issues/3525)
+- ConstantTile with NoData: support idempotent CellType conversions [#3553](https://github.com/locationtech/geotrellis/pull/3553)
 
 ## [3.7.1] - 2024-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependecies update & fix "not found: type Serializable" compiler bug [#3535](https://github.com/locationtech/geotrellis/pull/3535)
 - Update GDAL up to 3.9.x [#3540](https://github.com/locationtech/geotrellis/pull/3540)
 - Fix reprojection with downsampling for GeotiffRasterSource and tile RDDs. Reprojection outside the valid projection bounds may now throw a GeoAttrsError. [#3541](https://github.com/locationtech/geotrellis/issues/3541)
+- ConstantTile: fix 'convert' method when the constant value is nodata. [#3525](https://github.com/locationtech/geotrellis/issues/3525)
 
 ## [3.7.1] - 2024-01-08
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.3

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -36,10 +36,10 @@ abstract class ConstantTile extends Tile {
   def rows: Int
 
   /** Precomputed view of tile cells as seen by [[get]] method */
-  protected val iVal: Int
+  protected def iVal: Int
 
   /** Precomputed view of tile cells as seen by [[getDouble]] method */
-  protected val dVal: Double
+  protected def dVal: Double
 
   /**
     * Fetch the datum at the given column and row of the tile.
@@ -80,19 +80,17 @@ abstract class ConstantTile extends Tile {
     * @param   newType  The type of cells that the result should have
     * @return            The new Tile
     */
-  def convert(newType: CellType): Tile = {
+  def convert(newType: CellType): Tile =
     newType match {
-      case ct: CellType if  dVal.isNaN => ConstantTile.empty(newType, cols, rows)
       case BitCellType => new BitConstantTile(if (iVal == 0) false else true, cols, rows)
-      case ct: ByteCells => ByteConstantTile(iVal.toByte, cols, rows, ct)
+      case ct: ByteCells => ByteConstantTile(i2b(iVal), cols, rows, ct)
       case ct: UByteCells => UByteConstantTile(iVal.toByte, cols, rows, ct)
-      case ct: ShortCells => ShortConstantTile(iVal.toShort , cols, rows, ct)
-      case ct: UShortCells =>  UShortConstantTile(iVal.toShort , cols, rows, ct)
-      case ct: IntCells =>  IntConstantTile(iVal , cols, rows, ct)
-      case ct: FloatCells => FloatConstantTile(dVal.toFloat , cols, rows, ct)
+      case ct: ShortCells => ShortConstantTile(i2s(iVal), cols, rows, ct)
+      case ct: UShortCells => UShortConstantTile(i2us(iVal) , cols, rows, ct)
+      case ct: IntCells => IntConstantTile(iVal, cols, rows, ct)
+      case ct: FloatCells => FloatConstantTile(d2f(dVal), cols, rows, ct)
       case ct: DoubleCells => DoubleConstantTile(dVal, cols, rows, ct)
     }
-  }
 
   def interpretAs(newCellType: CellType): Tile =
     withNoData(None).convert(newCellType)
@@ -253,35 +251,31 @@ object ConstantTile {
    * @param   rows   The number of rows that the new [[ConstantTile]] should have
    * @return         The new [[ConstantTile]]
    */
-  def empty(t: CellType, cols: Int, rows: Int): Tile = {
+  def empty(t: CellType, cols: Int, rows: Int): Tile =
     t match {
-      case _: BitCells => BitConstantTile(false, cols, rows)
-      case ct: ByteUserDefinedNoDataCellType => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: ByteConstantNoDataCellType.type => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: ByteCellType.type => ByteConstantTile(byteNODATA ,cols, rows, ct)
-      case ct: UByteConstantNoDataCellType.type => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: UByteUserDefinedNoDataCellType => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: UByteCellType.type => UByteConstantTile(ubyteNODATA ,cols, rows, ct)
-      case ct: ShortUserDefinedNoDataCellType => ShortConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: ShortConstantNoDataCellType.type => ShortConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: ShortCellType.type => ShortConstantTile(shortNODATA ,cols, rows, ct)
-      case ct: UShortUserDefinedNoDataCellType => UShortConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: UShortConstantNoDataCellType.type => UShortConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: UShortCellType.type => UShortConstantTile(ushortNODATA ,cols, rows, ct)
-      case ct: IntUserDefinedNoDataCellType => IntConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: IntConstantNoDataCellType.type => IntConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: IntCellType.type => IntConstantTile(NODATA ,cols, rows, ct)
-      case ct: FloatUserDefinedNoDataCellType => FloatConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: FloatConstantNoDataCellType.type => FloatConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: FloatCellType.type => FloatConstantTile(floatNODATA ,cols, rows, ct)
-      case ct: DoubleUserDefinedNoDataCellType => DoubleConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: DoubleConstantNoDataCellType.type => DoubleConstantTile(ct.noDataValue ,cols, rows, ct)
-      case ct: DoubleCellType.type => DoubleConstantTile(doubleNODATA ,cols, rows, ct)
+      case _: BitCells => BitConstantTile(v = false, cols, rows)
+      case ct: ByteUserDefinedNoDataCellType => ByteConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: ByteConstantNoDataCellType.type => ByteConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: ByteCellType.type => ByteConstantTile(byteNODATA, cols, rows, ct)
+      case ct: UByteConstantNoDataCellType.type => UByteConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: UByteUserDefinedNoDataCellType => UByteConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: UByteCellType.type => UByteConstantTile(ubyteNODATA, cols, rows, ct)
+      case ct: ShortUserDefinedNoDataCellType => ShortConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: ShortConstantNoDataCellType.type => ShortConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: ShortCellType.type => ShortConstantTile(shortNODATA, cols, rows, ct)
+      case ct: UShortUserDefinedNoDataCellType => UShortConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: UShortConstantNoDataCellType.type => UShortConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: UShortCellType.type => UShortConstantTile(ushortNODATA, cols, rows, ct)
+      case ct: IntUserDefinedNoDataCellType => IntConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: IntConstantNoDataCellType.type => IntConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: IntCellType.type => IntConstantTile(NODATA, cols, rows, ct)
+      case ct: FloatUserDefinedNoDataCellType => FloatConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: FloatConstantNoDataCellType.type => FloatConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: FloatCellType.type => FloatConstantTile(floatNODATA, cols, rows, ct)
+      case ct: DoubleUserDefinedNoDataCellType => DoubleConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: DoubleConstantNoDataCellType.type => DoubleConstantTile(ct.noDataValue, cols, rows, ct)
+      case ct: DoubleCellType.type => DoubleConstantTile(doubleNODATA, cols, rows, ct)
     }
-  }
-
-
-
 }
 
 /**

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -21,8 +21,6 @@ import geotrellis.vector.Extent
 import java.nio.ByteBuffer
 import spire.syntax.cfor._
 
-import java.lang
-
 
 /**
   * The trait underlying constant tile types.
@@ -83,21 +81,17 @@ abstract class ConstantTile extends Tile {
     * @return            The new Tile
     */
   def convert(newType: CellType): Tile = {
-    if(dVal.isNaN && !newType.isInstanceOf[NoNoData]) {
-      ConstantTile.emptyTile(newType, cols, rows)
-    }else {
-      newType match {
-        case BitCellType => new BitConstantTile(if (iVal == 0) false else true, cols, rows)
-        case ct: ByteCells => ByteConstantTile(iVal.toByte, cols, rows, ct)
-        case ct: UByteCells => UByteConstantTile(iVal.toByte, cols, rows, ct)
-        case ct: ShortCells => ShortConstantTile(iVal.toShort , cols, rows, ct)
-        case ct: UShortCells =>  UShortConstantTile(iVal.toShort , cols, rows, ct)
-        case ct: IntCells =>  IntConstantTile(iVal , cols, rows, ct)
-        case ct: FloatCells => FloatConstantTile(dVal.toFloat , cols, rows, ct)
-        case ct: DoubleCells => DoubleConstantTile(dVal, cols, rows, ct)
-      }
+    newType match {
+      case ct: CellType if !ct.isInstanceOf[NoNoData] &&  dVal.isNaN => ConstantTile.emptyTile(newType, cols, rows)
+      case BitCellType => new BitConstantTile(if (iVal == 0) false else true, cols, rows)
+      case ct: ByteCells => ByteConstantTile(iVal.toByte, cols, rows, ct)
+      case ct: UByteCells => UByteConstantTile(iVal.toByte, cols, rows, ct)
+      case ct: ShortCells => ShortConstantTile(iVal.toShort , cols, rows, ct)
+      case ct: UShortCells =>  UShortConstantTile(iVal.toShort , cols, rows, ct)
+      case ct: IntCells =>  IntConstantTile(iVal , cols, rows, ct)
+      case ct: FloatCells => FloatConstantTile(dVal.toFloat , cols, rows, ct)
+      case ct: DoubleCells => DoubleConstantTile(dVal, cols, rows, ct)
     }
-
   }
 
   def interpretAs(newCellType: CellType): Tile =
@@ -265,9 +259,9 @@ object ConstantTile {
       t match {
         case _: BitCells => BitConstantTile(false, cols, rows)
         case ct: ByteUserDefinedNoDataCellType => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: ByteCells => ByteConstantTile(t.asInstanceOf[HasNoData[Byte]].noDataValue ,cols, rows, ct)
+        case ct: ByteConstantNoDataCellType => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
+        case ct: UByteConstantNoDataCellType => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
         case ct: UByteUserDefinedNoDataCellType => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: UByteCells => UByteConstantTile(t.asInstanceOf[HasNoData[Byte]].noDataValue ,cols, rows, ct)
         case ct: ShortUserDefinedNoDataCellType => {
           val theNoData: Short = ct.noDataValue
           ShortConstantTile(theNoData ,cols, rows, ct)

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -17,8 +17,6 @@
 package geotrellis.raster
 
 import geotrellis.vector.Extent
-import geotrellis.raster.ByteConstantNoDataCellType
-import geotrellis.raster.UByteConstantNoDataCellType
 
 import java.nio.ByteBuffer
 import spire.syntax.cfor._
@@ -261,8 +259,8 @@ object ConstantTile {
       t match {
         case _: BitCells => BitConstantTile(false, cols, rows)
         case ct: ByteUserDefinedNoDataCellType => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: ByteConstantNoDataCellType => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: UByteConstantNoDataCellType => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
+        case ct: ByteConstantNoDataCellType.type => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
+        case ct:  UByteConstantNoDataCellType.type => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
         case ct: UByteUserDefinedNoDataCellType => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
         case ct: ShortUserDefinedNoDataCellType => {
           val theNoData: Short = ct.noDataValue

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -250,6 +250,14 @@ object ConstantTile {
       case ct: DoubleCells => DoubleConstantTile.fromBytes(bytes, cols, rows, ct)
     }
 
+  /**
+   * Create a [[ConstantTile]] that is set to the nodata value of the given celltype.
+   *
+   * @param   t      The [[CellType]] of the new [[ConstantTile]], it should have a NoData value.
+   * @param   cols   The number of columns that the new [[ConstantTile]] should have
+   * @param   rows   The number of rows that the new [[ConstantTile]] should have
+   * @return         The new [[ConstantTile]]
+   */
   def emptyTile(t: CellType, cols: Int, rows: Int): Tile = {
     if(t.isInstanceOf[NoNoData]) {
       throw new IllegalArgumentException(s"Can not construct an empty constant tile for a celltype without nodata handling: $t")

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -17,6 +17,8 @@
 package geotrellis.raster
 
 import geotrellis.vector.Extent
+import geotrellis.raster.ByteConstantNoDataCellType
+import geotrellis.raster.UByteConstantNoDataCellType
 
 import java.nio.ByteBuffer
 import spire.syntax.cfor._

--- a/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/ConstantTile.scala
@@ -82,7 +82,7 @@ abstract class ConstantTile extends Tile {
     */
   def convert(newType: CellType): Tile = {
     newType match {
-      case ct: CellType if !ct.isInstanceOf[NoNoData] &&  dVal.isNaN => ConstantTile.emptyTile(newType, cols, rows)
+      case ct: CellType if  dVal.isNaN => ConstantTile.empty(newType, cols, rows)
       case BitCellType => new BitConstantTile(if (iVal == 0) false else true, cols, rows)
       case ct: ByteCells => ByteConstantTile(iVal.toByte, cols, rows, ct)
       case ct: UByteCells => UByteConstantTile(iVal.toByte, cols, rows, ct)
@@ -245,42 +245,41 @@ object ConstantTile {
     }
 
   /**
-   * Create a [[ConstantTile]] that is set to the nodata value of the given celltype.
+   * Create a [[ConstantTile]] that is set to the nodata value of the given celltype or to the default nodata value if
+   * the celltype does not have a nodata. BitCells are set to 'false'.
    *
-   * @param   t      The [[CellType]] of the new [[ConstantTile]], it should have a NoData value.
+   * @param   t      The [[CellType]] of the new [[ConstantTile]].
    * @param   cols   The number of columns that the new [[ConstantTile]] should have
    * @param   rows   The number of rows that the new [[ConstantTile]] should have
    * @return         The new [[ConstantTile]]
    */
-  def emptyTile(t: CellType, cols: Int, rows: Int): Tile = {
-    if(t.isInstanceOf[NoNoData]) {
-      throw new IllegalArgumentException(s"Can not construct an empty constant tile for a celltype without nodata handling: $t")
-    }else{
-      t match {
-        case _: BitCells => BitConstantTile(false, cols, rows)
-        case ct: ByteUserDefinedNoDataCellType => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: ByteConstantNoDataCellType.type => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct:  UByteConstantNoDataCellType.type => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: UByteUserDefinedNoDataCellType => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: ShortUserDefinedNoDataCellType => {
-          val theNoData: Short = ct.noDataValue
-          ShortConstantTile(theNoData ,cols, rows, ct)
-        }
-        case ct: ShortCells => {
-          val theNoData: Short = t.asInstanceOf[HasNoData[Short]].noDataValue
-          ShortConstantTile(theNoData ,cols, rows, ct)
-        }
-        case ct: UShortUserDefinedNoDataCellType => UShortConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: UShortCells => UShortConstantTile(t.asInstanceOf[HasNoData[Short]].noDataValue ,cols, rows, ct)
-        case ct: IntUserDefinedNoDataCellType => IntConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: IntCells => IntConstantTile(t.asInstanceOf[HasNoData[Int]].noDataValue ,cols, rows, ct)
-        case ct: FloatUserDefinedNoDataCellType => FloatConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: FloatCells => FloatConstantTile(t.asInstanceOf[HasNoData[Float]].noDataValue ,cols, rows, ct)
-        case ct: DoubleUserDefinedNoDataCellType => DoubleConstantTile(ct.noDataValue ,cols, rows, ct)
-        case ct: DoubleCells => DoubleConstantTile(t.asInstanceOf[HasNoData[Double]].noDataValue ,cols, rows, ct)
-      }
+  def empty(t: CellType, cols: Int, rows: Int): Tile = {
+    t match {
+      case _: BitCells => BitConstantTile(false, cols, rows)
+      case ct: ByteUserDefinedNoDataCellType => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: ByteConstantNoDataCellType.type => ByteConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: ByteCellType.type => ByteConstantTile(byteNODATA ,cols, rows, ct)
+      case ct: UByteConstantNoDataCellType.type => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: UByteUserDefinedNoDataCellType => UByteConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: UByteCellType.type => UByteConstantTile(ubyteNODATA ,cols, rows, ct)
+      case ct: ShortUserDefinedNoDataCellType => ShortConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: ShortConstantNoDataCellType.type => ShortConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: ShortCellType.type => ShortConstantTile(shortNODATA ,cols, rows, ct)
+      case ct: UShortUserDefinedNoDataCellType => UShortConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: UShortConstantNoDataCellType.type => UShortConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: UShortCellType.type => UShortConstantTile(ushortNODATA ,cols, rows, ct)
+      case ct: IntUserDefinedNoDataCellType => IntConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: IntConstantNoDataCellType.type => IntConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: IntCellType.type => IntConstantTile(NODATA ,cols, rows, ct)
+      case ct: FloatUserDefinedNoDataCellType => FloatConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: FloatConstantNoDataCellType.type => FloatConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: FloatCellType.type => FloatConstantTile(floatNODATA ,cols, rows, ct)
+      case ct: DoubleUserDefinedNoDataCellType => DoubleConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: DoubleConstantNoDataCellType.type => DoubleConstantTile(ct.noDataValue ,cols, rows, ct)
+      case ct: DoubleCellType.type => DoubleConstantTile(doubleNODATA ,cols, rows, ct)
     }
-    }
+  }
+
 
 
 }

--- a/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
@@ -17,7 +17,6 @@
 package geotrellis.raster
 
 import geotrellis.raster.testkit.{RasterMatchers, TileBuilders}
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 
@@ -104,7 +103,7 @@ class ConstantTileSpec extends AnyFunSpec with Matchers with RasterMatchers with
       FloatConstantTile(Float.NaN, cols = 1, rows = 1),
       DoubleConstantTile(Double.NaN, cols = 1, rows = 1)
     ).foreach { tile =>
-      val className = tile.getClass.getName.split("\\.").last
+      val className = getClassName(tile)
       it(s"should convert empty $className to empty $className") {
         assert(tile.isNoDataTile)
         assert(tile.convert(tile.cellType).isNoDataTile)
@@ -150,4 +149,6 @@ class ConstantTileSpec extends AnyFunSpec with Matchers with RasterMatchers with
       }
     }
   }
+
+  private def getClassName[T](obj: T): String = obj.getClass.getName.split("\\.").last
 }

--- a/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
@@ -105,5 +105,18 @@ class ConstantTileSpec extends AnyFunSpec with Matchers with RasterMatchers with
       val t = ByteConstantTile(10, cols = 1, rows = 1)
       assert(t.convert(FloatConstantNoDataCellType).getDouble(0,0) === 10.0)
     }
+
+    it("should convert empty IntConstantTile ") {
+      val t = ConstantTile.empty(IntCellType, 1, 1)
+      assert(t.isNoDataTile)
+      assert(t.convert(IntUserDefinedNoDataCellType(3)).isNoDataTile)
+    }
+
+    it("should convert empty FloatConstantTile ") {
+      val t = ConstantTile.empty(FloatCellType, 1, 1)
+      assert(t.isNoDataTile)
+      val converted: Tile = t.convert(FloatUserDefinedNoDataCellType(3.0f))
+      assert(converted.isNoDataTile)
+    }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
@@ -95,10 +95,15 @@ class ConstantTileSpec extends AnyFunSpec with Matchers with RasterMatchers with
   }
 
   describe("celltype conversion") {
-    it("should convert ByteConstantTile") {
+    it("should convert ByteConstantTile with nodata") {
       val t = ByteConstantTile(byteNODATA, cols = 1, rows = 1)
       assert(t.isNoDataTile)
       assert(t.convert(t.cellType).isNoDataTile)
+    }
+
+    it("should convert ByteConstantTile") {
+      val t = ByteConstantTile(10, cols = 1, rows = 1)
+      assert(t.convert(FloatConstantNoDataCellType).getDouble(0,0) === 10.0)
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/ConstantTileSpec.scala
@@ -93,4 +93,12 @@ class ConstantTileSpec extends AnyFunSpec with Matchers with RasterMatchers with
       int.combine(dt)(_ + _).cellType shouldBe int.cellType.union(dt.cellType)
     }
   }
+
+  describe("celltype conversion") {
+    it("should convert ByteConstantTile") {
+      val t = ByteConstantTile(byteNODATA, cols = 1, rows = 1)
+      assert(t.isNoDataTile)
+      assert(t.convert(t.cellType).isNoDataTile)
+    }
+  }
 }


### PR DESCRIPTION
# Overview

This PR fixes ConstantCellType conversions of the Byte and Short CellTypes as well as adds the ConstantTile.empty constructor.

Fixes https://github.com/locationtech/geotrellis/issues/3525
Supersedes & closes https://github.com/locationtech/geotrellis/pull/3552

cc @jdries 

