### PR TITLE
fix BigTiff offset overflow

### DIFF
--- a/.github/docker/gdal/3.x/ubuntu/Dockerfile
+++ b/.github/docker/gdal/3.x/ubuntu/Dockerfile
@@ -26,7 +26,7 @@ RUN update-alternatives --set java `update-alternatives --list java | grep java-
 
 ENV LD_LIBRARY_PATH="/lib/x86_64-linux-gnu/:/lib/x86_64-linux-gnu/jni/:/lib/aarch64-linux-gnu/:/lib/aarch64-linux-gnu/jni/:${LD_LIBRARY_PATH:-}"
 
-RUN apt-get update && apt-get -y install bash wget unzip gpg software-properties-common
+RUN apt-get update && apt-get -y install bash wget unzip gpg software-properties-common libtiff-tools
 
 # Install SBT
 RUN apt-get install -y curl gnupg && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Spark 4 Update; drops Scala 2.12 and JDK 11 support [#3582](https://github.com/locationtech/geotrellis/pull/3582)
 - GDAL 3.13 Update [#3606](https://github.com/locationtech/geotrellis/pull/3606)
 - Accumulo 2.1.4 Update [#3612](https://github.com/locationtech/geotrellis/pull/3612/)
+- Fixed BigTiff offset overflow ([#3616](https://github.com/locationtech/geotrellis/pull/3616))
 
 ## [3.8.1] - 2026-06-22
 

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
@@ -93,7 +93,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     val (fieldValues, offsetFieldValueBuilder) = TiffTagFieldValue.collect(geoTiff)
     val segments = geoTiff.imageData.segmentBytes
     val segmentCount = segments.size
-    val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).foldLeft(0L) {_ + _}
+    val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).foldLeft(0L)(_ + _)
 
     // footprint of tags themselves
     val tagFieldSize = if (isBigTiff) 20 else 12
@@ -212,7 +212,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       val (fieldValues, offsetFieldValueBuilder) = TiffTagFieldValue.collect(geoTiff)
       val segments = geoTiff.imageData.segmentBytes
       val segmentCount = segments.size
-      val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).foldLeft(0L) {_ + _}
+      val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).foldLeft(0L)(_ + _)
 
       val tagFieldSize = if (isBigTiff) 20 else 12
       val tagFieldByteCount = (fieldValues.length + 1) * tagFieldSize

--- a/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
+++ b/raster/src/main/scala/geotrellis/raster/io/geotiff/writer/GeoTiffWriter.scala
@@ -93,7 +93,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
     val (fieldValues, offsetFieldValueBuilder) = TiffTagFieldValue.collect(geoTiff)
     val segments = geoTiff.imageData.segmentBytes
     val segmentCount = segments.size
-    val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).sum
+    val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).foldLeft(0L) {_ + _}
 
     // footprint of tags themselves
     val tagFieldSize = if (isBigTiff) 20 else 12
@@ -212,7 +212,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       val (fieldValues, offsetFieldValueBuilder) = TiffTagFieldValue.collect(geoTiff)
       val segments = geoTiff.imageData.segmentBytes
       val segmentCount = segments.size
-      val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).sum
+      val segmentBytesCount = (0 until segmentCount).map(segments.getSegmentByteCount).foldLeft(0L) {_ + _}
 
       val tagFieldSize = if (isBigTiff) 20 else 12
       val tagFieldByteCount = (fieldValues.length + 1) * tagFieldSize
@@ -262,7 +262,7 @@ class GeoTiffWriter(geoTiff: GeoTiffData, dos: DataOutputStream) {
       // Sum smaller overviews + offset of the current IFD
       val imageDataStartOffset: Long =
       dataOffsets.slice(i + 1, dataOffsets.length).foldLeft(index) {
-        case (acc: Long, (_, _, (absStartOffset: Long, bytesCount: Int))) =>
+        case (acc: Long, (_, _, (absStartOffset: Long, bytesCount: Long))) =>
           acc + absStartOffset + bytesCount
       } + value._3._1
 

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -155,8 +155,8 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with BeforeAndAfterAll 
       // the overview having a finer resolution than the full res image does not make sense but the point is that
       // the overview already tips the file size over 2^32 and the full res image's offsets should go beyond that
       // without overflowing [in the case of a cloud-optimized file layout]
-      val overview = geoTiffData(cols = 32768, rows = 32768, subfileType = ReducedImage, overviews = Nil) // over 2^32
-      val fullRes = geoTiffData(cols = 256, rows = 256, subfileType = FullResolutionImage, overviews = List(overview))
+      val overview = constantBigTiff(cols = 32768, rows = 32768, subfileType = ReducedImage) // over 2^32
+      val fullRes = constantBigTiff(cols = 256, rows = 256, subfileType = FullResolutionImage, overviews = List(overview))
       GeoTiffWriter.write(fullRes, path = tempFile.toString, optimizedOrder = true)
 
       val bigTiffSizeThreshold = math.pow(2, 32).toLong
@@ -186,7 +186,8 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with BeforeAndAfterAll 
       }
   }
 
-  private def geoTiffData(cols: Int, rows: Int, subfileType: NewSubfileType, overviews: List[GeoTiffData]): GeoTiffData = {
+  private def constantBigTiff(cols: Int, rows: Int, subfileType: NewSubfileType, overviews: List[GeoTiffData] = Nil)
+  : GeoTiffData = {
     val (_cols, _rows) = (cols, rows)
     val _overviews = overviews
     val _cellType = IntConstantNoDataCellType

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -17,11 +17,11 @@
 package geotrellis.raster.io.geotiff
 
 import geotrellis.proj4.{CRS, LatLng}
-import geotrellis.raster.{IntConstantTile, Tile}
+import geotrellis.raster.io.geotiff.compression.{Decompressor, NoCompressor}
+import geotrellis.raster.{CellType, IntConstantNoDataCellType, TileLayout}
 import geotrellis.util._
 import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.raster.io.geotiff.writer.GeoTiffWriter
-import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.raster.testkit._
 import geotrellis.vector.Extent
 import org.scalatest.BeforeAndAfterAll
@@ -149,23 +149,77 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with BeforeAndAfterAll 
     }
 
     it("should handle offsets greater than 2^32 without overflowing") {
-      val (cols, rows) = (32768, 32768)
-      val tile: Tile = IntConstantTile(123, cols = cols, rows = rows) // over 2^32
-      val crs: CRS = LatLng
-      val extent: Extent = Extent(-180, -90, 180, 90)
+      val tempFile = File.createTempFile("bigtiff_", ".tif")
+      addToPurge(tempFile.toString)
 
-      val fullResolution = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = BigTiff))
-      val firstOverview = fullResolution.buildOverview(resampleMethod = NearestNeighbor, decimationFactor = 2)
+      val overview = geoTiffData(cols = 32768, rows = 32768, overviews = Nil, subfileType = ReducedImage) // over 2^32
+      val fullRes = geoTiffData(cols = 256, rows = 256, overviews = List(overview), subfileType = FullResolutionImage)
+      GeoTiffWriter.write(fullRes, path = tempFile.toString, optimizedOrder = true)
 
-      val tempFile = File.createTempFile("bigtiff", ".tif").toString
-      addToPurge(tempFile)
+      assert(tempFile.length() > scala.math.pow(2, 32))
 
-      firstOverview // intentionally make first overview already exceed the threshold
-        .copy(options = firstOverview.options.copy(subfileType = None))
-        .withOverviews(Seq(fullResolution.copy(options = fullResolution.options.copy(subfileType = Some(ReducedImage)))))
-        .write(tempFile, optimizedOrder = true)
+      // TODO: inspect offsets with e.g. tiffinfo -s or even tiffdump?
+    }
+  }
 
-      // TODO: inspect offsets with e.g. tiffinfo -s?
+  private def geoTiffData(cols: Int, rows: Int, overviews: List[GeoTiffData], subfileType: NewSubfileType): GeoTiffData = {
+    val (_cols, _rows) = (cols, rows)
+    val _overviews = overviews
+    val _cellType = IntConstantNoDataCellType
+
+    new GeoTiffData {
+      override val cellType: CellType = _cellType
+
+      override val extent: Extent = Extent(-180, -90, 180, 90)
+
+      override val crs: CRS = LatLng
+
+      override val tags: Tags = Tags.empty
+
+      override val options: GeoTiffOptions = GeoTiffOptions.DEFAULT
+        .copy(tiffType = BigTiff, subfileType = Some(subfileType))
+
+      override val overviews: List[GeoTiffData] = _overviews
+
+      override val imageData: GeoTiffImageData = new GeoTiffImageData {
+        private val (blockCols, blockRows) = (256, 256)
+
+        override val cols: Int = _cols
+
+        override val rows: Int = _rows
+
+        override val bandType: BandType = BandType.forCellType(_cellType)
+
+        override val bandCount: Int = 1
+
+        override val segmentBytes: SegmentBytes = new SegmentBytes {
+          private lazy val segment = (for {
+            _ <- 0 until (blockCols * blockRows)
+            byte <- Array[Byte](0, 0, 0, 123)
+          } yield byte).toArray
+
+          override def getSegment(i: Int): Array[Byte] = segment
+
+          override def getSegments(indices: Traversable[Int]): Iterator[(Int, Array[Byte])] =
+            indices.iterator.map(i => i -> getSegment(i))
+
+          override def getSegmentByteCount(i: Int): Int = blockCols * blockRows * cellType.bytes
+
+          override def length: Int = (cols / blockCols) * (rows / blockRows) // # of blocks
+        }
+
+        override val decompressor: Decompressor = NoCompressor
+
+        override val segmentLayout: GeoTiffSegmentLayout = {
+          GeoTiffSegmentLayout(
+            totalCols = cols,
+            totalRows = rows,
+            tileLayout = TileLayout(layoutCols = cols / blockCols, layoutRows = rows / blockRows, tileCols = blockCols, tileRows = blockRows),
+            storageMethod = Tiled(blockCols = blockCols, blockRows = blockRows),
+            interleaveMethod = BandInterleave,
+          )
+        }
+      }
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -16,9 +16,12 @@
 
 package geotrellis.raster.io.geotiff
 
+import geotrellis.proj4.{CRS, LatLng}
+import geotrellis.raster.{IntConstantTile, Tile}
 import geotrellis.util._
 import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.raster.io.geotiff.writer.GeoTiffWriter
+import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.raster.testkit._
 import geotrellis.vector.Extent
 import org.scalatest.funspec.AnyFunSpec
@@ -140,6 +143,26 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils w
         actual.options.storageMethod.getClass should be (storageMethod.getClass)
         actual.getOverviewsCount should be (5)
       }
+    }
+
+    it("should handle offsets greater than 2^32 without overflowing") {
+      val (cols, rows) = (32768, 32768)
+      val tile: Tile = IntConstantTile(123, cols = cols, rows = rows) // over 2^32
+      val crs: CRS = LatLng
+      val extent: Extent = Extent(-180, -90, 180, 90)
+
+      val fullResolution = SinglebandGeoTiff(tile, extent, crs, Tags.empty, GeoTiffOptions.DEFAULT.copy(tiffType = BigTiff))
+      val firstOverview = fullResolution.buildOverview(resampleMethod = NearestNeighbor, decimationFactor = 2)
+
+      val tempFile = File.createTempFile("bigtiff", ".tif").toString
+      addToPurge(tempFile)
+
+      firstOverview // intentionally make first overview already exceed the threshold
+        .copy(options = firstOverview.options.copy(subfileType = None))
+        .withOverviews(Seq(fullResolution.copy(options = fullResolution.options.copy(subfileType = Some(ReducedImage)))))
+        .write(tempFile, optimizedOrder = true)
+
+      // TODO: inspect offsets with e.g. tiffinfo -s?
     }
   }
 }

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -152,17 +152,41 @@ class BigTiffSpec extends AnyFunSpec with RasterMatchers with BeforeAndAfterAll 
       val tempFile = File.createTempFile("bigtiff_", ".tif")
       addToPurge(tempFile.toString)
 
-      val overview = geoTiffData(cols = 32768, rows = 32768, overviews = Nil, subfileType = ReducedImage) // over 2^32
-      val fullRes = geoTiffData(cols = 256, rows = 256, overviews = List(overview), subfileType = FullResolutionImage)
+      // the overview having a finer resolution than the full res image does not make sense but the point is that
+      // the overview already tips the file size over 2^32 and the full res image's offsets should go beyond that
+      // without overflowing [in the case of a cloud-optimized file layout]
+      val overview = geoTiffData(cols = 32768, rows = 32768, subfileType = ReducedImage, overviews = Nil) // over 2^32
+      val fullRes = geoTiffData(cols = 256, rows = 256, subfileType = FullResolutionImage, overviews = List(overview))
       GeoTiffWriter.write(fullRes, path = tempFile.toString, optimizedOrder = true)
 
-      assert(tempFile.length() > scala.math.pow(2, 32))
+      val bigTiffSizeThreshold = math.pow(2, 32).toLong
 
-      // TODO: inspect offsets with e.g. tiffinfo -s or even tiffdump?
+      assert(tempFile.length() > bigTiffSizeThreshold)
+
+      val Array(firstFullResTileOffset, _*) = firstTileOffsets(tempFile)
+      firstFullResTileOffset should be > bigTiffSizeThreshold
     }
   }
 
-  private def geoTiffData(cols: Int, rows: Int, overviews: List[GeoTiffData], subfileType: NewSubfileType): GeoTiffData = {
+  private def firstTileOffsets(tiff: File): Array[Long] = {
+    import sys.process._
+
+    val cmd = Seq("tiffdump", tiff.toString)
+    val output = cmd!!
+
+    val tagValue = raw"<(.+)>".r.unanchored
+
+    output.split("\n")
+      .filter(_ startsWith "TileOffsets")
+      .map { line =>
+        val firstTileOffset = line match {
+          case tagValue(values) => values.split(" ").head
+        }
+        firstTileOffset.toLong
+      }
+  }
+
+  private def geoTiffData(cols: Int, rows: Int, subfileType: NewSubfileType, overviews: List[GeoTiffData]): GeoTiffData = {
     val (_cols, _rows) = (cols, rows)
     val _overviews = overviews
     val _cellType = IntConstantNoDataCellType

--- a/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
+++ b/raster/src/test/scala/geotrellis/raster/io/geotiff/BigTiffSpec.scala
@@ -24,12 +24,15 @@ import geotrellis.raster.io.geotiff.writer.GeoTiffWriter
 import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.raster.testkit._
 import geotrellis.vector.Extent
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 import java.io.File
 
-class BigTiffSpec extends AnyFunSpec with RasterMatchers with GeoTiffTestUtils with TableDrivenPropertyChecks {
+class BigTiffSpec extends AnyFunSpec with RasterMatchers with BeforeAndAfterAll with GeoTiffTestUtils with TableDrivenPropertyChecks {
+  override def afterAll(): Unit = purge
+
   describe("Reading BigTiffs") {
     val smallPath = geoTiffPath("ls8_int32.tif")
     val bigPath = geoTiffPath("bigtiffs/ls8_int32-big.tif")


### PR DESCRIPTION
# Overview

Fixes offset overflow in full res BigTiffs. Manifests itself when the first overview already tips the image size over the 2^32 threshold.

## Checklist

- [x] [./CHANGELOG.md](https://github.com/locationtech/geotrellis/blob/master/CHANGELOG.md) updated, if necessary. Link to the issue if closed, otherwise the PR.
- [x] [Module Hierarchy](https://github.com/locationtech/geotrellis/blob/master/docs/guide/module-hierarchy.rst) updated, if necessary
- [x] `docs` guides update, if necessary
- [x] New user API has useful Scaladoc strings
- [x] Unit tests added for bug-fix or new feature