### PR TITLE
GeoTiffReader Unknown tags skip fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GDAL up to 3.9.x [#3540](https://github.com/locationtech/geotrellis/pull/3540)
 - Fix reprojection with downsampling for GeotiffRasterSource and tile RDDs. Reprojection outside the valid projection bounds may now throw a GeoAttrsError. [#3541](https://github.com/locationtech/geotrellis/issues/3541)
 - ConstantTile with NoData: support idempotent CellType conversions [#3553](https://github.com/locationtech/geotrellis/pull/3553)
+- GeoTiffReader Unknown tags skip fix [#3557](https://github.com/locationtech/geotrellis/pull/3557)
 
 ## [3.7.1] - 2024-01-08
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/tags/TiffTags.scala
@@ -692,7 +692,7 @@ object TiffTags {
         readLongsTag(byteReader, tiffTags, tagMetadata)
       case (_, IFDOffset) =>
         readLongsTag(byteReader, tiffTags, tagMetadata)
-      case _ => TiffTags() // skip unsupported tags
+      case _ => tiffTags // skip unsupported tags
     }
   }
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/reader/GeoTiffReaderSpec.scala
@@ -508,6 +508,12 @@ class GeoTiffReaderSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
 
       geoTiff.options.subfileType should be (None)
     }
+
+    // https://github.com/locationtech/geotrellis/issues/3556
+    it("should skip unknown tags") {
+      val geotiff = GeoTiff.readMultiband(geoTiffPath("unsupported-tiff-tags.tif"))
+      geotiff.tags.headTags.size should be (2)
+    }
   }
 
   describe("Reading and writing special metadata tags ") {


### PR DESCRIPTION
# Overview

This PR fixes the GeoTiffReader implementing a proper unknown TiffTags skip logic.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] Unit tests added for bug-fix or new feature

Closes #3556
Fixes #3088
