### PR TITLE
fix typo in caffeine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add predictor 2 (integer) and predictor 3 (float) support for writing compressed GTiff files [#3588](https://github.com/locationtech/geotrellis/pull/3588)
 - Support writing GeoTiffs as BigTiff [#3605](https://github.com/locationtech/geotrellis/pull/3605)
 - GeoTiffWriter minor cleanups [#3607](https://github.com/locationtech/geotrellis/pull/3607)
+- Fix version of caffeine dependency [#3609](https://github.com/locationtech/geotrellis/pull/3609)
 
 ### Changed
 - MinResample should ignore Int NODATA values [#3590](https://github.com/locationtech/geotrellis/pull/3590)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -98,7 +98,7 @@ object Dependencies {
   val cassandraDriverQueryBuilder = "org.apache.cassandra" % "java-driver-query-builder" % Version.cassandra
 
   val scaffeine = "com.github.blemale"           %% "scaffeine" % "5.3.0"
-  val caffeine  = "com.github.ben-manes.caffeine" % "caffeine"  % "v3.2.2"
+  val caffeine  = "com.github.ben-manes.caffeine" % "caffeine"  % "3.2.2"
 
   val geotoolsCoverage    = "org.geotools"                 % "gt-coverage"             % Version.geotools
   val geotoolsHsql        = "org.geotools"                 % "gt-epsg-hsql"            % Version.geotools


### PR DESCRIPTION
# Overview

Fixes what looks like a typo in the version of the `caffeine` dependency: `v3.2.2` -> `3.2.2`

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature

## Notes

Not sure why this doesn't fail the Geotrellis build but does fail the build of our project that depends on Geotrellis.
