### PR TITLE
ReprojectRasterExtent: support single pixel input

### DIFF
--- a/raster/src/main/scala/geotrellis/raster/reproject/ReprojectRasterExtent.scala
+++ b/raster/src/main/scala/geotrellis/raster/reproject/ReprojectRasterExtent.scala
@@ -57,7 +57,19 @@ object ReprojectRasterExtent {
               val cols = ge.extent.width / ge.cellwidth
               val rows = ge.extent.height / ge.cellheight
               val pixelSize = distance / math.sqrt(cols * cols + rows * rows)
-              (pixelSize, pixelSize)
+              val pixelWidth =
+                if(newExtent.width <0.5*pixelSize) {
+                  newExtent.width
+                }else{
+                  pixelSize
+                }
+              val pixelHeight =
+                if(newExtent.height <0.5*pixelSize) {
+                  newExtent.height
+                }else{
+                  pixelSize
+                }
+              (pixelWidth, pixelHeight)
           }
 
         val newCols = (newExtent.width / pixelSizeX + 0.5).toLong

--- a/raster/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/reproject/ReprojectRasterExtentSpec.scala
@@ -109,5 +109,14 @@ class ReprojectRasterExtentSpec extends AnyFunSpec
       assert(destinationRE.extent covers region)
       assert(destinationRE.extent.toPolygon() intersects region)
     }
+
+    it("should reproject single pixel extents") {
+      val inputExtent = GridExtent[Long](Extent(429180.0, 7652390.0, 429190.0, 7652400.0), CellSize(10.0,10.0))
+      val destinationRE = ReprojectRasterExtent(inputExtent, CRS.fromEpsgCode(32639), LatLng)
+
+      assert(destinationRE.cols == 1)
+      assert(destinationRE.rows == 1)
+
+    }
   }
 }


### PR DESCRIPTION
https://github.com/locationtech/geotrellis/issues/3559

# Overview

When a single pixel RasterExtent was reprojected, it often resulted in a GeoAttrsError. 
The main cause is warping of square pixels into rectangular.

In the case where we anyway compute a custom cellsize, it seems valid to return a single pixel extent in X or Y direction rather than trying to construct a 0 pixel gridextens, which fails.

## Checklist

- [ ] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature


Closes #3559
