### PR TITLE
GeoTools 35.1 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Spark 4 Update; drops Scala 2.12 and JDK 11 support [#3582](https://github.com/locationtech/geotrellis/pull/3582)
 - GDAL 3.13 Update [#3606](https://github.com/locationtech/geotrellis/pull/3606)
+- GeoTools 35.0 update [#3611](https://github.com/locationtech/geotrellis/pull/3611)
 
 ## [3.8.1] - 2026-06-22
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@
 import sbt.*
 
 object Version {
-  val geotools    = "33.2"
+  val geotools    = "35.0"
   val spire       = "0.17.0"
   val accumulo    = "1.10.4"
   val cassandra   = "4.19.3"
@@ -150,7 +150,7 @@ object Dependencies {
   val jaiCodec            = "javax.media" % "jai_codec"    % "1.1.3"
   val imageIo             = "javax.media" % "jai_imageio"  % "1.1"
 
-  val imageioExtUtilities = "it.geosolutions.imageio-ext" % "imageio-ext-utilities" % "1.4.16"
+  val imageioExtUtilities = "it.geosolutions.imageio-ext" % "imageio-ext-utilities" % "2.1.0"
 
   val worksWithDependencies = Seq(jaiCore, jaiCodec, imageIo, imageioExtUtilities).map(_ % Provided)
 }


### PR DESCRIPTION
# Overview

This PR updates GeoTools up to 35.1

## Checklist

- [ ] [CQs](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/work_items?sort=created_date&state=opened&author_username=gpomadchin&first_page_size=100)
- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
