### PR TITLE
support writing GeoTiffs as BigTiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ZStd compression support for GTiff [#3580](https://github.com/locationtech/geotrellis/pull/3580)
 - Do not depend on private Spark API, avoids sealing violation [#3586](https://github.com/locationtech/geotrellis/pull/3586)
 - Add predictor 2 (integer) and predictor 3 (float) support for writing compressed GTiff files [#3588](https://github.com/locationtech/geotrellis/pull/3588)
+- Support writing BigTiff
 
 ### Changed
 - MinResample should ignore Int NODATA values [#3590](https://github.com/locationtech/geotrellis/pull/3590)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ZStd compression support for GTiff [#3580](https://github.com/locationtech/geotrellis/pull/3580)
 - Do not depend on private Spark API, avoids sealing violation [#3586](https://github.com/locationtech/geotrellis/pull/3586)
 - Add predictor 2 (integer) and predictor 3 (float) support for writing compressed GTiff files [#3588](https://github.com/locationtech/geotrellis/pull/3588)
-- Support writing BigTiff
+- Support writing GeoTiffs as BigTiff [#3605](https://github.com/locationtech/geotrellis/pull/3605)
 
 ### Changed
 - MinResample should ignore Int NODATA values [#3590](https://github.com/locationtech/geotrellis/pull/3590)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
@@ -70,6 +70,7 @@ trait GeoTiff[T <: CellGrid[Int]] extends GeoTiffData {
 
   def withStorageMethod(storageMethod: StorageMethod): GeoTiff[T]
 
+  /** Applies the Tiff type (classic or BigTiff) to this GeoTiff and its overviews. */
   def withTiffType(tiffType: TiffType): GeoTiff[T]
 
   def write(path: String, optimizedOrder: Boolean = false): Unit =

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/GeoTiff.scala
@@ -70,6 +70,8 @@ trait GeoTiff[T <: CellGrid[Int]] extends GeoTiffData {
 
   def withStorageMethod(storageMethod: StorageMethod): GeoTiff[T]
 
+  def withTiffType(tiffType: TiffType): GeoTiff[T]
+
   def write(path: String, optimizedOrder: Boolean = false): Unit =
     GeoTiffWriter.write(this, path, optimizedOrder)
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/MultibandGeoTiff.scala
@@ -39,6 +39,9 @@ case class MultibandGeoTiff(
   def withStorageMethod(storageMethod: StorageMethod): MultibandGeoTiff =
     new MultibandGeoTiff(tile.toArrayTile(), extent, crs, tags, options.copy(storageMethod = storageMethod), overviews.map(_.withStorageMethod(storageMethod)))
 
+  override def withTiffType(tiffType: TiffType): MultibandGeoTiff =
+    new MultibandGeoTiff(tile, extent, crs, tags, options.copy(tiffType = tiffType), overviews.map(_.withTiffType(tiffType)))
+
   def imageData: GeoTiffImageData =
     tile match {
       case gtt: GeoTiffMultibandTile => gtt

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/SinglebandGeoTiff.scala
@@ -40,6 +40,9 @@ case class SinglebandGeoTiff(
   def withStorageMethod(storageMethod: StorageMethod): SinglebandGeoTiff =
     SinglebandGeoTiff(tile.toArrayTile(), extent, crs, tags, options.copy(storageMethod = storageMethod), overviews)
 
+  override def withTiffType(tiffType: TiffType): SinglebandGeoTiff =
+    SinglebandGeoTiff(tile, extent, crs, tags, options.copy(tiffType = tiffType), overviews.map(_.withTiffType(tiffType)))
+
   def imageData: GeoTiffImageData =
     tile match {
       case gtt: GeoTiffTile => gtt

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
@@ -144,15 +144,13 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     val sortedTagFieldValues = (offsetFieldValue :: fieldValues.toList).sortBy(_.tag).toArray
 
     // Write the number of tags
-    if (isBigTiff)
-      writeLong(sortedTagFieldValues.length)
-    else
-      writeShort(sortedTagFieldValues.length)
+    if (isBigTiff) writeLong(sortedTagFieldValues.length)
+    else writeShort(sortedTagFieldValues.length)
 
     // Write tag fields, sorted by tag code.
     val tagDataStartOffset = // offset of data behind a tag's offset (= doesn't fit in 4 bytes): TBC
       index +
-        offsetSize + // Long for next IFD address
+        offsetSize + // next IFD address
         tagFieldByteCount
 
     var tagDataOffset = tagDataStartOffset
@@ -203,40 +201,42 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
   }
 
   private def appendCloudOptimized(list: List[GeoTiffData]): Unit = {
-    // TODO: adapt as well
     val ifdCount = list.length
 
     val dataOffsets = list.map { geoTiff =>
+      val isBigTiff = geoTiff.options.tiffType == BigTiff
+      val offsetSize = if (isBigTiff) 8 else 4
+
       val (fieldValues, offsetFieldValueBuilder) = TiffTagFieldValue.collect(geoTiff)
       val segments = geoTiff.imageData.segmentBytes
       val segmentCount = segments.size
       val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).sum
 
-      val tagFieldByteCount = (fieldValues.length + 1) * 12 // Tiff Tag Fields are 12 bytes long.
+      val tagFieldSize = if (isBigTiff) 20 else 12
+      val tagFieldByteCount = (fieldValues.length + 1) * tagFieldSize
 
       val tagDataByteCount = {
         var s = 0
         cfor(0)(_ < fieldValues.length, _ + 1) { i =>
           val len = fieldValues(i).value.length
-          // If value fits in 4 bytes, we store it in the offset,
-          // so only count data more than 4 bytes.
-          if(len > 4) {
+          // If value fits, we store it in the offset,
+          // so only count data more than offset size.
+          if(len > offsetSize) {
             s += fieldValues(i).value.length
           }
         }
 
         // Account for offsetFieldValue size
-        // each offset is an Int long.
         if(segmentCount > 1) {
-          s += (segmentCount * 4)
+          s += (segmentCount * offsetSize)
         }
 
         s
       }
 
       val imageDataStartOffset =
-        2 + // Short for number of tags
-        4 + // Int for next IFD address
+        (if (isBigTiff) 8L else 2L) + // number of tags
+        offsetSize + // next IFD address
         tagFieldByteCount + tagDataByteCount
 
       (fieldValues -> offsetFieldValueBuilder, tagFieldByteCount -> tagDataByteCount, imageDataStartOffset -> segmentBytesCount)
@@ -248,6 +248,8 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     
     cfor(0)(_ < ifdCount, _ + 1) { i =>
       val (geoTiff, value, last) = (list(i), dataOffsets(i), i + 1 == ifdCount)
+      val isBigTiff = geoTiff.options.tiffType == BigTiff
+      val offsetSize = if (isBigTiff) 8 else 4
       val (fieldValues, offsetFieldValueBuilder) = value._1
       val segments = geoTiff.imageData.segmentBytes
       val segmentCount = segments.size
@@ -256,11 +258,11 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
 
       // Compute the offsetFieldValue
       // Sum smaller overviews + offset of the current IFD
-      val imageDataStartOffset: Int =
-        (dataOffsets.slice(i + 1, dataOffsets.length).foldLeft(index) {
-        case (acc: Long, (_, _, (absStartOffset: Int, bytesCount: Int))) =>
+      val imageDataStartOffset: Long =
+        dataOffsets.slice(i + 1, dataOffsets.length).foldLeft(index) {
+        case (acc: Long, (_, _, (absStartOffset: Long, bytesCount: Int))) =>
           acc + absStartOffset + bytesCount
-      } + value._3._1).toInt
+      } + value._3._1
 
       val offsetFieldValue = {
         val offsets = Array.ofDim[Long](segmentCount)
@@ -276,12 +278,13 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       val sortedTagFieldValues = (offsetFieldValue :: fieldValues.toList).sortBy(_.tag).toArray
 
       // Write the number of tags
-      writeShort(sortedTagFieldValues.length)
+      if (isBigTiff) writeLong(sortedTagFieldValues.length)
+      else writeShort(sortedTagFieldValues.length)
 
       // Write tag fields, sorted by tag code.
       val tagDataStartOffset =
         index +
-          4 + // Int for next IFD address
+          offsetSize + // next IFD address
           tagFieldByteCount
 
       var tagDataOffset = tagDataStartOffset
@@ -290,9 +293,9 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
         val TiffTagFieldValue(tag, fieldType, length, value) = sortedTagFieldValues(i)
         writeShort(tag)
         writeShort(fieldType)
-        writeInt(length.toInt)
-        if(value.length > 4) {
-          writeInt(tagDataOffset.toInt)
+        if (isBigTiff) writeLong(length) else writeInt(length.toInt)
+        if(value.length > offsetSize) {
+          if (isBigTiff) writeLong(tagDataOffset) else writeInt(tagDataOffset.toInt)
           tagDataOffset += value.length
         } else {
           var i = 0
@@ -300,7 +303,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
             writeByte(value(i))
             i += 1
           }
-          while(i < 4) {
+          while(i < offsetSize) {
             writeByte(0.toByte)
             i += 1
           }
@@ -308,8 +311,11 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       }
 
       // Write 0 integer to indicate the end of the last IFD.
-      if(last) writeInt(0)
-      else writeInt(tagDataOffset.toInt)
+      if(last) {
+        if (isBigTiff) writeLong(0) else writeInt(0)
+      } else {
+        if (isBigTiff) writeLong(tagDataOffset) else writeInt(tagDataOffset.toInt)
+      }
 
       assert(index == tagDataStartOffset, s"Writer error: index at $index, should be $tagDataStartOffset")
       assert(tagDataOffset == tagDataStartOffset + tagDataByteCount)
@@ -317,7 +323,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       // write tag data
       cfor(0)(_ < sortedTagFieldValues.length, _ + 1) { i =>
         val TiffTagFieldValue(tag, fieldType, length, value) = sortedTagFieldValues(i)
-        if(value.length > 4) {
+        if(value.length > offsetSize) {
           writeBytes(value)
         }
       }

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
@@ -256,11 +256,11 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
 
       // Compute the offsetFieldValue
       // Sum smaller overviews + offset of the current IFD
-      val imageDataStartOffset: Long =
-      dataOffsets.slice(i + 1, dataOffsets.length).foldLeft(index) {
+      val imageDataStartOffset: Int =
+        (dataOffsets.slice(i + 1, dataOffsets.length).foldLeft(index) {
         case (acc: Long, (_, _, (absStartOffset: Int, bytesCount: Int))) =>
           acc + absStartOffset + bytesCount
-      } + value._3._1
+      } + value._3._1).toInt
 
       val offsetFieldValue = {
         val offsets = Array.ofDim[Long](segmentCount)
@@ -290,9 +290,9 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
         val TiffTagFieldValue(tag, fieldType, length, value) = sortedTagFieldValues(i)
         writeShort(tag)
         writeShort(fieldType)
-        writeLong(length)
+        writeInt(length.toInt)
         if(value.length > 4) {
-          writeLong(tagDataOffset)
+          writeInt(tagDataOffset.toInt)
           tagDataOffset += value.length
         } else {
           var i = 0
@@ -308,8 +308,8 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       }
 
       // Write 0 integer to indicate the end of the last IFD.
-      if(last) writeLong(0)
-      else writeLong(tagDataOffset)
+      if(last) writeInt(0)
+      else writeInt(tagDataOffset.toInt)
 
       assert(index == tagDataStartOffset, s"Writer error: index at $index, should be $tagDataStartOffset")
       assert(tagDataOffset == tagDataStartOffset + tagDataByteCount)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
@@ -87,30 +87,33 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
   }
 
   private def append(geoTiff: GeoTiffData, last: Boolean = true): Unit = {
+    val isBigTiff = geoTiff.options.tiffType == BigTiff
+    val offsetSize = if (isBigTiff) 8 else 4
+
     val (fieldValues, offsetFieldValueBuilder) = TiffTagFieldValue.collect(geoTiff)
     val segments = geoTiff.imageData.segmentBytes
     val segmentCount = segments.size
     val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).sum
 
     // footprint of tags themselves
-    val tagFieldByteCount = (fieldValues.length + 1) * 20 // Tiff Tag Fields are 20 bytes long. +1 for the StripOffsets/TileOffsets tag (TBC)
+    val tagFieldSize = if (isBigTiff) 20 else 12
+    val tagFieldByteCount = (fieldValues.length + 1) * tagFieldSize // + 1 for StripOffsets/TileOffsets tag
 
     // footprint of data behind a tag's offset (= doesn't fit in 8 bytes)
     val tagDataByteCount = {
       var s = 0
       cfor(0)(_ < fieldValues.length, _ + 1) { i =>
         val len = fieldValues(i).value.length
-        // If value fits in 8 bytes, we store it in the offset,
-        // so only count data more than 8 bytes.
-        if(len > 8) {
+        // If value fits, we store it in the offset,
+        // so only count data larger than offset size.
+        if (len > offsetSize) {
           s += fieldValues(i).value.length
         }
       }
 
       // Account for offsetFieldValue size
-      // each offset is 8 bytes long.
       if(segmentCount > 1) {
-        s += (segmentCount * 8)
+        s += (segmentCount * offsetSize)
       }
 
       s
@@ -121,10 +124,10 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
 
     // Compute the offsetFieldValue
     val offsetFieldValue = { // StripOffsets/TileOffsets tag
-      val imageDataStartOffset = // image starts right after this IFD (TBC)
-        index + // currently right after the header
-          8 + // Long for number of tags
-          8 + // Long for next IFD address
+      val imageDataStartOffset = // image starts right after this IFD
+        index +
+          (if (isBigTiff) 8 else 2) + // number of tags
+          offsetSize + // next IFD address
           tagFieldByteCount + tagDataByteCount
 
 
@@ -141,12 +144,15 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     val sortedTagFieldValues = (offsetFieldValue :: fieldValues.toList).sortBy(_.tag).toArray
 
     // Write the number of tags
-    writeLong(sortedTagFieldValues.length)
+    if (isBigTiff)
+      writeLong(sortedTagFieldValues.length)
+    else
+      writeShort(sortedTagFieldValues.length)
 
     // Write tag fields, sorted by tag code.
     val tagDataStartOffset = // offset of data behind a tag's offset (= doesn't fit in 4 bytes): TBC
       index +
-        8 + // Long for next IFD address
+        offsetSize + // Long for next IFD address
         tagFieldByteCount
 
     var tagDataOffset = tagDataStartOffset
@@ -155,9 +161,9 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       val TiffTagFieldValue(tag, fieldType, length, value) = sortedTagFieldValues(i)
       writeShort(tag)
       writeShort(fieldType)
-      writeLong(length)
-      if(value.length > 8) {
-        writeLong(tagDataOffset)
+      if (isBigTiff) writeLong(length) else writeInt(length.toInt)
+      if(value.length > offsetSize) {
+        if (isBigTiff) writeLong(tagDataOffset) else writeInt(tagDataOffset.toInt)
         tagDataOffset += value.length
       } else {
         var i = 0
@@ -165,7 +171,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
           writeByte(value(i))
           i += 1
         }
-        while(i < 8) {
+        while(i < offsetSize) {
           writeByte(0.toByte)
           i += 1
         }
@@ -173,8 +179,11 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     }
 
     // Write 0 integer to indicate the end of the last IFD.
-    if(last) writeLong(0)
-    else writeLong(tagDataOffset + segmentBytesCount)
+    if(last) {
+      if (isBigTiff) writeLong(0) else writeInt(0)
+    } else {
+      if (isBigTiff) writeLong(tagDataOffset + segmentBytesCount) else writeInt((tagDataOffset + segmentBytesCount).toInt)
+    }
 
     assert(index == tagDataStartOffset, s"Writer error: index at $index, should be $tagDataStartOffset")
     assert(tagDataOffset == tagDataStartOffset + tagDataByteCount)
@@ -182,7 +191,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     // write tag data
     cfor(0)(_ < sortedTagFieldValues.length, _ + 1) { i =>
       val TiffTagFieldValue(tag, fieldType, length, value) = sortedTagFieldValues(i)
-      if(value.length > 8) {
+      if(value.length > offsetSize) {
         writeBytes(value)
       }
     }
@@ -337,15 +346,19 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       writeByte(i)
     }
 
+    val tiffType = geoTiff.options.tiffType
+
     // TIFF header code.
-    writeShort(geoTiff.options.tiffType.code.toShort) // TODO: restore classic Tiff
+    writeShort(tiffType.code.toShort)
 
-    writeShort(8) // offset size, fixed
-
-    writeShort(0) // reserved, fixed
-
-    // Write tag start offset (immediately after this 4 byte integer)
-    writeLong(index + 8)
+    tiffType match {
+      case BigTiff =>
+        writeShort(8) // offset size, fixed
+        writeShort(0) // reserved, fixed
+        writeLong(index + 8)// Write tag start offset (immediately after this 8 byte long)
+      case Tiff =>
+        writeInt(index.toInt + 4) // Write tag start offset (immediately after this 4 byte integer)
+    }
 
     // Append all IFDs
     if(optimizedOrder) appendCloudOptimized(IFDs)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
@@ -99,7 +99,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     val tagFieldSize = if (isBigTiff) 20 else 12
     val tagFieldByteCount = (fieldValues.length + 1) * tagFieldSize // + 1 for StripOffsets/TileOffsets tag
 
-    // footprint of data behind a tag's offset (= doesn't fit in 8 bytes)
+    // footprint of data behind a tag's offset (= doesn't fit in 4/8 bytes tag data)
     val tagDataByteCount = {
       var s = 0
       cfor(0)(_ < fieldValues.length, _ + 1) { i =>
@@ -148,7 +148,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     else writeShort(sortedTagFieldValues.length)
 
     // Write tag fields, sorted by tag code.
-    val tagDataStartOffset = // offset of data behind a tag's offset (= doesn't fit in 4 bytes): TBC
+    val tagDataStartOffset = // offset of data behind a tag's offset (= doesn't fit in 4/8 bytes tag data)
       index +
         offsetSize + // next IFD address
         tagFieldByteCount
@@ -259,7 +259,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       // Compute the offsetFieldValue
       // Sum smaller overviews + offset of the current IFD
       val imageDataStartOffset: Long =
-        dataOffsets.slice(i + 1, dataOffsets.length).foldLeft(index) {
+      dataOffsets.slice(i + 1, dataOffsets.length).foldLeft(index) {
         case (acc: Long, (_, _, (absStartOffset: Long, bytesCount: Int))) =>
           acc + absStartOffset + bytesCount
       } + value._3._1

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
@@ -71,7 +71,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
   lazy val IFDs: List[GeoTiffData] = geoTiff :: geoTiff.overviews
 
   // Used to immediately write values to our ultimate destination.
-  var index: Int = 0
+  var index: Long = 0
   def writeByte(value: Byte): Unit = { dos.writeByte(value.toInt); index += 1 }
   def writeBytes(value: Array[Byte]): Unit =  { dos.write(value, 0, value.length); index += value.length }
 
@@ -92,23 +92,25 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     val segmentCount = segments.size
     val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).sum
 
-    val tagFieldByteCount = (fieldValues.length + 1) * 12 // Tiff Tag Fields are 12 bytes long.
+    // footprint of tags themselves
+    val tagFieldByteCount = (fieldValues.length + 1) * 20 // Tiff Tag Fields are 20 bytes long. +1 for the StripOffsets/TileOffsets tag (TBC)
 
+    // footprint of data behind a tag's offset (= doesn't fit in 8 bytes)
     val tagDataByteCount = {
       var s = 0
       cfor(0)(_ < fieldValues.length, _ + 1) { i =>
         val len = fieldValues(i).value.length
-        // If value fits in 4 bytes, we store it in the offset,
-        // so only count data more than 4 bytes.
-        if(len > 4) {
+        // If value fits in 8 bytes, we store it in the offset,
+        // so only count data more than 8 bytes.
+        if(len > 8) {
           s += fieldValues(i).value.length
         }
       }
 
       // Account for offsetFieldValue size
-      // each offset is an Int long.
+      // each offset is 8 bytes long.
       if(segmentCount > 1) {
-        s += (segmentCount * 4)
+        s += (segmentCount * 8)
       }
 
       s
@@ -118,15 +120,15 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     // writeInt(index + 4)
 
     // Compute the offsetFieldValue
-    val offsetFieldValue = {
-      val imageDataStartOffset =
-        index +
-          2 + // Short for number of tags
-          4 + // Int for next IFD address
+    val offsetFieldValue = { // StripOffsets/TileOffsets tag
+      val imageDataStartOffset = // image starts right after this IFD (TBC)
+        index + // currently right after the header
+          8 + // Long for number of tags
+          8 + // Long for next IFD address
           tagFieldByteCount + tagDataByteCount
 
 
-      val offsets = Array.ofDim[Int](segmentCount)
+      val offsets = Array.ofDim[Long](segmentCount)
       var offset = imageDataStartOffset
       segments.getSegments(0 until segmentCount).foreach { case (i, segment) =>
         offsets(i) = offset
@@ -139,12 +141,12 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     val sortedTagFieldValues = (offsetFieldValue :: fieldValues.toList).sortBy(_.tag).toArray
 
     // Write the number of tags
-    writeShort(sortedTagFieldValues.length)
+    writeLong(sortedTagFieldValues.length)
 
     // Write tag fields, sorted by tag code.
-    val tagDataStartOffset =
+    val tagDataStartOffset = // offset of data behind a tag's offset (= doesn't fit in 4 bytes): TBC
       index +
-        4 + // Int for next IFD address
+        8 + // Long for next IFD address
         tagFieldByteCount
 
     var tagDataOffset = tagDataStartOffset
@@ -153,9 +155,9 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       val TiffTagFieldValue(tag, fieldType, length, value) = sortedTagFieldValues(i)
       writeShort(tag)
       writeShort(fieldType)
-      writeInt(length)
-      if(value.length > 4) {
-        writeInt(tagDataOffset)
+      writeLong(length)
+      if(value.length > 8) {
+        writeLong(tagDataOffset)
         tagDataOffset += value.length
       } else {
         var i = 0
@@ -163,7 +165,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
           writeByte(value(i))
           i += 1
         }
-        while(i < 4) {
+        while(i < 8) {
           writeByte(0.toByte)
           i += 1
         }
@@ -171,8 +173,8 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     }
 
     // Write 0 integer to indicate the end of the last IFD.
-    if(last) writeInt(0)
-    else writeInt(tagDataOffset + segmentBytesCount)
+    if(last) writeLong(0)
+    else writeLong(tagDataOffset + segmentBytesCount)
 
     assert(index == tagDataStartOffset, s"Writer error: index at $index, should be $tagDataStartOffset")
     assert(tagDataOffset == tagDataStartOffset + tagDataByteCount)
@@ -180,7 +182,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     // write tag data
     cfor(0)(_ < sortedTagFieldValues.length, _ + 1) { i =>
       val TiffTagFieldValue(tag, fieldType, length, value) = sortedTagFieldValues(i)
-      if(value.length > 4) {
+      if(value.length > 8) {
         writeBytes(value)
       }
     }
@@ -192,6 +194,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
   }
 
   private def appendCloudOptimized(list: List[GeoTiffData]): Unit = {
+    // TODO: adapt as well
     val ifdCount = list.length
 
     val dataOffsets = list.map { geoTiff =>
@@ -244,14 +247,14 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
 
       // Compute the offsetFieldValue
       // Sum smaller overviews + offset of the current IFD
-      val imageDataStartOffset: Int =
+      val imageDataStartOffset: Long =
       dataOffsets.slice(i + 1, dataOffsets.length).foldLeft(index) {
-        case (acc: Int, (_, _, (absStartOffset: Int, bytesCount: Int))) =>
+        case (acc: Long, (_, _, (absStartOffset: Int, bytesCount: Int))) =>
           acc + absStartOffset + bytesCount
       } + value._3._1
 
       val offsetFieldValue = {
-        val offsets = Array.ofDim[Int](segmentCount)
+        val offsets = Array.ofDim[Long](segmentCount)
         var offset = imageDataStartOffset
         segments.getSegments(0 until segmentCount).foreach { case (i, segment) =>
           offsets(i) = offset
@@ -278,9 +281,9 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
         val TiffTagFieldValue(tag, fieldType, length, value) = sortedTagFieldValues(i)
         writeShort(tag)
         writeShort(fieldType)
-        writeInt(length)
+        writeLong(length)
         if(value.length > 4) {
-          writeInt(tagDataOffset)
+          writeLong(tagDataOffset)
           tagDataOffset += value.length
         } else {
           var i = 0
@@ -296,8 +299,8 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       }
 
       // Write 0 integer to indicate the end of the last IFD.
-      if(last) writeInt(0)
-      else writeInt(tagDataOffset)
+      if(last) writeLong(0)
+      else writeLong(tagDataOffset)
 
       assert(index == tagDataStartOffset, s"Writer error: index at $index, should be $tagDataStartOffset")
       assert(tagDataOffset == tagDataStartOffset + tagDataByteCount)
@@ -335,10 +338,14 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     }
 
     // TIFF header code.
-    writeShort(Tiff.code.toShort)
+    writeShort(geoTiff.options.tiffType.code.toShort) // TODO: restore classic Tiff
+
+    writeShort(8) // offset size, fixed
+
+    writeShort(0) // reserved, fixed
 
     // Write tag start offset (immediately after this 4 byte integer)
-    writeInt(index + 4)
+    writeLong(index + 8)
 
     // Append all IFDs
     if(optimizedOrder) appendCloudOptimized(IFDs)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -199,6 +199,8 @@ object TiffTagFieldValue {
     // Tags that are different if it is striped or tiled storage, and a function
     // that sets up a tag to point to the offsets of the image data.
 
+    val isBigTiff = geoTiff.options.tiffType == BigTiff
+
     val segmentByteCounts = {
       val len = imageData.segmentBytes.length
       val arr = Array.ofDim[Long](len)
@@ -213,9 +215,15 @@ object TiffTagFieldValue {
         case Tiled(tileCols, tileRows) =>
           fieldValues += TiffTagFieldValue(TileWidthTag, IntsFieldType, 1, toBytes(tileCols))
           fieldValues += TiffTagFieldValue(TileLengthTag, IntsFieldType, 1, toBytes(tileRows))
-          fieldValues += TiffTagFieldValue(TileByteCountsTag, LongsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
+          fieldValues +=
+            (if (isBigTiff)
+            TiffTagFieldValue(TileByteCountsTag, LongsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
+          else
+            TiffTagFieldValue(TileByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts.map(_.toInt))))
 
-          { offsets: Array[Long] => TiffTagFieldValue(TileOffsetsTag, LongsFieldType, offsets.length, toBytes(offsets)) }
+          { offsets: Array[Long] =>
+            if (isBigTiff) TiffTagFieldValue(TileOffsetsTag, LongsFieldType, offsets.length, toBytes(offsets))
+            else TiffTagFieldValue(TileOffsetsTag, IntsFieldType, offsets.length, toBytes(offsets.map(_.toInt))) }
         case s: Striped =>
           val rowsPerStrip = imageData.segmentLayout.tileLayout.tileRows
           fieldValues += {
@@ -225,9 +233,14 @@ object TiffTagFieldValue {
               TiffTagFieldValue(RowsPerStripTag, IntsFieldType, 1, rowsPerStrip)
             }
           }
-          fieldValues += TiffTagFieldValue(StripByteCountsTag, LongsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
+          fieldValues +=
+            (if (isBigTiff)
+            TiffTagFieldValue(StripByteCountsTag, LongsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
+          else TiffTagFieldValue(StripByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts.map(_.toInt))))
 
-          { offsets: Array[Long] => TiffTagFieldValue(StripOffsetsTag, LongsFieldType, offsets.length, toBytes(offsets)) }
+          { offsets: Array[Long] =>
+            if (isBigTiff) TiffTagFieldValue(StripOffsetsTag, LongsFieldType, offsets.length, toBytes(offsets))
+            else TiffTagFieldValue(StripOffsetsTag, IntsFieldType, offsets.length, toBytes(offsets.map(_.toInt))) }
       }
 
     (fieldValues.toArray, offsetsFieldValueBuilder)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -25,6 +25,7 @@ import geotrellis.raster.io.geotiff.tags.codes.TiffFieldType._
 import spire.syntax.cfor._
 
 import scala.collection.mutable
+import scala.reflect.ClassTag
 import java.nio.ByteOrder
 
 case class TiffTagFieldValue(
@@ -201,7 +202,16 @@ object TiffTagFieldValue {
 
     val isBigTiff = geoTiff.options.tiffType == BigTiff
 
-    val segmentByteCounts = {
+    lazy val segmentByteCountsInt: Array[Int] = {
+      val len = imageData.segmentBytes.length
+      val arr = Array.ofDim[Int](len)
+      cfor(0)(_ < len, _ + 1) { i =>
+        arr(i) = imageData.segmentBytes.getSegmentByteCount(i)
+      }
+      arr
+    }
+
+    lazy val segmentByteCountsLong: Array[Long] = {
       val len = imageData.segmentBytes.length
       val arr = Array.ofDim[Long](len)
       cfor(0)(_ < len, _ + 1) { i =>
@@ -217,9 +227,9 @@ object TiffTagFieldValue {
           fieldValues += TiffTagFieldValue(TileLengthTag, IntsFieldType, 1, toBytes(tileRows))
           fieldValues +=
             (if (isBigTiff)
-            TiffTagFieldValue(TileByteCountsTag, LongsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
+            TiffTagFieldValue(TileByteCountsTag, LongsFieldType, segmentByteCountsLong.length, toBytes(segmentByteCountsLong))
           else
-            TiffTagFieldValue(TileByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts.map(_.toInt))))
+            TiffTagFieldValue(TileByteCountsTag, IntsFieldType, segmentByteCountsInt.length, toBytes(segmentByteCountsInt)))
 
           { offsets: Array[Long] =>
             if (isBigTiff) TiffTagFieldValue(TileOffsetsTag, LongsFieldType, offsets.length, toBytes(offsets))
@@ -235,8 +245,8 @@ object TiffTagFieldValue {
           }
           fieldValues +=
             (if (isBigTiff)
-            TiffTagFieldValue(StripByteCountsTag, LongsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
-          else TiffTagFieldValue(StripByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts.map(_.toInt))))
+            TiffTagFieldValue(StripByteCountsTag, LongsFieldType, segmentByteCountsLong.length, toBytes(segmentByteCountsLong))
+          else TiffTagFieldValue(StripByteCountsTag, IntsFieldType, segmentByteCountsInt.length, toBytes(segmentByteCountsInt)))
 
           { offsets: Array[Long] =>
             if (isBigTiff) TiffTagFieldValue(StripOffsetsTag, LongsFieldType, offsets.length, toBytes(offsets))

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/TiffTagFieldValue.scala
@@ -30,7 +30,7 @@ import java.nio.ByteOrder
 case class TiffTagFieldValue(
   tag: Int,
   fieldType: Int,
-  length: Int,
+  length: Long,
   value: Array[Byte]
 ) {
   assert(
@@ -44,14 +44,15 @@ case class TiffTagFieldValue(
       case SignedIntsFieldType => 4
       case FloatsFieldType => 4
       case DoublesFieldType => 8
+      case LongsFieldType => 8
     }) * length == value.length, s"Unexpected tag value size for tag $tag.")
 }
 
 object TiffTagFieldValue {
-  def apply(tag: Int, fieldType: Int, length: Int, value: Int)(implicit toBytes: ToBytes): TiffTagFieldValue =
+  def apply(tag: Int, fieldType: Int, length: Long, value: Long)(implicit toBytes: ToBytes): TiffTagFieldValue =
     fieldType match {
       case ShortsFieldType => TiffTagFieldValue(tag, fieldType, length, toBytes(value.toShort))
-      case IntsFieldType => TiffTagFieldValue(tag, fieldType, length, toBytes(value))
+      case IntsFieldType => TiffTagFieldValue(tag, fieldType, length, toBytes(value.toInt))
     }
 
   def createNoDataString(cellType: CellType): Option[String] =
@@ -73,7 +74,7 @@ object TiffTagFieldValue {
       case ct: DoubleUserDefinedNoDataCellType => Some(ct.widenedNoData.toString)
     }
 
-  def collect(geoTiff: GeoTiffData): (Array[TiffTagFieldValue], Array[Int] => TiffTagFieldValue) = {
+  def collect(geoTiff: GeoTiffData): (Array[TiffTagFieldValue], Array[Long] => TiffTagFieldValue) = {
     implicit val toBytes: ToBytes =
       if(geoTiff.imageData.decompressor.byteOrder == ByteOrder.BIG_ENDIAN)
         BigEndianToBytes
@@ -200,21 +201,21 @@ object TiffTagFieldValue {
 
     val segmentByteCounts = {
       val len = imageData.segmentBytes.length
-      val arr = Array.ofDim[Int](len)
+      val arr = Array.ofDim[Long](len)
       cfor(0)(_ < len, _ + 1) { i =>
         arr(i) = imageData.segmentBytes.getSegmentByteCount(i)
       }
       arr
     }
 
-    val offsetsFieldValueBuilder: Array[Int] => TiffTagFieldValue =
+    val offsetsFieldValueBuilder: Array[Long] => TiffTagFieldValue =
       imageData.segmentLayout.storageMethod match {
         case Tiled(tileCols, tileRows) =>
           fieldValues += TiffTagFieldValue(TileWidthTag, IntsFieldType, 1, toBytes(tileCols))
           fieldValues += TiffTagFieldValue(TileLengthTag, IntsFieldType, 1, toBytes(tileRows))
-          fieldValues += TiffTagFieldValue(TileByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
+          fieldValues += TiffTagFieldValue(TileByteCountsTag, LongsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
 
-          { offsets: Array[Int] => TiffTagFieldValue(TileOffsetsTag, IntsFieldType, offsets.length, toBytes(offsets)) }
+          { offsets: Array[Long] => TiffTagFieldValue(TileOffsetsTag, LongsFieldType, offsets.length, toBytes(offsets)) }
         case s: Striped =>
           val rowsPerStrip = imageData.segmentLayout.tileLayout.tileRows
           fieldValues += {
@@ -224,9 +225,9 @@ object TiffTagFieldValue {
               TiffTagFieldValue(RowsPerStripTag, IntsFieldType, 1, rowsPerStrip)
             }
           }
-          fieldValues += TiffTagFieldValue(StripByteCountsTag, IntsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
+          fieldValues += TiffTagFieldValue(StripByteCountsTag, LongsFieldType, segmentByteCounts.length, toBytes(segmentByteCounts))
 
-          { offsets: Array[Int] => TiffTagFieldValue(StripOffsetsTag, IntsFieldType, offsets.length, toBytes(offsets)) }
+          { offsets: Array[Long] => TiffTagFieldValue(StripOffsetsTag, LongsFieldType, offsets.length, toBytes(offsets)) }
       }
 
     (fieldValues.toArray, offsetsFieldValueBuilder)

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/ToBytes.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/ToBytes.scala
@@ -60,6 +60,17 @@ sealed trait ToBytes {
     }
     result
   }
+
+  def apply(arr: Array[Long]): Array[Byte] = {
+    val result = Array.ofDim[Byte](arr.length * 8)
+    var resultIndex = 0
+    cfor(0)(_ < arr.length, _ + 1) { i =>
+      val bytes = apply(arr(i))
+      System.arraycopy(bytes, 0, result, resultIndex, bytes.length)
+      resultIndex += bytes.length
+    }
+    result
+  }
 }
 
 object BigEndianToBytes extends ToBytes {

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -114,37 +114,6 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils w
   }
 
   describe("Writing BigTiffs") {
-    val tiffTypeTable = Table(
-      ("Tiff type", "is cloud optimized"),
-      (Tiff, false),
-      (Tiff, true),
-      (BigTiff, false),
-      (BigTiff, true),
-    )
-
-    it("should produce a BigTiff") {
-      import geotrellis.proj4._
-      import geotrellis.raster._
-      import geotrellis.raster.resample.NearestNeighbor
-
-      val tile: Tile = IntConstantTile(123, cols = 256, rows = 256)
-      val crs: CRS = LatLng
-      val extent: Extent = Extent(-180, -90, 180, 90)
-
-      forAll(tiffTypeTable) { (tiffType, isCloudOptimized) =>
-        val outputFile = s"/tmp/bigtiff_${tiffType}_$isCloudOptimized.tif"
-
-        val out = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = tiffType))
-          .withOverviews(resampleMethod = NearestNeighbor)
-
-        out.write(outputFile, isCloudOptimized)
-
-        val in = SinglebandGeoTiff(outputFile)
-        in.options.tiffType should be(tiffType)
-        in.overviews should not be empty
-      }
-    }
-
     val bigTiffPermutations = Table(
       ("cloud optimized", "storage method"),
       (true, Striped()),

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -16,11 +16,8 @@
 
 package geotrellis.raster.io.geotiff
 
-import geotrellis.proj4._
-import geotrellis.raster._
 import geotrellis.util._
 import geotrellis.raster.io.geotiff.tags.TiffTags
-import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.raster.testkit._
 import geotrellis.vector.Extent
 import org.scalatest.funspec.AnyFunSpec
@@ -112,20 +109,39 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils {
     }
 
     it("should produce a BigTiff") {
+      import geotrellis.proj4._
+      import geotrellis.raster._
+      import geotrellis.raster.resample.NearestNeighbor
+
       val tile: Tile = IntConstantTile(123, cols = 256, rows = 256)
       val crs: CRS = LatLng
       val extent: Extent = Extent(-180, -90, 180, 90)
 
-      val outputFile = "/tmp/bigtiff.tif"
+      {
+        val outputFile = "/tmp/bigtiff.tif"
 
-      val out = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = BigTiff))
-        .withOverviews(resampleMethod = NearestNeighbor)
+        val out = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = BigTiff))
+          .withOverviews(resampleMethod = NearestNeighbor)
 
-      out.write(outputFile)
+        out.write(outputFile)
 
-      val in = SinglebandGeoTiff(outputFile)
-      in.options.tiffType should be (BigTiff)
-      in.overviews should not be empty
+        val in = SinglebandGeoTiff(outputFile)
+        in.options.tiffType should be(BigTiff)
+        in.overviews should not be empty
+      }
+
+      {
+        val outputFile = "/tmp/classictiff.tif"
+
+        val out = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT)
+          .withOverviews(resampleMethod = NearestNeighbor)
+
+        out.write(outputFile)
+
+        val in = SinglebandGeoTiff(outputFile)
+        in.options.tiffType should be(Tiff)
+        in.overviews should not be empty
+      }
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -20,6 +20,7 @@ import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.util._
 import geotrellis.raster.io.geotiff.tags.TiffTags
+import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.raster.testkit._
 import geotrellis.vector.Extent
 import org.scalatest.funspec.AnyFunSpec
@@ -111,12 +112,20 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils {
     }
 
     it("should produce a BigTiff") {
-      val tile: Tile = IntConstantTile(123, cols = 4, rows = 4)
+      val tile: Tile = IntConstantTile(123, cols = 256, rows = 256)
       val crs: CRS = LatLng
       val extent: Extent = Extent(-180, -90, 180, 90)
 
-      val geoTiff = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = BigTiff))
-      geoTiff.write("/tmp/writeBigTiff.tif")
+      val outputFile = "/tmp/bigtiff.tif"
+
+      val out = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = BigTiff))
+        .withOverviews(resampleMethod = NearestNeighbor)
+
+      out.write(outputFile)
+
+      val in = SinglebandGeoTiff(outputFile)
+      in.options.tiffType should be (BigTiff)
+      in.overviews should not be empty
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -24,6 +24,8 @@ import geotrellis.vector.Extent
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
 
+import java.io.File
+
 class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils with TableDrivenPropertyChecks {
   describe("Reading BigTiffs") {
     val smallPath = geoTiffPath("ls8_int32.tif")
@@ -152,8 +154,6 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils w
     )
 
     it("should produce BigTiffs") {
-      import java.io.File
-
       forAll(bigTiffPermutations) { (cloudOptimized, storageMethod) =>
         val tiffOriginal = MultibandGeoTiff(geoTiffPath("overviews/multiband.tif"))
         tiffOriginal.options.storageMethod shouldBe a [Striped]

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -18,6 +18,7 @@ package geotrellis.raster.io.geotiff
 
 import geotrellis.util._
 import geotrellis.raster.io.geotiff.tags.TiffTags
+import geotrellis.raster.io.geotiff.writer.GeoTiffWriter
 import geotrellis.raster.testkit._
 import geotrellis.vector.Extent
 import org.scalatest.funspec.AnyFunSpec
@@ -106,9 +107,11 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils w
     it("should read a previously problematic big tiff") {
       val tags = TiffTags.read(geoTiffPath("bigtiff-marcuswr.tif"))
       val e = tags.extent
-      e should be (Extent(-105.06398320198056, 40.743636546229, -105.05724549293515, 40.751667086819424))
+      e should be(Extent(-105.06398320198056, 40.743636546229, -105.05724549293515, 40.751667086819424))
     }
+  }
 
+  describe("Writing BigTiffs") {
     val tiffTypeTable = Table(
       ("Tiff type", "is cloud optimized"),
       (Tiff, false),
@@ -137,6 +140,39 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils w
         val in = SinglebandGeoTiff(outputFile)
         in.options.tiffType should be(tiffType)
         in.overviews should not be empty
+      }
+    }
+
+    val bigTiffPermutations = Table(
+      ("cloud optimized", "storage method"),
+      (true, Striped()),
+      (true, Tiled()),
+      (false, Striped()),
+      (false, Tiled()),
+    )
+
+    it("should produce BigTiffs") {
+      import java.io.File
+
+      forAll(bigTiffPermutations) { (cloudOptimized, storageMethod) =>
+        val tiffOriginal = MultibandGeoTiff(geoTiffPath("overviews/multiband.tif"))
+        tiffOriginal.options.storageMethod shouldBe a [Striped]
+        tiffOriginal.options.tiffType should be (Tiff)
+
+        val tempFile = File.createTempFile("bigtiff", ".tif").toString
+        addToPurge(tempFile)
+
+        val bigTiff = tiffOriginal.copy(
+          options = tiffOriginal.options.copy(tiffType = BigTiff),
+          overviews = tiffOriginal.overviews.map(overview => overview.copy(options=overview.options.copy(tiffType = BigTiff))) // TODO: add withTiffType?
+        ).withStorageMethod(storageMethod)
+
+        GeoTiffWriter.write(bigTiff, tempFile, optimizedOrder = cloudOptimized)
+
+        val actual = MultibandGeoTiff(tempFile)
+        actual.options.tiffType should be (BigTiff)
+        actual.options.storageMethod.getClass should be (storageMethod.getClass)
+        actual.getOverviewsCount should be (5)
       }
     }
   }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -162,10 +162,7 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils w
         val tempFile = File.createTempFile("bigtiff", ".tif").toString
         addToPurge(tempFile)
 
-        val bigTiff = tiffOriginal.copy(
-          options = tiffOriginal.options.copy(tiffType = BigTiff),
-          overviews = tiffOriginal.overviews.map(overview => overview.copy(options=overview.options.copy(tiffType = BigTiff))) // TODO: add withTiffType?
-        ).withStorageMethod(storageMethod)
+        val bigTiff = tiffOriginal.withTiffType(BigTiff).withStorageMethod(storageMethod)
 
         GeoTiffWriter.write(bigTiff, tempFile, optimizedOrder = cloudOptimized)
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -16,11 +16,12 @@
 
 package geotrellis.raster.io.geotiff
 
+import geotrellis.proj4._
+import geotrellis.raster._
 import geotrellis.util._
 import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.raster.testkit._
 import geotrellis.vector.Extent
-
 import org.scalatest.funspec.AnyFunSpec
 
 class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils {
@@ -107,6 +108,15 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils {
       val tags = TiffTags.read(geoTiffPath("bigtiff-marcuswr.tif"))
       val e = tags.extent
       e should be (Extent(-105.06398320198056, 40.743636546229, -105.05724549293515, 40.751667086819424))
+    }
+
+    it("should produce a BigTiff") {
+      val tile: Tile = IntConstantTile(123, cols = 4, rows = 4)
+      val crs: CRS = LatLng
+      val extent: Extent = Extent(-180, -90, 180, 90)
+
+      val geoTiff = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = BigTiff))
+      geoTiff.write("/tmp/writeBigTiff.tif")
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -109,7 +109,7 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils w
     it("should read a previously problematic big tiff") {
       val tags = TiffTags.read(geoTiffPath("bigtiff-marcuswr.tif"))
       val e = tags.extent
-      e should be(Extent(-105.06398320198056, 40.743636546229, -105.05724549293515, 40.751667086819424))
+      e should be (Extent(-105.06398320198056, 40.743636546229, -105.05724549293515, 40.751667086819424))
     }
   }
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -21,8 +21,9 @@ import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.raster.testkit._
 import geotrellis.vector.Extent
 import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.prop.TableDrivenPropertyChecks
 
-class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils {
+class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils with TableDrivenPropertyChecks {
   describe("Reading BigTiffs") {
     val smallPath = geoTiffPath("ls8_int32.tif")
     val bigPath = geoTiffPath("bigtiffs/ls8_int32-big.tif")
@@ -108,6 +109,14 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils {
       e should be (Extent(-105.06398320198056, 40.743636546229, -105.05724549293515, 40.751667086819424))
     }
 
+    val tiffTypeTable = Table(
+      ("Tiff type", "is cloud optimized"),
+      (Tiff, false),
+      (Tiff, true),
+      (BigTiff, false),
+      (BigTiff, true),
+    )
+
     it("should produce a BigTiff") {
       import geotrellis.proj4._
       import geotrellis.raster._
@@ -117,29 +126,16 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils {
       val crs: CRS = LatLng
       val extent: Extent = Extent(-180, -90, 180, 90)
 
-      {
-        val outputFile = "/tmp/bigtiff.tif"
+      forAll(tiffTypeTable) { (tiffType, isCloudOptimized) =>
+        val outputFile = s"/tmp/bigtiff_${tiffType}_$isCloudOptimized.tif"
 
-        val out = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = BigTiff))
+        val out = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = tiffType))
           .withOverviews(resampleMethod = NearestNeighbor)
 
-        out.write(outputFile)
+        out.write(outputFile, isCloudOptimized)
 
         val in = SinglebandGeoTiff(outputFile)
-        in.options.tiffType should be(BigTiff)
-        in.overviews should not be empty
-      }
-
-      {
-        val outputFile = "/tmp/classictiff.tif"
-
-        val out = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT)
-          .withOverviews(resampleMethod = NearestNeighbor)
-
-        out.write(outputFile)
-
-        val in = SinglebandGeoTiff(outputFile)
-        in.options.tiffType should be(Tiff)
+        in.options.tiffType should be(tiffType)
         in.overviews should not be empty
       }
     }


### PR DESCRIPTION
# Overview

Regardless of the `tiffType` option, `geotrellis.raster.io.geotiff.writer.GeoTiffWriter` will always output a classic Tiff. This PR will take the `tiffType` into account and actually support writing a BigTiff.

Analogous to `withStorageMethod`, adds a convenient `withTiffType` method to `geotrellis.raster.io.geotiff.GeoTiff` instances to apply a `TiffType` to a GeoTiff and its overviews.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature