### PR TITLE
Add predictor 2 (integer) and predictor 3 (float) support for writing compressed GTiff files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add ZStd compression support for GTiff
+- Add predictor 2 (integer) and predictor 3 (float) support for writing compressed GTiff files
 
 ## [3.8.0] - 2025-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add ZStd compression support for GTiff
-- Add predictor 2 (integer) and predictor 3 (float) support for writing compressed GTiff files
+- Add predictor 2 (integer) and predictor 3 (float) support for writing compressed GTiff files [#3588](https://github.com/locationtech/geotrellis/pull/3588)
 
 ## [3.8.0] - 2025-04-23
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compression.scala
@@ -22,6 +22,14 @@ import cats.syntax.either._
 
 trait Compression extends Serializable {
   def createCompressor(segmentCount: Int): Compressor
+
+  def withPredictorEncoding(predictor: Predictor): Compression = {
+    new Compression {
+      override def createCompressor(segmentCount: Int): Compressor = {
+        Compression.this.createCompressor(segmentCount).withPredictorEncoding(predictor)
+      }
+    }
+  }
 }
 
 object Compression {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compression.scala
@@ -22,16 +22,13 @@ import io.circe.syntax._
 trait Compression extends Serializable {
   def createCompressor(segmentCount: Int): Compressor
 
-  def withPredictor(predictor: Predictor): Compression = {
-    (segmentCount: Int) => {
-      Compression.this.createCompressor(segmentCount).withPredictorEncoding(predictor)
-    }
-  }
+  def withPredictor(predictor: Predictor): Compression =
+    (segmentCount: Int) => createCompressor(segmentCount).withPredictorEncoding(predictor)
 }
 
 object Compression {
   implicit val compressionDecoder: Decoder[Compression] =
-    (c: HCursor) => {
+    (c: HCursor) =>
       c.downField("compressionType").as[String].map {
         case "NoCompression" => NoCompression
         case _ =>
@@ -40,13 +37,11 @@ object Compression {
             case Right(i) => DeflateCompression(i)
           }
       }
-    }
 
-  implicit val compressionEncoder: Encoder[Compression] =
-    (a: Compression) => a match {
-      case NoCompression =>
-        Json.obj(("compressionType", "NoCompression".asJson))
-      case d: DeflateCompression =>
-        Json.obj(("compressionType", "Deflate".asJson), ("level", d.level.asJson))
-    }
+  implicit val compressionEncoder: Encoder[Compression] = {
+    case NoCompression =>
+      Json.obj(("compressionType", "NoCompression".asJson))
+    case d: DeflateCompression =>
+      Json.obj(("compressionType", "Deflate".asJson), ("level", d.level.asJson))
+  }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compression.scala
@@ -18,42 +18,35 @@ package geotrellis.raster.io.geotiff.compression
 
 import io.circe._
 import io.circe.syntax._
-import cats.syntax.either._
 
 trait Compression extends Serializable {
   def createCompressor(segmentCount: Int): Compressor
 
-  def withPredictorEncoding(predictor: Predictor): Compression = {
-    new Compression {
-      override def createCompressor(segmentCount: Int): Compressor = {
-        Compression.this.createCompressor(segmentCount).withPredictorEncoding(predictor)
-      }
+  def withPredictor(predictor: Predictor): Compression = {
+    (segmentCount: Int) => {
+      Compression.this.createCompressor(segmentCount).withPredictorEncoding(predictor)
     }
   }
 }
 
 object Compression {
   implicit val compressionDecoder: Decoder[Compression] =
-    new Decoder[Compression] {
-      final def apply(c: HCursor): Decoder.Result[Compression] = {
-        c.downField("compressionType").as[String].map {
-          case "NoCompression" => NoCompression
-          case _ =>
-            c.downField("level").as[Int] match {
-              case Left(_)  => DeflateCompression()
-              case Right(i) => DeflateCompression(i)
-            }
-        }
+    (c: HCursor) => {
+      c.downField("compressionType").as[String].map {
+        case "NoCompression" => NoCompression
+        case _ =>
+          c.downField("level").as[Int] match {
+            case Left(_) => DeflateCompression()
+            case Right(i) => DeflateCompression(i)
+          }
       }
     }
 
   implicit val compressionEncoder: Encoder[Compression] =
-    new Encoder[Compression] {
-      final def apply(a: Compression): Json = a match {
-        case NoCompression =>
-          Json.obj(("compressionType", "NoCompression".asJson))
-        case d: DeflateCompression =>
-          Json.obj(("compressionType", "Deflate".asJson), ("level", d.level.asJson))
-      }
+    (a: Compression) => a match {
+      case NoCompression =>
+        Json.obj(("compressionType", "NoCompression".asJson))
+      case d: DeflateCompression =>
+        Json.obj(("compressionType", "Deflate".asJson), ("level", d.level.asJson))
     }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compressor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Compressor.scala
@@ -29,7 +29,7 @@ trait Compressor extends Serializable {
       def wrapped: Compressor = Compressor.this
 
       override def compress(bytes: Array[Byte], segmentIndex: Int): Array[Byte] = {
-        wrapped.compress(predictor.encode(bytes), segmentIndex = segmentIndex)
+        wrapped.compress(predictor.encode(bytes, segmentIndex), segmentIndex = segmentIndex)
       }
 
       /** Returns the decompressor that can decompress the segments compressed by this compressor */

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Decompressor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Decompressor.scala
@@ -62,14 +62,14 @@ trait Decompressor extends Serializable {
       }
     }
 
-  def withPredictor(predictor: Predictor): Decompressor =
+  def withPredictorDecoding(predictor: Predictor): Decompressor =
     new Decompressor {
       def code = Decompressor.this.code
       override def predictorCode = predictor.code
       override def byteOrder = Decompressor.this.byteOrder
 
       def decompress(bytes: Array[Byte], segmentIndex: Int): Array[Byte] =
-        predictor(Decompressor.this.decompress(bytes, segmentIndex), segmentIndex)
+        predictor.decode(Decompressor.this.decompress(bytes, segmentIndex), segmentIndex)
     }
 }
 
@@ -88,9 +88,9 @@ object Decompressor {
     def checkPredictor(d: Decompressor): Decompressor = {
       val predictor = Predictor(tiffTags)
       if(predictor.checkEndian)
-        checkEndian(d).withPredictor(predictor)
+        checkEndian(d).withPredictorDecoding(predictor)
       else
-        d.withPredictor(predictor)
+        d.withPredictorDecoding(predictor)
     }
 
     val segmentCount = tiffTags.segmentCount
@@ -108,7 +108,7 @@ object Decompressor {
 
     tiffTags.compression match {
       case Uncompressed =>
-        checkEndian(NoCompression)
+        checkEndian(NoCompressor)
       case LZWCoded =>
         checkPredictor(LZWDecompressor(segmentSizes))
       case ZLibCoded | PkZipCoded =>

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Decompressor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Decompressor.scala
@@ -34,18 +34,18 @@ trait Decompressor extends Serializable {
     */
   def flipEndian(bytesPerFlip: Int): Decompressor =
     new Decompressor {
-      def code = Decompressor.this.code
-      override def predictorCode = Decompressor.this.predictorCode
+      def code: Int = Decompressor.this.code
+      override def predictorCode: Int = Decompressor.this.predictorCode
 
       override
-      def byteOrder = ByteOrder.LITTLE_ENDIAN // Since we have to flip, image data is in Little Endian
+      def byteOrder: ByteOrder = ByteOrder.LITTLE_ENDIAN // Since we have to flip, image data is in Little Endian
 
       def decompress(bytes: Array[Byte], segmentIndex: Int): Array[Byte] =
         flip(Decompressor.this.decompress(bytes, segmentIndex))
 
       def flip(bytes: Array[Byte]): Array[Byte] = {
         val arr = bytes.clone
-        val size = arr.size
+        val size = arr.length
 
         var i = 0
         while (i < size) {
@@ -64,9 +64,9 @@ trait Decompressor extends Serializable {
 
   def withPredictorDecoding(predictor: Predictor): Decompressor =
     new Decompressor {
-      def code = Decompressor.this.code
-      override def predictorCode = predictor.code
-      override def byteOrder = Decompressor.this.byteOrder
+      def code: Int = Decompressor.this.code
+      override def predictorCode: Int = predictor.code
+      override def byteOrder: ByteOrder = Decompressor.this.byteOrder
 
       def decompress(bytes: Array[Byte], segmentIndex: Int): Array[Byte] =
         predictor.decode(Decompressor.this.decompress(bytes, segmentIndex), segmentIndex)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/FloatingPointPredictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/FloatingPointPredictor.scala
@@ -22,9 +22,38 @@ import spire.syntax.cfor._
 
 /** See TIFF Technical Note 3 */
 object FloatingPointPredictor {
+
+  def apply(imageData: GeoTiffImageData): Predictor = {
+    val colsPerRow = {
+      if (imageData.segmentLayout.isStriped) {
+        imageData.segmentLayout.totalCols
+      } else {
+        imageData.segmentLayout.tileLayout.tileCols
+      }
+    }
+
+    val rowsInSegment: Int => Int =
+      if (imageData.segmentLayout.isStriped) {
+        def stripedRowsInSegment(segmentIndex: Int): Int = {
+          imageData.segmentLayout.getSegmentDimensions(segmentIndex).rows
+        }
+        stripedRowsInSegment
+      } else {
+        def tiledRowsInSegment(segmentIndex: Int): Int = {
+          imageData.segmentLayout.tileLayout.tileRows
+        }
+        tiledRowsInSegment
+      }
+    if (imageData.segmentLayout.hasPixelInterleave) {
+      new FloatingPointPredictor(colsPerRow, rowsInSegment, imageData.bandType, imageData.bandCount)
+    } else {
+      new FloatingPointPredictor(colsPerRow, rowsInSegment, imageData.bandType,1)
+    }
+  }
+
   def apply(tiffTags: TiffTags): Predictor = {
     val colsPerRow = tiffTags.rowSize
-    val rowsInSegment: (Int => Int) = { i => tiffTags.rowsInSegment(i) }
+    val rowsInSegment: Int => Int = { i => tiffTags.rowsInSegment(i) }
 
     val bandType = tiffTags.bandType
 
@@ -36,12 +65,43 @@ object FloatingPointPredictor {
   }
 
   private class FloatingPointPredictor(colsPerRow: Int, rowsInSegment: Int => Int, bandType: BandType, bandCount: Int) extends Predictor {
-    val code = Predictor.PREDICTOR_FLOATINGPOINT
+    val code: Int = Predictor.PREDICTOR_FLOATINGPOINT
     val checkEndian = false
 
-    override def encode(bytes: Array[Byte]): Array[Byte] = {
-      bytes // TODO
+    private def encodeDeltaBytes(bytes: Array[Byte], rows:Int): Array[Byte] = {
+      val bytesPerSample = bandType.bytesPerSample
+      val colValuesPerRow = colsPerRow * bandCount
+      val the_cols = colsPerRow * bytesPerSample
+      val bytesPerRow = colValuesPerRow * bytesPerSample
+
+      cfor(0)(_ < rows, _ + 1) { row =>
+        val rowOffset = row * bytesPerRow
+        cfor(the_cols-1)(_ > 0, _ - 1) { col =>
+          cfor(0)(_ < bandCount, _ + 1) { band =>
+            bytes(rowOffset + col * bandCount + band) = (bytes(rowOffset + col * bandCount + band) - bytes(rowOffset + (col - 1) * bandCount + band)).toByte
+          }
+        }
+      }
+      bytes
     }
+
+    override def encode(bytes: Array[Byte], segmentIndex: Int): Array[Byte] = {
+      val rows = rowsInSegment(segmentIndex)
+      val bytesPerSample = bandType.bytesPerSample
+      val bytesPerRow = colsPerRow * bandCount * bytesPerSample
+
+      val outputBytes = new Array[Byte](bytes.length)
+      val rowIncrement = colsPerRow * bandCount
+      cfor(0)(_ < rows, _ + 1) { row =>
+        val rowOffset = bytesPerRow * row
+        cfor(0)(_ < rowIncrement, _ + 1) { col =>
+          cfor(0)(_ < bytesPerSample, _ + 1) { b =>
+            outputBytes(rowOffset + b * rowIncrement + col) = bytes(rowOffset + bytesPerSample * col + b)
+          }
+        }
+      }
+      encodeDeltaBytes(outputBytes, rows)
+  }
 
     override def decode(bytes: Array[Byte], segmentIndex: Int): Array[Byte] = {
       val rows = rowsInSegment(segmentIndex)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/FloatingPointPredictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/FloatingPointPredictor.scala
@@ -24,31 +24,13 @@ import spire.syntax.cfor._
 object FloatingPointPredictor {
 
   def apply(imageData: GeoTiffImageData): Predictor = {
-    val colsPerRow = {
-      if (imageData.segmentLayout.isStriped) {
-        imageData.segmentLayout.totalCols
-      } else {
-        imageData.segmentLayout.tileLayout.tileCols
-      }
-    }
+    val colsPerRow = Predictor.colsPerRow(imageData)
+    val rowsInSegment = Predictor.rowsInSegment(imageData)
 
-    val rowsInSegment: Int => Int =
-      if (imageData.segmentLayout.isStriped) {
-        def stripedRowsInSegment(segmentIndex: Int): Int = {
-          imageData.segmentLayout.getSegmentDimensions(segmentIndex).rows
-        }
-        stripedRowsInSegment
-      } else {
-        def tiledRowsInSegment(segmentIndex: Int): Int = {
-          imageData.segmentLayout.tileLayout.tileRows
-        }
-        tiledRowsInSegment
-      }
-    if (imageData.segmentLayout.hasPixelInterleave) {
+    if (imageData.segmentLayout.hasPixelInterleave)
       new FloatingPointPredictor(colsPerRow, rowsInSegment, imageData.bandType, imageData.bandCount)
-    } else {
-      new FloatingPointPredictor(colsPerRow, rowsInSegment, imageData.bandType,1)
-    }
+    else
+      new FloatingPointPredictor(colsPerRow, rowsInSegment, imageData.bandType, 1)
   }
 
   def apply(tiffTags: TiffTags): Predictor = {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/FloatingPointPredictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/FloatingPointPredictor.scala
@@ -39,7 +39,11 @@ object FloatingPointPredictor {
     val code = Predictor.PREDICTOR_FLOATINGPOINT
     val checkEndian = false
 
-    def apply(bytes: Array[Byte], segmentIndex: Int): Array[Byte] = {
+    override def encode(bytes: Array[Byte]): Array[Byte] = {
+      bytes // TODO
+    }
+
+    override def decode(bytes: Array[Byte], segmentIndex: Int): Array[Byte] = {
       val rows = rowsInSegment(segmentIndex)
       val stride = bandCount
       val bytesPerSample = bandType.bytesPerSample

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/HorizontalPredictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/HorizontalPredictor.scala
@@ -189,7 +189,7 @@ object HorizontalPredictor {
           if (col < bandCount) {
             encodedBuffer.put(index, buffer.get(index))
           } else {
-            encodedBuffer.put(index, (buffer.get(index) - buffer.get(index - bandCount)))
+            encodedBuffer.put(index, buffer.get(index) - buffer.get(index - bandCount))
           }
         }
       }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/HorizontalPredictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/HorizontalPredictor.scala
@@ -26,35 +26,16 @@ import spire.syntax.cfor._
 object HorizontalPredictor {
 
   def apply(imageData: GeoTiffImageData): Predictor = {
-    val colsPerRow = {
-      if (imageData.segmentLayout.isStriped) {
-        imageData.segmentLayout.totalCols
-      } else {
-        imageData.segmentLayout.tileLayout.tileCols
-      }
-    }
+    val colsPerRow = Predictor.colsPerRow(imageData)
+    val rowsInSegment = Predictor.rowsInSegment(imageData)
 
-    val rowsInSegment: Int => Int =
-      if (imageData.segmentLayout.isStriped) {
-        def stripedRowsInSegment(segmentIndex: Int): Int = {
-          imageData.segmentLayout.getSegmentDimensions(segmentIndex).rows
-        }
-        stripedRowsInSegment
-      } else {
-        def tiledRowsInSegment(segmentIndex: Int): Int = {
-          imageData.segmentLayout.tileLayout.tileRows
-        }
-        tiledRowsInSegment
-
-      }
     val bandType = imageData.bandType
 
     val predictor =
-      if (imageData.segmentLayout.hasPixelInterleave) {
+      if (imageData.segmentLayout.hasPixelInterleave)
         new HorizontalPredictor(colsPerRow, rowsInSegment, imageData.bandCount)
-      } else {
+      else
         new HorizontalPredictor(colsPerRow, rowsInSegment, 1)
-      }
 
     predictor.forBandType(bandType)
   }
@@ -117,11 +98,10 @@ object HorizontalPredictor {
       cfor(0)(_ < rows, _ + 1) { row =>
         cfor(n - 1)({ k => k >= 0 }, _ - 1) { col =>
           val index = row * n + col
-          if (col < bandCount) {
+          if (col < bandCount)
             encodedBytes(index) = bytes(index)
-          } else {
+          else
             encodedBytes(index) = (bytes(index) - bytes(index - bandCount)).toByte
-          }
         }
       }
       encodedBytes
@@ -151,11 +131,10 @@ object HorizontalPredictor {
       cfor(0)(_ < rows, _ + 1) { row =>
         cfor(n - 1)({ k => k >= 0 }, _ - 1) { col =>
           val index = row * n + col
-          if (col < bandCount) {
+          if (col < bandCount)
             encodedBuffer.put(index, buffer.get(index))
-          } else {
+          else
             encodedBuffer.put(index, (buffer.get(index) - buffer.get(index - bandCount)).toShort)
-          }
         }
       }
       encodedBytes
@@ -186,11 +165,10 @@ object HorizontalPredictor {
       cfor(0)(_ < rows, _ + 1) { row =>
         cfor(n - 1)({ k => k >= 0 }, _ - 1) { col =>
           val index = row * n + col
-          if (col < bandCount) {
+          if (col < bandCount)
             encodedBuffer.put(index, buffer.get(index))
-          } else {
+          else
             encodedBuffer.put(index, buffer.get(index) - buffer.get(index - bandCount))
-          }
         }
       }
       encodedBytes

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/NoCompression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/NoCompression.scala
@@ -19,14 +19,13 @@ package geotrellis.raster.io.geotiff.compression
 import geotrellis.raster.io.geotiff.tags.codes.CompressionType._
 
 object NoCompression extends Compression {
-
-  override def createCompressor(segmentCount: Int): NoCompressor.type = NoCompressor
+  def createCompressor(segmentCount: Int): NoCompressor.type = NoCompressor
 }
 
 object NoCompressor extends Compressor with Decompressor {
-  override def code: Int = Uncompressed
+  def code: Int = Uncompressed
 
-  override def createDecompressor(): NoCompressor.type = NoCompressor
-  override def compress(bytes: Array[Byte], sectionIndex: Int): Array[Byte] = { bytes }
-  override def decompress(bytes: Array[Byte], sectionIndex: Int): Array[Byte] = { bytes }
+  def createDecompressor(): NoCompressor.type = NoCompressor
+  def compress(bytes: Array[Byte], sectionIndex: Int): Array[Byte] = { bytes }
+  def decompress(bytes: Array[Byte], sectionIndex: Int): Array[Byte] = { bytes }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/NoCompression.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/NoCompression.scala
@@ -18,11 +18,15 @@ package geotrellis.raster.io.geotiff.compression
 
 import geotrellis.raster.io.geotiff.tags.codes.CompressionType._
 
-object NoCompression extends Compression with Compressor with Decompressor {
-  def code = Uncompressed
+object NoCompression extends Compression {
 
-  def createCompressor(segmentCount: Int) = NoCompression
-  def createDecompressor() = NoCompression
-  def compress(bytes: Array[Byte], sectionIndex: Int): Array[Byte] = { bytes }
-  def decompress(bytes: Array[Byte], sectionIndex: Int): Array[Byte] = { bytes }
+  override def createCompressor(segmentCount: Int): NoCompressor.type = NoCompressor
+}
+
+object NoCompressor extends Compressor with Decompressor {
+  override def code: Int = Uncompressed
+
+  override def createDecompressor(): NoCompressor.type = NoCompressor
+  override def compress(bytes: Array[Byte], sectionIndex: Int): Array[Byte] = { bytes }
+  override def decompress(bytes: Array[Byte], sectionIndex: Int): Array[Byte] = { bytes }
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Predictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Predictor.scala
@@ -34,7 +34,9 @@ object Predictor {
         new Predictor {
           val code = PREDICTOR_NONE
           val checkEndian = true
-          def apply(bytes: Array[Byte], segmentIndex: Int) = bytes
+
+          override def encode(bytes: Array[Byte]): Array[Byte] = bytes
+          override def decode(bytes: Array[Byte], segmentIndex: Int) = bytes
         }
       case Some(PREDICTOR_HORIZONTAL) =>
         HorizontalPredictor(tiffTags)
@@ -52,5 +54,7 @@ trait Predictor extends Serializable {
   /** GeoTiff tag value for this predictor */
   def code: Int
 
-  def apply(bytes: Array[Byte], segmentIndex: Int): Array[Byte]
+  def encode(bytes: Array[Byte]): Array[Byte]
+
+  def decode(bytes: Array[Byte], segmentIndex: Int): Array[Byte]
 }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Predictor.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/compression/Predictor.scala
@@ -56,6 +56,24 @@ object Predictor {
         throw new MalformedGeoTiffException(s"predictor tag $i is not valid (require 1, 2 or 3)")
     }
   }
+
+  def colsPerRow(imageData: GeoTiffImageData): Int =
+    if (imageData.segmentLayout.isStriped)
+      imageData.segmentLayout.totalCols
+    else
+      imageData.segmentLayout.tileLayout.tileCols
+
+  def rowsInSegment(imageData: GeoTiffImageData): Int => Int =
+    if (imageData.segmentLayout.isStriped) {
+      def stripedRowsInSegment(segmentIndex: Int): Int =
+        imageData.segmentLayout.getSegmentDimensions(segmentIndex).rows
+
+      stripedRowsInSegment
+    } else {
+      def tiledRowsInSegment(segmentIndex: Int): Int =
+        imageData.segmentLayout.tileLayout.tileRows
+      tiledRowsInSegment
+    }
 }
 
 trait Predictor extends Serializable {

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffInfo.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/reader/GeoTiffInfo.scala
@@ -236,7 +236,7 @@ object GeoTiffInfo {
         // If it's any sort of compression, move forward with ZLib compression.
         val compression =
         decompressor match {
-          case NoCompression => NoCompression
+          case NoCompressor => NoCompression
           case _ => DeflateCompression
         }
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/compression/PredictorSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/compression/PredictorSpec.scala
@@ -1,0 +1,169 @@
+package geotrellis.raster.io.geotiff.compression
+
+import geotrellis.raster.io.geotiff.tags.TiffTags
+import geotrellis.raster.io.geotiff.{GeoTiffReader, GeoTiffTestUtils, MultibandGeoTiff}
+import geotrellis.raster.testkit.RasterMatchers
+import geotrellis.raster.{FloatCellType, IntCellType, ShortCellType}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PredictorSpec extends AnyFunSpec with Matchers with GeoTiffTestUtils with RasterMatchers with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = purge
+
+  describe("Write compressed tiff files with predictor") {
+    it("8 bits, predictor 2, deflate compression") {
+      val originalTiff = GeoTiffReader.readMultiband(geoTiffPath(s"jpeg-test-small-uncompressed.tif"))
+      val compression = DeflateCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "8bits_predictor2_deflated.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZLibCoded)
+      tags.nonBasicTags.predictor should be(Some(2))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile)
+    }
+
+    it("8 bits, predictor 2, ZStd compression") {
+      val originalTiff = GeoTiffReader.readMultiband(geoTiffPath(s"jpeg-test-small-uncompressed.tif"))
+      val compression = ZStdCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "8bits_predictor2_zstd.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZStdCoded)
+      tags.nonBasicTags.predictor should be(Some(2))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile)
+    }
+
+    it("16 bits, predictor 2, deflate compression") {
+      val sourceTiff = GeoTiffReader.readMultiband(geoTiffPath(s"jpeg-test-small-uncompressed.tif"))
+      val tile = sourceTiff.tile.convert(ShortCellType)
+      val originalTiff = MultibandGeoTiff(tile, sourceTiff.extent, sourceTiff.crs, sourceTiff.options)
+      val compression = DeflateCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "16bits_predictor2_deflated.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZLibCoded)
+      tags.nonBasicTags.predictor should be(Some(2))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile)
+    }
+
+    it("32 bits, predictor 2, deflate compression") {
+      val sourceTiff = GeoTiffReader.readMultiband(geoTiffPath(s"jpeg-test-small-uncompressed.tif"))
+      val tile = sourceTiff.tile.convert(IntCellType)
+      val originalTiff = MultibandGeoTiff(tile, sourceTiff.extent, sourceTiff.crs, sourceTiff.options)
+      val compression = DeflateCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "32bits_predictor2_deflated.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZLibCoded)
+      tags.nonBasicTags.predictor should be(Some(2))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile)
+    }
+
+    it("32 bits, striped, predictor 3, deflate compression") {
+      val originalTiff = GeoTiffReader.readMultiband(s"raster/data/slope.tif")
+      val compression = DeflateCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "32bits_striped_predictor3_deflated.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZLibCoded)
+      tags.nonBasicTags.predictor should be(Some(3))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile, 100)
+    }
+
+    it("64 bits, predictor 3, deflate compression") {
+      val originalTiff = GeoTiffReader.readMultiband(geoTiffPath(s"jpeg-test-small-gaussian-expected.tif"))
+      val compression = DeflateCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "32bits_predictor2_deflated.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZLibCoded)
+      tags.nonBasicTags.predictor should be(Some(3))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile)
+    }
+
+    it("64 bits, predictor 3, zstd compression") {
+      val originalTiff = GeoTiffReader.readMultiband(geoTiffPath(s"jpeg-test-small-gaussian-expected.tif"))
+      val compression = ZStdCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "32bits_predictor2_zstd.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZStdCoded)
+      tags.nonBasicTags.predictor should be(Some(3))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile)
+    }
+
+    it("32 bits, tiled, predictor 3, zstd compression") {
+      val sourceTiff = GeoTiffReader.readMultiband(geoTiffPath(s"jpeg-test-small-gaussian-expected.tif"))
+      val tile = sourceTiff.tile.convert(FloatCellType)
+      val originalTiff = MultibandGeoTiff(tile, sourceTiff.extent, sourceTiff.crs, sourceTiff.options)
+      val compression = ZStdCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "32bits_tiled_predictor3_zstd.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZStdCoded)
+      tags.nonBasicTags.predictor should be(Some(3))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile)
+    }
+
+
+    it("32 bits, tiled, predictor 2, zstd compression") {
+      val sourceTiff = GeoTiffReader.readMultiband(geoTiffPath(s"jpeg-test-small-gaussian-expected.tif"))
+      val tile = sourceTiff.tile.convert(IntCellType)
+      val originalTiff = MultibandGeoTiff(tile, sourceTiff.extent, sourceTiff.crs, sourceTiff.options)
+      val compression = ZStdCompression.withPredictor(Predictor(originalTiff.imageData))
+      val tiff = MultibandGeoTiff(originalTiff.raster.tile.toArrayTile(), originalTiff.raster.extent, originalTiff.crs, originalTiff.options.copy(compression = compression))
+      val path = "32bits_tiled_predictor2_zstd.tif"
+      tiff.write(path)
+      addToPurge(path)
+
+      val tags = TiffTags.read(path)
+      tags.compression should be(geotrellis.raster.io.geotiff.tags.codes.CompressionType.ZStdCoded)
+      tags.nonBasicTags.predictor should be(Some(2))
+
+      val rewrittenTiff = GeoTiffReader.readMultiband(path)
+      assertEqual(originalTiff.tile, rewrittenTiff.tile)
+    }
+  }
+}


### PR DESCRIPTION
# Overview

- This PR adds predictor 2&3 support for writing compressed GTiff files
  cfr. https://github.com/locationtech/geotrellis/issues/3587

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [ ] `docs` guides update, if necessary
- [ ] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

## Demo

Optional. Screenshots/REPL

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Closes #3587
