### PR TITLE
set gdal roles for well known tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ConstantTile with NoData: support idempotent CellType conversions [#3553](https://github.com/locationtech/geotrellis/pull/3553)
 - GeoTiffReader Unknown tags skip fix [#3557](https://github.com/locationtech/geotrellis/pull/3557)
 - Fix implicitNotFound error and rename RGBAMethods implicit class [#3563](https://github.com/locationtech/geotrellis/pull/3563)
+- Set 'role' attribute in GDALMetadata tag written to tiff header, to match GDAL behaviour. [#3496](https://github.com/locationtech/geotrellis/issues/3496)
 
 ## [3.7.1] - 2024-01-08
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Tags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Tags.scala
@@ -49,7 +49,10 @@ case class Tags(headTags: Map[String, String], bandTags: List[Map[String, String
     val bandTagsXml: Seq[scala.xml.Elem] =
       bandTags.zipWithIndex.flatMap { case (map, i) =>
         map.toSeq.map { case (key, value) =>
-          <Item name={key} sample={i.toString}>{value}</Item>
+          if (Tags.TAG_TO_ROLE.contains(key.toUpperCase))
+            <Item name={key} sample={i.toString} role={Tags.TAG_TO_ROLE(key.toUpperCase)}>{value}</Item>
+          else
+            <Item name={key} sample={i.toString}>{value}</Item>
         }
       }
 
@@ -65,4 +68,11 @@ object Tags {
 
   final val AREA_OR_POINT = "AREA_OR_POINT"
   final val TIFFTAG_DATETIME = "TIFFTAG_DATETIME"
+  final val TIFFTAG_IMAGEDESCRIPTION = "TIFFTAG_IMAGEDESCRIPTION"
+  final val TAG_TO_ROLE = Map(
+    "OFFSET" -> "offset",
+    "SCALE" -> "scale",
+    "DESCRIPTION" -> "description"
+  )
+
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Tags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Tags.scala
@@ -49,8 +49,8 @@ case class Tags(headTags: Map[String, String], bandTags: List[Map[String, String
     val bandTagsXml: Seq[scala.xml.Elem] =
       bandTags.zipWithIndex.flatMap { case (map, i) =>
         map.toSeq.map { case (key, value) =>
-          if (Tags.TAG_TO_ROLE.contains(key.toUpperCase))
-            <Item name={key} sample={i.toString} role={Tags.TAG_TO_ROLE(key.toUpperCase)}>{value}</Item>
+          if (Tags.TAG_ROLES.contains(key.toLowerCase()))
+            <Item name={key} sample={i.toString} role={key.toLowerCase}>{value}</Item>
           else
             <Item name={key} sample={i.toString}>{value}</Item>
         }
@@ -69,10 +69,12 @@ object Tags {
   final val AREA_OR_POINT = "AREA_OR_POINT"
   final val TIFFTAG_DATETIME = "TIFFTAG_DATETIME"
   final val TIFFTAG_IMAGEDESCRIPTION = "TIFFTAG_IMAGEDESCRIPTION"
-  final val TAG_TO_ROLE = Map(
-    "OFFSET" -> "offset",
-    "SCALE" -> "scale",
-    "DESCRIPTION" -> "description"
+  final val TAG_ROLES = Array(
+    "offset",
+    "scale",
+    "description",
+    "unittype",
+    "colorinterp"
   )
 
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/Tags.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/Tags.scala
@@ -69,7 +69,7 @@ object Tags {
   final val AREA_OR_POINT = "AREA_OR_POINT"
   final val TIFFTAG_DATETIME = "TIFFTAG_DATETIME"
   final val TIFFTAG_IMAGEDESCRIPTION = "TIFFTAG_IMAGEDESCRIPTION"
-  final val TAG_ROLES = Array(
+  final val TAG_ROLES = Set(
     "offset",
     "scale",
     "description",

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -114,8 +114,10 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
       val newTag1 = ("SOME_CUSTOM_TAG1" -> "1234567890123456789012345678901")
       val newTag2 = ("SOME_CUSTOM_TAG2" -> "12345678901234567890123456789012")
       val newTag3 = ("OFFSET" -> "43")
+      val newTag4 = ("DESCRIPTION" -> "band description")
+      val newTag5 = ("SCALE" -> "0.1")
       val headTags = geoTiff.tags.headTags + newTag1 + newTag2
-      val bandTags = geoTiff.tags.bandTags.map(_ + newTag1 + newTag2 + newTag3)
+      val bandTags = geoTiff.tags.bandTags.map(_ + newTag1 + newTag2 + newTag3 + newTag4 + newTag5)
 
       val taggedTiff = geoTiff.copy(tags = Tags(headTags, bandTags))
 
@@ -125,7 +127,40 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
 
       val tags = TiffTags.read(path)
 
-      tags.geoTiffTags.metadata.get should be ("<GDALMetadata>\n  <Item name=\"SOME_CUSTOM_TAG2\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\">HEAD</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\">1234567890123456789012345678901</Item>\n  <Item name=\"HEADTAG\">1</Item>\n  <Item name=\"SOME_CUSTOM_TAG2\" sample=\"0\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\" sample=\"0\">BAND1</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\" sample=\"0\">1234567890123456789012345678901</Item>\n  <Item name=\"BANDTAG\" sample=\"0\">1</Item>\n  <Item name=\"OFFSET\" sample=\"0\" role=\"offset\">43</Item>\n  <Item name=\"SOME_CUSTOM_TAG2\" sample=\"1\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\" sample=\"1\">BAND2</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\" sample=\"1\">1234567890123456789012345678901</Item>\n  <Item name=\"BANDTAG\" sample=\"1\">2</Item>\n  <Item name=\"OFFSET\" sample=\"1\" role=\"offset\">43</Item>\n  <Item name=\"SOME_CUSTOM_TAG2\" sample=\"2\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\" sample=\"2\">BAND3</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\" sample=\"2\">1234567890123456789012345678901</Item>\n  <Item name=\"BANDTAG\" sample=\"2\">3</Item>\n  <Item name=\"OFFSET\" sample=\"2\" role=\"offset\">43</Item>\n  <Item name=\"SOME_CUSTOM_TAG2\" sample=\"3\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\" sample=\"3\">BAND4</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\" sample=\"3\">1234567890123456789012345678901</Item>\n  <Item name=\"BANDTAG\" sample=\"3\">4</Item>\n  <Item name=\"OFFSET\" sample=\"3\" role=\"offset\">43</Item>\n</GDALMetadata>")
+      tags.geoTiffTags.metadata.get.replaceAll("\\s+","") should be ("""<GDALMetadata>
+        <Item name="SOME_CUSTOM_TAG2">12345678901234567890123456789012</Item>
+        <Item name="TAG_TYPE">HEAD</Item>
+        <Item name="SOME_CUSTOM_TAG1">1234567890123456789012345678901</Item>
+        <Item name="HEADTAG">1</Item>
+        <Item name="SOME_CUSTOM_TAG2" sample="0">12345678901234567890123456789012</Item>
+        <Item name="DESCRIPTION" sample="0" role="description">band description</Item>
+        <Item name="TAG_TYPE" sample="0">BAND1</Item>
+        <Item name="BANDTAG" sample="0">1</Item>
+        <Item name="OFFSET" sample="0" role="offset">43</Item>
+        <Item name="SOME_CUSTOM_TAG1" sample="0">1234567890123456789012345678901</Item>
+        <Item name="SCALE" sample="0" role="scale">0.1</Item>
+        <Item name="SOME_CUSTOM_TAG2" sample="1">12345678901234567890123456789012</Item>
+        <Item name="DESCRIPTION" sample="1" role="description">band description</Item>
+        <Item name="TAG_TYPE" sample="1">BAND2</Item>
+        <Item name="BANDTAG" sample="1">2</Item>
+        <Item name="OFFSET" sample="1" role="offset">43</Item>
+        <Item name="SOME_CUSTOM_TAG1" sample="1">1234567890123456789012345678901</Item>
+        <Item name="SCALE" sample="1" role="scale">0.1</Item>
+        <Item name="SOME_CUSTOM_TAG2" sample="2">12345678901234567890123456789012</Item>
+        <Item name="DESCRIPTION" sample="2" role="description">band description</Item>
+        <Item name="TAG_TYPE" sample="2">BAND3</Item>
+        <Item name="BANDTAG" sample="2">3</Item>
+        <Item name="OFFSET" sample="2" role="offset">43</Item>
+        <Item name="SOME_CUSTOM_TAG1" sample="2">1234567890123456789012345678901</Item>
+        <Item name="SCALE" sample="2" role="scale">0.1</Item>
+        <Item name="SOME_CUSTOM_TAG2" sample="3">12345678901234567890123456789012</Item>
+        <Item name="DESCRIPTION" sample="3" role="description">band description</Item>
+        <Item name="TAG_TYPE" sample="3">BAND4</Item>
+        <Item name="BANDTAG" sample="3">4</Item>
+        <Item name="OFFSET" sample="3" role="offset">43</Item>
+        <Item name="SOME_CUSTOM_TAG1" sample="3">1234567890123456789012345678901</Item>
+        <Item name="SCALE" sample="3" role="scale">0.1</Item>
+      </GDALMetadata>""".replaceAll("\\s+",""))
 
       val actual = MultibandGeoTiff(path).tags
       val expected = taggedTiff.tags

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriterSpec.scala
@@ -113,14 +113,19 @@ class GeoTiffWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll 
 
       val newTag1 = ("SOME_CUSTOM_TAG1" -> "1234567890123456789012345678901")
       val newTag2 = ("SOME_CUSTOM_TAG2" -> "12345678901234567890123456789012")
+      val newTag3 = ("OFFSET" -> "43")
       val headTags = geoTiff.tags.headTags + newTag1 + newTag2
-      val bandTags = geoTiff.tags.bandTags.map(_ + newTag1 + newTag2)
+      val bandTags = geoTiff.tags.bandTags.map(_ + newTag1 + newTag2 + newTag3)
 
       val taggedTiff = geoTiff.copy(tags = Tags(headTags, bandTags))
 
       GeoTiffWriter.write(taggedTiff, path)
 
       addToPurge(path)
+
+      val tags = TiffTags.read(path)
+
+      tags.geoTiffTags.metadata.get should be ("<GDALMetadata>\n  <Item name=\"SOME_CUSTOM_TAG2\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\">HEAD</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\">1234567890123456789012345678901</Item>\n  <Item name=\"HEADTAG\">1</Item>\n  <Item name=\"SOME_CUSTOM_TAG2\" sample=\"0\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\" sample=\"0\">BAND1</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\" sample=\"0\">1234567890123456789012345678901</Item>\n  <Item name=\"BANDTAG\" sample=\"0\">1</Item>\n  <Item name=\"OFFSET\" sample=\"0\" role=\"offset\">43</Item>\n  <Item name=\"SOME_CUSTOM_TAG2\" sample=\"1\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\" sample=\"1\">BAND2</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\" sample=\"1\">1234567890123456789012345678901</Item>\n  <Item name=\"BANDTAG\" sample=\"1\">2</Item>\n  <Item name=\"OFFSET\" sample=\"1\" role=\"offset\">43</Item>\n  <Item name=\"SOME_CUSTOM_TAG2\" sample=\"2\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\" sample=\"2\">BAND3</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\" sample=\"2\">1234567890123456789012345678901</Item>\n  <Item name=\"BANDTAG\" sample=\"2\">3</Item>\n  <Item name=\"OFFSET\" sample=\"2\" role=\"offset\">43</Item>\n  <Item name=\"SOME_CUSTOM_TAG2\" sample=\"3\">12345678901234567890123456789012</Item>\n  <Item name=\"TAG_TYPE\" sample=\"3\">BAND4</Item>\n  <Item name=\"SOME_CUSTOM_TAG1\" sample=\"3\">1234567890123456789012345678901</Item>\n  <Item name=\"BANDTAG\" sample=\"3\">4</Item>\n  <Item name=\"OFFSET\" sample=\"3\" role=\"offset\">43</Item>\n</GDALMetadata>")
 
       val actual = MultibandGeoTiff(path).tags
       val expected = taggedTiff.tags


### PR DESCRIPTION
https://github.com/locationtech/geotrellis/issues/3496

# Overview

Certain tags in GDAL are standardized, but this requires a 'role' attribute to be set.
In this PR, I take the approach of simply having a static list of such 'well-known' tags that seem to be part of the GDAL standard.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature


## Notes

Caveat: if gdal invents new roles, we need to update the list.

Closes #3496
