### PR TITLE
MinResample should ignore Int NODATA values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not depend on private Spark API, avoids sealing violation [#3586](https://github.com/locationtech/geotrellis/pull/3586)
 - Add predictor 2 (integer) and predictor 3 (float) support for writing compressed GTiff files [#3588](https://github.com/locationtech/geotrellis/pull/3588)
 
+### Changed
+- MinResample should ignore Int NODATA values [#3590](https://github.com/locationtech/geotrellis/pull/3590)
+
 ## [3.8.0] - 2025-04-23
 
 ### Added

--- a/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
+++ b/raster/src/main/scala/geotrellis/raster/IntArrayTile.scala
@@ -213,11 +213,11 @@ object IntArrayTile {
   def apply(arr: Array[Int], cols: Int, rows: Int, cellType: IntCells with NoDataHandling): IntArrayTile =
     cellType match {
       case IntCellType =>
-        new IntRawArrayTile(arr, cols, rows)
+        IntRawArrayTile(arr, cols, rows)
       case IntConstantNoDataCellType =>
-        new IntConstantNoDataArrayTile(arr, cols, rows)
+        IntConstantNoDataArrayTile(arr, cols, rows)
       case udct: IntUserDefinedNoDataCellType =>
-        new IntUserDefinedNoDataArrayTile(arr, cols, rows, udct)
+        IntUserDefinedNoDataArrayTile(arr, cols, rows, udct)
     }
 
   /**

--- a/raster/src/main/scala/geotrellis/raster/resample/MaxResample.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/MaxResample.scala
@@ -29,6 +29,7 @@ class MaxResample(tile: Tile, extent: Extent, targetCS: CellSize)
     extends AggregateResample(tile, extent, targetCS) {
 
   private def calculateMax(indices: Seq[(Int, Int)]): Int =
+    // NODATA would always be min
     indices.foldLeft(Int.MinValue) { case (currentMax, coords) =>
       math.max(currentMax, tile.get(coords._1, coords._2))
     }

--- a/raster/src/main/scala/geotrellis/raster/resample/MinResample.scala
+++ b/raster/src/main/scala/geotrellis/raster/resample/MinResample.scala
@@ -28,10 +28,14 @@ import scala.math
 class MinResample(tile: Tile, extent: Extent, targetCS: CellSize)
     extends AggregateResample(tile, extent, targetCS) {
 
-  private def calculateMin(indices: Seq[(Int, Int)]): Int =
-    indices.foldLeft(Int.MaxValue) { case (currentMin, coords) =>
-      math.min(currentMin, tile.get(coords._1, coords._2))
+  private def calculateMin(indices: Seq[(Int, Int)]): Int = {
+    val intMin = indices.foldLeft(Int.MaxValue) { case (currentMin, coords) =>
+      val v = tile.get(coords._1, coords._2)
+      // NODATA would *always* be min
+      if (isData(v)) math.min(currentMin, v) else currentMin
     }
+    if (intMin == Int.MaxValue) NODATA else intMin
+  }
 
   private def calculateMinDouble(indices: Seq[(Int, Int)]): Double = {
     val doubleMin = indices.foldLeft(Double.MaxValue) { case (currentMin, coords) =>

--- a/raster/src/test/scala/geotrellis/raster/resample/MaxResampleSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/resample/MaxResampleSpec.scala
@@ -66,5 +66,11 @@ class MaxResampleSpec extends AnyFunSpec with Matchers {
       val cellsize = CellSize(extent, 3, 3)
       tile.resample(extent, 1, 1, Max).getDouble(0, 0) should be (100.1)
     }
+
+    it("should for an int tile compute the correct maximum value - ignoring the user defined nodata value") {
+      val tile = IntArrayTile(Array(2, 4, 256, 16), 2, 2, noDataValue = 256)
+      val extent = Extent(0, 0, 2, 2)
+      tile.resample(extent, 1, 1, method = Max).get(0, 0) should be (16)
+    }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/resample/MinResampleSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/resample/MinResampleSpec.scala
@@ -66,5 +66,23 @@ class MinResampleSpec extends AnyFunSpec with Matchers {
       val cellsize = CellSize(extent, 3, 3)
       tile.resample(extent, 1, 1, Min).getDouble(0, 0) should be (0.19)
     }
+
+    it("should for an int tile compute the correct minimum value - ignoring the user defined nodata value") {
+      val tile = IntArrayTile(Array(2, 4, 256, 16), 2, 2, noDataValue = 256)
+      val extent = Extent(0, 0, 2, 2)
+      tile.resample(extent, 1, 1, method = Min).get(0, 0) should be (2)
+    }
+
+    it("should for an int tile compute the correct minimum value - ignoring the int nodata value") {
+      val tile = IntArrayTile(Array(2, 4, NODATA, 16), 2, 2)
+      val extent = Extent(0, 0, 2, 2)
+      tile.resample(extent, 1, 1, method = Min).get(0, 0) should be (2)
+    }
+
+    it("should for a double tile compute the correct minimum value - ignoring the double nodata value") {
+      val tile = DoubleArrayTile(Array(2d, 4d, doubleNODATA, 16d), 2, 2)
+      val extent = Extent(0, 0, 2, 2)
+      tile.resample(extent, 1, 1, method = Min).get(0, 0) should be (2)
+    }
   }
 }


### PR DESCRIPTION
# Overview

This PR addresses the incorrect MinResampling for the non floating point Tiles.

Closes #3589
